### PR TITLE
Update comment in createMotionLayerState()

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -224,7 +224,7 @@ createMotionLayerState(int maxMotNodeID)
 
 		/*
 		 * we'll just set this to 0.  later, ml_ipc will call
-		 * setExpectedReceivers() to set this if we are a "Receiving" motion node.
+		 * UpdateMotionExpectedReceivers() to set this if we are a "Receiving" motion node.
 		 */
 		pEntry->num_senders = 0;
 	}


### PR DESCRIPTION
Function `setExpectedReceivers()` is replaced by `UpdateMotionExpectedReceivers()`
in this commit https://github.com/greenplum-db/gpdb/commit/b0353e0ad5
Update the comment.
    
Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>