### PR TITLE
[ORCA] update relcache logic for setting hashable for RANGETYPES 

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2665,4 +2665,17 @@ gpdb::FlatCopyTargetEntry(TargetEntry *src_tle)
 }
 
 
+// Returns true if type is a RANGE
+// pg_type (typtype = 'r')
+bool
+gpdb::IsTypeRange(Oid typid)
+{
+	GP_WRAP_START;
+	{
+		return type_is_range(typid);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
 // EOF

--- a/src/backend/gporca/data/dxl/minidump/ExceptHashCompatibleRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExceptHashCompatibleRange.mdp
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+      Objective: Test for a range type with a subtype that supports hashing, ORCA
+      generates a HASH JOIN plan.
+
+      create type intrange as range (subtype = int);
+      select '(2,5)'::intrange except select '(5,6)'::intrange;
+
+      GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
+        Group Key: ('(2,5)'::intrange)
+        ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+              Sort Key: ('(2,5)'::intrange)
+              ->  Hash Anti Join  (cost=0.00..0.00 rows=1 width=8)
+                    Hash Cond: (NOT ((('(2,5)'::intrange))::anyrange IS DISTINCT FROM (('(5,6)'::intrange))::anyrange))
+                    ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                    ->  Hash  (cost=0.00..0.00 rows=1 width=8)
+                          ->  Result  (cost=0.00..0.00 rows=1 width=1)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103003,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.3882.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3855.1.0"/>
+        <dxl:Commutator Mdid="0.3882.1.0"/>
+        <dxl:InverseOp Mdid="0.3883.1.0"/>
+        <dxl:HashOpfamily Mdid="0.3903.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3474.1.0"/>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.3903.1.0"/>
+          <dxl:Opfamily Mdid="0.3919.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.3884.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3871.1.0"/>
+        <dxl:Commutator Mdid="0.3887.1.0"/>
+        <dxl:InverseOp Mdid="0.3886.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.3887.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3874.1.0"/>
+        <dxl:Commutator Mdid="0.3884.1.0"/>
+        <dxl:InverseOp Mdid="0.3885.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.17737.1.0" Name="intrange" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.3903.1.0"/>
+        <dxl:PartOpfamily Mdid="0.3901.1.0"/>
+        <dxl:EqualityOp Mdid="0.3882.1.0"/>
+        <dxl:InequalityOp Mdid="0.3883.1.0"/>
+        <dxl:LessThanOp Mdid="0.3884.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.3885.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.3887.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.3886.1.0"/>
+        <dxl:ComparisonOp Mdid="0.3870.1.0"/>
+        <dxl:ArrayType Mdid="0.17738.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.3831.1.0;3831.1.0" Name="anyrange" BinaryCoercible="true" SourceTypeId="0.3831.1.0" DestinationTypeId="0.3831.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.17737.1.0;3831.1.0" Name="anyrange" BinaryCoercible="true" SourceTypeId="0.17737.1.0" DestinationTypeId="0.3831.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="2" ColName="intrange" TypeMdid="0.17737.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:Difference InputColumns="2;4" CastAcrossInputs="false">
+        <dxl:Columns>
+          <dxl:Column ColId="2" Attno="1" ColName="intrange" TypeMdid="0.17737.1.0"/>
+        </dxl:Columns>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="intrange">
+              <dxl:ConstValue TypeMdid="0.17737.1.0" Value="AAAAEUlFAAACAAAABQAAAAA="/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="4" Alias="intrange">
+              <dxl:ConstValue TypeMdid="0.17737.1.0" Value="AAAAEUlFAAAFAAAABgAAAAA="/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="3" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+      </dxl:Difference>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="120">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.000519" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="1"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="1" Alias="intrange">
+            <dxl:Ident ColId="1" ColName="intrange" TypeMdid="0.17737.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000506" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="intrange">
+              <dxl:Ident ColId="1" ColName="intrange" TypeMdid="0.17737.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.3884.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000506" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="intrange">
+                <dxl:Ident ColId="1" ColName="intrange" TypeMdid="0.17737.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.3882.1.0">
+                  <dxl:Cast TypeMdid="0.3831.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="1" ColName="intrange" TypeMdid="0.17737.1.0"/>
+                  </dxl:Cast>
+                  <dxl:Cast TypeMdid="0.3831.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="3" ColName="intrange" TypeMdid="0.17737.1.0"/>
+                  </dxl:Cast>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="intrange">
+                  <dxl:ConstValue TypeMdid="0.17737.1.0" Value="AAAAEUlFAAACAAAABQAAAAA="/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="intrange">
+                  <dxl:ConstValue TypeMdid="0.17737.1.0" Value="AAAAEUlFAAAFAAAABgAAAAA="/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:HashJoin>
+        </dxl:Sort>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ExceptHashIncompatibleRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExceptHashIncompatibleRange.mdp
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+      Objective: Test for a range type with a subtype that doesn't support hashing, ORCA
+      generates a NLJ plan.
+
+      create type cashrange as range (subtype = money);
+      explain select '(2,5)'::cashrange except select '(5,6)'::cashrange;
+
+      GroupAggregate  (cost=0.00..441344.33 rows=1 width=8)
+        Group Key: ('($2.00,$5.00)'::cashrange)
+        ->  Sort  (cost=0.00..441344.33 rows=1 width=8)
+              Sort Key: ('($2.00,$5.00)'::cashrange)
+              ->  Nested Loop Anti Join  (cost=0.00..441344.33 rows=1 width=8)
+                    Join Filter: (NOT ((('($2.00,$5.00)'::cashrange))::anyrange IS DISTINCT FROM (('($5.00,$6.00)'::cashrange))::anyrange))
+                    ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                    ->  Materialize  (cost=0.00..0.00 rows=1 width=8)
+                          ->  Result  (cost=0.00..0.00 rows=1 width=1)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103003,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.3882.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3855.1.0"/>
+        <dxl:Commutator Mdid="0.3882.1.0"/>
+        <dxl:InverseOp Mdid="0.3883.1.0"/>
+        <dxl:HashOpfamily Mdid="0.3903.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3474.1.0"/>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.3903.1.0"/>
+          <dxl:Opfamily Mdid="0.3919.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.3884.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3871.1.0"/>
+        <dxl:Commutator Mdid="0.3887.1.0"/>
+        <dxl:InverseOp Mdid="0.3886.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.3887.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3831.1.0"/>
+        <dxl:RightType Mdid="0.3831.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.3874.1.0"/>
+        <dxl:Commutator Mdid="0.3884.1.0"/>
+        <dxl:InverseOp Mdid="0.3885.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.3901.1.0"/>
+          <dxl:Opfamily Mdid="0.4103.1.0"/>
+          <dxl:Opfamily Mdid="0.10031.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.17741.1.0" Name="cashrange" IsRedistributable="false" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:PartOpfamily Mdid="0.3901.1.0"/>
+        <dxl:EqualityOp Mdid="0.3882.1.0"/>
+        <dxl:InequalityOp Mdid="0.3883.1.0"/>
+        <dxl:LessThanOp Mdid="0.3884.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.3885.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.3887.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.3886.1.0"/>
+        <dxl:ComparisonOp Mdid="0.3870.1.0"/>
+        <dxl:ArrayType Mdid="0.17742.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.3831.1.0;3831.1.0" Name="anyrange" BinaryCoercible="true" SourceTypeId="0.3831.1.0" DestinationTypeId="0.3831.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.17741.1.0;3831.1.0" Name="anyrange" BinaryCoercible="true" SourceTypeId="0.17741.1.0" DestinationTypeId="0.3831.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="2" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:Difference InputColumns="2;4" CastAcrossInputs="false">
+        <dxl:Columns>
+          <dxl:Column ColId="2" Attno="1" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+        </dxl:Columns>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="cashrange">
+              <dxl:ConstValue TypeMdid="0.17741.1.0" Value="AAAAGU1FAADIAAAAAAAAAPQBAAAAAAAAAA=="/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="4" Alias="cashrange">
+              <dxl:ConstValue TypeMdid="0.17741.1.0" Value="AAAAGU1FAAD0AQAAAAAAAFgCAAAAAAAAAA=="/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="3" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+      </dxl:Difference>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="12">
+      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="441344.325391" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="1"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="1" Alias="cashrange">
+            <dxl:Ident ColId="1" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="441344.325378" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="cashrange">
+              <dxl:Ident ColId="1" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.3884.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoin" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="441344.325378" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="cashrange">
+                <dxl:Ident ColId="1" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.3882.1.0">
+                  <dxl:Cast TypeMdid="0.3831.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="1" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+                  </dxl:Cast>
+                  <dxl:Cast TypeMdid="0.3831.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="3" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+                  </dxl:Cast>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:JoinFilter>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="cashrange">
+                  <dxl:ConstValue TypeMdid="0.17741.1.0" Value="AAAAGU1FAADIAAAAAAAAAPQBAAAAAAAAAA=="/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+            <dxl:Materialize Eager="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="cashrange">
+                  <dxl:Ident ColId="3" ColName="cashrange" TypeMdid="0.17741.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="3" Alias="cashrange">
+                    <dxl:ConstValue TypeMdid="0.17741.1.0" Value="AAAAGU1FAAD0AQAAAAAAAFgCAAAAAAAAAA=="/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="2" Alias="">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:Materialize>
+          </dxl:NestedLoopJoin>
+        </dxl:Sort>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -635,6 +635,20 @@ CPhysicalJoin::FHashJoinCompatible(
 		return false;
 	}
 
+	// This check is mainly added for RANGE TYPES; RANGE's are treated as
+	// containers and whether a range type can support hashing is decided
+	// based on hashing support of its subtype
+	if (COperator::EopScalarCast == pexprPredOuter->Pop()->Eopid())
+	{
+		pmdidTypeOuter =
+			CScalar::PopConvert((*pexprPredOuter)[0]->Pop())->MdidType();
+	}
+	if (COperator::EopScalarCast == pexprPredInner->Pop()->Eopid())
+	{
+		pmdidTypeInner =
+			CScalar::PopConvert((*pexprPredInner)[0]->Pop())->MdidType();
+	}
+
 	if (md_accessor->RetrieveType(pmdidTypeOuter)->IsHashable() &&
 		md_accessor->RetrieveType(pmdidTypeInner)->IsHashable())
 	{

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -263,7 +263,8 @@ CSetop3Test:
 UnionWithOuterRefs UnionAll
 Union-Distributed-Table-With-Const-Table ExceptAllCompatibleDataType
 UnionAllCompatibleDataType UnionOfDQAQueries Union-Volatile-Func
-Intersect-Volatile-Func Except-Volatile-Func UnionWithCTE;
+Intersect-Volatile-Func Except-Volatile-Func UnionWithCTE ExceptHashCompatibleRange
+ExceptHashIncompatibleRange;
 
 CSetop4Test:
 PushSelectDownUnionAllOfCTG Push-Subplan-Below-Union Intersect-OuterRefs

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -663,6 +663,8 @@ Var *MakeVarFromTargetEntry(Index varno, TargetEntry *tle);
 
 TargetEntry *FlatCopyTargetEntry(TargetEntry *src_tle);
 
+bool IsTypeRange(Oid typid);
+
 }  //namespace gpdb
 
 #define ForEach(cell, l) \

--- a/src/test/regress/expected/rangetypes.out
+++ b/src/test/regress/expected/rangetypes.out
@@ -1457,8 +1457,6 @@ select array[1,3] <@ arrayrange(array[1,2], array[2,1]);
  t
 (1 row)
 
--- start_ignore
--- GPDB_94_MERGE_FIXME: orca can not run the test green.
 --
 -- Check behavior when subtype lacks a hash function
 --
@@ -1471,7 +1469,6 @@ select '(2,5)'::cashrange except select '(5,6)'::cashrange;
 (1 row)
 
 reset enable_sort;
--- end_ignore
 --
 -- Ranges of composites
 --

--- a/src/test/regress/expected/rangetypes_optimizer.out
+++ b/src/test/regress/expected/rangetypes_optimizer.out
@@ -1459,8 +1459,6 @@ select array[1,3] <@ arrayrange(array[1,2], array[2,1]);
  t
 (1 row)
 
--- start_ignore
--- GPDB_94_MERGE_FIXME: orca can not run the test green.
 --
 -- Check behavior when subtype lacks a hash function
 --
@@ -1473,7 +1471,6 @@ select '(2,5)'::cashrange except select '(5,6)'::cashrange;
 (1 row)
 
 reset enable_sort;
--- end_ignore
 --
 -- Ranges of composites
 --

--- a/src/test/regress/sql/rangetypes.sql
+++ b/src/test/regress/sql/rangetypes.sql
@@ -486,9 +486,6 @@ select arrayrange(ARRAY[2,1], ARRAY[1,2]);  -- fail
 select array[1,1] <@ arrayrange(array[1,2], array[2,1]);
 select array[1,3] <@ arrayrange(array[1,2], array[2,1]);
 
--- start_ignore
--- GPDB_94_MERGE_FIXME: orca can not run the test green.
-
 --
 -- Check behavior when subtype lacks a hash function
 --
@@ -500,8 +497,6 @@ set enable_sort = off;  -- try to make it pick a hash setop implementation
 select '(2,5)'::cashrange except select '(5,6)'::cashrange;
 
 reset enable_sort;
-
--- end_ignore
 
 --
 -- Ranges of composites


### PR DESCRIPTION
Previously, ORCA would set a datatype as hashable or not based on the
equality operator. As part of postgres 9.4 merge commit
(https://github.com/postgres/postgres/commit/36ea99c84d856177ec307307788a279cc600566e)
range's are treated as containers and whether a range type can support
hashing is decided based on hashing support of the range's subtype. This
check is done as part of fetching `HASH_PROC` in `lookup_typ_cache()`, which
is also later fetched when executing the query with a range type.
For a query where the range's subtype is not hashable, ORCA treats it as hashable
and generates a HASH plan which later fails during execution.  Below is an example:
```
create type cashrange as range (subtype = money);
select '(2,5)'::cashrange except select '(5,6)'::cashrange;
```

Here ORCA transforms the Setop(except) into a LeftAntiSemiJoin(CXformDifference2LeftAntiSemiJoin)
and generates an IDF perdicate with cashrange casted to anyrange. The operator that is used can hash
but since it is a range we actually need to look at the hashing support for its subtype.  
This PR fixes this issue by adding a special case for rangetypes when doing a
lookup and sets hashable information for the type based on the HASH_PROC
info fetched instead of the operator and when checking if the type being compatible for Hash Join
(`CPhysicalJoin::FHashJoinCompatible()`), ORCA looks for a cast and checks the Hash compatibility
of the underlying scalar operator. (We can restrict this cast check for specific cases, but seems reasonable to 
check it for casts)  

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
