### PR TITLE
Remove MemoryContext s_tupSerMemCtxt

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -39,13 +39,6 @@
  */
 #define RECORD_CACHE_MAGIC_TUPLEN	-1
 
-/* A MemoryContext used within the tuple serialize code, so that freeing of
- * space is SUPAFAST.  It is initialized in the first call to InitSerTupInfo()
- * since that must be called before any tuple serialization or deserialization
- * work can be done.
- */
-static MemoryContext s_tupSerMemCtxt = NULL;
-
 static void addByteStringToChunkList(TupleChunkList tcList, char *data, int datalen, TupleChunkListCache *cache);
 
 #define addCharToChunkList(tcList, x, c)							\
@@ -80,18 +73,6 @@ InitSerTupInfo(TupleDesc tupdesc, SerTupInfo *pSerInfo)
 
 	AssertArg(tupdesc != NULL);
 	AssertArg(pSerInfo != NULL);
-
-	if (s_tupSerMemCtxt == NULL)
-	{
-		/* Create tuple-serialization memory context. */
-		s_tupSerMemCtxt =
-			AllocSetContextCreate(TopMemoryContext,
-								  "TupSerMemCtxt",
-								  ALLOCSET_DEFAULT_INITSIZE,	/* always have some
-																 * memory */
-								  ALLOCSET_DEFAULT_INITSIZE,
-								  ALLOCSET_DEFAULT_MAXSIZE);
-	}
 
 	/* Set contents to all 0, just to make things clean and easy. */
 	memset(pSerInfo, 0, sizeof(SerTupInfo));
@@ -272,7 +253,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 							   MotionConn *conn)
 {
 	TupleChunkListItem tcItem = NULL;
-	MemoryContext oldCtxt;
 	List	   *typelist = NULL;
 	int			size = -1;
 	char	   *buf = NULL;
@@ -294,8 +274,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 	appendChunkToTCList(tcList, tcItem);
 
-	AssertState(s_tupSerMemCtxt != NULL);
-
 	/*
 	 * To avoid inconsistency of record cache between sender and receiver in
 	 * the same motion, send the serialized record cache to receiver before
@@ -303,10 +281,9 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	 * the records to its own local cache and remapping the typmod of tuples
 	 * sent by sender.
 	 */
-	oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
 	typelist = build_tuple_node_list(conn->sent_record_typmod);
 	buf = serializeNode((Node *) typelist, &size, NULL);
-	MemoryContextSwitchTo(oldCtxt);
+	list_free_deep(typelist);
 
 	/*
 	 * we use magic tuplen to identify that this chunk (or list of chunks)
@@ -320,6 +297,7 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	addByteStringToChunkList(tcList, (char *) &size, sizeof(int),
 							 &pSerInfo->chunkCache);
 	addByteStringToChunkList(tcList, buf, size, &pSerInfo->chunkCache);
+	pfree(buf);
 
 	/*
 	 * if we have more than 1 chunk we have to set the chunk types on our
@@ -492,17 +470,8 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 	appendChunkToTCList(tcList, tcItem);
 
-	AssertState(s_tupSerMemCtxt != NULL);
-
 	addByteStringToChunkList(tcList, (char *) &tupbodylen, sizeof(tupbodylen), &pSerInfo->chunkCache);
 	addByteStringToChunkList(tcList, tupbody, tupbodylen, &pSerInfo->chunkCache);
-
-	/*
-	 * GPDB_12_MERGE_FIXME: This function does not use this context. This context
-	 * is only used in SerializeRecordCacheIntoChunks(). We need to find a better
-	 * place for resetting it, or eliminating the needs for this context.
-	 */
-	MemoryContextReset(s_tupSerMemCtxt);
 
 	/*
 	 * if we have more than 1 chunk we have to set the chunk types on our


### PR DESCRIPTION
Addressed the following GPDB_12_MERGE_FIXME in tupser.c:

/*
 * GPDB_12_MERGE_FIXME: This function does not use this context. This context
 * is only used in SerializeRecordCacheIntoChunks(). We need to find a better
 * place for resetting it, or eliminating the needs for this context. */ MemoryContextReset(s_tupSerMemCtxt);

As the FIXME stated, post 12 merge, the allocation of memory under this memory context is more temporary and localized, so remove it altogether and instead directly call pfree().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
