### PR TITLE
Fix REORGANIZE=true not redistributing randomly-distributed tables

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2303,7 +2303,8 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 			/*
 			 * If the target table is DISTRIBUTED RANDOMLY, we can insert the
 			 * rows anywhere. So if the input path is already partitioned, let
-			 * the insertions happen where they are.
+			 * the insertions happen where they are. Unless the GUC gp_force_random_redistribution
+			 * tells us to force the redistribution.
 			 *
 			 * If you `explain` the query insert into tab_random select * from tab_partition
 			 * there is not Motion node in plan. However, it is not means that the query only
@@ -2312,7 +2313,7 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 			 * But, we need to grant a Motion node if target locus' segnumber is different with
 			 * subpath.
 			 */
-			if(targetLocus.numsegments != subpath->locus.numsegments)
+			if (gp_force_random_redistribution || targetLocus.numsegments != subpath->locus.numsegments)
 			{
 				CdbPathLocus_MakeStrewn(&targetLocus, policy->numsegments);
 				subpath = cdbpath_create_motion_path(root, subpath, NIL, false, targetLocus);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -262,6 +262,7 @@ bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
 bool		gp_eager_two_phase_agg = false;
+bool		gp_force_random_redistribution = false;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -1794,6 +1795,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_eager_two_phase_agg,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_force_random_redistribution", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Force redistribution of insert for randomly-distributed."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_force_random_redistribution,
 		false, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -631,6 +631,9 @@ extern bool		gp_statistics_use_fkeys;
 /* Allow user to force tow stage agg */
 extern bool     gp_eager_two_phase_agg;
 
+/* Force redistribution of insert into randomly-distributed table */
+extern bool     gp_force_random_redistribution;
+
 /* Analyze tools */
 extern int gp_motion_slice_noop;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -177,6 +177,7 @@
 		"gp_external_enable_exec",
 		"gp_external_max_segs",
 		"gpfdist_retry_timeout",
+		"gp_force_random_redistribution",
 		"gp_fts_mark_mirror_down_grace_period",
 		"gp_fts_probe_interval",
 		"gp_fts_probe_retries",

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1488,3 +1488,120 @@ SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 (1 row)
 
 DROP TABLE t_reorganize_false;
+--
+-- Test case for GUC gp_force_random_redistribution.
+-- Manually toggle the GUC should control the behavior of redistribution for randomly-distributed tables.
+-- But REORGANIZE=true should redistribute no matter what.
+--
+-- this only affects postgres planner;
+set optimizer = false;
+-- check the distribution difference between 't1' and 't2' after executing 'query_string'
+-- return true if data distribution changed, otherwise false.
+-- Note: in extremely rare cases, even after 't2' being randomly-distributed from 't1', they could still have the 
+-- exact same distribution. So let the tables have a reasonably large number of rows to reduce that possibility.
+CREATE OR REPLACE FUNCTION check_redistributed(query_string text, t1 text, t2 text) 
+RETURNS BOOLEAN AS 
+$$
+DECLARE
+    before_query TEXT;
+    after_query TEXT;
+    comparison_query TEXT;
+    comparison_count INT;
+BEGIN
+    -- Prepare the query strings
+    before_query := format('SELECT gp_segment_id as segid, count(*) AS tupcount FROM %I GROUP BY gp_segment_id', t1);
+    after_query := format('SELECT gp_segment_id as segid, count(*) AS tupcount FROM %I GROUP BY gp_segment_id', t2);
+    comparison_query := format('SELECT COUNT(*) FROM ((TABLE %I EXCEPT TABLE %I) UNION ALL (TABLE %I EXCEPT TABLE %I))q', 'distribution1', 'distribution2', 'distribution2', 'distribution1');
+
+    -- Create temp tables to store the result
+    EXECUTE format('CREATE TEMP TABLE distribution1 AS %s DISTRIBUTED REPLICATED', before_query);
+
+    -- Execute provided query string
+    EXECUTE query_string;
+
+    EXECUTE format('CREATE TEMP TABLE distribution2 AS %s DISTRIBUTED REPLICATED', after_query);
+
+    -- Compare the tables using EXCEPT clause
+    EXECUTE comparison_query INTO comparison_count;
+
+    -- Drop temp tables
+    EXECUTE 'DROP TABLE distribution1';
+    EXECUTE 'DROP TABLE distribution2';
+
+    -- If count is greater than zero, then there's a difference
+    RETURN comparison_count > 0;
+END;
+$$ 
+LANGUAGE plpgsql;
+-- CO table builds temp table first instead of doing CTAS during REORGANIZE=true
+create table t_reorganize(a int, b int) using ao_column distributed by (a);
+insert into t_reorganize select 0,i from generate_series(1,1000)i;
+select gp_segment_id, count(*) from t_reorganize group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |  1000
+(1 row)
+
+-- firstly, no redistribute
+set gp_force_random_redistribution = off;
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+-- reorganize from randomly to randomly should still redistribute
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+-- but insert into table won't redistribute
+create table t_random (like t_reorganize) distributed randomly;
+select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
+ check_redistributed 
+------------
+ f
+(1 row)
+
+-- but insert into a different distribution policy would still redistribute
+create table t_distbya (like t_reorganize) distributed by (a);
+select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+-- now force distribute should redistribute in all cases
+set gp_force_random_redistribution = on;
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+create table t_random (like t_reorganize) distributed randomly;
+ERROR:  relation "t_random" already exists
+select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+create table t_distbya (like t_reorganize) distributed by (a);
+ERROR:  relation "t_distbya" already exists
+select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+ check_redistributed 
+------------
+ t
+(1 row)
+
+reset optimizer;
+reset gp_force_random_redistribution;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -740,3 +740,99 @@ RESET log_statement;
 SET statement_mem = '4000MB';
 ERROR:  Invalid input for statement_mem, must be less than max_statement_mem (2048000 kB)
 RESET statement_mem;
+-- enabling gp_force_random_redistribution makes sure random redistribution happens
+-- only relevant to postgres optimizer
+set optimizer = false;
+create table t1_dist_rand(a int) distributed randomly;
+create table t2_dist_rand(a int) distributed randomly;
+create table t_dist_hash(a int) distributed by (a);
+-- with the GUC turned off, redistribution won't happen (no redistribution motion)
+set gp_force_random_redistribution = false;
+explain insert into t2_dist_rand select * from t1_dist_rand;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'id' => 2,
+      'parent' => 1,
+      'short' => 'Seq Scan on t1_dist_rand'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Insert on t2_dist_rand'
+}
+GP_IGNORE:(3 rows)
+
+explain insert into t2_dist_rand select * from t_dist_hash;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'id' => 2,
+      'parent' => 1,
+      'short' => 'Seq Scan on t_dist_hash'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Insert on t2_dist_rand'
+}
+GP_IGNORE:(3 rows)
+
+-- with the GUC turned on, redistribution would happen
+set gp_force_random_redistribution = true;
+explain insert into t2_dist_rand select * from t1_dist_rand;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'child' => [
+        {
+          'id' => 3,
+          'parent' => 2,
+          'short' => 'Seq Scan on t1_dist_rand'
+        }
+      ],
+      'id' => 2,
+      'parent' => 1,
+      'recvsize' => 3,
+      'segments' => 3,
+      'sendsize' => 3,
+      'short' => 'Redistribute Motion'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Insert on t2_dist_rand'
+}
+GP_IGNORE:(4 rows)
+
+explain insert into t2_dist_rand select * from t_dist_hash;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'child' => [
+        {
+          'id' => 3,
+          'parent' => 2,
+          'short' => 'Seq Scan on t_dist_hash'
+        }
+      ],
+      'id' => 2,
+      'parent' => 1,
+      'recvsize' => 3,
+      'segments' => 3,
+      'sendsize' => 3,
+      'short' => 'Redistribute Motion'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Insert on t2_dist_rand'
+}
+GP_IGNORE:(4 rows)
+
+reset gp_force_random_redistribution;
+reset optimizer;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -132,6 +132,8 @@ m/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/
 s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:XXX)/
 m/ERROR:  requested functionality not allowed in FIPS mode .*/
 s/ERROR:  requested functionality not allowed in FIPS mode .*/ERROR:  requested functionality not allowed in FIPS mode (openssl.c:XXX)/
