### PR TITLE
Fix gp_stat_bgwriter which shows incomplete/incorrect results

### DIFF
--- a/src/test/regress/expected/sysviews_gp.out
+++ b/src/test/regress/expected/sysviews_gp.out
@@ -44,271 +44,277 @@ AND REPLACE(table_name, 'pg_', 'gp_') NOT IN
 (27 rows)
 
 -- check each gp_ view created in system_views_gp.sql
-select count(*) >= 0 from gp_config;
+-- that it returns either no result (e.g. no user table for gp_stat_user_tables) 
+-- or a complete list of views from all segments (with just a few exceptions).
+-- total segment count including coordinator
+select count(*) + 1 as segcount from gp_dist_random('gp_id') \gset
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_config;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_cursors;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_cursors;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_file_settings;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_file_settings;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_replication_origin_status;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_replication_origin_status;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_replication_slots;
+-- coordinator doesn't seem have a replication slot
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount -1 from gp_replication_slots;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_settings;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_settings;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_activity;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_activity;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_all_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_all_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_all_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_archiver;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_archiver;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_bgwriter;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_bgwriter;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_database;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_database;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_database_conflicts;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_database_conflicts;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_gssapi;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_gssapi;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_analyze;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_analyze;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_basebackup;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_basebackup;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_cluster;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_cluster;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_copy;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_copy;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_create_index;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_create_index;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_progress_vacuum;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_vacuum;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_slru;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_slru;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_ssl;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_ssl;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_subscription;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_subscription;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_sys_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_sys_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_sys_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_user_functions;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_functions;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_user_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_wal;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_wal;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_wal_receiver;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_wal_receiver;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_xact_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_all_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_xact_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_sys_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_xact_user_functions;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_user_functions;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stat_xact_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_user_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_all_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_all_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_sequences;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_sys_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_sys_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_sequences;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_user_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_indexes;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_user_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_sequences;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_statio_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_tables;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stats;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stats;
  ?column? 
 ----------
  t
 (1 row)
 
-select count(*) >= 0 from gp_stats_ext;
+-- only coordinator could have any pg_stats_ext data
+select count(*) = 0 or count(distinct gp_segment_id) = 1 from gp_stats_ext;
  ?column? 
 ----------
  t

--- a/src/test/regress/sql/sysviews_gp.sql
+++ b/src/test/regress/sql/sysviews_gp.sql
@@ -15,48 +15,56 @@ AND REPLACE(table_name, 'pg_', 'gp_') NOT IN
 );
 
 -- check each gp_ view created in system_views_gp.sql
