### PR TITLE
fix the name of "cpu_hard_quota_limit" in resgroup_syntax.sql

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -378,9 +378,9 @@ DROP RESOURCE GROUP rg2_test_group;
 ERROR:  resource group "rg2_test_group" does not exist
 
 -- positive: min_cost should be in [0,INT32_MAX]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=0);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=0);
 CREATE
-CREATE RESOURCE GROUP rg1_test_group WITH (cpu_hard_quota_limit=10, min_cost=2147483647);
+CREATE RESOURCE GROUP rg1_test_group WITH (cpu_max_percent=10, min_cost=2147483647);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET min_cost 2147483647;
 ALTER
@@ -392,11 +392,11 @@ DROP RESOURCE GROUP rg1_test_group;
 DROP
 
 -- negative: min_cost should be in [0,INT32_MAX]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=-1);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=-1);
 ERROR:  The min_cost value can't be less than 0.
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=2147483648);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=2147483648);
 ERROR:  capability min_cost is out of range
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=0);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=0);
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET min_cost -1;
 ERROR:  The min_cost value can't be less than 0.

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -197,17 +197,17 @@ DROP RESOURCE GROUP rg1_test_group;
 DROP RESOURCE GROUP rg2_test_group;
 
 -- positive: min_cost should be in [0,INT32_MAX]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=0);
-CREATE RESOURCE GROUP rg1_test_group WITH (cpu_hard_quota_limit=10, min_cost=2147483647);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=0);
+CREATE RESOURCE GROUP rg1_test_group WITH (cpu_max_percent=10, min_cost=2147483647);
 ALTER RESOURCE GROUP rg_test_group SET min_cost 2147483647;
 ALTER RESOURCE GROUP rg1_test_group SET min_cost 0;
 DROP RESOURCE GROUP rg_test_group;
 DROP RESOURCE GROUP rg1_test_group;
 
 -- negative: min_cost should be in [0,INT32_MAX]
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=-1);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=2147483648);
-CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10, min_cost=0);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=-1);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=2147483648);
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, min_cost=0);
 ALTER RESOURCE GROUP rg_test_group SET min_cost -1;
 ALTER RESOURCE GROUP rg_test_group SET min_cost 2147483648;
 DROP RESOURCE GROUP rg_test_group;


### PR DESCRIPTION
As the PR title said, just fix the field name to correctness.