### PR TITLE
Fix a code flaw in gpfdist

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -4913,7 +4913,7 @@ static void request_cleanup(request_t *r)
 	if (r->zstd && !r->is_get)
 	{
 		ZSTD_freeDCtx(r->zstd_dctx);
-		r->zstd_cctx = NULL;
+		r->zstd_dctx = NULL;
 	}
 #endif
 }


### PR DESCRIPTION
There is a code flaw in gpfdist. This PR is to fix it.  `r->zstd_dctx` should be set to `NULL` in  `r->zstd_dctx` branch.