### PR TITLE
pg_resgroup_move_query() improvements

### DIFF
--- a/gpcontrib/gp_internal_tools/gp_resource_group.c
+++ b/gpcontrib/gp_internal_tools/gp_resource_group.c
@@ -84,6 +84,11 @@ pg_resgroup_move_query(PG_FUNCTION_ARGS)
 		pid_t pid = PG_GETARG_INT32(0);
 		groupName = text_to_cstring(PG_GETARG_TEXT_PP(1));
 
+		if (pid == MyProcPid)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 (errmsg("cannot move myself"))));
+
 		groupId = GetResGroupIdForName(groupName);
 		if (groupId == InvalidOid)
 			ereport(ERROR,
@@ -112,7 +117,8 @@ pg_resgroup_move_query(PG_FUNCTION_ARGS)
 		groupName = text_to_cstring(PG_GETARG_TEXT_PP(1));
 		groupId = GetResGroupIdForName(groupName);
 		Assert(groupId != InvalidOid);
-		ResGroupSignalMoveQuery(sessionId, NULL, groupId);
+		if (!ResGroupMoveSignalTarget(sessionId, NULL, groupId, true))
+			elog(NOTICE, "cannot send signal to QE; ignoring...");
 	}
 
 	PG_RETURN_BOOL(true);

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -299,6 +299,7 @@
             <li><xref href="#gp_resource_group_cpu_limit"/></li>
             <li><xref href="#gp_resource_group_memory_limit"/></li>
             <li><xref href="#gp_resource_group_queuing_timeout"/></li>
+            <li><xref href="#gp_resource_group_move_timeout"/></li>
             <li>
               <xref href="#gp_resource_manager"/>
             </li>
@@ -4898,6 +4899,38 @@
               <entry colname="col1">0 - <codeph>INT_MAX</codeph> millisecs</entry>
               <entry colname="col2">0 millisecs</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_resource_group_move_timeout">
+    <title>gp_resource_group_move_timeout</title>
+    <body>
+      <note>The <codeph>gp_resource_group_move_timeout</codeph> server configuration parameter
+        is enforced only when resource group-based resource management is active.</note>
+      <p>Cancel movement of process to another resource group if target process
+        not replies longer than the specified number of milliseconds. This parameter
+        doesn't include <codeph>gp_resource_group_queuing_timeout</codeph> - queuing
+        on resource group performed before sending movement request.</p>
+      <table id="gp_resource_group_move_timeout_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">10 - <codeph>INT_MAX</codeph> millisecs</entry>
+              <entry colname="col2">30000 millisecs</entry>
+              <entry colname="col3">master<p>system</p><p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1233,6 +1233,9 @@
               <xref href="guc-list.xml#gp_resource_group_queuing_timeout" type="section"
                 >gp_resource_group_queuing_timeout</xref>
             </p><p>
+              <xref href="guc-list.xml#gp_resource_group_move_timeout" type="section"
+                >gp_resource_group_move_timeout</xref>
+            </p><p>
               <xref href="guc-list.xml#gp_resource_manager" type="section"
                 >gp_resource_manager</xref>
             </p></stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -157,6 +157,7 @@
             <topicref href="guc-list.xml#gp_resource_group_cpu_limit"/>
             <topicref href="guc-list.xml#gp_resource_group_memory_limit"/>
             <topicref href="guc-list.xml#gp_resource_group_queuing_timeout"/>
+            <topicref href="guc-list.xml#gp_resource_group_move_timeout"/>
             <topicref href="guc-list.xml#gp_resource_manager"/>
             <topicref href="guc-list.xml#gp_retrieve_conn"/>
             <topicref href="guc-list.xml#gp_role"/>

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -653,14 +653,18 @@ You can obtain the pid of a running query from the `pg_stat_activity` system vie
 
 When you invoke `pg_resgroup_move_query()`, the query is subject to the limits configured for the destination resource group:
 
