### PR TITLE
Remove fixme in relation_open()

### DIFF
--- a/src/backend/access/common/relation.c
+++ b/src/backend/access/common/relation.c
@@ -58,7 +58,6 @@ relation_open(Oid relationId, LOCKMODE lockmode)
 	/* The relcache does all the real work... */
 	r = RelationIdGetRelation(relationId);
 
-	/* GPDB_12_MERGE_FIXME: We had added the errdetail in GPDB. Is it still valid? */
 	if (!RelationIsValid(r))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_TABLE),


### PR DESCRIPTION
Long log:

The error and errdetail are both valid. Please refer to 
[issue 15095](https://github.com/greenplum-db/gpdb/issues/15095).

The mini repo below will trigger this errdetail
```
create table t1(c1 int);
create temporary table t2(c1 int);
create index i0 on t1(c1);
create index i0 on t2(c1);
discard all;
drop index i0;
vacuum t1;
```
So revome this fixme.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>