### PR TITLE
Fix intermittent test failure

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -246,14 +246,16 @@ test: pg_basebackup_large_database_oid
 test: basebackup_progress
 test: vacuum_progress_row
 test: vacuum_progress_column
+
+test: analyze_progress
+test: appendonly_analyze_progress
+test: aoco_analyze_progress
+test: ao_index_build_progress
+
 test: enable_autovacuum
 test: idle_gang_cleaner
 # test idle_in_transaction_session_timeout
 
-test: ao_index_build_progress
-test: analyze_progress
-test: appendonly_analyze_progress
-test: aoco_analyze_progress
 test: copy_progress
 
 test: segwalrep/die_commit_pending_replication


### PR DESCRIPTION
The following isolation2 tests needs to run prior to enabling autovacuum. Otherwise, the test will be polluted by the auto-analyze and auto-vacuum and cause intermittent failures.

    test: analyze_progress
    test: appendonly_analyze_progress
    test: aoco_analyze_progress
    test: ao_index_build_progress

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
