### PR TITLE
[WIP] Add macro for debugging functions in cdb ic_udp (7X)

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -6696,6 +6696,7 @@ cleanupStartupCache()
  * These functions can be called from gdb to output internal information to a file.
  */
 
+#ifdef DEBUG
 /*
  * dumpICBufferList_Internal
  * 		Dump a buffer list.
@@ -6865,6 +6866,7 @@ dumpConnections(ChunkTransportStateEntry *pEntry, const char *fname)
 	}
 	fclose(ofile);
 }
+#endif
 
 void
 WaitInterconnectQuitUDPIFC(void)

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -532,8 +532,10 @@ typedef struct ChunkTransportState
 	struct ICProxyBackendContext *proxyContext;
 } ChunkTransportState;
 
+#ifdef DEBUG
 extern void dumpICBufferList(ICBufferList *list, const char *fname);
 extern void dumpUnackQueueRing(const char *fname);
 extern void dumpConnections(ChunkTransportStateEntry *pEntry, const char *fname);
+#endif
 
 #endif   /* CDBINTERCONNECT_H */


### PR DESCRIPTION
Add macro for debugging functions in cdb ic_udp
- dumpICBufferList()
- dumpICBufferList_Internal()
- dumpUnackQueueRing()
- dumpConnections()

These functions will be compiled only in DEBUG version.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>