### PR TITLE
Fix the bug for error report in pg_basebackup().

### DIFF
--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -117,7 +117,7 @@ if slotname is not None: cmd += ' --slot %s' % (slotname)
 if force_overwrite: cmd += ' --force-overwrite' 
 if xlog_method == 'stream': cmd += ' --wal-method stream' elif xlog_method == 'fetch': cmd += ' --wal-method fetch' else: plpy.error('invalid xlog method') 
 cmd += ' --no-verify-checksums' 
-try: # Unset PGAPPNAME so that the pg_stat_replication.application_name is not affected if os.getenv('PGAPPNAME') is not None: os.environ.pop('PGAPPNAME') results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace(b'.', b'').decode() except subprocess.CalledProcessError as e: results = str(e) + "\ncommand output: " + e.output 
+try: # Unset PGAPPNAME so that the pg_stat_replication.application_name is not affected if os.getenv('PGAPPNAME') is not None: os.environ.pop('PGAPPNAME') results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace(b'.', b'').decode() except subprocess.CalledProcessError as e: results = str(e) + "\ncommand output: " + (e.output.decode()) 
 return results $$ language plpython3u;
 CREATE
 

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -363,7 +363,7 @@ create or replace function pg_basebackup(host text, dbid int, port int, create_s
             os.environ.pop('PGAPPNAME')
         results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace(b'.', b'').decode()
     except subprocess.CalledProcessError as e:
-        results = str(e) + "\ncommand output: " + e.output
+        results = str(e) + "\ncommand output: " + (e.output.decode())
 
     return results
 $$ language plpython3u;


### PR DESCRIPTION
# Problem

When an error occurs in pg_basebackup(), its detail can not be printed properly. Instead, the following error will be raised:

```
+ERROR:  TypeError: can only concatenate str (not "bytes") to str
+CONTEXT:  Traceback (most recent call last):
+  PL/Python function "pg_basebackup", line 26, in <module>
+    results = str(e) + "\ncommand output: " + e.output
+PL/Python function "pg_basebackup"
```

This problem is caused by that `e.output` is a bytes array and cannot contact with str.

# Solution
Change `e.output` to `e.output.decode()`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
