### PR TITLE
6X: Don't create unique rowid paths if there is a table function scan

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2824,6 +2824,17 @@ create_tablefunction_path(PlannerInfo *root, RelOptInfo *rel,
 
 	Assert(rte->rtekind == RTE_TABLEFUNCTION);
 
+	/*
+	 * Greenplum specific behavior
+	 *
+	 * Greenplum has a special path to handle semjoin, the planner might add a
+	 * unique_row_id path to the first inner join and then de-duplicate.
+	 *
+	 * Table function scan has no corresponding dedup workflow. Here we
+	 * introduce a switch to turn off it when there is a table function scan.
+	 */
+	root->disallow_unique_rowid_path = true;
+
 	/* Setup the basics of the TableFunction path */
 	pathnode->pathtype	   = T_TableFunctionScan;
 	pathnode->parent	   = rel;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -58,8 +58,8 @@ test: gpcopy
 # this test fiddles with relfrozenxid, so run independently as any
 # parallel test running vacuum could have trouble
 test: matview_ao
-
-test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var distributed_transactions explain_format direct_dispatch_explain_analyze
+test: table_functions
+test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink olap_setup complex opclass_ddl information_schema guc_env_var distributed_transactions explain_format direct_dispatch_explain_analyze
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: gp_explain

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -6,6 +6,8 @@
 CREATE SCHEMA table_function;
 SET search_path TO table_function, public;
 
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
 CREATE TABLE example(a int, b text) DISTRIBUTED by (a);
 COPY example FROM stdin;
 1	 value1.1/4
@@ -420,6 +422,11 @@ SELECT * FROM example where (a,b) in (select * from example) order by a, b;
 SELECT * FROM example where (a,b) in (select * from multiset_5( TABLE(SELECT a, b from example) )) order by a, b;
 SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (select a,b from example) order by a, b;
 -- end equivalent
+
+-- Don't generate unique rowid path if there is a table function scan
+SELECT gp_inject_fault_infinite('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT count(*) FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (select a,b from example);
+SELECT gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -5,6 +5,7 @@
 -- ===================
 CREATE SCHEMA table_function;
 SET search_path TO table_function, public;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE TABLE example(a int, b text) DISTRIBUTED by (a);
 COPY example FROM stdin;
 CREATE TABLE history(id integer, time timestamp) DISTRIBUTED BY (id);
@@ -1548,6 +1549,25 @@ SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (selec
 (10 rows)
 
 -- end equivalent
+-- Don't generate unique rowid path if there is a table function scan
+SELECT gp_inject_fault_infinite('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+SELECT count(*) FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (select a,b from example);
+ count 
+-------
+    10
+(1 row)
+
+SELECT gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
                               QUERY PLAN                               

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -5,6 +5,7 @@
 -- ===================
 CREATE SCHEMA table_function;
 SET search_path TO table_function, public;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE TABLE example(a int, b text) DISTRIBUTED by (a);
 COPY example FROM stdin;
 CREATE TABLE history(id integer, time timestamp) DISTRIBUTED BY (id);
@@ -1549,6 +1550,25 @@ SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (selec
 (10 rows)
 
 -- end equivalent
+-- Don't generate unique rowid path if there is a table function scan
+SELECT gp_inject_fault_infinite('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+SELECT count(*) FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (select a,b from example);
+ count 
+-------
+    10
+(1 row)
+
+SELECT gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
                               QUERY PLAN                               


### PR DESCRIPTION
Greenplum has a special path to handle semjoin, the planner might add a
unique_row_id path to the first inner join and then de-duplicate.

Table function scan has no corresponding dedup workflow. Here we
introduce a switch to turn off it when there is a table function scan.
