### PR TITLE
Add two macros RelationStorageIsAoRows|RelationStorageIsAoCols

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -58,7 +58,7 @@ AOCSCompaction_DropSegmentFile(Relation aorel, int segno, AOVacuumRelStats *vacr
 {
 	int			col;
 
-	Assert(RelationIsAoCols(aorel));
+	Assert(RelationStorageIsAoCols(aorel));
 
 	for (col = 0; col < RelationGetNumberOfAttributes(aorel); col++)
 	{
@@ -110,7 +110,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel, int segno, AOCSVPInfo *vpinfo, AOVa
 	const char *relname = RelationGetRelationName(aorel);
 	int			j;
 
-	Assert(RelationIsAoCols(aorel));
+	Assert(RelationStorageIsAoCols(aorel));
 
 	for (j = 0; j < vpinfo->nEntry; ++j)
 	{
@@ -234,7 +234,7 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 	int64		prev_heap_blks_scanned = 0;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
-	Assert(RelationIsAoCols(aorel));
+	Assert(RelationStorageIsAoCols(aorel));
 	Assert(insertDesc);
 
 	compact_segno = fsinfo->segno;
@@ -381,7 +381,7 @@ AOCSCompact(Relation aorel,
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
-	Assert(RelationIsAoCols(aorel));
+	Assert(RelationStorageIsAoCols(aorel));
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 
 	relname = RelationGetRelationName(aorel);

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -636,7 +636,7 @@ ao_rel_get_physical_size(Relation aorel)
 		int			segno;
 		bool		isNull;
 
-		if (RelationIsAoRows(aorel))
+		if (RelationStorageIsAoRows(aorel))
 		{
 			segno = DatumGetInt32(fastgetattr(tuple,
 											  Anum_pg_aoseg_segno,
@@ -649,7 +649,7 @@ ao_rel_get_physical_size(Relation aorel)
 			AOCSVPInfo *vpinfo;
 			int			col;
 
-			Assert(RelationIsAoCols(aorel));
+			Assert(RelationStorageIsAoCols(aorel));
 
 			segno = DatumGetInt32(fastgetattr(tuple,
 											  Anum_pg_aocs_segno,

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -366,8 +366,6 @@ GetAllFileSegInfo(Relation parentrel,
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
 			 RelationGetRelationName(parentrel));
 
-	Assert(RelationIsAoRows(parentrel));
-
 	if (segrelidptr != NULL)
 		*segrelidptr = segrelid;
 
@@ -625,8 +623,6 @@ ClearFileSegInfo(Relation parentrel, int segno)
 
 	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
-	Assert(RelationIsAoRows(parentrel));
-
 	elogif(Debug_appendonly_print_compaction, LOG,
 		   "Clear seg file info: segno %d table '%s'",
 		   segno,
@@ -761,9 +757,9 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	bool		isNull;
 	Oid segrelid;
 
+	Assert(RelationStorageIsAoRows(parentrel));
 	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
-	Assert(RelationIsAoRows(parentrel));
 	Assert(newState >= AOSEG_STATE_USECURRENT && newState <= AOSEG_STATE_AWAITING_DROP);
 
 	/*
@@ -964,8 +960,6 @@ GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 	bool		isNull;
 	Oid			segrelid;
 
-	Assert(RelationIsAoRows(parentrel));
-
 	result = (FileSegTotals *) palloc0(sizeof(FileSegTotals));
 
 	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
@@ -1081,10 +1075,10 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 		context->aoRelOid = aoRelOid;
 
 		aocsRel = table_open(aoRelOid, AccessShareLock);
-		if (!RelationIsAoRows(aocsRel))
+		if (!RelationStorageIsAoRows(aocsRel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("'%s' is not an append-only row relation",
+					 errmsg("Relation '%s' does not have appendoptimized row-oriented storage",
 							RelationGetRelationName(aocsRel))));
 
 		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL);
@@ -1233,10 +1227,10 @@ gp_aoseg(PG_FUNCTION_ARGS)
 		context->aoRelOid = aoRelOid;
 
 		aocsRel = table_open(aoRelOid, AccessShareLock);
-		if (!RelationIsAoRows(aocsRel))
+		if (!RelationStorageIsAoRows(aocsRel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("'%s' is not an append-only row relation",
+					 errmsg("Relation '%s' does not have appendoptimized row-oriented storage",
 							RelationGetRelationName(aocsRel))));
 
 		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL);

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -74,7 +74,7 @@ AppendOnlyCompaction_DropSegmentFile(Relation aorel, int segno, AOVacuumRelStats
 	int32		fileSegNo;
 	File		fd;
 
-	Assert(RelationIsAoRows(aorel));
+	Assert(RelationStorageIsAoRows(aorel));
 
 	if (Debug_appendonly_print_compaction)
 		elog(LOG, "Drop segment file: segno %d", segno);
@@ -229,7 +229,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel, int segno, int64 segeof, AOVa
 	int32		fileSegNo;
 	char		filenamepath[MAXPGPATH];
 
-	Assert(RelationIsAoRows(aorel));
+	Assert(RelationStorageIsAoRows(aorel));
 
 	relname = RelationGetRelationName(aorel);
 
@@ -397,7 +397,7 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	int64		heap_blks_scanned = 0;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
-	Assert(RelationIsAoRows(aorel));
+	Assert(RelationStorageIsAoRows(aorel));
 	Assert(insertDesc);
 
 	compact_segno = fsinfo->segno;
@@ -649,6 +649,8 @@ AppendOptimizedCollectDeadSegments(Relation aorel)
 static inline void
 AppendOptimizedDropDeadSegment(Relation aorel, int segno, AOVacuumRelStats *vacrelstats)
 {
+	Assert(RelationStorageIsAO(aorel));
+
 	if (RelationIsAoRows(aorel))
 	{
 		AppendOnlyCompaction_DropSegmentFile(aorel, segno, vacrelstats);
@@ -793,7 +795,7 @@ AppendOnlyCompact(Relation aorel,
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
-	Assert(RelationIsAoRows(aorel));
+	Assert(RelationStorageIsAoRows(aorel));
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 
 	relname = RelationGetRelationName(aorel);

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -609,6 +609,8 @@ choose_new_segfile(Relation rel, bool *used, List *avoid_segnos)
 {
 	int		chosen_segno = -1;
 
+	Assert(RelationStorageIsAO(rel));
+
 	/* No segment found. Try to create a new one. */
 	for (int segno = 0; segno < MAX_AOREL_CONCURRENCY; segno++)
 	{
@@ -666,6 +668,8 @@ get_aoseg_fields(Relation rel, Relation pg_aoseg_rel, HeapTuple tuple,
 	TupleDesc	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 	bool		isNull;
 
+	Assert(RelationStorageIsAO(rel));
+
 	if (RelationIsAoRows(rel))
 	{
 		*segno = DatumGetInt32(fastgetattr(tuple,
@@ -721,6 +725,8 @@ void
 AORelIncrementModCount(Relation parentrel)
 {
 	int			segno;
+
+	Assert(RelationStorageIsAO(parentrel));
 
 	if (Debug_appendonly_print_segfile_choice)
 		ereport(LOG,

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -421,9 +421,9 @@ RemoveFastSequenceEntry(Oid relid, Oid objid)
 	/*
 	 * Currently lastrownums are only used by ao_row tables. Once ao_column
 	 * tables need them (i.e. when the same ADD COLUMN optimization for 
-	 * ao_column), we can remove this check.
+	 * ao_column), we can change this check to RelationStorageIsAO.
 	 */
-	if (RelationIsAoRows(rel))
+	if (RelationStorageIsAoRows(rel))
 		ClearAttributeEncodingLastrownums(relid);
 	table_close(rel, NoLock);
 }

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7577,7 +7577,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	/*
 	 * Add a pg_attribute_encoding entry for ao_row tables, containing the last row numbers of each segfile.
 	 */
-	if (RelationIsAoRows(rel) && rel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
+	if (RelationStorageIsAoRows(rel))
 	{
 		Oid 	segrelid;
 		int64 	lastrownums[MAX_AOREL_CONCURRENCY];

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -178,6 +178,8 @@ ao_vacuum_rel_pre_cleanup(Relation onerel, VacuumParams *params, BufferAccessStr
 	};
 	int64		initprog_val[3];
 
+	Assert(RelationStorageIsAO(onerel));
+
 	if (options & VACOPT_VERBOSE)
 		elevel = INFO;
 	else
@@ -265,7 +267,7 @@ ao_vacuum_rel_post_cleanup(Relation onerel, VacuumParams *params, BufferAccessSt
 	 * 
 	 * 4. Update statistics.
 	 */
-	Assert(RelationIsAoRows(onerel) || RelationIsAoCols(onerel));
+	Assert(RelationStorageIsAO(onerel));
 	Assert(vacrelstats != NULL);
 
 	pgstat_progress_update_param(PROGRESS_VACUUM_PHASE,
@@ -329,7 +331,7 @@ ao_vacuum_rel_compact(Relation onerel, VacuumParams *params, BufferAccessStrateg
 		   Gp_role == GP_ROLE_UTILITY ||
 		   DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
 		   DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER);
-	Assert(RelationIsAoRows(onerel) || RelationIsAoCols(onerel));
+	Assert(RelationStorageIsAO(onerel));
 	Assert(vacrelstats != NULL);
 
 	if (options & VACOPT_VERBOSE)
@@ -693,7 +695,7 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 	AppendOnlyVisimap visimap;
 	Oid			visimaprelid;
 
-	Assert(RelationIsAoRows(aorel) || RelationIsAoCols(aorel));
+	Assert(RelationStorageIsAO(aorel));
 
 	relname = RelationGetRelationName(aorel);
 

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -124,7 +124,7 @@ IndexOnlyNext(IndexOnlyScanState *node)
 
 		CHECK_FOR_INTERRUPTS();
 
-		if (RelationAMIsAO(scandesc->xs_heapfetch->rel))
+		if (RelationIsAppendOptimized(scandesc->xs_heapfetch->rel))
 		{
 			if (!table_index_fetch_tuple_visible(scandesc->xs_heapfetch,
 												 tid,

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -196,7 +196,7 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 		 * GPDB supports index-only scan on AO starting from AORelationVersion_GP7.
 		 */
 		bool enable_ios_ao = false;
-		if (RelationAMIsAO(relation) &&
+		if (RelationIsAppendOptimized(relation) &&
 			AORelationVersion_Validate(relation, AORelationVersion_GP7))
 			enable_ios_ao = true;
 
@@ -286,7 +286,7 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 				info->indexkeys[i] = index->indkey.values[i];
 
 				/* GPDB: This AO table might not have met the requirement for IOScan. */
-				if (RelationAMIsAO(relation) && !enable_ios_ao)
+				if (RelationIsAppendOptimized(relation) && !enable_ios_ao)
 					info->canreturn[i] = false;
 				else
 					info->canreturn[i] = index_can_return(indexRelation, i + 1);
@@ -628,7 +628,7 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 	 * pages added since the last VACUUM are most likely not marked
 	 * all-visible.  But costsize.c wants it converted to a fraction.
 	 */
-	if (RelationAMIsAO(rel))
+	if (RelationIsAppendOptimized(rel))
 	{
 		/* see appendonly_estimate_rel_size()/aoco_estimate_rel_size() */
 		*allvisfrac = 1;

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -437,6 +437,10 @@ typedef struct ViewOptions
 #define RelationIsAoRows(relation) \
 	((relation)->rd_rel->relam == AO_ROW_TABLE_AM_OID)
 
+#define RelationStorageIsAoRows(relation) \
+	((relation)->rd_rel->relam == AO_ROW_TABLE_AM_OID && \
+		(relation)->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
+
 /*
  * CAUTION: this macro is a violation of the absraction that table AM and
  * index AM interfaces provide.  Use of this macro is discouraged.  If
@@ -448,6 +452,10 @@ typedef struct ViewOptions
  */
 #define RelationIsAoCols(relation) \
 	((relation)->rd_rel->relam == AO_COLUMN_TABLE_AM_OID)
+
+#define RelationStorageIsAoCols(relation) \
+	((relation)->rd_rel->relam == AO_COLUMN_TABLE_AM_OID && \
+		(relation)->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
 
 /*
  * CAUTION: this macro is a violation of the absraction that table AM and
@@ -463,16 +471,7 @@ typedef struct ViewOptions
 
 #define RelationStorageIsAO(relation) \
 	((RelationIsAoRows(relation) || RelationIsAoCols(relation)) && \
-		relation->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
-
-/*
- * Convenient macro for checking AO AMs
- *
- * RelationAMIsAO
- * 		True iff relam is ao_row or or ao_column.
- */
-#define RelationAMIsAO(relation) \
-	IsAccessMethodAO((relation)->rd_rel->relam)
+		(relation)->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
 
 /*
  * RelationIsBitmapIndex

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -338,11 +338,11 @@ SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapbase
 
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild');
-ERROR:  'heapchild' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+ERROR:  Relation 'heapchild' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild')).* FROM gp_dist_random('gp_id');
 ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild2');
-ERROR:  'heapchild2' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+ERROR:  Relation 'heapchild2' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild2')).* FROM gp_dist_random('gp_id');
 ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapchild%' AND c.oid = p.relid;
@@ -421,13 +421,13 @@ SELECT * FROM ao2heap2;
 
 -- No AO aux tables should be left
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
-ERROR:  'ao2heap' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+ERROR:  Relation 'ao2heap' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap')).* FROM gp_dist_random('gp_id');
 ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('ao2heap')).* FROM gp_dist_random('gp_id');
 ERROR:  function not supported on non append-optimized relation  (seg2 slice1 192.168.0.148:7004 pid=1401173)
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
-ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+ERROR:  Relation 'ao2heap2' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap2')).* FROM gp_dist_random('gp_id');
 ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 -- No pg_appendonly entries should be left too
@@ -705,7 +705,7 @@ SELECT count(*) FROM ao2co4;
 -- Only tested for 2 out of the 4 tables being created, where the tables were altered w/wo reloptions. 
 -- No need to test the other ones created by the alternative syntax SET WITH().
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2co');
-ERROR:  'ao2co' is not an append-only row relation
+ERROR:  Relation 'ao2co' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT * FROM gp_toolkit.__gp_aovisimap('ao2co');
  tid | segno | row_num 
 -----+-------+---------
@@ -723,7 +723,7 @@ SELECT * FROM gp_toolkit.__gp_aoblkdir('ao2co');
 (0 rows)
 
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2co3');
-ERROR:  'ao2co3' is not an append-only row relation
+ERROR:  Relation 'ao2co3' does not have appendoptimized row-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT * FROM gp_toolkit.__gp_aovisimap('ao2co3');
  tid | segno | row_num 
 -----+-------+---------
@@ -864,19 +864,19 @@ SELECT count(*) FROM co2heap4;
 -- Only testing 2 out of the 4 tables being created, where the tables were altered w/wo reloptions.
 -- No need to test the other ones created by the alternative syntax SET WITH().
 SELECT * FROM gp_toolkit.__gp_aoseg('co2heap');
-ERROR:  'co2heap' is not an append-only row relation
+ERROR:  Relation 'co2heap' does not have appendoptimized row-oriented storage  (seg1 slice1 127.0.1.1:7003 pid=26473)
 SELECT * FROM gp_toolkit.__gp_aovisimap('co2heap');
 ERROR:  function not supported on relation
 SELECT count(*) FROM gp_toolkit.__gp_aocsseg('co2heap');
-ERROR:  'co2heap' is not an append-only columnar relation
+ERROR:  Relation 'co2heap' does not have append-optimized column-oriented storage  (seg1 slice1 127.0.1.1:7003 pid=26473)
 SELECT * FROM gp_toolkit.__gp_aoblkdir('co2heap');
 ERROR:  function not supported on non append-optimized relation
 SELECT * FROM gp_toolkit.__gp_aoseg('co2heap3');
-ERROR:  'co2heap3' is not an append-only row relation
+ERROR:  Relation 'co2heap3' does not have appendoptimized row-oriented storage  (seg1 slice1 127.0.1.1:7003 pid=26473)
 SELECT * FROM gp_toolkit.__gp_aovisimap('co2heap3');
 ERROR:  function not supported on relation
 SELECT count(*) FROM gp_toolkit.__gp_aocsseg('co2heap3');
-ERROR:  'co2heap3' is not an append-only columnar relation
+ERROR:  Relation 'co2heap3' does not have append-optimized column-oriented storage  (seg1 slice1 127.0.1.1:7003 pid=26473)
 SELECT * FROM gp_toolkit.__gp_aoblkdir('co2heap3');
 ERROR:  function not supported on non append-optimized relation
 -- No pg_appendonly entries should be left too
@@ -1044,7 +1044,7 @@ SELECT * FROM gp_toolkit.__gp_aoseg('co2ao');
 (3 rows)
 
 SELECT * FROM gp_toolkit.__gp_aocsseg('co2ao');
-ERROR:  'co2ao' is not an append-only columnar relation
+ERROR:  Relation 'co2ao' does not have append-optimized column-oriented storage  (seg2 slice1 127.0.1.1:7004 pid=26474)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('co2ao')).* FROM gp_dist_random('gp_id');
  gp_segment_id | tid | segno | row_num 
 ---------------+-----+-------+---------
@@ -1067,7 +1067,7 @@ SELECT * FROM gp_toolkit.__gp_aoseg('co2ao3');
 (3 rows)
 
 SELECT * FROM gp_toolkit.__gp_aocsseg('co2ao3');
-ERROR:  'co2ao3' is not an append-only columnar relation
+ERROR:  Relation 'co2ao3' does not have append-optimized column-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=26472)
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('co2ao3')).* FROM gp_dist_random('gp_id');
  gp_segment_id | tid | segno | row_num 
 ---------------+-----+-------+---------


### PR DESCRIPTION
Similar to RelationIsAppendOptimized vs RelationStorageIsAO (https://github.com/greenplum-db/gpdb/pull/15546), add `RelationStorageIsAoRows | RelationStorageIsAoCols` corresponding to the existing `RelationIsAoRows | RelationIsAoCols` but exclude tables that do not have has storage. Currently only partitioned table is excluded.

Replace the existing with the new macros for callsites that are meant for accessing table storage or AO/CO aux tables.

But no change if:
* The callsite allows partitioned table to be there, or already excludes partitioned tables through some ERROR or Assert previously.
* The callsites are used in the way like if (RelationIsAoRows) ... else (RelationIsAoCols) ..., in that case we just add an `Assert(RelationStorageIsAO)` before that.

Also remove RelationAMIsAO which became redundant after RelationIsAppendOptimized. Adjusted some error message too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