--   If the group has already reached its concurrent task limit, Greenplum Database queues the query until a slot opens.
+-   If the group has already reached its concurrent task limit, Greenplum Database queues the query until a slot opens or for `gp_resource_group_queuing_timeout` milliseconds if set. 
+-   If the group has a free slot, `pg_resgroup_move_query()` tries to give slot control away to the target process for up to `gp_resource_group_move_timeout` milliseconds. If target process can't handle movement request until `gp_resource_group_queuing_timeout` exceeds, Greenplum Database returns the error: `target process failed to move to a new group`.
+-   If `pg_resgroup_move_query()` was cancelled, but target process already got all slot control, then segment's processes will not be moved to new group. Such inconsistent state will be fixed by the end of transaction or by the any next command dispatched by target process inside same transaction.
 -   If the destination resource group does not have enough memory available to service the query's current memory requirements, Greenplum Database returns the error: `group <group_name> doesn't have enough memory ...`. In this situation, you may choose to increase the group shared memory allotted to the destination resource group, or perhaps wait a period of time for running queries to complete and then invoke the function again.
 
 After Greenplum moves the query, there is no way to guarantee that a query currently running in the destination resource group does not exceed the group memory quota. In this situation, one or more running queries in the destination group may fail, including the moved query. Reserve enough resource group global shared memory to minimize the potential for this scenario to occur.
 
 `pg_resgroup_move_query()` moves only the specified query to the destination resource group. Greenplum Database assigns subsequent queries that you submit in the session to the original resource group.
 
-> **Note** Greenplum Database version 6.8 introduced support for moving a query to a different resource group.
+Successful return of `pg_resgroup_move_query()` doesn't mean target process was successfully moved. Process movement is asynchronous. The current resource group can be checked via `pg_stat_activity` system view.
+
+**Note:** Greenplum Database version 6.8 introduced support for moving a query to a different resource group.
 
 -   If you upgraded from a previous Greenplum 6.x installation, you must manually register the supporting functions for this feature, and grant access to the functions as follows:
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2899,7 +2899,7 @@ CommitTransaction(void)
 
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
-		UnassignResGroup(false);
+		UnassignResGroup();
 }
 
 /*
@@ -3211,7 +3211,7 @@ PrepareTransaction(void)
 
 	/* Release resource group slot at the end of prepare transaction on segment */
 	if (ShouldUnassignResGroup())
-		UnassignResGroup(false);
+		UnassignResGroup();
 }
 
 
@@ -3430,7 +3430,7 @@ AbortTransaction(void)
 
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
-		UnassignResGroup(false);
+		UnassignResGroup();
 }
 
 /*
@@ -3481,7 +3481,7 @@ CleanupTransaction(void)
 
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())
-		UnassignResGroup(false);
+		UnassignResGroup();
 }
 
 /*

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4928,44 +4928,210 @@ GetSessionIdByPid(int pid)
 /*
  * Set the destination group slot or group id in PGPROC, and send a signal to the proc.
  * slot is NULL on QE.
+ * The process we want to notify on coordinator can act as executor(GP_ROLE_EXECUTE) in case of
+ * entrydb. 'isExecutor' helps us to determine a process to which we need to
+ * send signal.
  */
-void
-ResGroupSignalMoveQuery(int sessionId, void *slot, Oid groupId)
+bool
+ResGroupMoveSignalTarget(int sessionId, void *slot, Oid groupId,
+						 bool isExecutor)
 {
-	pid_t pid;
-	BackendId backendId;
+	pid_t		pid;
+	BackendId	backendId;
 	ProcArrayStruct *arrayP = procArray;
+	bool		sent = false;
+	bool		found = false;
+
+	Assert(groupId != InvalidOid);
+	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE);
+	AssertImply(Gp_role == GP_ROLE_EXECUTE, isExecutor);
 
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 	for (int i = 0; i < arrayP->numProcs; i++)
 	{
-		volatile PGPROC *proc = &allProcs[arrayP->pgprocnos[i]];
+		PGPROC	   *proc = &allProcs[arrayP->pgprocnos[i]];
+
 		if (proc->mppSessionId != sessionId)
+			continue;
+
+		/*
+		 * Before, we didn't distinguish entrydb processes from main target
+		 * process on coordinator. There was a case with enrtydb executors
+		 * when we can send a signal to target process only, but not to
+		 * entrydb executor process or vice versa. As a mediocre solution we
+		 * assume mppIsWriter for entrydb processes is always false.
+		 *
+		 * We can send a signal to target or entrydb processes only from QD.
+		 * The second (XOR) part of condition checks did we find entrydb
+		 * (isExecutor && !mppIsWriter) or target (!isExecutor &&
+		 * mppIsWriter). If neither, we continue the search.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH && !(isExecutor ^ proc->mppIsWriter))
+			continue;
+
+		found = true;
+		pid = proc->pid;
+		backendId = proc->backendId;
+
+		SpinLockAcquire(&proc->movetoMutex);
+		/* only target process needs slot and callerPid to operate */
+		if (Gp_role == GP_ROLE_DISPATCH && proc->mppIsWriter)
+		{
+			/*
+			 * movetoCallerPid is a guard which marks there is currently
+			 * active initiator process
+			 */
+			if (proc->movetoCallerPid != InvalidPid)
+			{
+				SpinLockRelease(&proc->movetoMutex);
+				elog(NOTICE, "cannot move process, which is already moving");
+				break;
+			}
+			Assert(proc->movetoResSlot == NULL);
+			Assert(slot != NULL);
+
+			proc->movetoResSlot = slot;
+			proc->movetoCallerPid = MyProc->pid;
+		}
+		proc->movetoGroupId = groupId;
+		SpinLockRelease(&proc->movetoMutex);
+
+		if (SendProcSignal(pid, PROCSIG_RESOURCE_GROUP_MOVE_QUERY, backendId))
+		{
+			SpinLockAcquire(&proc->movetoMutex);
+			if (Gp_role == GP_ROLE_DISPATCH && proc->mppIsWriter)
+			{
+				proc->movetoResSlot = NULL;
+				proc->movetoCallerPid = InvalidPid;
+			}
+			proc->movetoGroupId = InvalidOid;
+			SpinLockRelease(&proc->movetoMutex);
+
+			/*
+			 * It's not an error, if we can't notify, for example, already
+			 * finished QE process (because of async nature of resgroup
+			 * moving). If we can't notify QD, the caller should raise an
+			 * error by itself, based on returned value.
+			 */
+			elog(NOTICE, "cannot send signal to backend %d with PID %d",
+				 backendId, pid);
+		}
+		else
+			sent = true;
+
+		/*
+		 * Don't break for executors, need to signal all the procs of this
+		 * session. It's safe to break if we are QD, because we want to notify
+		 * only one process at once - main target or entrydb.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH)
+			break;
+	}
+	LWLockRelease(ProcArrayLock);
+
+	if (!found && !isExecutor)
+		elog(NOTICE, "cannot find target process");
+
+	return sent;
+}
+
+/*
+ * Check if slot control is on the target side and clean all target's
+ * moveto* params.
+ *
+ * Cleaning and checking should be performed as one atomic operation inside one
+ * mutex.
+ * 'clean' flag is bidirectional. If 'clean' is set to true, then all moveto*
+ * params will be cleaned, no matter was target handled them or not.
+ * More, it will be forcefully set to true, if target process handled our
+ * command. Thus, if function returned true in 'clean', it should be treated
+ * as terminal state and all new calls to ResGroupMoveCheckTargetReady()
+ * before calling ResGroupMoveSignalTarget() make no sense.
+ */
+void
+ResGroupMoveCheckTargetReady(int sessionId, bool *clean, bool *result)
+{
+	pid_t		pid;
+	BackendId	backendId;
+	ProcArrayStruct *arrayP = procArray;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	*result = false;
+
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+	for (int i = 0; i < arrayP->numProcs; i++)
+	{
+		PGPROC	   *proc = &allProcs[arrayP->pgprocnos[i]];
+
+		/*
+		 * Also ignore entrydb processes. We use mppIsWriter which described
+		 * in ResGroupMoveSignalTarget().
+		 */
+		if (proc->mppSessionId != sessionId || !proc->mppIsWriter)
 			continue;
 
 		pid = proc->pid;
 		backendId = proc->backendId;
 
-		if (Gp_role == GP_ROLE_DISPATCH)
+		SpinLockAcquire(&proc->movetoMutex);
+		if (proc->movetoCallerPid == MyProc->pid)
 		{
-			SpinLockAcquire(&proc->movetoMutex);
-			Assert(proc->movetoResSlot == NULL);
-			Assert(slot != NULL);
-			proc->movetoResSlot = slot;
-			SpinLockRelease(&proc->movetoMutex);
-			SendProcSignal(pid, PROCSIG_RESOURCE_GROUP_MOVE_QUERY, backendId);
-			break;
+			/*
+			 * InvalidOid of movetoGroupId means target process tried to
+			 * handle our command
+			 */
+			if (proc->movetoGroupId == InvalidOid)
+			{
+				/*
+				 * empty movetoResSlot means target process got all the
+				 * control over slot
+				 */
+				*result = (proc->movetoResSlot == NULL);
+				*clean = true;
+			}
+
+			/*
+			 * Clean all params, especially movetoCallerPid, which guards
+			 * target processes from another initiators. After releasing
+			 * spinlock any other process allowed to start new move command.
+			 */
+			if (*clean)
+			{
+				proc->movetoResSlot = NULL;
+				proc->movetoGroupId = InvalidOid;
+				proc->movetoCallerPid = InvalidPid;
+			}
 		}
-		else if (Gp_role == GP_ROLE_EXECUTE)
-		{
-			SpinLockAcquire(&proc->movetoMutex);
-			Assert(groupId != InvalidOid);
-			Assert(proc->movetoGroupId == InvalidOid);
-			proc->movetoGroupId = groupId;
-			SpinLockRelease(&proc->movetoMutex);
-			SendProcSignal(pid, PROCSIG_RESOURCE_GROUP_MOVE_QUERY, backendId);
-			/* don't break, need to signal all the procs of this session */
-		}
+		SpinLockRelease(&proc->movetoMutex);
+		break;
+	}
+	LWLockRelease(ProcArrayLock);
+}
+
+/*
+ * Notify initiator process that target process is ready to move to a new
+ * group. This is an optional feature to speed up initiator's awakening.
+ * Inititator will get the actual command result by changed movetoResSlot
+ * and movetoGroupId values.
+ */
+void
+ResGroupMoveNotifyInitiator(pid_t callerPid)
+{
+	ProcArrayStruct *arrayP = procArray;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+	for (int i = 0; i < arrayP->numProcs; i++)
+	{
+		PGPROC	   *proc = &allProcs[arrayP->pgprocnos[i]];
+
+		if (proc->pid != callerPid)
+			continue;
+
+		SetLatch(&proc->procLatch);
+		break;
 	}
 	LWLockRelease(ProcArrayLock);
 }

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -446,6 +446,7 @@ InitProcess(void)
 	SpinLockInit(&MyProc->movetoMutex);
 	MyProc->movetoResSlot = NULL;
 	MyProc->movetoGroupId = InvalidOid;
+	MyProc->movetoCallerPid = InvalidPid;
 
     /* 
      * mppLocalProcessSerial uniquely identifies this backend process among

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4261,6 +4261,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		NULL, NULL, NULL
 	},
 	{
+		{"gp_resource_group_move_timeout", PGC_USERSET, RESOURCES_MGM,
+			gettext_noop("Wait up to the specified time (in ms) while moving process to another resource group (after queuing on it) before give up."),
+			NULL,
+			GUC_UNIT_MS
+		},
+		&gp_resource_group_move_timeout,
+		30000, 10, INT_MAX,
+		NULL, NULL, NULL
+	},
+	{
 		{"gp_perfmon_segment_interval", PGC_POSTMASTER, STATS,
 			gettext_noop("Interval (in ms) between sending segment statistics to perfmon."),
 			NULL,

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -69,6 +69,7 @@
 #include "utils/session_state.h"
 #include "utils/tqual.h"
 #include "utils/vmem_tracker.h"
+#include "access/xact.h"
 
 #define InvalidSlotId	(-1)
 #define RESGROUP_MAX_SLOTS	(MaxConnections)
@@ -91,6 +92,7 @@ bool						gp_resgroup_print_operator_memory_limits = false;
 bool						gp_resgroup_debug_wait_queue = true;
 int							memory_spill_ratio = 20;
 int							gp_resource_group_queuing_timeout = 0;
+int							gp_resource_group_move_timeout = 30000;
 
 /*
  * Data structures
@@ -2691,7 +2693,7 @@ AssignResGroupOnMaster(void)
 	}
 	PG_CATCH();
 	{
-		UnassignResGroup(false);
+		UnassignResGroup();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -2701,10 +2703,10 @@ AssignResGroupOnMaster(void)
  * Detach from a resource group at the end of the transaction.
  */
 void
-UnassignResGroup(bool releaseSlot)
+UnassignResGroup(void)
 {
-	ResGroupData		*group = self->group;
-	ResGroupSlotData	*slot = self->slot;
+	ResGroupData		*group;
+	ResGroupSlotData	*slot;
 
 	if (bypassedGroup)
 	{
@@ -2737,19 +2739,15 @@ UnassignResGroup(bool releaseSlot)
 
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 
+	group = self->group;
+	slot = self->slot;
+
 	/* Sub proc memory accounting info from group and slot */
 	selfDetachResGroup(group, slot);
 
 	/* Release the slot if no reference. */
-	if (slot->nProcs == 0 || releaseSlot)
+	if (slot->nProcs == 0)
 	{
-		if (releaseSlot)
-		{
-			/* release the memory left in the slot if there's entryDB */
-			groupDecSlotMemUsage(group, slot);
-			slot->nProcs = 0;
-		}
-
 		groupReleaseSlot(group, slot, false);
 
 		/*
@@ -2816,9 +2814,20 @@ SwitchResGroupOnSegment(const char *buf, int len)
 
 	if (newGroupId == InvalidOid)
 	{
-		UnassignResGroup(false);
+		UnassignResGroup();
 		return;
 	}
+
+	/*
+	 * The working case: pg_resgroup_move_query command was interrupted, but
+	 * at the time target (dispatcher) process already got control over slot.
+	 * If we'll wait until the end of current target process command and then
+	 * will dispatch something on segments in the same transaction, then
+	 * newGroupId will not be equal to current segment's one. We want to move
+	 * out of inconsistent state.
+	 */
+	if (newGroupId != self->groupId)
+		UnassignResGroup();
 
 	if (self->groupId != InvalidOid)
 	{
@@ -2957,7 +2966,7 @@ waitOnGroup(ResGroupData *group, bool isMoveQuery)
 			pfree(new_status);
 		}
 
-		groupWaitCancel(false);
+		groupWaitCancel(isMoveQuery);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -3395,7 +3404,12 @@ slotValidate(const ResGroupSlotData *slot)
 	else
 	{
 		Assert(!slotIsInFreelist(slot));
-		AssertImply(Gp_role == GP_ROLE_EXECUTE, slot == sessionGetSlot());
+		/*
+		 * Entrydb process can have different self and session slots at the
+		 * time of moving to another group.
+		 */
+		AssertImply(Gp_role == GP_ROLE_EXECUTE && !IS_QUERY_DISPATCHER(),
+					slot == sessionGetSlot());
 	}
 }
 
@@ -3985,7 +3999,17 @@ static void
 sessionSetSlot(ResGroupSlotData *slot)
 {
 	Assert(slot != NULL);
-	Assert(MySessionState->resGroupSlot == NULL);
+	/*
+	 * Previously, we had an assertion, that MySessionState->resGroupSlot
+	 * should be NULL here. There is a case, when we want to move processes
+	 * from one group to another. We got assertion error on main process,
+	 * if entrydb process not called UnassignResGroup() yet (and vice versa).
+	 * Next call to UnassignResGroup() (by main or entrydb process) will free
+	 * slot and it's OK, but here we want to set new slot to session, so we
+	 * changed assertion.
+	 */
+	AssertImply((Gp_role == GP_ROLE_EXECUTE && !IS_QUERY_DISPATCHER()),
+		MySessionState->resGroupSlot == NULL);
 
 	/*
 	 * SessionStateLock is required since runaway detector will traverse
@@ -4592,8 +4616,6 @@ IsGroupInRedZone(void)
 	return true;
 }
 
-
-
 /*
  * Dump memory information for current resource group.
  * This is the output of resource group runaway.
@@ -4680,47 +4702,149 @@ HandleMoveResourceGroup(void)
 	ResGroupSlotData *slot;
 	ResGroupData *group;
 	ResGroupData *oldGroup;
+	Oid			groupId;
+	pid_t		callerPid;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE);
 
 	/* transaction has finished */
-	if (!selfIsAssigned())
+	if (!IsTransactionState() || !selfIsAssigned())
+	{
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			SpinLockAcquire(&MyProc->movetoMutex);
+
+			/*
+			 * setting movetoGroupId to InvalidOid alone without setting
+			 * movetoResSlot to NULL means target process tried to handle, but
+			 * can't do anything with a command
+			 */
+			MyProc->movetoGroupId = InvalidOid;
+			callerPid = MyProc->movetoCallerPid;
+			SpinLockRelease(&MyProc->movetoMutex);
+
+			/* notify initiator, current command is irrelevant */
+			if (callerPid != InvalidPid)
+				ResGroupMoveNotifyInitiator(callerPid);
+		}
 		return;
+	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		SIMPLE_FAULT_INJECTOR("resource_group_move_handler_before_qd_control");
+
 		SpinLockAcquire(&MyProc->movetoMutex);
-		slot = (ResGroupSlotData *)MyProc->movetoResSlot;
-		group = slot->group;
+		slot = (ResGroupSlotData *) MyProc->movetoResSlot;
+		groupId = MyProc->movetoGroupId;
+		callerPid = MyProc->movetoCallerPid;
+
+		/* set to NULL to mark we got slot control */
 		MyProc->movetoResSlot = NULL;
+		/* set to InvalidOid to mark we handling the command */
+		MyProc->movetoGroupId = InvalidOid;
+
+		/*
+		 * Don't clean movetoCallerPid. It guards us from another initiators,
+		 * which may overwrite moveto* params.
+		 */
 		SpinLockRelease(&MyProc->movetoMutex);
 
+		if (!slot)
+		{
+			/* moving command is irrelevant */
+			return;
+		}
+
+		/*
+		 * starting from this point, all control over slot should be done
+		 * here, from target process
+		 */
+
+		Assert(groupId != InvalidOid);
+		SIMPLE_FAULT_INJECTOR("resource_group_move_handler_after_qd_control");
+
+		ResGroupMoveNotifyInitiator(callerPid);
+
 		/* unassign the old resource group and release the old slot */
-		UnassignResGroup(true);
+		UnassignResGroup();
 
-		PG_TRY();
-		{
-			sessionSetSlot(slot);
+		sessionSetSlot(slot);
 
-			/* Add proc memory accounting info into group and slot */
-			selfAttachResGroup(group, slot);
+		/* Add proc memory accounting info into group and slot */
+		group = slot->group;
+		selfAttachResGroup(group, slot);
 
-			/* Init self */
-			self->caps = slot->caps;
+		/* Init self */
+		self->caps = slot->caps;
 
-			/* Add into cgroup */
-			ResGroupOps_AssignGroup(self->groupId, &(self->caps), MyProcPid);
-		}
-		PG_CATCH();
-		{
-			UnassignResGroup(false);
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
+		/*
+		 * You may say it's ugly to notify entrydb process here, but not in
+		 * initiator process, but we want to be sure slot was actually
+		 * assigned to session using sessionSetSlot(). We can't do much inside
+		 * one spinlock. Especially, we can't work with multiple LWLocks
+		 * inside of it. So, to keep the solution simple and plain, we decided
+		 * to signal entrydb process here, inside of target process handler.
+		 */
+		(void) ResGroupMoveSignalTarget(MyProc->mppSessionId,
+										NULL, groupId, true);
+
+		/*
+		 * Add into cgroup. On any exception slot will be freed by the end of
+		 * transaction.
+		 */
+		ResGroupOps_AssignGroup(self->groupId, &(self->caps), MyProcPid);
+
 		pgstat_report_resgroup(0, self->groupId);
 	}
-	else if (Gp_role == GP_ROLE_EXECUTE)
+
+	/*
+	 * Move entrydb process. This is very similar to moving of target process,
+	 * but without setting session level slot, which was already set by
+	 * target.
+	 */
+	else if (Gp_role == GP_ROLE_EXECUTE && IS_QUERY_DISPATCHER())
 	{
 		SpinLockAcquire(&MyProc->movetoMutex);
-		Oid groupId = MyProc->movetoGroupId;
+		groupId = MyProc->movetoGroupId;
+		MyProc->movetoGroupId = InvalidOid;
+		SpinLockRelease(&MyProc->movetoMutex);
+
+		/*
+		 * The right session-level slot was set by the dispatcher's part of
+		 * handler (above).
+		 */
+		slot = sessionGetSlot();
+		Assert(slot != NULL);
+		Assert(slot->groupId == groupId);
+
+		group = slot->group;
+
+		/*
+		 * But before we'll attach new slot to current entrydb process, we
+		 * need to unassign all from 'self'.
+		 */
+		UnassignResGroup();
+		/* And now, attach it and increment all counters we need. */
+		selfAttachResGroup(group, slot);
+
+		self->caps = group->caps;
+
+		/* finally we can say we are in a valid resgroup */
+		Assert(selfIsAssigned());
+
+		/* Add into cgroup */
+		ResGroupOps_AssignGroup(self->groupId, &(self->caps), MyProcPid);
+	}
+
+	/*
+	 * Move segment's executor. Use simple manual counters manipulation. We
+	 * can't call same complex designed for coordinator functions like above.
+	 */
+	else if (Gp_role == GP_ROLE_EXECUTE && !IS_QUERY_DISPATCHER())
+	{
+		SpinLockAcquire(&MyProc->movetoMutex);
+		groupId = MyProc->movetoGroupId;
 		MyProc->movetoGroupId = InvalidOid;
 		SpinLockRelease(&MyProc->movetoMutex);
 
@@ -4737,8 +4861,8 @@ HandleMoveResourceGroup(void)
 		Assert(oldGroup != NULL);
 
 		/*
-		 * move the slot memory to the new group, only do it once
-		 * if there're more than once slice.
+		 * move the slot memory to the new group, only do it once if there're
+		 * more than once slice.
 		 */
 		if (slot->groupId != groupId)
 		{
@@ -4760,15 +4884,11 @@ HandleMoveResourceGroup(void)
 			group->nRunning++;
 			Assert(group->memQuotaUsed <= group->memQuotaGranted);
 		}
-
-		/* add the memory of entryDB to slot and group */
-		if (IS_QUERY_DISPATCHER())
-			selfAttachResGroup(group, slot);
-
 		LWLockRelease(ResGroupLock);
 
 		selfSetGroup(group);
 		selfSetSlot(slot);
+
 		self->caps = group->caps;
 
 		/* finally we can say we are in a valid resgroup */
@@ -4834,13 +4954,96 @@ moveQueryCheck(int sessionId, Oid groupId)
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 }
 
+/*
+ * Try to give away all slot control to target process.
+ */
+static void
+resGroupGiveSlotAway(int sessionId, ResGroupSlotData ** slot, Oid groupId)
+{
+	long		timeout;
+	int64		curTime;
+	int64		waitStart;
+	int			latchRes;
+	bool		clean = false;
+	bool		res = false;
+
+	SIMPLE_FAULT_INJECTOR("resource_group_give_away_begin");
+
+	if (!ResGroupMoveSignalTarget(sessionId, *slot, groupId, false))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 (errmsg("cannot send signal to process"))));
+
+	waitStart = GetCurrentIntegerTimestamp();
+
+	for (;;)
+	{
+		curTime = GetCurrentIntegerTimestamp();
+		timeout = gp_resource_group_move_timeout - (curTime - waitStart) / 1000;
+		if (timeout > 0)
+		{
+			PG_TRY();
+			{
+				SIMPLE_FAULT_INJECTOR("resource_group_give_away_wait_latch");
+
+				/*
+				 * do check here to clean all target's moveto* params in case
+				 * of interruption or any exception
+				 */
+				CHECK_FOR_INTERRUPTS();
+
+				latchRes = WaitLatch(&MyProc->procLatch,
+				   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, timeout);
+
+				if (latchRes & WL_POSTMASTER_DEATH)
+					elog(ERROR,
+					 "got WL_POSTMASTER_DEATH waiting on latch; exiting...");
+			}
+			PG_CATCH();
+			{
+				clean = true;
+				ResGroupMoveCheckTargetReady(sessionId, &clean, &res);
+				if (res)
+				{
+					/*
+					 * clean slot variable, because we don't need to touch it
+					 * in current process as control is on the target side
+					 */
+					*slot = NULL;
+					ereport(WARNING,
+							(errmsg("got exception, but slot control is on the target process side"),
+							 errhint("QEs weren't moved. They'll be moved by the next command dispatched in the target transaction, if any.")));
+				}
+				PG_RE_THROW();
+			}
+			PG_END_TRY();
+		}
+		else
+			latchRes = WL_TIMEOUT;
+
+		SIMPLE_FAULT_INJECTOR("resource_group_give_away_after_latch");
+
+		clean = (latchRes & WL_TIMEOUT);
+		ResGroupMoveCheckTargetReady(sessionId, &clean, &res);
+		if (clean)
+			break;
+
+		ResetLatch(&MyProc->procLatch);
+	}
+
+	if (!res)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 (errmsg("target process failed to move to a new group"))));
+}
+
 void
 ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 {
 	ResGroupInfo groupInfo;
 	ResGroupData *group;
 	ResGroupSlotData *slot;
-	char *cmd;
+	char	   *cmd;
 
 	Assert(pResGroupControl != NULL);
 	Assert(pResGroupControl->segmentsOnMaster > 0);
@@ -4848,14 +5051,13 @@ ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 
 	LWLockAcquire(ResGroupLock, LW_SHARED);
 	group = groupHashFind(groupId, false);
+	LWLockRelease(ResGroupLock);
 	if (!group)
 	{
-		LWLockRelease(ResGroupLock);
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 (errmsg("invalid resource group id: %d", groupId))));
 	}
-	LWLockRelease(ResGroupLock);
 
 	groupInfo.group = group;
 	groupInfo.groupId = groupId;
@@ -4869,22 +5071,36 @@ ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 	{
 		moveQueryCheck(sessionId, groupId);
 
-		ResGroupSignalMoveQuery(sessionId, slot, groupId);
-
-		cmd = psprintf("SELECT gp_toolkit.pg_resgroup_move_query(%d, %s)",
-				sessionId,
-				quote_literal_cstr(groupName));
-		CdbDispatchCommand(cmd, 0, NULL);
+		resGroupGiveSlotAway(sessionId, &slot, groupId);
 	}
 	PG_CATCH();
 	{
-		LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
-		groupReleaseSlot(group, slot, true);
-		LWLockRelease(ResGroupLock);
+		/*
+		 * There can be exceptional situations, when slot is already on the
+		 * target side. Release slot only if available.
+		 */
+		if (slot)
+		{
+			LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+			groupReleaseSlot(group, slot, true);
+			LWLockRelease(ResGroupLock);
+		}
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	/*
+	 * starting from this point, all slot control should be done from target
+	 * process, so we don't need to release it here if something will go wrong
+	 */
+
+	cmd = psprintf("SELECT gp_toolkit.pg_resgroup_move_query(%d, %s)",
+				   sessionId,
+				   quote_literal_cstr(groupName));
+
+	CdbDispatchCommand(cmd, 0, NULL);
 }
+
 /*
  * get resource group id by session id
  */

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -106,6 +106,9 @@ extern void ProcArrayGetReplicationSlotXmin(TransactionId *xmin,
 								TransactionId *catalog_xmin);
 extern DistributedTransactionId LocalXidGetDistributedXid(TransactionId xid);
 extern int GetSessionIdByPid(int pid);
-extern void ResGroupSignalMoveQuery(int sessionId, void *slot, Oid groupId);
+extern bool ResGroupMoveSignalTarget(int sessionId, void *slot, Oid groupId,
+								bool isExecutor);
+extern void ResGroupMoveCheckTargetReady(int sessionId, bool *clean, bool *result);
+extern void ResGroupMoveNotifyInitiator(pid_t callerPid);
 
 #endif   /* PROCARRAY_H */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -106,6 +106,7 @@ extern double gp_resource_group_memory_limit;
 extern bool gp_resource_group_bypass;
 extern int gp_resource_group_queuing_timeout;
 extern bool gp_resource_group_bypass_catalog_query;
+extern int gp_resource_group_move_timeout;
 
 /*
  * Non-GUC global variables.
@@ -168,7 +169,7 @@ extern void DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 extern bool ShouldAssignResGroupOnMaster(void);
 extern bool ShouldUnassignResGroup(void);
 extern void AssignResGroupOnMaster(void);
-extern void UnassignResGroup(bool releaseSlot);
+extern void UnassignResGroup(void);
 extern void SwitchResGroupOnSegment(const char *buf, int len);
 
 extern bool ResGroupIsAssigned(void);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -239,6 +239,7 @@
 		"gp_resource_group_bypass_catalog_query",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_group_enable_recalculate_query_mem",
+		"gp_resource_group_move_timeout",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",
 		"gp_resqueue_priority",

--- a/src/test/isolation2/input/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/input/resgroup/resgroup_move_query.source
@@ -47,16 +47,24 @@ sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" %
 result = conn.query(sql).getresult()
 groupid = result[0][0] 
 
-process = subprocess.Popen("ps -ef | grep postgres | grep con%d | grep -v grep | awk '{print $2}'" % session_id, shell=True, stdout=subprocess.PIPE)
-session_pids = process.communicate()[0].split('\n')[:-1] 
+sql = "select hostname from gp_segment_configuration group by hostname"
+result = conn.query(sql).getresult()
+hosts = result[0]
 
-cgroups_pids = []
-path = "@cgroup_mnt_point@/cpu/gpdb/%d/cgroup.procs" % groupid
-fd = open(path)
-for line in fd.readlines():
-    cgroups_pids.append(line.strip('\n'))
+def get_result(host):
+    stdout = subprocess.check_output(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)])
+    session_pids = stdout.split('\n')
 
-return set(session_pids).issubset(set(cgroups_pids))
+    path = "@cgroup_mnt_point@/cpu/gpdb/{}/cgroup.procs".format(groupid)
+    stdout= subprocess.check_output(["ssh", "{}".format(host), "cat {}".format(path)])
+    cgroups_pids = stdout.split('\n')
+
+    return set(session_pids).issubset(set(cgroups_pids))
+
+for host in hosts:
+    if not get_result(host):
+        return False
+return True
 $$ LANGUAGE plpythonu;
 
 DROP ROLE IF EXISTS role_move_query;
@@ -65,6 +73,8 @@ DROP RESOURCE GROUP rg_move_query;
 -- end_ignore
 CREATE RESOURCE GROUP rg_move_query WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
 CREATE ROLE role_move_query RESOURCE GROUP rg_move_query;
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 -- test1: cannot move IDLE sessions
 1: SET ROLE role_move_query;
@@ -91,6 +101,7 @@ CREATE ROLE role_move_query_mem_small RESOURCE GROUP rg_move_query_mem_small;
 1: SELECT hold_memory_by_percent(1,1.0);
 SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent%' AND state = 'idle in transaction';
 SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent%' AND state = 'idle in transaction';
+SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query_mem_small';
 1: END;
 1q:
 
@@ -100,6 +111,7 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 1: SELECT hold_memory_by_percent_on_qe(1,1.0);
 SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
 SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query_mem_small';
 1: END;
 1q:
 
@@ -141,8 +153,163 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 1: SELECT hold_memory_by_percent_on_qe(1,0.1);
 2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
 2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+1: END;
 1q:
 2q:
+
+-- test8: check destination group has no slot leaking if move signal processed at the time target process became idle
+-- start transaction at first process
+-- start to move it at second process, but suspend before sending signal to it
+-- end transaction at first process
+-- resume at second process, it should throw an error
+1: SET ROLE role_move_query_mem_small;
+1: BEGIN;
+1: SELECT 1 a FROM pg_class LIMIT 1;
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_class%' AND rsgname='rg_move_query_mem_small';
+1: END;
+1: SELECT gp_wait_until_triggered_fault('resource_group_give_away_begin', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_give_away_begin', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2<:
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+
+-- test9: check destination group has no slot leaking if move signal processed at the time target process became dead
+-- start transaction at first process
+-- start to move it at second process, but suspend before sending signal to it
+-- end transaction at first process and quit
+-- resume at second process, it should throw an error
+1: SET ROLE role_move_query_mem_small;
+1: BEGIN;
+1: SELECT 1 a FROM pg_class LIMIT 1;
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_class%' AND rsgname='rg_move_query_mem_small';
+1: END;
+1q:
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_begin', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_inject_fault('resource_group_give_away_begin', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2<:
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+
+-- test10: check destination group has no slot leaking if we got an error on latch waiting
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process after handling moveto* params
+-- interrupt in WaitLatch block at second process, this will force pg_resgroup_move_query to continue
+-- second process should throw an error, but consider moveto* params handled by target
+-- resume at first process
+-- first process should continue with moving as all slot control is on it's side
+-- segments will not be moved to new group until the next command begins
+1: SET ROLE role_move_query_mem_small;
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: BEGIN;
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(5) LIMIT 1;
+2: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_wait_latch', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE '%pg_resgroup_move_query%' AND pid != pg_backend_pid();
+3: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2<:
+2: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1<:
+--is_session_in_group works only if all backends moved to group, so it will show 'f', but gp_resgroup_status will show actual result
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+--if there any next command called in the same transaction, segments will try to fix the situation and move out of inconsistent state
+1: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(1) LIMIT 1;
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+1: END;
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+1q:
+
+-- test11: check destination group has no slot leaking if target process set latch at the last moment
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process just before setting latch
+-- wait for timeout on WaitLatch on second process and suspend
+-- resume at first process, it should set latch (which is late) and clean moveto* values
+-- resume at second process, as moveto* was cleaned, we know first process handled signal
+-- moving command at second process should finish successfully
+1: SET ROLE role_move_query_mem_small;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: BEGIN;
+1&: SELECT pg_sleep(3) FROM gp_dist_random('gp_id') LIMIT 1;
+2: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: SET gp_resource_group_move_timeout = 1000;
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_after_latch', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_wait_until_triggered_fault('resource_group_move_handler_after_qd_control', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1<:
+2<:
+2: RESET gp_resource_group_move_timeout;
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+1: END;
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+1q:
+
+-- test12: check destination group has no slot leaking if taget process recieved one move command at the time of processing another
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process just before setting latch and moving
+-- run another moving command at third process, it should throw an error as target process is alredy moving
+-- resume at first process, it should continue with moving
+-- moving command at second process should finish successfully
+1: SET ROLE role_move_query_mem_small;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: BEGIN;
+1&: SELECT pg_sleep(5) FROM gp_dist_random('gp_id') LIMIT 1;
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+3: SELECT gp_wait_until_triggered_fault('resource_group_move_handler_before_qd_control', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+3: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'default_group') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+3: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1<:
+2<:
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+1: END;
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='default_group';
+1q:
+
+-- Test13: check we'll wait and quit by gp_resource_group_move_timeout if target process stuck on signal handling
+1: SET ROLE role_move_query_mem_small;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+1: BEGIN;
+1&: SELECT pg_sleep(3);
+2: SET gp_resource_group_move_timeout = 3000;
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+2: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+2: RESET gp_resource_group_move_timeout;
+1<:
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+1: END;
+
+-- Test14: check entrydb queries working
+-- Previously, we sent a signal to only one process - dispatcher or entrydb.
+-- This led to various errors - triggered assertions or only entrydb process moving.
+-- But it never led to the only one correct result - ALL processes should be moved.
+-- Here we use is_session_in_group() to precisely check ALL processes were moved.
+1: SET ROLE role_move_query_mem_small;
+1: BEGIN;
+--spawn all backends at first short call to guarantee correct pg_resgroup_move_query() execution
+1: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(1) LIMIT 1;
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+1<:
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+1: END;
 
 DROP ROLE role_move_query;
 DROP RESOURCE GROUP rg_move_query;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -32,9 +32,11 @@ CREATE OR REPLACE FUNCTION is_session_in_group(pid integer, groupname text) RETU
 conn = pg.connect(dbname="isolation2resgrouptest") pt = re.compile(r'con(\d+)') 
 sql = "select sess_id from pg_stat_activity where pid = '%d'" % pid result = conn.query(sql).getresult() session_id = result[0][0] 
 sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" % groupname result = conn.query(sql).getresult() groupid = result[0][0] 
-process = subprocess.Popen("ps -ef | grep postgres | grep con%d | grep -v grep | awk '{print $2}'" % session_id, shell=True, stdout=subprocess.PIPE) session_pids = process.communicate()[0].split('\n')[:-1] 
-cgroups_pids = [] path = "@cgroup_mnt_point@/cpu/gpdb/%d/cgroup.procs" % groupid fd = open(path) for line in fd.readlines(): cgroups_pids.append(line.strip('\n')) 
-return set(session_pids).issubset(set(cgroups_pids)) $$ LANGUAGE plpythonu;
+sql = "select hostname from gp_segment_configuration group by hostname" result = conn.query(sql).getresult() hosts = result[0] 
+def get_result(host): stdout = subprocess.check_output(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)]) session_pids = stdout.split('\n') 
+path = "@cgroup_mnt_point@/cpu/gpdb/{}/cgroup.procs".format(groupid) stdout= subprocess.check_output(["ssh", "{}".format(host), "cat {}".format(path)]) cgroups_pids = stdout.split('\n') 
+return set(session_pids).issubset(set(cgroups_pids)) 
+for host in hosts: if not get_result(host): return False return True $$ LANGUAGE plpythonu;
 CREATE
 
 DROP ROLE IF EXISTS role_move_query;
@@ -46,6 +48,9 @@ ERROR:  resource group "rg_move_query" does not exist
 CREATE RESOURCE GROUP rg_move_query WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
 CREATE
 CREATE ROLE role_move_query RESOURCE GROUP rg_move_query;
+CREATE
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 CREATE
 
 -- test1: cannot move IDLE sessions
@@ -104,6 +109,11 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 ---------------------
  f                   
 (1 row)
+SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query_mem_small';
+ num_running 
+-------------
+ 0           
+(1 row)
 1: END;
 END
 1q: ... <quitting>
@@ -124,6 +134,11 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
  is_session_in_group 
 ---------------------
  f                   
+(1 row)
+SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query_mem_small';
+ num_running 
+-------------
+ 0           
 (1 row)
 1: END;
 END
@@ -220,8 +235,434 @@ BEGIN
 ---------------------
  t                   
 (1 row)
+1: END;
+END
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- test8: check destination group has no slot leaking if move signal processed at the time target process became idle
+-- start transaction at first process
+-- start to move it at second process, but suspend before sending signal to it
+-- end transaction at first process
+-- resume at second process, it should throw an error
+1: SET ROLE role_move_query_mem_small;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT 1 a FROM pg_class LIMIT 1;
+ a 
+---
+ 1 
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_class%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+1: END;
+END
+1: SELECT gp_wait_until_triggered_fault('resource_group_give_away_begin', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+1: SELECT gp_inject_fault('resource_group_give_away_begin', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  target process failed to move to a new group
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+
+-- test9: check destination group has no slot leaking if move signal processed at the time target process became dead
+-- start transaction at first process
+-- start to move it at second process, but suspend before sending signal to it
+-- end transaction at first process and quit
+-- resume at second process, it should throw an error
+1: SET ROLE role_move_query_mem_small;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT 1 a FROM pg_class LIMIT 1;
+ a 
+---
+ 1 
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_begin', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_class%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+1: END;
+END
+1q: ... <quitting>
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_begin', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT gp_inject_fault('resource_group_give_away_begin', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  cannot send signal to process
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+
+-- test10: check destination group has no slot leaking if we got an error on latch waiting
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process after handling moveto* params
+-- interrupt in WaitLatch block at second process, this will force pg_resgroup_move_query to continue
+-- second process should throw an error, but consider moveto* params handled by target
+-- resume at first process
+-- first process should continue with moving as all slot control is on it's side
+-- segments will not be moved to new group until the next command begins
+1: SET ROLE role_move_query_mem_small;
+SET
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: BEGIN;
+BEGIN
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(5) LIMIT 1;  <waiting ...>
+2: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_wait_latch', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE '%pg_resgroup_move_query%' AND pid != pg_backend_pid();
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+3: SELECT gp_inject_fault('resource_group_give_away_wait_latch', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+2: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+(1 row)
+--is_session_in_group works only if all backends moved to group, so it will show 'f', but gp_resgroup_status will show actual result
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ f                   
+(1 row)
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 1           
+(1 row)
+--if there any next command called in the same transaction, segments will try to fix the situation and move out of inconsistent state
+1: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(1) LIMIT 1;
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+(1 row)
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 1           
+(1 row)
+1: END;
+END
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+1q: ... <quitting>
+
+-- test11: check destination group has no slot leaking if target process set latch at the last moment
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process just before setting latch
+-- wait for timeout on WaitLatch on second process and suspend
+-- resume at first process, it should set latch (which is late) and clean moveto* values
+-- resume at second process, as moveto* was cleaned, we know first process handled signal
+-- moving command at second process should finish successfully
+1: SET ROLE role_move_query_mem_small;
+SET
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: BEGIN;
+BEGIN
+1&: SELECT pg_sleep(3) FROM gp_dist_random('gp_id') LIMIT 1;  <waiting ...>
+2: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SET gp_resource_group_move_timeout = 1000;
+SET
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('resource_group_give_away_after_latch', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT gp_wait_until_triggered_fault('resource_group_move_handler_after_qd_control', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT gp_inject_fault('resource_group_move_handler_after_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT gp_inject_fault('resource_group_give_away_after_latch', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ pg_sleep 
+----------
+          
+(1 row)
+2<:  <... completed>
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+2: RESET gp_resource_group_move_timeout;
+RESET
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+1: END;
+END
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+1q: ... <quitting>
+
+-- test12: check destination group has no slot leaking if taget process recieved one move command at the time of processing another
+-- sleep at first process
+-- start to move it at second process, send moving signal to first process
+-- suspend at first process just before setting latch and moving
+-- run another moving command at third process, it should throw an error as target process is alredy moving
+-- resume at first process, it should continue with moving
+-- moving command at second process should finish successfully
+1: SET ROLE role_move_query_mem_small;
+SET
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: BEGIN;
+BEGIN
+1&: SELECT pg_sleep(5) FROM gp_dist_random('gp_id') LIMIT 1;  <waiting ...>
+2&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('resource_group_move_handler_before_qd_control', 1, dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'default_group') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+ERROR:  cannot send signal to process
+3: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ pg_sleep 
+----------
+          
+(1 row)
+2<:  <... completed>
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+1: END;
+END
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+3: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='default_group';
+ num_running 
+-------------
+ 0           
+(1 row)
+1q: ... <quitting>
+
+-- Test13: check we'll wait and quit by gp_resource_group_move_timeout if target process stuck on signal handling
+1: SET ROLE role_move_query_mem_small;
+SET
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'reset', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'suspend', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: BEGIN;
+BEGIN
+1&: SELECT pg_sleep(3);  <waiting ...>
+2: SET gp_resource_group_move_timeout = 3000;
+SET
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+ERROR:  target process failed to move to a new group
+2: SELECT gp_inject_fault('resource_group_move_handler_before_qd_control', 'resume', dbid) FROM gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: RESET gp_resource_group_move_timeout;
+RESET
+1<:  <... completed>
+ pg_sleep 
+----------
+          
+(1 row)
+2: SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_query';
+ num_running 
+-------------
+ 0           
+(1 row)
+1: END;
+END
+
+-- Test14: check entrydb queries working
+-- Previously, we sent a signal to only one process - dispatcher or entrydb.
+-- This led to various errors - triggered assertions or only entrydb process moving.
+-- But it never led to the only one correct result - ALL processes should be moved.
+-- Here we use is_session_in_group() to precisely check ALL processes were moved.
+1: SET ROLE role_move_query_mem_small;
+SET
+1: BEGIN;
+BEGIN
+--spawn all backends at first short call to guarantee correct pg_resgroup_move_query() execution
+1: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(1) LIMIT 1;
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+(1 row)
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;  <waiting ...>
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+1<:  <... completed>
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+(1 row)
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+1: END;
+END
 
 DROP ROLE role_move_query;
 DROP


### PR DESCRIPTION
This is the copy of #13481 

-----

The pg_resgroup_move_query() function implemented in 51ee26b has several disadvantages:
1) Slot leaking. The slot acquired in initiator process doesn't free if target process isn't alive, didn't receive a signal, or even received, but at the time it was in idle state.
2) Race condition between UnassignResGroup() called at the end of transaction (or honestly any other code) and handler called immediately after USR1 signal.
3) Not working entrydb process moving. Previously, the USR1 signal was sent to only one process, target or entrydb. Entrydb moving was never tested properly.

Improvements added to solve the first problem:
1) Feedback from target process to initiator. Target process can set initiator's latch to quickly interrupt pg_resgroup_move_query() from awaiting.
2) Existed movetoResSlot parameter acts like a mark. Initiator sets it and waits on latch. If movetoResSlot become NULL, slot control is on the target process side.
3) Initiator PID. Used by target process to get initiator's latch. 4) Mutex. To guard all critical moveto* parameters from parallel changes.

To solve the second problem, there was an attempt to use Postgres interruptions. I was unhappy to know GPDB use raw InterruptPending value to do some pre-cancellation of dispatched queries. GPDB thinks InterruptPending can be triggered only by "negative" events, which leads to cancelation. The temporary solution with InterruptPending-like "positive" flag showed that we may wait for next CHECK_FOR_INTERRUPTS() call for a long. For example, some fat insert may do group moving only at the end of dispatching, which makes no sense.
Thus, I decided to decrease the probability of races by using additional IsTransactionState() check.
IMPORTANT NOTICE. The existed solution still affected by race conditions. The current handler's implementation is an example of bad design and should be reworked.

To solve the third problem, now we send signals to target and entrydb processes separately. We do UnassignResGroup() for one process only, not cleaning all counters for still working entrydb process inside handler. More, entrydb moving logic is now separated from segments moving, and so, it became more readable.

New GUC (gp_resource_group_move_timeout) was added to limit a time we're waiting for feedback from target.

New regression tests shows there is no slot leaking with some rare and now correctly resolved cases.
