### PR TITLE
Modifications to resource group parameter changes

### DIFF
--- a/gpdb-doc/markdown/ref_guide/gp_toolkit.html.md
+++ b/gpdb-doc/markdown/ref_guide/gp_toolkit.html.md
@@ -536,7 +536,7 @@ This view is accessible to all users.
 |groupid|The ID of the resource group.|
 |groupname|The name of the resource group.|
 |concurrency|The concurrency \(`CONCURRENCY`\) value specified for the resource group.|
-|cpu\_rate\_limit|The CPU limit \(`cpu_max_percent`\) value specified for the resource group, or -1.|
+|cpu\_rate\_limit|The CPU limit \(`CPU_MAX_PERCENT`\) value specified for the resource group, or -1.|
 |memory\_limit|The memory limit \(`MEMORY_LIMIT`\) value specified for the resource group.|
 |memory\_shared\_quota|The shared memory quota \(`MEMORY_SHARED_QUOTA`\) value specified for the resource group.|
 |memory\_spill\_ratio|The memory spill ratio \(`MEMORY_SPILL_RATIO`\) value specified for the resource group.|

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
@@ -93,7 +93,7 @@ ALTER RESOURCE GROUP rgroup1 SET CONCURRENCY 13;
 Update the CPU limit for a resource group:
 
 ```
-ALTER RESOURCE GROUP rgroup2 SET cpu_max_percent 45;
+ALTER RESOURCE GROUP rgroup2 SET CPU_MAX_PERCENT 45;
 ```
 
 Update the memory limit for a resource group:

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
@@ -95,20 +95,20 @@ SELECT * FROM gp_toolkit.gp_resgroup_config;
 Create a resource group with CPU and memory limit percentages of 35:
 
 ```
-CREATE RESOURCE GROUP rgroup1 WITH (cpu_max_percent=35, MEMORY_LIMIT=35);
+CREATE RESOURCE GROUP rgroup1 WITH (CPU_MAX_PERCENT=35, MEMORY_LIMIT=35);
 ```
 
 Create a resource group with a concurrent transaction limit of 20, a memory limit of 15, and a CPU limit of 25:
 
 ```
 CREATE RESOURCE GROUP rgroup2 WITH (CONCURRENCY=20, 
-  MEMORY_LIMIT=15, cpu_max_percent=25);
+  MEMORY_LIMIT=15, CPU_MAX_PERCENT=25);
 ```
 
 Create a resource group to manage PL/Container resources specifying a memory limit of 10, and a CPU limit of 10:
 
 ```
-CREATE RESOURCE GROUP plc_run1 WITH (MEMORY_LIMIT=10, cpu_max_percent=10,
+CREATE RESOURCE GROUP plc_run1 WITH (MEMORY_LIMIT=10, CPU_MAX_PERCENT=10,
   CONCURRENCY=0);
 ```
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -280,7 +280,7 @@ The `gp_toolkit.gp_resgroup_config` view allows administrators to see the curren
 |`groupid`|oid|pg\_resgroup.oid|The ID of the resource group.|
 |`groupname`|name|pg\_resgroup.rsgname|The name of the resource group.|
 |`concurrency`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 1|The concurrency \(`CONCURRENCY`\) value specified for the resource group.|
-|`cpu_max_percent`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 2|The CPU limit \(`cpu_max_percent`\) value specified for the resource group, or -1.|
+|`cpu_max_percent`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 2|The CPU limit \(`CPU_MAX_PERCENT`\) value specified for the resource group, or -1.|
 |`memory_limit`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 3|The memory limit \(`MEMORY_LIMIT`\) value specified for the resource group.|
 |`memory_shared_quota`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 4|The shared memory quota \(`MEMORY_SHARED_QUOTA`\) value specified for the resource group.|
 |`memory_spill_ratio`|text|pg\_resgroupcapability.value for pg\_resgroupcapability.reslimittype = 5|The memory spill ratio \(`MEMORY_SPILL_RATIO`\) value specified for the resource group.|


### PR DESCRIPTION
Follow up from PR https://github.com/greenplum-db/gpdb/pull/15765 which renames the resource groups parameters   “cpu_hard_quota_limit” to “cpu_max_percent”, and “cpu_soft_priority”  to “cpu_weight”. 