+m/ERROR:  could not devise a plan.*/
+s/ERROR:  could not devise a plan.*/ERROR:  could not devise a plan (cdbpath.c:XXX)/
 
 # Mask out OpenSSL behavior change in different version
 m/ERROR:  Cannot use "md5": No such hash algorithm/

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -478,3 +478,80 @@ SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
 SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 DROP TABLE t_reorganize_false;
+
+--
+-- Test case for GUC gp_force_random_redistribution.
+-- Manually toggle the GUC should control the behavior of redistribution for randomly-distributed tables.
+-- But REORGANIZE=true should redistribute no matter what.
+--
+
+-- this only affects postgres planner;
+set optimizer = false;
+
+-- check the distribution difference between 't1' and 't2' after executing 'query_string'
+-- return true if data distribution changed, otherwise false.
+-- Note: in extremely rare cases, even after 't2' being randomly-distributed from 't1', they could still have the 
+-- exact same distribution. So let the tables have a reasonably large number of rows to reduce that possibility.
+CREATE OR REPLACE FUNCTION check_redistributed(query_string text, t1 text, t2 text) 
+RETURNS BOOLEAN AS 
+$$
+DECLARE
+    before_query TEXT;
+    after_query TEXT;
+    comparison_query TEXT;
+    comparison_count INT;
+BEGIN
+    -- Prepare the query strings
+    before_query := format('SELECT gp_segment_id as segid, count(*) AS tupcount FROM %I GROUP BY gp_segment_id', t1);
+    after_query := format('SELECT gp_segment_id as segid, count(*) AS tupcount FROM %I GROUP BY gp_segment_id', t2);
+    comparison_query := format('SELECT COUNT(*) FROM ((TABLE %I EXCEPT TABLE %I) UNION ALL (TABLE %I EXCEPT TABLE %I))q', 'distribution1', 'distribution2', 'distribution2', 'distribution1');
+
+    -- Create temp tables to store the result
+    EXECUTE format('CREATE TEMP TABLE distribution1 AS %s DISTRIBUTED REPLICATED', before_query);
+
+    -- Execute provided query string
+    EXECUTE query_string;
+
+    EXECUTE format('CREATE TEMP TABLE distribution2 AS %s DISTRIBUTED REPLICATED', after_query);
+
+    -- Compare the tables using EXCEPT clause
+    EXECUTE comparison_query INTO comparison_count;
+
+    -- Drop temp tables
+    EXECUTE 'DROP TABLE distribution1';
+    EXECUTE 'DROP TABLE distribution2';
+
+    -- If count is greater than zero, then there's a difference
+    RETURN comparison_count > 0;
+END;
+$$ 
+LANGUAGE plpgsql;
+
+-- CO table builds temp table first instead of doing CTAS during REORGANIZE=true
+create table t_reorganize(a int, b int) using ao_column distributed by (a);
+insert into t_reorganize select 0,i from generate_series(1,1000)i;
+select gp_segment_id, count(*) from t_reorganize group by gp_segment_id;
+
+-- firstly, no redistribute
+set gp_force_random_redistribution = off;
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+-- reorganize from randomly to randomly should still redistribute
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+-- but insert into table won't redistribute
+create table t_random (like t_reorganize) distributed randomly;
+select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
+-- but insert into a different distribution policy would still redistribute
+create table t_distbya (like t_reorganize) distributed by (a);
+select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+
+-- now force distribute should redistribute in all cases
+set gp_force_random_redistribution = on;
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
+create table t_random (like t_reorganize) distributed randomly;
+select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
+create table t_distbya (like t_reorganize) distributed by (a);
+select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+
+reset optimizer;
+reset gp_force_random_redistribution;


### PR DESCRIPTION
We made an optimization (1dc3e975b8a) in which we skip redistribution in an INSERT query if the target table is randomly-distributed. In normal cases that makes sense, but in case of ALTER TABLE SET (REORGANIZE=true), the expectation is that the table's data should be redistributed randomly again.

So now adding a GUC `gp_force_random_redistribution` to force the redistribution if wished (i.e. for REORGANIZE=true). The default is set to false to keep the aforementioned optimization unaffected.

Fix #15733.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
