### PR TITLE
Enable two-phase commit for foreign table.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1587,13 +1587,6 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 		if ((rte->requiredPerms & (~ACL_SELECT)) == 0)
 			continue;
 
-		/*
-		 * External and foreign tables don't need two phase commit which is for
-		 * local mpp tables
-		 */
-		if (get_rel_relkind(rte->relid) == RELKIND_FOREIGN_TABLE)
-			continue;
-
 		if (isTempNamespace(get_rel_namespace(rte->relid)))
 		{
 			ExecutorMarkTransactionDoesWrites();


### PR DESCRIPTION
For postgres_fdw and greenplum_fdw foreign table, two-phase commit is needed to ensure transaction atomicity. In scenarios like parallel writing, we need to ensure all segments succeed writing or all of them write nothing.

Co-authored-by: jingwen-yang-yjw <jingweny1@vmware.com>
