### PR TITLE
Add resumable download logic for gpfdist in gpdb7

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -207,6 +207,11 @@ static struct
 	int			multi_thread; /* The number of working threads for compression transmission */
 } opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0, 300, 0, 0};
 
+#define START_BUFFER_SIZE (1 << 20) /* 1M as start size */
+#define MAXIMUM_BUFFER_SIZE (1 << 30) /* 1G as Maximum size */
+static void *write_file_buffer = NULL;
+static size_t write_file_size = START_BUFFER_SIZE;
+
 typedef union address
 {
     struct sockaddr sa;
@@ -251,6 +256,7 @@ struct session_t
 	const char* 	path;			/* path requested */
 	fstream_t* 		fstream;
 	int 			is_error;		/* error flag */
+	const char*		errmsg;			/* The real error message */
 	int 			nrequest;		/* # requests attached to this session */
 	int				is_get;     	/* true for GET, false for POST */
 	int*			active_segids;	/* array indexed by segid. used for write operations
@@ -392,7 +398,7 @@ static int setup_write(request_t* r);
 static void setup_do_close(request_t* r);
 static int session_attach(request_t* r);
 static void session_detach(request_t* r);
-static void session_end(session_t* s, int error);
+static void session_end(session_t* s, int error, const char *errmsg);
 static void session_free(session_t* s);
 static void session_active_segs_dump(session_t* session);
 static int session_active_segs_isempty(session_t* session);
@@ -1285,7 +1291,7 @@ static void request_end(request_t* r, int error, const char* errmsg)
 	{
 		gwarning(r, "request failure resulting in session failure: top = %d, bot = %d", r->outblock.top, r->outblock.bot);
 		if (s)
-			session_end(s, ERROR_CODE_GENERIC);
+			session_end(s, ERROR_CODE_GENERIC, "request failure resulting in session failure");
 	}
 	else
 	{
@@ -1331,18 +1337,10 @@ static int local_send(request_t *r, const char* buf, int buflen)
 				else
 #endif
 				{
-					session_end(r->session, ERROR_CODE_SUCCESS);
+					session_end(r->session, ERROR_CODE_SUCCESS, NULL);
 				}
 			}
-			/* 
-			 * For post requests, the error msg may not be transmited
- 			 * to the client side because of network failure. So the
- 			 * session has to be set an error to inform the client
- 			 * through the following request response with an
- 			 * internal error. 
-			 */
-			else if (r->session && !r->is_get)
-				session_end(r->session, ERROR_CODE_GENERIC);
+			/* For POST request, we did not send response successfully, so allow peer retry */
 		} else {
 			if (!ok) 
 			{
@@ -1385,7 +1383,7 @@ int recycle_thread(request_t *r)
 
 		if (r->session_end)
 		{
-			session_end(r->session, ERROR_CODE_SUCCESS);
+			session_end(r->session, ERROR_CODE_SUCCESS, NULL);
 		}
 
 		if (last_send < 0)
@@ -1628,7 +1626,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	if (session->is_error || 0 == session->fstream)
 	{
 		gprintln(NULL, "session_get_block: end session is_error: %d", session->is_error);
-		session_end(session, ERROR_CODE_SUCCESS);
+		session_end(session, ERROR_CODE_SUCCESS, NULL);
 		return 0;
 	}
 
@@ -1643,7 +1641,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	{
 		gprintln(NULL, "session_get_block: end session due to EOF");
 		gcb.read_bytes += fstream_get_compressed_size(session->fstream);
-		session_end(session, ERROR_CODE_SUCCESS);
+		session_end(session, ERROR_CODE_SUCCESS, NULL);
 		return 0;
 	}
 
@@ -1653,7 +1651,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	{
 		const char* ferror = fstream_get_error(session->fstream);
 		gwarning(NULL, "session_get_block end session due to %s", ferror);
-		session_end(session, ERROR_CODE_GENERIC);
+		session_end(session, ERROR_CODE_GENERIC, ferror);
 		return ferror;
 	}
 
@@ -1665,12 +1663,15 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 }
 
 /* finish the session - close the file */
-static void session_end(session_t* session, int error)
+static void session_end(session_t* session, int error, const char *errmsg)
 {
 	gprintln(NULL, "session end. id = %ld, is_error = %d, error = %d", session->id, session->is_error, error);
 
-	if (error)
+	if (error) 
+	{
 		session->is_error = error;
+		session->errmsg = errmsg;
+	}
 
 	if (session->fstream)
 	{
@@ -1995,7 +1996,7 @@ static int session_attach(request_t* r)
 	/* if error, send an error and close */
 	if (session->is_error)
 	{
-		http_error(r, FDIST_INTERNAL_ERROR, "session error");
+		http_error(r, FDIST_INTERNAL_ERROR, session->errmsg);
 		request_end(r, ERROR_CODE_GENERIC, 0);
 		return -1;
 	}
@@ -3461,7 +3462,6 @@ static void handle_post_request(request_t *r, int header_end)
 	{
 		case OPEN_SEQ:
 			/* sequence number is 1, it's the first OPEN request */
-			session->seq_segs[r->segid] = r->seq;
 			goto done_processing_request;
 
 		case NO_SEQ:
@@ -3517,13 +3517,50 @@ static void handle_post_request(request_t *r, int header_end)
 			}
 	}
 
+	if (r->in.davailable < 0 || r->in.davailable > MAXIMUM_BUFFER_SIZE)
+	{
+		http_error(r, FDIST_BAD_REQUEST, "invalid Content-Length");
+		gwarning(r, "got an request with invalid Content-Length: %d", r->in.davailable);
+		request_end(r, 1, 0);
+		return;
+	}
+
+	/*
+	 * The write_file_buffer is used by all POST request. The start buffer size will be 1M.
+	 * The maximum size will be 1G. We want all POST data fit in the write_file_buffer, so
+	 * that when network error happens, no data will be written into the fstream.
+	 * The sending buffer at segment size will be range from 32K to 128M, so 1G is large
+	 * enough to hold all the POST data.
+	 */
+	if (write_file_buffer == NULL) 
+	{
+		write_file_buffer = malloc(write_file_size);
+		if (write_file_buffer == NULL) 
+		{
+			gfatal(r, "Cannot alloc memory for write_file_buffer");
+		}
+	}
+	if (r->in.davailable > (int) write_file_size) 
+	{
+		while(r->in.davailable > (int) write_file_size) 
+		{
+			write_file_size <<= 1;
+		}
+		write_file_buffer = realloc(write_file_buffer, write_file_size);
+		if (write_file_buffer == NULL) 
+		{
+			gfatal(r, "Cannot realloc memory for write_file_buffer");
+		}
+	}
+
 	/* create a buffer to hold the incoming raw data */
-	r->in.dbufmax = opt.m; /* size of max line size */
+	r->in.dbufmax = (int) write_file_size; /* size of max line size */
 	r->in.dbuftop = 0;
 	r->in.wbuftop = 0;
 	r->in.dbuf = palloc_safe(r, r->pool, r->in.dbufmax, "out of memory when allocating r->in.dbuf: %d bytes", r->in.dbufmax);
 	if (r->zstd)
 		r->in.wbuf = palloc_safe(r, r->pool, MAX_FRAME_SIZE, "out of memory when allocating r->in.wbuf: %d bytes", MAX_FRAME_SIZE);
+	r->in.dbuf = (char *) write_file_buffer;
 
 	/* if some data come along with the request, copy it first */
 	data_start = strstr(r->in.hbuf, "\r\n\r\n");
@@ -3544,31 +3581,6 @@ static void handle_post_request(request_t *r, int header_end)
 		r->in.dbuftop += data_bytes_in_req;
 
 		r->in.davailable -= data_bytes_in_req;
-
-		/* only write it out if no more data is expected */
-		if (r->in.davailable == 0)
-		{
-#ifdef USE_ZSTD
-			if (r->zstd)
-			{
-				wrote = decompress_write_loop(r);
-				if (wrote == -1)
-					return;
-			}
-			else
-#endif
-			{
-				wrote = fstream_write(session->fstream, r->in.dbuf, data_bytes_in_req, 1, r->line_delim_str, r->line_delim_length);
-				delay_watchdog_timer();
-				if (wrote == -1)
-				{
-					/* write error */
-					http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
-					request_end(r, ERROR_CODE_GENERIC, 0);
-					return;
-				}
-			}
-		}
 	}
 
 	/*
@@ -3577,14 +3589,10 @@ static void handle_post_request(request_t *r, int header_end)
 	 */
 	while (r->in.davailable > 0)
 	{
-		size_t want;
-		ssize_t n = 0;
-		size_t buf_space_left = r->in.dbufmax - r->in.dbuftop;
-
-		if (r->in.davailable > buf_space_left)
-			want = buf_space_left;
-		else
-			want = r->in.davailable;
+		ssize_t n;
+		/* We can make sure that want is r->in.davailable is less than r->in.dbufmax - r->in.dbuftop,
+		 * so we just read the left size in the POST request */
+		size_t want = r->in.davailable;
 
 		/* read from socket into data buf */
 		n = gpfdist_receive(r, r->in.dbuf + r->in.dbuftop, want);
@@ -3601,7 +3609,8 @@ static void handle_post_request(request_t *r, int header_end)
 			if (!ok)
 			{
 				gwarning(r, "handle_post_request receive errno: %d, msg: %s", e, strerror(e));
-			    http_error(r, FDIST_INTERNAL_ERROR, "internal error");
+				/* Give another chance for retry */
+				http_error(r, FDIST_TIMEOUT, "receive POST data from network error");
 				request_end(r, ERROR_CODE_GENERIC, 0);
 				return;
 			}
@@ -3615,46 +3624,38 @@ static void handle_post_request(request_t *r, int header_end)
 		}
 		else
 		{
-			/* gprint("received %d bytes from client\n", n); */
-
+			r->in.davailable -= n;
 			r->bytes += n;
 			r->last = apr_time_now();
-			r->in.davailable -= n;
 			r->in.dbuftop += n;
-
-			/* 
-			 * success is a flag to check whether data is written into file successfully.
-			 * There is no need to do anything when success is less than 0, since all
-			 * error handling has been done in 'check_output_to_file' function.
-			 */
-			int success = 0;
-
-			/* if filled our buffer or no more data expected, write it */
-			if (r->in.dbufmax == r->in.dbuftop || r->in.davailable == 0)
-			{
-#ifdef USE_ZSTD
-				/* only write up to end of last row */
-				if (r->zstd)
-				{
-					success = decompress_write_loop(r);
-				}
-				else
-#endif
-				{
-					wrote = fstream_write(session->fstream, r->in.dbuf, r->in.dbuftop, 1, r->line_delim_str, r->line_delim_length);
-					gdebug(r, "wrote %d bytes to file", wrote);
-					delay_watchdog_timer();
-
-					success = check_output_to_file(r, wrote);
-				}
-			}
-			if (success < 0)
-				return;
 		}
-
 	}
