### PR TITLE
Fix case pg_rewind_fail_missing_xlog

### DIFF
--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -3,6 +3,11 @@
 -- if more than one CHECKPOINTs are performed after that restart_lsn. Otherwise
 -- gprecoverseg (based on pg_rewind) would fail due to missing wal file
 
+CREATE OR REPLACE LANGUAGE plpython3u;
+CREATE LANGUAGE
+CREATE OR REPLACE FUNCTION connectSeg(n int, port int, hostname text) RETURNS bool AS $$ import os import subprocess import time for i in range(n): try: subprocess.run(["psql", "-h", str(hostname), "-p", str(port), "postgres", "-Xc", "select 1;"], env={"PGOPTIONS": "-c gp_role=utility", "PATH": os.getenv("PATH")}, check=True) return True except Exception as e: time.sleep(1) raise Exception("wait connection timeout") $$ LANGUAGE plpython3u;
+CREATE FUNCTION
+
 CREATE TABLE tst_missing_tbl (a int);
 CREATE TABLE
 INSERT INTO tst_missing_tbl values(2),(1),(5);
@@ -190,6 +195,12 @@ INSERT 0 3
  gp_request_fts_probe_scan 
 ---------------------------
  t                         
+(1 row)
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
+ connectseg 
+------------
+ t          
 (1 row)
 -- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted
 3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
@@ -460,6 +471,12 @@ INSERT 0 3
  t                         
 (1 row)
 
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
+ connectseg 
+------------
+ t          
+(1 row)
 -- Reset faults and confirm FTS configuration
 3: SELECT gp_inject_fault('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
  gp_inject_fault 
@@ -636,6 +653,8 @@ DROP TABLE
 
 5: DROP TABLE tst_missing_tbl;
 DROP TABLE
+5: DROP FUNCTION connectSeg;
+DROP FUNCTION
 !\retcode gpconfig -r wal_keep_size;
 (exited with code 0)
 !\retcode gpconfig -r wal_recycle;


### PR DESCRIPTION
When execute inject fault `checkpoint_after_redo_calculated` or 'checkpoint_control_file_updated' in a newly promoted mirror node, connection failed error occurs due to the fatal log 'mirror is being promoted'. It means when connection state is MIRROR_READY but the role change to primary during promoting, the connection will be declined to avoid confusion.

Sleep 5 seconds to wait until the mirror node promotion is finished and the role change to primary.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
