### PR TITLE
create icw task under resource group mode

### DIFF
--- a/concourse/pipelines/gpdb_main-generated.yml
+++ b/concourse/pipelines/gpdb_main-generated.yml
@@ -196,6 +196,8 @@ groups:
   - gpexpand_rocky8
   - pg_upgrade_rocky8
   - interconnect_rocky8
+  - icw_planner_resgroup_rocky8
+  - icw_gporca_resgroup_rocky8
   - gate_icw_end
   - gate_cli_start
   - cli_cross_subnet
@@ -265,6 +267,8 @@ groups:
   - gpexpand_rocky8
   - pg_upgrade_rocky8
   - interconnect_rocky8
+  - icw_planner_resgroup_rocky8
+  - icw_gporca_resgroup_rocky8
   - gate_icw_end
 
 - name: CLI
@@ -1064,6 +1068,93 @@ jobs:
         sqldump: icw_planner_rocky8_dump
       params:
         NUMBER_OF_NODES: 2
+
+- name: icw_planner_resgroup_rocky8
+  plan:
+    - in_parallel:
+        steps:
+          - get: gpdb_src
+            passed: [gate_icw_start]
+          - get: gpdb_binary
+            resource: bin_gpdb
+            passed: [gate_icw_start]
+            trigger: true
+          - get: ccp_src
+          - get: ccp-image
+          - get: terraform.d
+            params:
+              unpack: true
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          <<: *ccp_default_vars
+          instance_type: n1-standard-32
+          number_of_nodes: 1
+          segments_per_host: 3
+          disk_size: 800
+    - task: gen_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        DATA_MOUNT_DIR: "/home/gpadmin"
+        CREATE_DATA_DIR: false
+    - task: run_tests
+      file: gpdb_src/concourse/tasks/ic_resgroup.yml
+      image: ccp-image
+      params:
+        TEST_OS: rocky8
+        MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off -c jit=off' installcheck-world
+        BLDWRAP_POSTGRES_CONF_ADDONS:
+          - gp_resource_manager=group
+      on_success:
+        <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
+
+- name: icw_gporca_resgroup_rocky8
+  plan:
+    - in_parallel:
+        steps:
+          - get: gpdb_src
+            passed: [gate_icw_start]
+          - get: gpdb_binary
+            resource: bin_gpdb
+            passed: [gate_icw_start]
+            trigger: true
+          - get: ccp_src
+          - get: ccp-image
+          - get: terraform.d
+            params:
+              unpack: true
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          <<: *ccp_default_vars
+          instance_type: n1-standard-32
+          number_of_nodes: 1
+          segments_per_host: 3
+          disk_size: 800
+    - task: gen_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        DATA_MOUNT_DIR: "/home/gpadmin"
+        CREATE_DATA_DIR: false
+    - task: run_tests
+      file: gpdb_src/concourse/tasks/ic_resgroup.yml
+      image: ccp-image
+      params:
+        TEST_OS: rocky8
+        MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on -c jit=off' installcheck-world
+        BLDWRAP_POSTGRES_CONF_ADDONS:
+          - gp_resource_manager=group
+      on_success:
+        <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
+
 - name: gate_icw_end
   plan:
   - in_parallel:
@@ -1107,6 +1198,8 @@ jobs:
         - gpdb_pitr_rocky8
         - gpexpand_rocky8
         - pg_upgrade_rocky8
+        - icw_planner_resgroup_rocky8
+        - icw_gporca_resgroup_rocky8
         - interconnect_rocky8
         trigger: true
       - get: bin_gpdb_clients

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -229,6 +229,8 @@ groups:
   - gpexpand_[[ os_type ]]
   - pg_upgrade_[[ os_type ]]
   - interconnect_[[ os_type ]]
+  - icw_planner_resgroup_[[ os_type ]]
+  - icw_gporca_resgroup_[[ os_type ]]
   - gate_icw_end
 {% endif %}
 {% if "CLI" in test_sections %}
@@ -299,6 +301,8 @@ groups:
   - gpexpand_[[ os_type ]]
   - pg_upgrade_[[ os_type ]]
   - interconnect_[[ os_type ]]
+  - icw_planner_resgroup_[[ os_type ]]
+  - icw_gporca_resgroup_[[ os_type ]]
   - gate_icw_end
 {% endif %}
 
@@ -1213,6 +1217,93 @@ jobs:
         sqldump: icw_planner_[[ os_type ]]_dump
       params:
         NUMBER_OF_NODES: 2
+
+- name: icw_planner_resgroup_[[ os_type ]]
+  plan:
+    - in_parallel:
+        steps:
+          - get: gpdb_src
+            passed: [gate_icw_start]
+          - get: gpdb_binary
+            resource: bin_gpdb
+            passed: [gate_icw_start]
+            trigger: true
+          - get: ccp_src
+          - get: ccp-image
+          - get: terraform.d
+            params:
+              unpack: true
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          <<: *ccp_default_vars
+          instance_type: n1-standard-32
+          number_of_nodes: 1
+          segments_per_host: 3
+          disk_size: 800
+    - task: gen_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        DATA_MOUNT_DIR: "/home/gpadmin"
+        CREATE_DATA_DIR: false
+    - task: run_tests
+      file: gpdb_src/concourse/tasks/ic_resgroup.yml
+      image: ccp-image
+      params:
+        TEST_OS: [[ os_type ]]
+        MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off -c jit=off' installcheck-world
+        BLDWRAP_POSTGRES_CONF_ADDONS:
+          - gp_resource_manager=group
+      on_success:
+        <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
+
+- name: icw_gporca_resgroup_[[ os_type ]]
+  plan:
+    - in_parallel:
+        steps:
+          - get: gpdb_src
+            passed: [gate_icw_start]
+          - get: gpdb_binary
+            resource: bin_gpdb
+            passed: [gate_icw_start]
+            trigger: true
+          - get: ccp_src
+          - get: ccp-image
+          - get: terraform.d
+            params:
+              unpack: true
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          <<: *ccp_default_vars
+          instance_type: n1-standard-32
+          number_of_nodes: 1
+          segments_per_host: 3
+          disk_size: 800
+    - task: gen_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        DATA_MOUNT_DIR: "/home/gpadmin"
+        CREATE_DATA_DIR: false
+    - task: run_tests
+      file: gpdb_src/concourse/tasks/ic_resgroup.yml
+      image: ccp-image
+      params:
+        TEST_OS: [[ os_type ]]
+        MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=on -c jit=off' installcheck-world
+        BLDWRAP_POSTGRES_CONF_ADDONS:
+          - gp_resource_manager=group
+      on_success:
+        <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
+
 - name: gate_icw_end
   plan:
   - in_parallel:
@@ -1256,6 +1347,8 @@ jobs:
         - gpdb_pitr_[[ os_type ]]
         - gpexpand_[[ os_type ]]
         - pg_upgrade_[[ os_type ]]
+        - icw_planner_resgroup_[[ os_type ]]
+        - icw_gporca_resgroup_[[ os_type ]]
         - interconnect_[[ os_type ]]
         trigger: true
       - get: bin_gpdb_clients