+	
+	/* 
+	 * success is a flag to check whether data is written into file successfully.
+	 * There is no need to do anything when success is less than 0, since all
+	 * error handling has been done in 'check_output_to_file' function.
+	 */
+	int success = 0;
+#ifdef USE_ZSTD
+	/* only write up to end of last row */
+	if (r->zstd)
+	{
+		success = decompress_write_loop(r);
+	}
+	else
+#endif
+	{
+		wrote = fstream_write(session->fstream, r->in.dbuf, r->in.dbuftop, 1, r->line_delim_str, r->line_delim_length);
+		gdebug(r, "wrote %d bytes to file", wrote);
+		delay_watchdog_timer();
 
-	session->seq_segs[r->segid] = r->seq;
+		success = check_output_to_file(r, wrote);
+	}
+	/* if filled our buffer or no more data expected, write it */
+	
+	if (success < 0)
+		return;
 
 done_processing_request:
 
@@ -3662,8 +3663,15 @@ done_processing_request:
 	if (0 != http_ok(r))
 		request_end(r, ERROR_CODE_GENERIC, 0);
 	else
+	{
 		request_end(r, ERROR_CODE_SUCCESS, 0); /* we're done! */
-
+		/* 
+		 * Only when send http_ok successfully will we set
+		 * OPEN_SEQ and normal seq, we just add 1.
+		 * For duplicate case, we set it unchanged.
+		 */
+		session->seq_segs[r->segid] = r->seq;
+	}
 }
 
 static int request_set_path(request_t *r, const char* d, char* p, char* pp, char* path)

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -489,6 +489,7 @@ COPY wet_region FROM STDIN DELIMITER '|';
 \.
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
 -- Check error correctness, if trying to insert too long row
