### PR TITLE
Fix two missing code

### DIFF
--- a/src/backend/cdb/cdbvarblock.c
+++ b/src/backend/cdb/cdbvarblock.c
@@ -580,6 +580,7 @@ VarBlockIsValid(
 		{
 			VarBlockByteOffset prevOffset = offset;
 
+			offset = VarBlockGetOffset(header, offsetToOffsetArray, i);
 			if (offset < prevOffset)
 			{
 				sprintf(VarBlockCheckErrorStr,

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -870,7 +870,10 @@ LockErrorCleanup(void)
 	/* Don't try to cancel resource locks.*/
 	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled() &&
 		LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD)
+	{
+		RESUME_INTERRUPTS();
 		return;
+	}
 
 	/*
 	 * Turn off the deadlock and lock timeout timers, if they are still


### PR DESCRIPTION
I found two obvious missing code when reading AOCS code.

- VarBlockIsValid(): offset is not updated when checking the offset array.

- LockErrorCleanup(): missing RESUME_INTERRUPTS() call before return.

Easy to understand, so no more explanation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
