### PR TITLE
Notice who opened the parallel retrieve cursor

### DIFF
--- a/src/backend/cdb/endpoint/README
+++ b/src/backend/cdb/endpoint/README
@@ -122,7 +122,7 @@ due to the security concern, e.g. if user2 is nologin, we should not be able to
 retrieve using user2.
 
 There is another similar gp_get_session_endpoints() that shows the endpoint
-informations that belong to this session only.
+information that belong to this session only.
 
 Start A Retrieve Session
 ========================

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -422,8 +422,8 @@ gp_get_segment_endpoints(PG_FUNCTION_ARGS)
 		MemSet(nulls, 0, sizeof(nulls));
 
 		/*
-		 * Only allow current user to list his/her own endpoints, or let
-		 * superuser list all endpoints.
+		 * Only allow the current user to list own endpoints, or let superuser
+		 * list all endpoints.
 		 */
 		if (!entry->empty && entry->databaseID == MyDatabaseId && (superuser() || entry->userID == GetUserId()))
 		{

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -201,6 +201,10 @@ PerformCursorOpen(DeclareCursorStmt *cstmt, ParamListInfo params,
 				(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
 				 errmsg("Opened parallel cursor number exceeded allowed concurrency: %d", gp_max_parallel_cursors)));
 		}
+
+		if (GetSessionUserId() != GetUserId())
+			ereport(NOTICE,
+					(errmsg("Parallel retrieve cursor is opened on the behalf of the session user: %s", GetUserNameFromId(GetSessionUserId(), false))));
 	}
 
 	/*

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -25,6 +25,8 @@ data/wet_execute.tbl
 data/gpsd-without-hll.sql
 data/gpsd-with-hll.sql
 data/minirepro.sql
+data/copy_no_cols.data
+data/gpsd_db_ext_data.sql
 
 # Note: regreesion.* are only left behind on a failure; that's why they're not ignored
 #/regression.diffs


### PR DESCRIPTION
The userid of the endpoint is the session user for security reasons but not the
current user if the role is switched. Add a notice.