+-- Since the resumable download feature has been added to gpfdist, a too long row will not trigger error.
 INSERT INTO wet_pos1(a)
 SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
 --

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -464,6 +464,7 @@ drop external table bad_location2;
 -- CREATE (including LIKE, DISTRIBUTED BY)
 --
 -- positive
+set writable_external_table_bufsize = 131072;
 create writable external table wet_pos1(a text, b text) location('gpfdist://@hostname@:7070/wet.out') format 'text';
 \d wet_pos1
 create writable external table wet_pos2(a text, b text) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(b);

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -641,6 +641,7 @@ drop external table bad_location2;
 -- CREATE (including LIKE, DISTRIBUTED BY)
 --
 -- positive
+set writable_external_table_bufsize = 131072;
 create writable external table wet_pos1(a text, b text) location('gpfdist://@hostname@:7070/wet.out') format 'text';
 \d wet_pos1
                Foreign table "public.wet_pos1"

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -683,9 +683,9 @@ INSERT INTO wet_region SELECT * from reg_region;
 COPY wet_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
 -- Check error correctness, if trying to insert too long row
+-- Since the resumable download feature has been added to gpfdist, a too long row will not trigger error.
 INSERT INTO wet_pos1(a)
 SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
-ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger


### PR DESCRIPTION
When insert into writable external tables, the gpfdist is the server, and segments are clients. The clients will send POST requests one by one in sequence order. There is a retry mechanism on the gpdb segment side when it fails to send one POST request to gpfdist because of network failure. If the network failure happens after the connection has been made, then gpfdist will also get an error when reading data from the socket.
However, the retry is not working because of gpfdist legacy code that will close fstream when failed to receive data from the socket. Gpfdist will close the file stream and set an error, so when the retry POST request arrives at gpfdist, an "500 internal error" will be sent back to the segment which will stop the whole insert procedure.

This commit will let gpfdist confirm the receiving data from the POST request without error and then write it into the local file stream. After sending "HTTP/1.0 200 ok" successfully, gpfdist will add the SEQ number. It will not release the file stream because of a network error. And when gpfdist receives the retry POST request again, it continues to process until successful. So this could allow the segment to retry sending POST requests to gpfdist to avoid 500 errors because of network failure.
