### PR TITLE
Fix incorrect testcase aoco_column_rewrite.

### DIFF
--- a/src/test/isolation2/expected/aoco_column_rewrite.out
+++ b/src/test/isolation2/expected/aoco_column_rewrite.out
@@ -1281,14 +1281,11 @@ INSERT 10
 BEGIN
 1: INSERT INTO aoco_concurrent_inserts SELECT i,i,i FROM generate_series(1,10)i;
 INSERT 10
-1: END;
-END
 2&: ALTER TABLE aoco_concurrent_inserts ALTER COLUMN b TYPE text;  <waiting ...>
-FAILED:  Forked command is not blocking; got output: ALTER
 1: END;
 END
 2<:  <... completed>
-FAILED:  Execution failed
+ALTER
 -- should see 20 rows
 SELECT count(*) FROM aoco_concurrent_inserts;
  count 

--- a/src/test/isolation2/sql/aoco_column_rewrite.sql
+++ b/src/test/isolation2/sql/aoco_column_rewrite.sql
@@ -468,7 +468,6 @@ CREATE TABLE aoco_concurrent_inserts(a int, b int, c int) USING ao_column;
 INSERT INTO aoco_concurrent_inserts SELECT i,i,i FROM generate_series(1,10)i;
 1: BEGIN;
 1: INSERT INTO aoco_concurrent_inserts SELECT i,i,i FROM generate_series(1,10)i;
-1: END;
 2&: ALTER TABLE aoco_concurrent_inserts ALTER COLUMN b TYPE text;
 1: END;
 2<:


### PR DESCRIPTION
The expected behavior of this test case is that 'ALTER TABLE' and
'INSERT' commands will block each other. This patch helps fix it.

Co-Authored-By: Hao Zhang <hzhang2@vmware.com>

- [x] Pass `make installcheck`