-select count(*) >= 0 from gp_config;
-select count(*) >= 0 from gp_cursors;
-select count(*) >= 0 from gp_file_settings;
-select count(*) >= 0 from gp_replication_origin_status;
-select count(*) >= 0 from gp_replication_slots;
-select count(*) >= 0 from gp_settings;
-select count(*) >= 0 from gp_stat_activity;
-select count(*) >= 0 from gp_stat_all_indexes;
-select count(*) >= 0 from gp_stat_all_tables;
-select count(*) >= 0 from gp_stat_archiver;
-select count(*) >= 0 from gp_stat_bgwriter;
-select count(*) >= 0 from gp_stat_database;
-select count(*) >= 0 from gp_stat_database_conflicts;
-select count(*) >= 0 from gp_stat_gssapi;
-select count(*) >= 0 from gp_stat_progress_analyze;
-select count(*) >= 0 from gp_stat_progress_basebackup;
-select count(*) >= 0 from gp_stat_progress_cluster;
-select count(*) >= 0 from gp_stat_progress_copy;
-select count(*) >= 0 from gp_stat_progress_create_index;
-select count(*) >= 0 from gp_stat_progress_vacuum;
-select count(*) >= 0 from gp_stat_slru;
-select count(*) >= 0 from gp_stat_ssl;
-select count(*) >= 0 from gp_stat_subscription;
-select count(*) >= 0 from gp_stat_sys_indexes;
-select count(*) >= 0 from gp_stat_sys_tables;
-select count(*) >= 0 from gp_stat_user_functions;
-select count(*) >= 0 from gp_stat_user_indexes;
-select count(*) >= 0 from gp_stat_user_tables;
-select count(*) >= 0 from gp_stat_wal;
-select count(*) >= 0 from gp_stat_wal_receiver;
-select count(*) >= 0 from gp_stat_xact_all_tables;
-select count(*) >= 0 from gp_stat_xact_sys_tables;
-select count(*) >= 0 from gp_stat_xact_user_functions;
-select count(*) >= 0 from gp_stat_xact_user_tables;
-select count(*) >= 0 from gp_statio_all_indexes;
-select count(*) >= 0 from gp_statio_all_sequences;
-select count(*) >= 0 from gp_statio_all_tables;
-select count(*) >= 0 from gp_statio_sys_indexes;
-select count(*) >= 0 from gp_statio_sys_sequences;
-select count(*) >= 0 from gp_statio_sys_tables;
-select count(*) >= 0 from gp_statio_user_indexes;
-select count(*) >= 0 from gp_statio_user_sequences;
-select count(*) >= 0 from gp_statio_user_tables;
-select count(*) >= 0 from gp_stats;
-select count(*) >= 0 from gp_stats_ext;
+-- that it returns either no result (e.g. no user table for gp_stat_user_tables) 
+-- or a complete list of views from all segments (with just a few exceptions).
+
+-- total segment count including coordinator
+select count(*) + 1 as segcount from gp_dist_random('gp_id') \gset
+
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_config;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_cursors;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_file_settings;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_replication_origin_status;
+-- coordinator doesn't seem have a replication slot
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount -1 from gp_replication_slots;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_settings;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_activity;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_all_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_archiver;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_bgwriter;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_database;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_database_conflicts;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_gssapi;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_analyze;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_basebackup;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_cluster;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_copy;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_create_index;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_vacuum;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_slru;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_ssl;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_subscription;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_sys_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_functions;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_wal;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_wal_receiver;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_user_functions;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_xact_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_all_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_sys_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_indexes;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_sequences;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_statio_user_tables;
+select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stats;
+-- only coordinator could have any pg_stats_ext data
+select count(*) = 0 or count(distinct gp_segment_id) = 1 from gp_stats_ext;


### PR DESCRIPTION
The `gp_stat_bgwriter` view which is supposed to show cluster-wide view of `pg_stat_bgwriter` only shows part of the segments, e.g.:

```sql
postgres=# select * from gp_stat_bgwriter;
 segment_id | checkpoints_timed | checkpoints_req | checkpoint_write_time | checkpoint_sync_time | buffers_checkpoint | buffers_clean | maxwritten_clean | buffers_backend | buffers_backend_fsync | buffers_alloc |          stats_reset
------------+-------------------+-----------------+-----------------------+----------------------+--------------------+---------------+------------------+-----------------+-----------------------+---------------+-------------------------------
          0 |              1097 |               0 |                 37946 |                   15 |                378 |             0 |                0 |            5133 |                     0 |           387 | 2023-04-28 12:46:24.938582-07
         -1 |              1097 |               0 |                 37946 |                   15 |                378 |             0 |                0 |            5133 |                     0 |           387 | 2023-04-28 12:46:24.938582-07
(2 rows)
```
And even the result of the only primary segment is not correct - it is just repeating the result from the coordinator.

The root cause is that because `pg_stat_bgwriter` is selecting from a bunch of STABLE functions, they are being evaluated and simplied in planning phase. As a result, the coordinator's results are incorrectly used for the primary. In addition, the subquery `SELECT * FROM pg_stat_bgwriter` is given a locus `CdbLocusType_General` which results in direct dispatch and only one primary is being dispatched to.

The initial fix that I thought was to not simplify stable functions at all, but that would be an overkill. And it's not easy to do something like in #14499 where we skip the simpifying just for the functions in `pg_stat_bgwriter` - there are too many functions and there's no clear pattern to distinguish them.

So just do a simpler fix which is to have a volatile function to select the results, and let `pg_stat_bgwriter` select from that function.

Also modified the regress test to be able to catch such issue in future. Found a new issue with pg_replication_slot which is unrelated to the current one. Added a FIXME for it.

Fix #15455

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