--- a/concourse/scripts/ic_resgroup.bash
+++ b/concourse/scripts/ic_resgroup.bash
@@ -87,8 +87,8 @@ run_resgroup_icw_test() {
 
         cd /home/gpadmin/gpdb_src
         sed -i 's/explain_format//g' src/test/regress/greenplum_schedule
-        sed -i '330,337d' src/test/regress/greenplum_schedule
-        sed -i '1,6d' src/test/isolation2/isolation2_resqueue_schedule
+        sed -i '/resource_manager_switch/,/resource_manager_restore/d' src/test/regress/greenplum_schedule
+        echo>src/test/isolation2/isolation2_resqueue_schedule
         ./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpfdist \
          --enable-gpcloud --enable-mapreduce --enable-orafce --enable-tap-tests \
          --with-gssapi --with-libxml --with-openssl --with-perl --with-python \

--- a/concourse/scripts/ic_resgroup.bash
+++ b/concourse/scripts/ic_resgroup.bash
@@ -1,0 +1,121 @@
+#!/bin/bash -l
+
+set -eox pipefail
+
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${CWDIR}/common.bash"
+
+./ccp_src/scripts/setup_ssh_to_cluster.sh
+
+CLUSTER_NAME=$(cat ./cluster_env_files/terraform/name)
+
+CGROUP_BASEDIR=/sys/fs/cgroup
+
+if [ "$TEST_OS" = centos7 ]; then
+    CGROUP_AUTO_MOUNTED=1
+fi
+
+mount_cgroups() {
+    local gpdb_host_alias=$1
+    local basedir=$CGROUP_BASEDIR
+    local options=rw,nosuid,nodev,noexec,relatime
+    local groups="cpuset blkio cpuacct cpu memory"
+    local rhel8_groups="cpuset blkio cpu,cpuacct memory"
+
+    if [ "$CGROUP_AUTO_MOUNTED" ]; then
+        # nothing to do as cgroup is already automatically mounted
+        return
+    fi
+
+    if [ "$TEST_OS" = rhel8 ]; then
+      ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+        mkdir -p $basedir
+        mount -t tmpfs tmpfs $basedir
+        for group in $rhel8_groups; do
+                mkdir -p $basedir/\$group
+                mount -t cgroup -o $options,\$group cgroup $basedir/\$group
+        done
+        ln -s $basedir/cpu,cpuacct $basedir/cpu
+        ln -s $basedir/cpu,cpuacct $basedir/cpuacct
+EOF
+    fi
+}
+
+make_cgroups_dir() {
+    local gpdb_host_alias=$1
+    local basedir=$CGROUP_BASEDIR
+
+    ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+        for comp in cpuset cpu cpuacct memory; do
+            chmod -R 777 $basedir/\$comp
+            mkdir -p $basedir/\$comp/gpdb
+            chown -R gpadmin:gpadmin $basedir/\$comp/gpdb
+            chmod -R 777 $basedir/\$comp/gpdb
+        done
+EOF
+}
+
+# remove resource queue test from icw task,else the resoure manager mode may change to 'none'
+run_resgroup_icw_test() {
+    local gpdb_master_alias=$1
+
+    ssh $gpdb_master_alias bash -ex <<EOF
+        trap look4diffs ERR
+        
+	function look4diffs() {
+		
+		diff_files=\`find -name regression.diffs\`
+		
+		for diff_file in \${diff_files}; do
+		if [ -f "\${diff_file}" ]; then
+		    cat <<-FEOF
+				======================================================================
+				DIFF FILE: \${diff_file}
+				----------------------------------------------------------------------
+
+				\$(cat "\${diff_file}")
+
+			FEOF
+		fi
+		done
+		exit 1
+	}
+        source /usr/local/greenplum-db-devel/greenplum_path.sh
+        export LDFLAGS="-L\${GPHOME}/lib"
+        export CPPFLAGS="-I\${GPHOME}/include"
+        export BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS}
+
+        cd /home/gpadmin/gpdb_src
+        sed -i 's/explain_format//g' src/test/regress/greenplum_schedule
+        sed -i '330,337d' src/test/regress/greenplum_schedule
+        sed -i '1,6d' src/test/isolation2/isolation2_resqueue_schedule
+        ./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpfdist \
+         --enable-gpcloud --enable-mapreduce --enable-orafce --enable-tap-tests \
+         --with-gssapi --with-libxml --with-openssl --with-perl --with-python \
+         --with-uuid=e2fs --with-llvm --with-zstd PYTHON=python3.9 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
+
+        LANG=en_US.utf8 make create-demo-cluster WITH_MIRRORS=${WITH_MIRRORS:-true}
+        source /home/gpadmin/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+
+        PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
+EOF
+}
+
+keep_minimal_cgroup_dirs() {
+    local gpdb_master_alias=$1
+    local basedir=$CGROUP_BASEDIR
+
+    ssh -t $gpdb_master_alias sudo bash -ex <<EOF
+        rmdir $basedir/memory/gpdb/*/ || :
+        rmdir $basedir/memory/gpdb
+        rmdir $basedir/cpuset/gpdb/*/ || :
+        rmdir $basedir/cpuset/gpdb
+EOF
+}
+
+
+mount_cgroups ccp-${CLUSTER_NAME}-0
+make_cgroups_dir ccp-${CLUSTER_NAME}-0
+run_resgroup_icw_test cdw
+
+keep_minimal_cgroup_dirs ccp-${CLUSTER_NAME}-0

--- a/concourse/tasks/ic_resgroup.yml
+++ b/concourse/tasks/ic_resgroup.yml
@@ -1,0 +1,19 @@
+platform: linux
+image_resource:
+  type: registry-image
+
+inputs:
+  - name: gpdb_src
+  - name: ccp_src
+  - name: cluster_env_files
+outputs:
+
+params:
+  MAKE_TEST_COMMAND: ""
+  BLDWRAP_POSTGRES_CONF_ADDONS: ""
+  TEST_OS: ""
+  TEST_BINARY_SWAP: false
+  CONFIGURE_FLAGS: ""
+
+run:
+  path: gpdb_src/concourse/scripts/ic_resgroup.bash

--- a/contrib/extprotocol/Makefile
+++ b/contrib/extprotocol/Makefile
@@ -1,6 +1,7 @@
 MODULE_big = gpextprotocol
 OBJS       = gpextprotocol.o
 REGRESS = setup exttableext
+REGRESS_OPTS = --init-file=../file_fdw/init_file
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 PG_LIBS = $(libpq_pgport)

--- a/contrib/file_fdw/init_file
+++ b/contrib/file_fdw/init_file
@@ -20,4 +20,11 @@ m/^ Settings:.*/
 # of messages.
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 
+# The following NOTICE is generated when creating a role. It is to inform the
+# user that the database will assign the default resource queue or default resource
+# group to the role if the user has not explicitly specified one. Merging tests
+# from postgres will cause the tests to output these messages and we would need
+# to manually modify the corresponding expected output. Hence we want to ignore these.
+m/^NOTICE:  resource group required -- using .* resource group ".*"$/
+
 -- end_matchignore

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -1,3 +1,10 @@
+-- start_matchignore
+m/^WARNING:  nonstandard use of.*/
+m/^LINE \d+:                  and pgext.fmtopts like.*/
+m/ +\^/
+m/^HINT:  Use the escape string syntax for backslashes.*/
+-- end_matchignore
+
 -- start_matchsubs
 -- m/|/
 -- s/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d+)-(\d+)/TODAYS_DATE/

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
@@ -20,12 +20,18 @@ CREATE TABLE toolkit_aopart (
             N_COMMENT VARCHAR(152)
             )
 partition by range (n_nationkey)
-subpartition by range (n_regionkey) subpartition template (start('0') end('1') inclusive,start('1') exclusive
+subpartition by range (n_regionkey) subpartition template (start('0') end('2') exclusive,start('2') inclusive
 )
 (
 partition p1 start('0') end('10') WITH (appendonly=true,checksum=true,compresslevel=9), partition p2 start('10') end('25') WITH (checksum=false,appendonly=true,compresslevel=7)
 );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n_nationkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE MATERIALIZED VIEW toolkit_matview AS SELECT * FROM toolkit_heap;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE MATERIALIZED VIEW toolkit_matview_nodata AS SELECT * FROM toolkit_heap WITH NO DATA;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select count(iaotype),iaotype
 from gp_toolkit.__gp_is_append_only iao
@@ -34,9 +40,25 @@ where c.relname like 'toolkit_%'
 group by iaotype;
  count | iaotype 
 -------+---------
-     7 | t
-     2 | f
+     6 | f
+     5 | t
 (2 rows)
+
+select fnnspname, fnrelname from gp_toolkit.__gp_fullname where fnrelname like 'toolkit_%';
+ fnnspname |            fnrelname            
+-----------+---------------------------------
+ public    | toolkit_matview_nodata
+ public    | toolkit_matview
+ public    | toolkit_heap
+ public    | toolkit_aopart_1_prt_p2_2_prt_2
+ public    | toolkit_aopart_1_prt_p2_2_prt_1
+ public    | toolkit_aopart_1_prt_p2
+ public    | toolkit_aopart_1_prt_p1_2_prt_2
+ public    | toolkit_aopart_1_prt_p1_2_prt_1
+ public    | toolkit_aopart_1_prt_p1
+ public    | toolkit_aopart
+ public    | toolkit_ao
+(11 rows)
 
 drop table toolkit_aopart;
 select count(iaotype),iaotype
@@ -46,8 +68,8 @@ where c.relname like 'toolkit_%'
 group by iaotype;
  count | iaotype 
 -------+---------
+     3 | f
      1 | t
-     1 | f
 (2 rows)
 
 select aunnspname from gp_toolkit.__gp_user_namespaces where aunnspname='tktest';
@@ -67,37 +89,6 @@ select aunnspname from gp_toolkit.__gp_user_namespaces where aunnspname='tktest'
  aunnspname 
 ------------
 (0 rows)
-
-select  autnspname, autrelname, autrelkind, autreltuples, autrelpages, autrelacl from gp_toolkit.__gp_user_data_tables where autrelname like 'toolkit%' order by 2;
- autnspname |  autrelname  | autrelkind | autreltuples | autrelpages | autrelacl 
-------------+--------------+------------+--------------+-------------+-----------
- public     | toolkit_ao   | r          |            0 |           0 | 
- public     | toolkit_heap | r          |            0 |           0 | 
-(2 rows)
-
-create table toolkit_a (a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table toolkit_b (b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select  autnspname, autrelname, autrelkind, autreltuples, autrelpages, autrelacl from gp_toolkit.__gp_user_data_tables where autrelname like 'toolkit%' order by 2;
- autnspname |  autrelname  | autrelkind | autreltuples | autrelpages | autrelacl 
-------------+--------------+------------+--------------+-------------+-----------
- public     | toolkit_a    | r          |            0 |           0 | 
- public     | toolkit_ao   | r          |            0 |           0 | 
- public     | toolkit_b    | r          |            0 |           0 | 
- public     | toolkit_heap | r          |            0 |           0 | 
-(4 rows)
-
-drop table toolkit_a;
-drop table toolkit_b;
-select  autnspname, autrelname, autrelkind, autreltuples, autrelpages, autrelacl from gp_toolkit.__gp_user_data_tables where autrelname like 'toolkit%' order by 2;
- autnspname |  autrelname  | autrelkind | autreltuples | autrelpages | autrelacl 
-------------+--------------+------------+--------------+-------------+-----------
- public     | toolkit_ao   | r          |            0 |           0 | 
- public     | toolkit_heap | r          |            0 |           0 | 
-(2 rows)
 
 -- Test log reading functions
 select logseverity from gp_toolkit.__gp_log_segment_ext where logseverity='LOG' limit 5;
@@ -205,7 +196,6 @@ select sifnamespace, sifrelname from gp_toolkit.gp_skew_idle_fractions where sif
  public       | toolkit_skew
 (1 row)
 
------------------------------------
 -- Test gp_bloat_expected_pages and gp_bloat_diag views
 -- (re-using the toolkit_skew table)
 analyze toolkit_skew;
@@ -267,6 +257,83 @@ select * from gp_toolkit.gp_bloat_diag where bdirelid = 'toolkit_skew'::regclass
 ----------+------------+------------+-------------+-------------+---------
 (0 rows)
 
+-- Test that gp_toolkit.gp_skew* functions works for the replicated table.
+create table toolkit_skew_rpt (i int, j int) distributed replicated;
+insert into toolkit_skew_rpt select i, i from generate_series(1, 100) i;
+select segid, segtupcount FROM gp_toolkit.gp_skew_details('toolkit_skew_rpt'::regclass);
+ segid | segtupcount 
+-------+-------------
+     0 |         100
+     1 |         100
+     2 |         100
+(3 rows)
+
+select skccoeff from gp_toolkit.gp_skew_coefficient('toolkit_skew_rpt'::regclass);
+        skccoeff         
+-------------------------
+ 0.000000000000000000000
+(1 row)
+
+select siffraction from gp_toolkit.gp_skew_idle_fraction('toolkit_skew_rpt'::regclass);
+      siffraction       
+------------------------
+ 0.00000000000000000000
+(1 row)
+
+-- Make sure gp_toolkit.gp_bloat_expected_pages does not report partition roots
+create table do_not_report_partition_root (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(2) every(1));
+insert into do_not_report_partition_root values (1,1);
+analyze do_not_report_partition_root;
+select count(*) from gp_toolkit.gp_bloat_expected_pages where btdrelid = 'do_not_report_partition_root'::regclass::oid;
+ count 
+-------
+     0
+(1 row)
+
+-- Check that gp_bloat_diag can deal with big numbers. (This used to provoke an
+-- integer overflow error, before the view was fixed to use numerics for all the
+-- calculations.)
+create table wide_width_test(
+  c01 text, c02 text, c03 text, c04 text, c05 text,
+  c06 text, c07 text, c08 text, c09 text, c10 text,
+  c11 text, c12 text, c13 text, c14 text, c15 text,
+  c16 text, c17 text, c18 text, c19 text, c20 text,
+  c21 text, c22 text, c23 text, c24 text, c25 text,
+  c26 text, c27 text, c28 text, c29 text, c30 text,
+  c31 text, c32 text, c33 text, c34 text, c35 text,
+  c36 text, c37 text, c38 text, c39 text, c40 text,
+  c41 text, c42 text, c43 text, c44 text, c45 text,
+  c46 text, c47 text, c48 text, c49 text, c50 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c01' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into wide_width_test
+select 'foo01', 'foo02', 'foo03', 'foo04', 'foo05',
+       'foo06', 'foo07', 'foo08', 'foo09', 'foo10',
+       'foo11', 'foo12', 'foo13', 'foo14', 'foo15',
+       'foo16', 'foo17', 'foo18', 'foo19', 'foo20',
+       'foo21', 'foo22', 'foo23', 'foo24', 'foo25',
+       'foo26', 'foo27', 'foo28', 'foo29', 'foo30',
+       'foo31', 'foo32', 'foo33', 'foo34', 'foo35',
+       'foo36', 'foo37', 'foo38', 'foo39', 'foo40',
+       'foo41', 'foo42', 'foo43', 'foo44', 'foo45',
+       'foo46', 'foo47', 'foo48', 'foo49', 'foo50'
+from generate_series(1, 1000);
+analyze wide_width_test;
+set allow_system_table_mods=true;
+update pg_statistic set stawidth=2034567890 where starelid = 'wide_width_test'::regclass;
+select btdrelpages, btdexppages from gp_toolkit.gp_bloat_expected_pages where btdrelid='wide_width_test'::regclass;
+ btdrelpages | btdexppages 
+-------------+-------------
+          11 |  3104504228
+(1 row)
+
+select * from gp_toolkit.gp_bloat_diag WHERE bdinspname <> 'pg_catalog';
+ bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages | bdidiag 
+----------+------------+------------+-------------+-------------+---------
+(0 rows)
+
 -- MPP-5871 : ERROR: GetSnapshotData timed out waiting for Writer to set the shared snapshot.
 set client_min_messages='warning';
 CREATE TABLE mpp5871_statistics (
@@ -311,7 +378,7 @@ create table gptoolkit_user_table_ao (
             N_COMMENT VARCHAR(152)
             )
 partition by range (n_nationkey)
-subpartition by range (n_regionkey) subpartition template (start('0') end('1') inclusive,start('1') exclusive
+subpartition by range (n_regionkey) subpartition template (start('0') end('2') exclusive,start('2') inclusive
 )
 (
 partition p1 start('0') end('10') WITH (appendonly=true,checksum=true,compresslevel=9), partition p2 start('10') end('25') WITH (checksum=false,appendonly=true,compresslevel=7)
@@ -326,13 +393,13 @@ create table gptoolkit_user_table_co (id VARCHAR, lname CHAR(20), fname CHAR(10)
 select autnspname,autrelname,autrelkind from gp_toolkit.__gp_user_tables where autrelname like 'gptoolkit_user_table%';
  autnspname |                autrelname                | autrelkind 
 ------------+------------------------------------------+------------
- tktest     | gptoolkit_user_table_heap                | r
- tktest     | gptoolkit_user_table_ao                  | r
- tktest     | gptoolkit_user_table_ao_1_prt_p1_2_prt_1 | r
- tktest     | gptoolkit_user_table_ao_1_prt_p1         | r
  tktest     | gptoolkit_user_table_ao_1_prt_p1_2_prt_2 | r
+ tktest     | gptoolkit_user_table_heap                | r
+ tktest     | gptoolkit_user_table_ao                  | p
+ tktest     | gptoolkit_user_table_ao_1_prt_p1_2_prt_1 | r
+ tktest     | gptoolkit_user_table_ao_1_prt_p1         | p
  tktest     | gptoolkit_user_table_ao_1_prt_p2_2_prt_1 | r
- tktest     | gptoolkit_user_table_ao_1_prt_p2         | r
+ tktest     | gptoolkit_user_table_ao_1_prt_p2         | p
  tktest     | gptoolkit_user_table_ao_1_prt_p2_2_prt_2 | r
  tktest     | gptoolkit_user_table_co                  | r
 (9 rows)
@@ -370,7 +437,6 @@ select rarolename,ramemberid,ramembername from gp_toolkit.gp_roles_assigned wher
  toolkit_user1 |            | 
 (2 rows)
 
------------------------------------
 -- Test size views.
 --
 -- We can't include the exact sizes in the output, as they differ slightly depending
@@ -494,37 +560,6 @@ from gp_toolkit.gp_size_of_database where sodddatname='contrib_regression';
  contrib_regression | t                 | t
 (1 row)
 
--- gp_size_of_partition_and_indexes_disk
-select pg.relname,
-       sopaidpartitiontablesize > 50000 as tblsz_over50k,
-       sopaidpartitiontablesize < 5000000 as tblsz_under5mb,
-       sopaidpartitionindexessize
-from pg_class pg,gp_toolkit.gp_size_of_partition_and_indexes_disk gsopai
-where pg.oid=gsopai.sopaidpartitionoid and pg.relname like 'gptoolkit_user_table_ao%';
-                 relname                  | tblsz_over50k | tblsz_under5mb | sopaidpartitionindexessize 
-------------------------------------------+---------------+----------------+----------------------------
- gptoolkit_user_table_ao_1_prt_p1_2_prt_1 | t             | t              |                          0
- gptoolkit_user_table_ao_1_prt_p1         | t             | t              |                          0
- gptoolkit_user_table_ao_1_prt_p1_2_prt_2 | t             | t              |                          0
- gptoolkit_user_table_ao_1_prt_p2_2_prt_1 | t             | t              |                          0
- gptoolkit_user_table_ao_1_prt_p2         | t             | t              |                          0
- gptoolkit_user_table_ao_1_prt_p2_2_prt_2 | t             | t              |                          0
-(6 rows)
-
--- Test __gp_localid and __gp_masterid functions. The output of __gp_localid
--- depends on the number of segments, so just check that it returns something.
-select count(*) > 0 from gp_toolkit.__gp_localid;
- ?column? 
-----------
- t
-(1 row)
-
-select * from gp_toolkit.__gp_masterid;
- masterid 
-----------
-       -1
-(1 row)
-
 -- This also depends on the number of segments
 select count(*) > 0 from gp_toolkit.__gp_number_of_segments;
  ?column? 
@@ -532,7 +567,6 @@ select count(*) > 0 from gp_toolkit.__gp_number_of_segments;
  t
 (1 row)
 
------------------------------------
 -- Test Resource Queue views
 -- GP Resource Queue Activity
 select * from gp_toolkit.gp_resq_activity;
@@ -547,6 +581,17 @@ select * from gp_toolkit.gp_resq_activity_by_queue;
 ---------+----------+----------+------------+-----------
 (0 rows)
 
+-- should be empty too
+select * from gp_toolkit.gp_resq_priority_statement;
+ rqpdatname | rqpusename | rqpsession | rqpcommand | rqppriority | rqpweight | rqpquery 
+------------+------------+------------+------------+-------------+-----------+----------
+(0 rows)
+
+select * from gp_toolkit.gp_resq_priority_backend;
+ rqpsession | rqpcommand | rqppriority | rqpweight 
+------------+------------+-------------+-----------
+(0 rows)
+
 -- gp_resq_role
 select * from gp_toolkit.gp_resq_role where rrrolname like 'toolkit%';
    rrrolname   | rrrsqname  
@@ -558,8 +603,8 @@ select * from gp_toolkit.gp_resq_role where rrrolname like 'toolkit%';
 -- gp_locks_on_resqueue
 -- Should be empty because there is no one in the queue
 select * from gp_toolkit.gp_locks_on_resqueue;
- lorusename | lorrsqname | lorlocktype | lorobjid | lortransaction | lorpid | lormode | lorgranted | lorwaiting 
-------------+------------+-------------+----------+----------------+--------+---------+------------+------------
+ lorusename | lorrsqname | lorlocktype | lorobjid | lortransaction | lorpid | lormode | lorgranted | lorwaitevent | lorwaiteventtype 
+------------+------------+-------------+----------+----------------+--------+---------+------------+--------------+------------------
 (0 rows)
 
 -- GP Resource Queue Activity for User
@@ -576,6 +621,14 @@ select * from gp_toolkit.gp_resq_activity where resqrole = 'toolkit_user1';
 -------------+----------+---------+----------+-----------+------------
 (0 rows)
 
+-- resource group view
+select * from gp_toolkit.gp_resgroup_role where rrrolname like 'toolkit%';
+   rrrolname   |   rrrsgname   
+---------------+---------------
+ toolkit_admin | admin_group
+ toolkit_user1 | default_group
+(2 rows)
+
 -- gp_pgdatabase_invalid
 -- Should be empty unless there is failure in the segment, it's a view from gp_pgdatabase
 select * from gp_toolkit.gp_pgdatabase_invalid;
@@ -588,13 +641,15 @@ select * from gp_toolkit.gp_pgdatabase_invalid;
 -- view.
 select autnspname, autrelname, autrelkind, autoid::regclass, autrelacl
 from gp_toolkit.__gp_user_data_tables_readable where autrelname like 'toolkit%';
- autnspname |  autrelname  | autrelkind |       autoid        | autrelacl 
-------------+--------------+------------+---------------------+-----------
- public     | toolkit_ao   | r          | public.toolkit_ao   | 
- public     | toolkit_heap | r          | public.toolkit_heap | 
- public     | toolkit_skew | r          | public.toolkit_skew | 
- tktest     | toolkit_ao2  | r          | toolkit_ao2         | 
-(4 rows)
+ autnspname |    autrelname    | autrelkind |         autoid          | autrelacl 
+------------+------------------+------------+-------------------------+-----------
+ public     | toolkit_ao       | r          | public.toolkit_ao       | 
+ public     | toolkit_heap     | r          | public.toolkit_heap     | 
+ public     | toolkit_matview  | m          | public.toolkit_matview  | 
+ public     | toolkit_skew     | r          | public.toolkit_skew     | 
+ public     | toolkit_skew_rpt | r          | public.toolkit_skew_rpt | 
+ tktest     | toolkit_ao2      | r          | toolkit_ao2             | 
+(6 rows)
 
 -- Switch to non-privileged user, and test that they are no longer visible.
 set session authorization toolkit_user1;

--- a/gpcontrib/orafce/init_file
+++ b/gpcontrib/orafce/init_file
@@ -20,10 +20,11 @@
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 
 # The following NOTICE is generated when creating a role. It is to inform the
-# user that the database will assign the default resource queue to the role if
-# the user has not explicitly specified one. Merging tests from postgres will
-# cause the tests to output these messages and we would need to manually modify
-# the corresponding expected output. Hence we want to ignore these.
+# user that the database will assign the default resource queue or default resource
+# group to the role if the user has not explicitly specified one. Merging tests
+# from postgres will cause the tests to output these messages and we would need
+# to manually modify the corresponding expected output. Hence we want to ignore these.
 m/^NOTICE:.*resource queue required -- using default resource queue ".*"/
+m/^NOTICE:.*resource group required -- using default resource group ".*"/
 
 -- end_matchignore

--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -26,6 +26,9 @@
 -- segments. As a result the SELECT executed by session3 used to fail
 -- because the twopcbug table only existed on the coordinator.
 --
+-- start_ignore
+100: alter resource group admin_group set concurrency 30;
+-- end_ignore
 1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
  gp_inject_fault_infinite 
 --------------------------
@@ -363,3 +366,7 @@ server closed the connection unexpectedly
 
 3: drop table ckpt_xlog_len_tbl;
 DROP
+
+-- start_ignore
+alter resource group admin_group set concurrency 10;
+-- end_ignore

--- a/src/test/isolation2/sql/checkpoint_dtx_info.sql
+++ b/src/test/isolation2/sql/checkpoint_dtx_info.sql
@@ -26,6 +26,9 @@
 -- segments. As a result the SELECT executed by session3 used to fail
 -- because the twopcbug table only existed on the coordinator.
 --
+-- start_ignore
+100: alter resource group admin_group set concurrency 30;
+-- end_ignore
 1: select gp_inject_fault_infinite('start_insertedDistributedCommitted', 'suspend', 1);
 1: begin;
 1: create table twopcbug(i int, j int);
@@ -183,3 +186,7 @@ create table ckpt_xlog_len_tbl(a int, b int);
 3: select count(*) from ckpt_xlog_len_tbl;
 
 3: drop table ckpt_xlog_len_tbl;
+
+-- start_ignore
+alter resource group admin_group set concurrency 10;
+-- end_ignore

--- a/src/test/regress/expected/resource_group_cpuset_resgroup.out
+++ b/src/test/regress/expected/resource_group_cpuset_resgroup.out
@@ -1,0 +1,12 @@
+--
+-- Test: cpuset cannot be specified when group is disabled.
+--
+-- start_ignore
+DROP RESOURCE GROUP resource_group1;
+ERROR:  resource group "resource_group1" does not exist
+-- end_ignore
+CREATE RESOURCE GROUP resource_group1 WITH (cpuset='0');
+CREATE RESOURCE GROUP resource_group1 WITH (cpu_max_percent=5);
+ERROR:  resource group "resource_group1" already exists
+ALTER RESOURCE GROUP resource_group1 SET cpuset '0';
+DROP RESOURCE GROUP resource_group1;

--- a/src/test/regress/expected/resource_group_resgroup.out
+++ b/src/test/regress/expected/resource_group_resgroup.out
@@ -1,0 +1,29 @@
+--
+-- Test: create objects for pg_dumpall/pg_upgrade
+--
+-- this test creates resource group objects and roles associated with
+-- resource groups so pg_dumpall/pg_upgrade can dump those objects at
+-- the end of ICW.
+-- 
+-- NOTE: please always put this test in the end of this file and do not
+-- drop them.
+-- start_ignore
+DROP ROLE IF EXISTS role_dump_test1;
+NOTICE:  role "role_dump_test1" does not exist, skipping
+DROP ROLE IF EXISTS role_dump_test2;
+NOTICE:  role "role_dump_test2" does not exist, skipping
+DROP ROLE IF EXISTS role_dump_test3;
+NOTICE:  role "role_dump_test3" does not exist, skipping
+DROP RESOURCE GROUP rg_dump_test1;
+ERROR:  resource group "rg_dump_test1" does not exist
+DROP RESOURCE GROUP rg_dump_test2;
+ERROR:  resource group "rg_dump_test2" does not exist
+DROP RESOURCE GROUP rg_dump_test3;
+ERROR:  resource group "rg_dump_test3" does not exist
+-- end_ignore
+CREATE RESOURCE GROUP rg_dump_test1 WITH (concurrency=2, cpu_max_percent=5);
+CREATE RESOURCE GROUP rg_dump_test2 WITH (concurrency=2, cpu_max_percent=5);
+CREATE RESOURCE GROUP rg_dump_test3 WITH (concurrency=2, cpu_max_percent=5);
+CREATE ROLE role_dump_test1 RESOURCE GROUP rg_dump_test1;
+CREATE ROLE role_dump_test2 RESOURCE GROUP rg_dump_test2;
+CREATE ROLE role_dump_test3 RESOURCE GROUP rg_dump_test3;

--- a/src/test/regress/expected/strings_resgroup.out
+++ b/src/test/regress/expected/strings_resgroup.out
@@ -1,0 +1,2138 @@
+--
+-- STRINGS
+-- Test various data entry syntaxes.
+--
+-- create required tables
+CREATE TABLE CHAR_STRINGS_TBL(f1 char(4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO CHAR_STRINGS_TBL (f1) VALUES ('a'),
+('ab'),
+('abcd'),
+('abcd    ');
+CREATE TABLE VARCHAR_STRINGS_TBL(f1 varchar(4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO VARCHAR_STRINGS_TBL (f1) VALUES ('a'),
+('ab'),
+('abcd'),
+('abcd    ');
+CREATE TABLE TEXT_STRINGS_TBL (f1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO TEXT_STRINGS_TBL VALUES ('doh!'),
+('hi de ho neighbor');
+-- SQL string continuation syntax
+-- E021-03 character string literals
+SELECT 'first line'
+' - next line'
+	' - third line'
+	AS "Three lines to one";
+         Three lines to one          
+-------------------------------------
+ first line - next line - third line
+(1 row)
+
+-- illegal string continuation syntax
+SELECT 'first line'
+' - next line' /* this comment is not allowed here */
+' - third line'
+	AS "Illegal comment within continuation";
+ERROR:  syntax error at or near "' - third line'"
+LINE 3: ' - third line'
+        ^
+-- bytea
+SET bytea_output TO hex;
+SELECT E'\\xDeAdBeEf'::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\xDeAdBeE'::bytea;
+ERROR:  invalid hexadecimal data: odd number of digits
+LINE 1: SELECT E'\\xDeAdBeE'::bytea;
+               ^
+SELECT E'\\xDeAdBeEx'::bytea;
+ERROR:  invalid hexadecimal digit: "x"
+LINE 1: SELECT E'\\xDeAdBeEx'::bytea;
+               ^
+SELECT E'\\xDe00BeEf'::bytea;
+   bytea    
+------------
+ \xde00beef
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465416442654566
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465006442654566
+(1 row)
+
+SELECT E'De\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\678dBeEf'::bytea;
+ERROR:  invalid input syntax for type bytea
+LINE 1: SELECT E'De\\678dBeEf'::bytea;
+               ^
+SET bytea_output TO escape;
+SELECT E'\\xDeAdBeEf'::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\xDe00BeEf'::bytea;
+      bytea       
+------------------
+ \336\000\276\357
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+  bytea   
+----------
+ DeAdBeEf
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+    bytea    
+-------------
+ De\000dBeEf
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+  bytea   
+----------
+ DeSdBeEf
+(1 row)
+
+-- Unicode escapes
+SET standard_conforming_strings TO on;
+SELECT U&'d\0061t\+000061' AS U&"d\0061t\+000061";
+ data 
+------
+ data
+(1 row)
+
+SELECT U&'d!0061t\+000061' UESCAPE '!' AS U&"d*0061t\+000061" UESCAPE '*';
+ dat\+000061 
+-------------
+ dat\+000061
+(1 row)
+
+SELECT U&' \' UESCAPE '!' AS "tricky";
+ tricky 
+--------
+  \
+(1 row)
+
+SELECT 'tricky' AS U&"\" UESCAPE '!';
+   \    
+--------
+ tricky
+(1 row)
+
+SELECT U&'wrong: \061';
+ERROR:  invalid Unicode escape value at or near "\061'"
+LINE 1: SELECT U&'wrong: \061';
+                         ^
+SELECT U&'wrong: \+0061';
+ERROR:  invalid Unicode escape value at or near "\+0061'"
+LINE 1: SELECT U&'wrong: \+0061';
+                         ^
+SELECT U&'wrong: +0061' UESCAPE '+';
+ERROR:  invalid Unicode escape character at or near "+'"
+LINE 1: SELECT U&'wrong: +0061' UESCAPE '+';
+                                         ^
+SET standard_conforming_strings TO off;
+SELECT U&'d\0061t\+000061' AS U&"d\0061t\+000061";
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&'d\0061t\+000061' AS U&"d\0061t\+000061";
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+SELECT U&'d!0061t\+000061' UESCAPE '!' AS U&"d*0061t\+000061" UESCAPE '*';
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&'d!0061t\+000061' UESCAPE '!' AS U&"d*0061t\+000061...
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+SELECT U&' \' UESCAPE '!' AS "tricky";
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&' \' UESCAPE '!' AS "tricky";
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+SELECT 'tricky' AS U&"\" UESCAPE '!';
+   \    
+--------
+ tricky
+(1 row)
+
+SELECT U&'wrong: \061';
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&'wrong: \061';
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+SELECT U&'wrong: \+0061';
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&'wrong: \+0061';
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+SELECT U&'wrong: +0061' UESCAPE '+';
+ERROR:  unsafe use of string constant with Unicode escapes
+LINE 1: SELECT U&'wrong: +0061' UESCAPE '+';
+               ^
+DETAIL:  String constants with Unicode escapes cannot be used when standard_conforming_strings is off.
+RESET standard_conforming_strings;
+-- bytea
+SET bytea_output TO hex;
+SELECT E'\\xDeAdBeEf'::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\xDeAdBeE'::bytea;
+ERROR:  invalid hexadecimal data: odd number of digits
+LINE 1: SELECT E'\\xDeAdBeE'::bytea;
+               ^
+SELECT E'\\xDeAdBeEx'::bytea;
+ERROR:  invalid hexadecimal digit: "x"
+LINE 1: SELECT E'\\xDeAdBeEx'::bytea;
+               ^
+SELECT E'\\xDe00BeEf'::bytea;
+   bytea    
+------------
+ \xde00beef
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465416442654566
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465006442654566
+(1 row)
+
+SELECT E'De\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\678dBeEf'::bytea;
+ERROR:  invalid input syntax for type bytea
+LINE 1: SELECT E'De\\678dBeEf'::bytea;
+               ^
+SET bytea_output TO escape;
+SELECT E'\\xDeAdBeEf'::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\xDe00BeEf'::bytea;
+      bytea       
+------------------
+ \336\000\276\357
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+  bytea   
+----------
+ DeAdBeEf
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+    bytea    
+-------------
+ De\000dBeEf
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+  bytea   
+----------
+ DeSdBeEf
+(1 row)
+
+--
+-- test conversions between various string types
+-- E021-10 implicit casting among the character data types
+--
+SELECT CAST(f1 AS text) AS "text(char)" FROM CHAR_STRINGS_TBL;
+ text(char) 
+------------
+ ab
+ abcd
+ abcd
+ a
+(4 rows)
+
+SELECT CAST(f1 AS text) AS "text(varchar)" FROM VARCHAR_STRINGS_TBL;
+ text(varchar) 
+---------------
+ ab
+ abcd
+ abcd
+ a
+(4 rows)
+
+SELECT CAST(name 'namefield' AS text) AS "text(name)";
+ text(name) 
+------------
+ namefield
+(1 row)
+
+-- since this is an explicit cast, it should truncate w/o error:
+SELECT CAST(f1 AS char(10)) AS "char(text)" FROM TEXT_STRINGS_TBL;
+ char(text) 
+------------
+ doh!      
+ hi de ho n
+(2 rows)
+
+-- note: implicit-cast case is tested in char.sql
+SELECT CAST(f1 AS char(20)) AS "char(text)" FROM TEXT_STRINGS_TBL;
+      char(text)      
+----------------------
+ doh!                
+ hi de ho neighbor   
+(2 rows)
+
+SELECT CAST(f1 AS char(10)) AS "char(varchar)" FROM VARCHAR_STRINGS_TBL;
+ char(varchar) 
+---------------
+ ab        
+ abcd      
+ abcd      
+ a         
+(4 rows)
+
+SELECT CAST(name 'namefield' AS char(10)) AS "char(name)";
+ char(name) 
+------------
+ namefield 
+(1 row)
+
+SELECT CAST(f1 AS varchar) AS "varchar(text)" FROM TEXT_STRINGS_TBL;
+   varchar(text)   
+-------------------
+ doh!
+ hi de ho neighbor
+(2 rows)
+
+SELECT CAST(f1 AS varchar) AS "varchar(char)" FROM CHAR_STRINGS_TBL;
+ varchar(char) 
+---------------
+ ab
+ abcd
+ abcd
+ a
+(4 rows)
+
+SELECT CAST(name 'namefield' AS varchar) AS "varchar(name)";
+ varchar(name) 
+---------------
+ namefield
+(1 row)
+
+--
+-- test SQL string functions
+-- E### and T### are feature reference numbers from SQL99
+--
+-- E021-09 trim function
+SELECT TRIM(BOTH FROM '  bunch o blanks  ') = 'bunch o blanks' AS "bunch o blanks";
+ bunch o blanks 
+----------------
+ t
+(1 row)
+
+SELECT TRIM(LEADING FROM '  bunch o blanks  ') = 'bunch o blanks  ' AS "bunch o blanks  ";
+ bunch o blanks   
+------------------
+ t
+(1 row)
+
+SELECT TRIM(TRAILING FROM '  bunch o blanks  ') = '  bunch o blanks' AS "  bunch o blanks";
+   bunch o blanks 
+------------------
+ t
+(1 row)
+
+SELECT TRIM(BOTH 'x' FROM 'xxxxxsome Xsxxxxx') = 'some Xs' AS "some Xs";
+ some Xs 
+---------
+ t
+(1 row)
+
+-- E021-06 substring expression
+SELECT SUBSTRING('1234567890' FROM 3) = '34567890' AS "34567890";
+ 34567890 
+----------
+ t
+(1 row)
+
+SELECT SUBSTRING('1234567890' FROM 4 FOR 3) = '456' AS "456";
+ 456 
+-----
+ t
+(1 row)
+
+-- test overflow cases
+SELECT SUBSTRING('string' FROM 2 FOR 2147483646) AS "tring";
+ tring 
+-------
+ tring
+(1 row)
+
+SELECT SUBSTRING('string' FROM -10 FOR 2147483646) AS "string";
+ string 
+--------
+ string
+(1 row)
+
+SELECT SUBSTRING('string' FROM -10 FOR -2147483646) AS "error";
+ERROR:  negative substring length not allowed
+-- T581 regular expression substring (with SQL's bizarre regexp syntax)
+SELECT SUBSTRING('abcdefg' FROM 'a#"(b_d)#"%' FOR '#') AS "bcd";
+ bcd 
+-----
+ bcd
+(1 row)
+
+-- No match should return NULL
+SELECT SUBSTRING('abcdefg' FROM '#"(b_d)#"%' FOR '#') IS NULL AS "True";
+ True 
+------
+ t
+(1 row)
+
+-- Null inputs should return NULL
+SELECT SUBSTRING('abcdefg' FROM '%' FOR NULL) IS NULL AS "True";
+ True 
+------
+ t
+(1 row)
+
+SELECT SUBSTRING(NULL FROM '%' FOR '#') IS NULL AS "True";
+ True 
+------
+ t
+(1 row)
+
+SELECT SUBSTRING('abcdefg' FROM NULL FOR '#') IS NULL AS "True";
+ True 
+------
+ t
+(1 row)
+
+-- The first and last parts should act non-greedy
+SELECT SUBSTRING('abcdefg' FROM 'a#"%#"g' FOR '#') AS "bcdef";
+ bcdef 
+-------
+ bcdef
+(1 row)
+
+SELECT SUBSTRING('abcdefg' FROM 'a*#"%#"g*' FOR '#') AS "abcdefg";
+ abcdefg 
+---------
+ abcdefg
+(1 row)
+
+-- Vertical bar in any part affects only that part
+SELECT SUBSTRING('abcdefg' FROM 'a|b#"%#"g' FOR '#') AS "bcdef";
+ bcdef 
+-------
+ bcdef
+(1 row)
+
+SELECT SUBSTRING('abcdefg' FROM 'a#"%#"x|g' FOR '#') AS "bcdef";
+ bcdef 
+-------
+ bcdef
+(1 row)
+
+SELECT SUBSTRING('abcdefg' FROM 'a#"%|ab#"g' FOR '#') AS "bcdef";
+ bcdef 
+-------
+ bcdef
+(1 row)
+
+-- Can't have more than two part separators
+SELECT SUBSTRING('abcdefg' FROM 'a*#"%#"g*#"x' FOR '#') AS "error";
+ERROR:  SQL regular expression may not contain more than two escape-double-quote separators
+CONTEXT:  SQL function "substring" statement 1
+-- Postgres extension: with 0 or 1 separator, assume parts 1 and 3 are empty
+SELECT SUBSTRING('abcdefg' FROM 'a#"%g' FOR '#') AS "bcdefg";
+ bcdefg 
+--------
+ bcdefg
+(1 row)
+
+SELECT SUBSTRING('abcdefg' FROM 'a%g' FOR '#') AS "abcdefg";
+ abcdefg 
+---------
+ abcdefg
+(1 row)
+
+-- substring() with just two arguments is not allowed by SQL spec;
+-- we accept it, but we interpret the pattern as a POSIX regexp not SQL
+SELECT SUBSTRING('abcdefg' FROM 'c.e') AS "cde";
+ cde 
+-----
+ cde
+(1 row)
+
+-- With a parenthesized subexpression, return only what matches the subexpr
+SELECT SUBSTRING('abcdefg' FROM 'b(.*)f') AS "cde";
+ cde 
+-----
+ cde
+(1 row)
+
+-- PostgreSQL extension to allow using back reference in replace string;
+SELECT regexp_replace('1112223333', E'(\\d{3})(\\d{3})(\\d{4})', E'(\\1) \\2-\\3');
+ regexp_replace 
+----------------
+ (111) 222-3333
+(1 row)
+
+SELECT regexp_replace('AAA   BBB   CCC   ', E'\\s+', ' ', 'g');
+ regexp_replace 
+----------------
+ AAA BBB CCC 
+(1 row)
+
+SELECT regexp_replace('AAA', '^|$', 'Z', 'g');
+ regexp_replace 
+----------------
+ ZAAAZ
+(1 row)
+
+SELECT regexp_replace('AAA aaa', 'A+', 'Z', 'gi');
+ regexp_replace 
+----------------
+ Z Z
+(1 row)
+
+-- invalid regexp option
+SELECT regexp_replace('AAA aaa', 'A+', 'Z', 'z');
+ERROR:  invalid regular expression option: "z"
+-- set so we can tell NULL from empty string
+\pset null '\\N'
+-- return all matches from regexp
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(beque)$re$);
+ regexp_matches 
+----------------
+ {bar,beque}
+(1 row)
+
+-- test case insensitive
+SELECT regexp_matches('foObARbEqUEbAz', $re$(bar)(beque)$re$, 'i');
+ regexp_matches 
+----------------
+ {bAR,bEqUE}
+(1 row)
+
+-- global option - more than one match
+SELECT regexp_matches('foobarbequebazilbarfbonk', $re$(b[^b]+)(b[^b]+)$re$, 'g');
+ regexp_matches 
+----------------
+ {bar,beque}
+ {bazil,barf}
+(2 rows)
+
+-- empty capture group (matched empty string)
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(.*)(beque)$re$);
+ regexp_matches 
+----------------
+ {bar,"",beque}
+(1 row)
+
+-- no match
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(.+)(beque)$re$);
+ regexp_matches 
+----------------
+(0 rows)
+
+-- optional capture group did not match, null entry in array
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(.+)?(beque)$re$);
+  regexp_matches  
+------------------
+ {bar,NULL,beque}
+(1 row)
+
+-- no capture groups
+SELECT regexp_matches('foobarbequebaz', $re$barbeque$re$);
+ regexp_matches 
+----------------
+ {barbeque}
+(1 row)
+
+-- start/end-of-line matches are of zero length
+SELECT regexp_matches('foo' || chr(10) || 'bar' || chr(10) || 'bequq' || chr(10) || 'baz', '^', 'mg');
+ regexp_matches 
+----------------
+ {""}
+ {""}
+ {""}
+ {""}
+(4 rows)
+
+SELECT regexp_matches('foo' || chr(10) || 'bar' || chr(10) || 'bequq' || chr(10) || 'baz', '$', 'mg');
+ regexp_matches 
+----------------
+ {""}
+ {""}
+ {""}
+ {""}
+(4 rows)
+
+SELECT regexp_matches('1' || chr(10) || '2' || chr(10) || '3' || chr(10) || '4' || chr(10), '^.?', 'mg');
+ regexp_matches 
+----------------
+ {1}
+ {2}
+ {3}
+ {4}
+ {""}
+(5 rows)
+
+SELECT regexp_matches(chr(10) || '1' || chr(10) || '2' || chr(10) || '3' || chr(10) || '4' || chr(10), '.?$', 'mg');
+ regexp_matches 
+----------------
+ {""}
+ {1}
+ {""}
+ {2}
+ {""}
+ {3}
+ {""}
+ {4}
+ {""}
+ {""}
+(10 rows)
+
+SELECT regexp_matches(chr(10) || '1' || chr(10) || '2' || chr(10) || '3' || chr(10) || '4', '.?$', 'mg');
+ regexp_matches 
+----------------
+ {""}
+ {1}
+ {""}
+ {2}
+ {""}
+ {3}
+ {""}
+ {4}
+ {""}
+(9 rows)
+
+-- give me errors
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(beque)$re$, 'gz');
+ERROR:  invalid regular expression option: "z"
+SELECT regexp_matches('foobarbequebaz', $re$(barbeque$re$);
+ERROR:  invalid regular expression: parentheses () not balanced
+SELECT regexp_matches('foobarbequebaz', $re$(bar)(beque){2,1}$re$);
+ERROR:  invalid regular expression: invalid repetition count(s)
+-- split string on regexp
+SELECT foo, length(foo) FROM regexp_split_to_table('the quick brown fox jumps over the lazy dog', $re$\s+$re$) AS foo;
+  foo  | length 
+-------+--------
+ the   |      3
+ quick |      5
+ brown |      5
+ fox   |      3
+ jumps |      5
+ over  |      4
+ the   |      3
+ lazy  |      4
+ dog   |      3
+(9 rows)
+
+SELECT regexp_split_to_array('the quick brown fox jumps over the lazy dog', $re$\s+$re$);
+             regexp_split_to_array             
+-----------------------------------------------
+ {the,quick,brown,fox,jumps,over,the,lazy,dog}
+(1 row)
+
+SELECT foo, length(foo) FROM regexp_split_to_table('the quick brown fox jumps over the lazy dog', $re$\s*$re$) AS foo;
+ foo | length 
+-----+--------
+ t   |      1
+ h   |      1
+ e   |      1
+ q   |      1
+ u   |      1
+ i   |      1
+ c   |      1
+ k   |      1
+ b   |      1
+ r   |      1
+ o   |      1
+ w   |      1
+ n   |      1
+ f   |      1
+ o   |      1
+ x   |      1
+ j   |      1
+ u   |      1
+ m   |      1
+ p   |      1
+ s   |      1
+ o   |      1
+ v   |      1
+ e   |      1
+ r   |      1
+ t   |      1
+ h   |      1
+ e   |      1
+ l   |      1
+ a   |      1
+ z   |      1
+ y   |      1
+ d   |      1
+ o   |      1
+ g   |      1
+(35 rows)
+
+SELECT regexp_split_to_array('the quick brown fox jumps over the lazy dog', $re$\s*$re$);
+                          regexp_split_to_array                          
+-------------------------------------------------------------------------
+ {t,h,e,q,u,i,c,k,b,r,o,w,n,f,o,x,j,u,m,p,s,o,v,e,r,t,h,e,l,a,z,y,d,o,g}
+(1 row)
+
+SELECT foo, length(foo) FROM regexp_split_to_table('the quick brown fox jumps over the lazy dog', '') AS foo;
+ foo | length 
+-----+--------
+ t   |      1
+ h   |      1
+ e   |      1
+     |      1
+ q   |      1
+ u   |      1
+ i   |      1
+ c   |      1
+ k   |      1
+     |      1
+ b   |      1
+ r   |      1
+ o   |      1
+ w   |      1
+ n   |      1
+     |      1
+ f   |      1
+ o   |      1
+ x   |      1
+     |      1
+ j   |      1
+ u   |      1
+ m   |      1
+ p   |      1
+ s   |      1
+     |      1
+ o   |      1
+ v   |      1
+ e   |      1
+ r   |      1
+     |      1
+ t   |      1
+ h   |      1
+ e   |      1
+     |      1
+ l   |      1
+ a   |      1
+ z   |      1
+ y   |      1
+     |      1
+ d   |      1
+ o   |      1
+ g   |      1
+(43 rows)
+
+SELECT regexp_split_to_array('the quick brown fox jumps over the lazy dog', '');
+                                          regexp_split_to_array                                          
+---------------------------------------------------------------------------------------------------------
+ {t,h,e," ",q,u,i,c,k," ",b,r,o,w,n," ",f,o,x," ",j,u,m,p,s," ",o,v,e,r," ",t,h,e," ",l,a,z,y," ",d,o,g}
+(1 row)
+
+-- case insensitive
+SELECT foo, length(foo) FROM regexp_split_to_table('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'i') AS foo;
+            foo            | length 
+---------------------------+--------
+ th                        |      2
+  QUick bROWn FOx jUMPs ov |     25
+ r Th                      |      4
+  lazy dOG                 |      9
+(4 rows)
+
+SELECT regexp_split_to_array('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'i');
+                regexp_split_to_array                
+-----------------------------------------------------
+ {th," QUick bROWn FOx jUMPs ov","r Th"," lazy dOG"}
+(1 row)
+
+-- no match of pattern
+SELECT foo, length(foo) FROM regexp_split_to_table('the quick brown fox jumps over the lazy dog', 'nomatch') AS foo;
+                     foo                     | length 
+---------------------------------------------+--------
+ the quick brown fox jumps over the lazy dog |     43
+(1 row)
+
+SELECT regexp_split_to_array('the quick brown fox jumps over the lazy dog', 'nomatch');
+              regexp_split_to_array              
+-------------------------------------------------
+ {"the quick brown fox jumps over the lazy dog"}
+(1 row)
+
+-- some corner cases
+SELECT regexp_split_to_array('123456','1');
+ regexp_split_to_array 
+-----------------------
+ {"",23456}
+(1 row)
+
+SELECT regexp_split_to_array('123456','6');
+ regexp_split_to_array 
+-----------------------
+ {12345,""}
+(1 row)
+
+SELECT regexp_split_to_array('123456','.');
+ regexp_split_to_array  
+------------------------
+ {"","","","","","",""}
+(1 row)
+
+SELECT regexp_split_to_array('123456','');
+ regexp_split_to_array 
+-----------------------
+ {1,2,3,4,5,6}
+(1 row)
+
+SELECT regexp_split_to_array('123456','(?:)');
+ regexp_split_to_array 
+-----------------------
+ {1,2,3,4,5,6}
+(1 row)
+
+SELECT regexp_split_to_array('1','');
+ regexp_split_to_array 
+-----------------------
+ {1}
+(1 row)
+
+-- errors
+SELECT foo, length(foo) FROM regexp_split_to_table('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'zippy') AS foo;
+ERROR:  invalid regular expression option: "z"
+SELECT regexp_split_to_array('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'iz');
+ERROR:  invalid regular expression option: "z"
+-- global option meaningless for regexp_split
+SELECT foo, length(foo) FROM regexp_split_to_table('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'g') AS foo;
+ERROR:  regexp_split_to_table() does not support the "global" option
+SELECT regexp_split_to_array('thE QUick bROWn FOx jUMPs ovEr The lazy dOG', 'e', 'g');
+ERROR:  regexp_split_to_array() does not support the "global" option
+-- change NULL-display back
+\pset null ''
+-- E021-11 position expression
+SELECT POSITION('4' IN '1234567890') = '4' AS "4";
+ 4 
+---
+ t
+(1 row)
+
+SELECT POSITION('5' IN '1234567890') = '5' AS "5";
+ 5 
+---
+ t
+(1 row)
+
+-- T312 character overlay function
+SELECT OVERLAY('abcdef' PLACING '45' FROM 4) AS "abc45f";
+ abc45f 
+--------
+ abc45f
+(1 row)
+
+SELECT OVERLAY('yabadoo' PLACING 'daba' FROM 5) AS "yabadaba";
+ yabadaba 
+----------
+ yabadaba
+(1 row)
+
+SELECT OVERLAY('yabadoo' PLACING 'daba' FROM 5 FOR 0) AS "yabadabadoo";
+ yabadabadoo 
+-------------
+ yabadabadoo
+(1 row)
+
+SELECT OVERLAY('babosa' PLACING 'ubb' FROM 2 FOR 4) AS "bubba";
+ bubba 
+-------
+ bubba
+(1 row)
+
+--
+-- test LIKE
+-- Be sure to form every test as a LIKE/NOT LIKE pair.
+--
+-- simplest examples
+-- E061-04 like predicate
+SELECT 'hawkeye' LIKE 'h%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT LIKE 'h%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'hawkeye' LIKE 'H%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'hawkeye' NOT LIKE 'H%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' LIKE 'indio%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'hawkeye' NOT LIKE 'indio%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' LIKE 'h%eye' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT LIKE 'h%eye' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' LIKE '_ndio' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'indio' NOT LIKE '_ndio' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' LIKE 'in__o' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'indio' NOT LIKE 'in__o' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' LIKE 'in_o' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' NOT LIKE 'in_o' AS "true";
+ true 
+------
+ t
+(1 row)
+
+-- unused escape character
+SELECT 'hawkeye' LIKE 'h%' ESCAPE '#' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT LIKE 'h%' ESCAPE '#' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' LIKE 'ind_o' ESCAPE '$' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'indio' NOT LIKE 'ind_o' ESCAPE '$' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+-- escape character
+-- E061-05 like predicate with escape clause
+SELECT 'h%' LIKE 'h#%' ESCAPE '#' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'h%' NOT LIKE 'h#%' ESCAPE '#' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'h%wkeye' LIKE 'h#%' ESCAPE '#' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'h%wkeye' NOT LIKE 'h#%' ESCAPE '#' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'h%wkeye' LIKE 'h#%%' ESCAPE '#' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'h%wkeye' NOT LIKE 'h#%%' ESCAPE '#' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'h%awkeye' LIKE 'h#%a%k%e' ESCAPE '#' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'h%awkeye' NOT LIKE 'h#%a%k%e' ESCAPE '#' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'indio' LIKE '_ndio' ESCAPE '$' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'indio' NOT LIKE '_ndio' ESCAPE '$' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'i_dio' LIKE 'i$_d_o' ESCAPE '$' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'i_dio' NOT LIKE 'i$_d_o' ESCAPE '$' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'i_dio' LIKE 'i$_nd_o' ESCAPE '$' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'i_dio' NOT LIKE 'i$_nd_o' ESCAPE '$' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'i_dio' LIKE 'i$_d%o' ESCAPE '$' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'i_dio' NOT LIKE 'i$_d%o' ESCAPE '$' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+-- escape character same as pattern character
+SELECT 'maca' LIKE 'm%aca' ESCAPE '%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'maca' NOT LIKE 'm%aca' ESCAPE '%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'ma%a' LIKE 'm%a%%a' ESCAPE '%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'ma%a' NOT LIKE 'm%a%%a' ESCAPE '%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'bear' LIKE 'b_ear' ESCAPE '_' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'bear' NOT LIKE 'b_ear' ESCAPE '_' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'be_r' LIKE 'b_e__r' ESCAPE '_' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'be_r' NOT LIKE 'b_e__r' ESCAPE '_' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'be_r' LIKE '__e__r' ESCAPE '_' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'be_r' NOT LIKE '__e__r' ESCAPE '_' AS "true";
+ true 
+------
+ t
+(1 row)
+
+--
+-- test ILIKE (case-insensitive LIKE)
+-- Be sure to form every test as an ILIKE/NOT ILIKE pair.
+--
+SELECT 'hawkeye' ILIKE 'h%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT ILIKE 'h%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'hawkeye' ILIKE 'H%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT ILIKE 'H%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'hawkeye' ILIKE 'H%Eye' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'hawkeye' NOT ILIKE 'H%Eye' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+SELECT 'Hawkeye' ILIKE 'h%' AS "true";
+ true 
+------
+ t
+(1 row)
+
+SELECT 'Hawkeye' NOT ILIKE 'h%' AS "false";
+ false 
+-------
+ f
+(1 row)
+
+--
+-- test %/_ combination cases, cf bugs #4821 and #5478
+--
+SELECT 'foo' LIKE '_%' as t, 'f' LIKE '_%' as t, '' LIKE '_%' as f;
+ t | t | f 
+---+---+---
+ t | t | f
+(1 row)
+
+SELECT 'foo' LIKE '%_' as t, 'f' LIKE '%_' as t, '' LIKE '%_' as f;
+ t | t | f 
+---+---+---
+ t | t | f
+(1 row)
+
+SELECT 'foo' LIKE '__%' as t, 'foo' LIKE '___%' as t, 'foo' LIKE '____%' as f;
+ t | t | f 
+---+---+---
+ t | t | f
+(1 row)
+
+SELECT 'foo' LIKE '%__' as t, 'foo' LIKE '%___' as t, 'foo' LIKE '%____' as f;
+ t | t | f 
+---+---+---
+ t | t | f
+(1 row)
+
+SELECT 'jack' LIKE '%____%' AS t;
+ t 
+---
+ t
+(1 row)
+
+--
+-- basic tests of LIKE with indexes
+--
+CREATE TABLE texttest (a text PRIMARY KEY, b int);
+SELECT * FROM texttest WHERE a LIKE '%1%';
+ a | b 
+---+---
+(0 rows)
+
+CREATE TABLE byteatest (a bytea PRIMARY KEY, b int);
+SELECT * FROM byteatest WHERE a LIKE '%1%';
+ a | b 
+---+---
+(0 rows)
+
+DROP TABLE texttest, byteatest;
+--
+-- test implicit type conversion
+--
+-- E021-07 character concatenation
+SELECT 'unknown' || ' and unknown' AS "Concat unknown types";
+ Concat unknown types 
+----------------------
+ unknown and unknown
+(1 row)
+
+SELECT text 'text' || ' and unknown' AS "Concat text to unknown type";
+ Concat text to unknown type 
+-----------------------------
+ text and unknown
+(1 row)
+
+SELECT char(20) 'characters' || ' and text' AS "Concat char to unknown type";
+ Concat char to unknown type 
+-----------------------------
+ characters and text
+(1 row)
+
+SELECT text 'text' || char(20) ' and characters' AS "Concat text to char";
+ Concat text to char 
+---------------------
+ text and characters
+(1 row)
+
+SELECT text 'text' || varchar ' and varchar' AS "Concat text to varchar";
+ Concat text to varchar 
+------------------------
+ text and varchar
+(1 row)
+
+--
+-- test substr with toasted text values
+--
+CREATE TABLE toasttest(f1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into toasttest values(repeat('1234567890',10000));
+insert into toasttest values(repeat('1234567890',10000));
+--
+-- Ensure that some values are uncompressed, to test the faster substring
+-- operation used in that case
+--
+alter table toasttest alter column f1 set storage external;
+insert into toasttest values(repeat('1234567890',10000));
+insert into toasttest values(repeat('1234567890',10000));
+-- If the starting position is zero or less, then return from the start of the string
+-- adjusting the length to be consistent with the "negative start" per SQL.
+SELECT substr(f1, -1, 5) from toasttest;
+ substr 
+--------
+ 123
+ 123
+ 123
+ 123
+(4 rows)
+
+-- If the length is less than zero, an ERROR is thrown.
+SELECT substr(f1, 5, -1) from toasttest;
+ERROR:  negative substring length not allowed  (seg2 slice1 127.0.1.1:7004 pid=866419)
+-- If no third argument (length) is provided, the length to the end of the
+-- string is assumed.
+SELECT substr(f1, 99995) from toasttest;
+ substr 
+--------
+ 567890
+ 567890
+ 567890
+ 567890
+(4 rows)
+
+-- If start plus length is > string length, the result is truncated to
+-- string length
+SELECT substr(f1, 99995, 10) from toasttest;
+ substr 
+--------
+ 567890
+ 567890
+ 567890
+ 567890
+(4 rows)
+
+-- GPDB: These tests are sensitive to block size. In GPDB, the block
+-- size is 32 kB, whereas in PostgreSQL it's 8kB. Therefore make
+-- the data 4x larger here.
+TRUNCATE TABLE toasttest;
+INSERT INTO toasttest values (repeat('1234567890',300*4));
+INSERT INTO toasttest values (repeat('1234567890',300*4));
+INSERT INTO toasttest values (repeat('1234567890',300*4));
+INSERT INTO toasttest values (repeat('1234567890',300*4));
+-- expect >0 blocks
+SELECT pg_relation_size(reltoastrelid) = 0 AS is_empty
+  FROM pg_class where relname = 'toasttest';
+ is_empty 
+----------
+ f
+(1 row)
+
+TRUNCATE TABLE toasttest;
+ALTER TABLE toasttest set (toast_tuple_target = 4080);
+INSERT INTO toasttest values (repeat('1234567890',300));
+INSERT INTO toasttest values (repeat('1234567890',300));
+INSERT INTO toasttest values (repeat('1234567890',300));
+INSERT INTO toasttest values (repeat('1234567890',300));
+-- expect 0 blocks
+SELECT pg_relation_size(reltoastrelid) = 0 AS is_empty
+  FROM pg_class where relname = 'toasttest';
+ is_empty 
+----------
+ t
+(1 row)
+
+DROP TABLE toasttest;
+--
+-- test substr with toasted bytea values
+--
+CREATE TABLE toasttest(f1 bytea);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into toasttest values("decode"(repeat('1234567890',10000),'escape'));
+insert into toasttest values(pg_catalog.decode(repeat('1234567890',10000),'escape'));
+--
+-- Ensure that some values are uncompressed, to test the faster substring
+-- operation used in that case
+--
+alter table toasttest alter column f1 set storage external;
+insert into toasttest values("decode"(repeat('1234567890',10000),'escape'));
+insert into toasttest values(pg_catalog.decode(repeat('1234567890',10000),'escape'));
+-- If the starting position is zero or less, then return from the start of the string
+-- adjusting the length to be consistent with the "negative start" per SQL.
+SELECT substr(f1, -1, 5) from toasttest;
+ substr 
+--------
+ 123
+ 123
+ 123
+ 123
+(4 rows)
+
+-- If the length is less than zero, an ERROR is thrown.
+SELECT substr(f1, 5, -1) from toasttest;
+ERROR:  negative substring length not allowed  (seg2 slice1 127.0.1.1:7004 pid=866419)
+-- If no third argument (length) is provided, the length to the end of the
+-- string is assumed.
+SELECT substr(f1, 99995) from toasttest;
+ substr 
+--------
+ 567890
+ 567890
+ 567890
+ 567890
+(4 rows)
+
+-- If start plus length is > string length, the result is truncated to
+-- string length
+SELECT substr(f1, 99995, 10) from toasttest;
+ substr 
+--------
+ 567890
+ 567890
+ 567890
+ 567890
+(4 rows)
+
+DROP TABLE toasttest;
+-- test internally compressing datums
+-- this tests compressing a datum to a very small size which exercises a
+-- corner case in packed-varlena handling: even though small, the compressed
+-- datum must be given a 4-byte header because there are no bits to indicate
+-- compression in a 1-byte header
+CREATE TABLE toasttest (c char(4096));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO toasttest VALUES('x');
+SELECT length(c), c::text FROM toasttest;
+ length | c 
+--------+---
+      1 | x
+(1 row)
+
+SELECT c FROM toasttest;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                c                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ x                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+(1 row)
+
+DROP TABLE toasttest;
+--
+-- test length
+--
+SELECT length('abcdef') AS "length_6";
+ length_6 
+----------
+        6
+(1 row)
+
+--
+-- test strpos
+--
+SELECT strpos('abcdef', 'cd') AS "pos_3";
+ pos_3 
+-------
+     3
+(1 row)
+
+SELECT strpos('abcdef', 'xy') AS "pos_0";
+ pos_0 
+-------
+     0
+(1 row)
+
+SELECT strpos('abcdef', '') AS "pos_1";
+ pos_1 
+-------
+     1
+(1 row)
+
+SELECT strpos('', 'xy') AS "pos_0";
+ pos_0 
+-------
+     0
+(1 row)
+
+SELECT strpos('', '') AS "pos_1";
+ pos_1 
+-------
+     1
+(1 row)
+
+--
+-- test replace
+--
+SELECT replace('abcdef', 'de', '45') AS "abc45f";
+ abc45f 
+--------
+ abc45f
+(1 row)
+
+SELECT replace('yabadabadoo', 'ba', '123') AS "ya123da123doo";
+ ya123da123doo 
+---------------
+ ya123da123doo
+(1 row)
+
+SELECT replace('yabadoo', 'bad', '') AS "yaoo";
+ yaoo 
+------
+ yaoo
+(1 row)
+
+--
+-- test split_part
+--
+select split_part('joeuser@mydatabase','@',0) AS "an error";
+ERROR:  field position must be greater than zero
+select split_part('joeuser@mydatabase','@',1) AS "joeuser";
+ joeuser 
+---------
+ joeuser
+(1 row)
+
+select split_part('joeuser@mydatabase','@',2) AS "mydatabase";
+ mydatabase 
+------------
+ mydatabase
+(1 row)
+
+select split_part('joeuser@mydatabase','@',3) AS "empty string";
+ empty string 
+--------------
+ 
+(1 row)
+
+select split_part('@joeuser@mydatabase@','@',2) AS "joeuser";
+ joeuser 
+---------
+ joeuser
+(1 row)
+
+--
+-- test to_hex
+--
+select to_hex(256*256*256 - 1) AS "ffffff";
+ ffffff 
+--------
+ ffffff
+(1 row)
+
+select to_hex(256::bigint*256::bigint*256::bigint*256::bigint - 1) AS "ffffffff";
+ ffffffff 
+----------
+ ffffffff
+(1 row)
+
+--
+-- MD5 test suite - from IETF RFC 1321
+-- (see: ftp://ftp.rfc-editor.org/in-notes/rfc1321.txt)
+--
+select md5('') = 'd41d8cd98f00b204e9800998ecf8427e' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('a') = '0cc175b9c0f1b6a831c399e269772661' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('abc') = '900150983cd24fb0d6963f7d28e17f72' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('message digest') = 'f96b697d7cb7938d525a2f31aaf161d0' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('abcdefghijklmnopqrstuvwxyz') = 'c3fcd3d76192e4007dfb496cca67e13b' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') = 'd174ab98d277d9f5a5611c2c9f419d9f' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('12345678901234567890123456789012345678901234567890123456789012345678901234567890') = '57edf4a22be3c955ac49da2e2107b67a' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5(''::bytea) = 'd41d8cd98f00b204e9800998ecf8427e' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('a'::bytea) = '0cc175b9c0f1b6a831c399e269772661' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('abc'::bytea) = '900150983cd24fb0d6963f7d28e17f72' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('message digest'::bytea) = 'f96b697d7cb7938d525a2f31aaf161d0' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('abcdefghijklmnopqrstuvwxyz'::bytea) = 'c3fcd3d76192e4007dfb496cca67e13b' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'::bytea) = 'd174ab98d277d9f5a5611c2c9f419d9f' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+select md5('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::bytea) = '57edf4a22be3c955ac49da2e2107b67a' AS "TRUE";
+ TRUE 
+------
+ t
+(1 row)
+
+--
+-- SHA-2
+--
+SET bytea_output TO hex;
+SELECT sha224('');
+                           sha224                           
+------------------------------------------------------------
+ \xd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
+(1 row)
+
+SELECT sha224('The quick brown fox jumps over the lazy dog.');
+                           sha224                           
+------------------------------------------------------------
+ \x619cba8e8e05826e9b8c519c0a5c68f4fb653e8a3d8aa04bb2c8cd4c
+(1 row)
+
+SELECT sha256('');
+                               sha256                               
+--------------------------------------------------------------------
+ \xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+(1 row)
+
+SELECT sha256('The quick brown fox jumps over the lazy dog.');
+                               sha256                               
+--------------------------------------------------------------------
+ \xef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c
+(1 row)
+
+SELECT sha384('');
+                                               sha384                                               
+----------------------------------------------------------------------------------------------------
+ \x38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+(1 row)
+
+SELECT sha384('The quick brown fox jumps over the lazy dog.');
+                                               sha384                                               
+----------------------------------------------------------------------------------------------------
+ \xed892481d8272ca6df370bf706e4d7bc1b5739fa2177aae6c50e946678718fc67a7af2819a021c2fc34e91bdb63409d7
+(1 row)
+
+SELECT sha512('');
+                                                               sha512                                                               
+------------------------------------------------------------------------------------------------------------------------------------
+ \xcf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+(1 row)
+
+SELECT sha512('The quick brown fox jumps over the lazy dog.');
+                                                               sha512                                                               
+------------------------------------------------------------------------------------------------------------------------------------
+ \x91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed
+(1 row)
+
+--
+-- encode/decode
+--
+SELECT encode('\x1234567890abcdef00', 'hex');
+       encode       
+--------------------
+ 1234567890abcdef00
+(1 row)
+
+SELECT decode('1234567890abcdef00', 'hex');
+        decode        
+----------------------
+ \x1234567890abcdef00
+(1 row)
+
+SELECT encode(('\x' || repeat('1234567890abcdef0001', 7))::bytea, 'base64');
+                                    encode                                    
+------------------------------------------------------------------------------
+ EjRWeJCrze8AARI0VniQq83vAAESNFZ4kKvN7wABEjRWeJCrze8AARI0VniQq83vAAESNFZ4kKvN+
+ 7wABEjRWeJCrze8AAQ==
+(1 row)
+
+SELECT decode(encode(('\x' || repeat('1234567890abcdef0001', 7))::bytea,
+                     'base64'), 'base64');
+                                                                     decode                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------
+ \x1234567890abcdef00011234567890abcdef00011234567890abcdef00011234567890abcdef00011234567890abcdef00011234567890abcdef00011234567890abcdef0001
+(1 row)
+
+SELECT encode('\x1234567890abcdef00', 'escape');
+           encode            
+-----------------------------
+ \x124Vx\220\253\315\357\000
+(1 row)
+
+SELECT decode(encode('\x1234567890abcdef00', 'escape'), 'escape');
+        decode        
+----------------------
+ \x1234567890abcdef00
+(1 row)
+
+--
+-- get_bit/set_bit etc
+--
+SELECT get_bit('\x1234567890abcdef00'::bytea, 43);
+ get_bit 
+---------
+       1
+(1 row)
+
+SELECT get_bit('\x1234567890abcdef00'::bytea, 99);  -- error
+ERROR:  index 99 out of valid range, 0..71
+SELECT set_bit('\x1234567890abcdef00'::bytea, 43, 0);
+       set_bit        
+----------------------
+ \x1234567890a3cdef00
+(1 row)
+
+SELECT set_bit('\x1234567890abcdef00'::bytea, 99, 0);  -- error
+ERROR:  index 99 out of valid range, 0..71
+SELECT get_byte('\x1234567890abcdef00'::bytea, 3);
+ get_byte 
+----------
+      120
+(1 row)
+
+SELECT get_byte('\x1234567890abcdef00'::bytea, 99);  -- error
+ERROR:  index 99 out of valid range, 0..8
+SELECT set_byte('\x1234567890abcdef00'::bytea, 7, 11);
+       set_byte       
+----------------------
+ \x1234567890abcd0b00
+(1 row)
+
+SELECT set_byte('\x1234567890abcdef00'::bytea, 99, 11);  -- error
+ERROR:  index 99 out of valid range, 0..8
+--
+-- test behavior of escape_string_warning and standard_conforming_strings options
+--
+set escape_string_warning = off;
+set standard_conforming_strings = off;
+show escape_string_warning;
+ escape_string_warning 
+-----------------------
+ off
+(1 row)
+
+show standard_conforming_strings;
+ standard_conforming_strings 
+-----------------------------
+ off
+(1 row)
+
+set escape_string_warning = on;
+set standard_conforming_strings = on;
+show escape_string_warning;
+ escape_string_warning 
+-----------------------
+ on
+(1 row)
+
+show standard_conforming_strings;
+ standard_conforming_strings 
+-----------------------------
+ on
+(1 row)
+
+select 'a\bcd' as f1, 'a\b''cd' as f2, 'a\b''''cd' as f3, 'abcd\'   as f4, 'ab\''cd' as f5, '\\' as f6;
+  f1   |   f2   |   f3    |  f4   |   f5   | f6 
+-------+--------+---------+-------+--------+----
+ a\bcd | a\b'cd | a\b''cd | abcd\ | ab\'cd | \\
+(1 row)
+
+set standard_conforming_strings = off;
+select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd' as f5, '\\\\' as f6;
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+               ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+                               ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+                                                 ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'  ...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd'...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd' as f5, '\\\\' as ...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+               ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+                               ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3,...
+                                                 ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'  ...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd'...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+WARNING:  nonstandard use of \\ in a string literal
+LINE 1: ...'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd' as f5, '\\\\' as ...
+                                                             ^
+HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
+  f1   |   f2   |   f3    |  f4   |   f5   | f6 
+-------+--------+---------+-------+--------+----
+ a\bcd | a\b'cd | a\b''cd | abcd\ | ab\'cd | \\
+(1 row)
+
+set escape_string_warning = off;
+set standard_conforming_strings = on;
+select 'a\bcd' as f1, 'a\b''cd' as f2, 'a\b''''cd' as f3, 'abcd\'   as f4, 'ab\''cd' as f5, '\\' as f6;
+  f1   |   f2   |   f3    |  f4   |   f5   | f6 
+-------+--------+---------+-------+--------+----
+ a\bcd | a\b'cd | a\b''cd | abcd\ | ab\'cd | \\
+(1 row)
+
+set standard_conforming_strings = off;
+select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd' as f5, '\\\\' as f6;
+  f1   |   f2   |   f3    |  f4   |   f5   | f6 
+-------+--------+---------+-------+--------+----
+ a\bcd | a\b'cd | a\b''cd | abcd\ | ab\'cd | \\
+(1 row)
+
+--
+-- test unicode escape
+--
+select E'A\u0041' as f1, E'\u0127' as f2;
+ f1 | f2 
+----+----
+ AA | ħ
+(1 row)
+
+select E'\u0000';
+ERROR:  invalid Unicode escape value at or near "E'\u0000"
+LINE 1: select E'\u0000';
+               ^
+select E'\udsfs';
+ERROR:  invalid Unicode escape
+LINE 1: select E'\udsfs';
+               ^
+HINT:  Unicode escapes must be \uXXXX or \UXXXXXXXX.
+select E'\uD843\uE001';
+ERROR:  invalid Unicode surrogate pair at or near "E'\uD843\uE001"
+LINE 1: select E'\uD843\uE001';
+               ^
+select E'\uDC01';
+ERROR:  invalid Unicode surrogate pair at or near "E'\uDC01"
+LINE 1: select E'\uDC01';
+               ^
+select E'\uD834';
+ERROR:  invalid Unicode surrogate pair at or near "E'\uD834'"
+LINE 1: select E'\uD834';
+               ^
+--
+-- Additional string functions
+--
+SET bytea_output TO escape;
+SELECT initcap('hi THOMAS');
+  initcap  
+-----------
+ Hi Thomas
+(1 row)
+
+SELECT lpad('hi', 5, 'xy');
+ lpad  
+-------
+ xyxhi
+(1 row)
+
+SELECT lpad('hi', 5);
+ lpad  
+-------
+    hi
+(1 row)
+
+SELECT lpad('hi', -5, 'xy');
+ lpad 
+------
+ 
+(1 row)
+
+SELECT lpad('hello', 2);
+ lpad 
+------
+ he
+(1 row)
+
+SELECT lpad('hi', 5, '');
+ lpad 
+------
+ hi
+(1 row)
+
+SELECT rpad('hi', 5, 'xy');
+ rpad  
+-------
+ hixyx
+(1 row)
+
+SELECT rpad('hi', 5);
+ rpad  
+-------
+ hi   
+(1 row)
+
+SELECT rpad('hi', -5, 'xy');
+ rpad 
+------
+ 
+(1 row)
+
+SELECT rpad('hello', 2);
+ rpad 
+------
+ he
+(1 row)
+
+SELECT rpad('hi', 5, '');
+ rpad 
+------
+ hi
+(1 row)
+
+SELECT ltrim('zzzytrim', 'xyz');
+ ltrim 
+-------
+ trim
+(1 row)
+
+SELECT translate('', '14', 'ax');
+ translate 
+-----------
+ 
+(1 row)
+
+SELECT translate('12345', '14', 'ax');
+ translate 
+-----------
+ a23x5
+(1 row)
+
+SELECT ascii('x');
+ ascii 
+-------
+   120
+(1 row)
+
+SELECT ascii('');
+ ascii 
+-------
+     0
+(1 row)
+
+SELECT chr(65);
+ chr 
+-----
+ A
+(1 row)
+
+SELECT chr(0);
+ERROR:  null character not permitted
+SELECT repeat('Pg', 4);
+  repeat  
+----------
+ PgPgPgPg
+(1 row)
+
+SELECT repeat('Pg', -4);
+ repeat 
+--------
+ 
+(1 row)
+
+SELECT SUBSTRING('1234567890'::bytea FROM 3) "34567890";
+ 34567890 
+----------
+ 34567890
+(1 row)
+
+SELECT SUBSTRING('1234567890'::bytea FROM 4 FOR 3) AS "456";
+ 456 
+-----
+ 456
+(1 row)
+
+SELECT SUBSTRING('string'::bytea FROM 2 FOR 2147483646) AS "tring";
+ tring 
+-------
+ tring
+(1 row)
+
+SELECT SUBSTRING('string'::bytea FROM -10 FOR 2147483646) AS "string";
+ string 
+--------
+ string
+(1 row)
+
+SELECT SUBSTRING('string'::bytea FROM -10 FOR -2147483646) AS "error";
+ERROR:  negative substring length not allowed
+SELECT trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea);
+ btrim 
+-------
+ Tom
+(1 row)
+
+SELECT btrim(E'\\000trim\\000'::bytea, E'\\000'::bytea);
+ btrim 
+-------
+ trim
+(1 row)
+
+SELECT btrim(''::bytea, E'\\000'::bytea);
+ btrim 
+-------
+ 
+(1 row)
+
+SELECT btrim(E'\\000trim\\000'::bytea, ''::bytea);
+    btrim     
+--------------
+ \000trim\000
+(1 row)
+
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2),'escape');
+   encode    
+-------------
+ TTh\x01omas
+(1 row)
+
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
+       encode       
+--------------------
+ Th\000omas\x02\x03
+(1 row)
+
+SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
+     encode      
+-----------------
+ Th\000o\x02\x03
+(1 row)
+
+-- Clean up GPDB-added tables
+DROP TABLE char_strings_tbl;
+DROP TABLE varchar_strings_tbl;
+DROP TABLE text_strings_tbl;


### PR DESCRIPTION
generate ic_resgroup task to run icw test under resoure group mode.

resource queue test case in icw test under rg task will change the resource manager's configure, remove these test case from rg icw task, also explain_format need llvm package to test jit, it's meaningless, also remove the test case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
