### PR TITLE
Add multi_hosts and multi_ports option for postgres_fdw server

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -10,7 +10,7 @@ SHLIB_LINK_INTERNAL = $(libpq)
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql
 
-REGRESS = gp2pg_postgres_fdw gp_postgres_fdw
+REGRESS = gp2pg_postgres_fdw gp_postgres_fdw mpp_gp2pg_postgres_fdw
 REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
 
 ifdef USE_PGXS

--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -25,6 +25,8 @@
 #include "utils/inval.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
+#include "commands/defrem.h"
+#include <sys/param.h>
 
 
 /*
@@ -43,7 +45,12 @@
  * ourselves, so that rolling back a subtransaction will kill the right
  * queries and not the wrong ones.
  */
-typedef Oid ConnCacheKey;
+typedef struct ConnCacheKey
+{
+	Oid		umid;							/* Oid of user mapping */
+	char 	hostname[MAXHOSTNAMELEN];		/* hostname of remote server */
+	int 	port;							/* port of remote server */
+} ConnCacheKey;
 
 typedef struct ConnCacheEntry
 {
@@ -104,11 +111,11 @@ static bool pgfdw_get_cleanup_result(PGconn *conn, TimestampTz endtime,
  * (not even on error), we need this flag to cue manual cleanup.
  */
 PGconn *
-GetConnection(UserMapping *user, bool will_prep_stmt)
+GetConnection(ForeignServer *server, UserMapping *user, bool will_prep_stmt)
 {
 	bool		found;
 	ConnCacheEntry *entry;
-	ConnCacheKey key;
+	ConnCacheKey key = {0};
 
 	/* First time through, initialize connection cache hashtable */
 	if (ConnectionHash == NULL)
@@ -140,7 +147,19 @@ GetConnection(UserMapping *user, bool will_prep_stmt)
 	xact_got_connection = true;
 
 	/* Create hash key for the entry.  Assume no pad bytes in key struct */
-	key = user->umid;
+	key.umid = user->umid;
+	ListCell   *lc = NULL;
+	foreach(lc, server->options)
+	{
+		DefElem    *d = (DefElem *) lfirst(lc);
+		if (strcmp(d->defname, "host") == 0)
+		{
+			char *host = defGetString(d);
+			strncpy(key.hostname, host, MAXHOSTNAMELEN);
+		}
+		else if (strcmp(d->defname, "port") == 0)
+			key.port = atoi(defGetString(d));
+	}
 
 	/*
 	 * Find or create cached entry for requested connection.
@@ -182,8 +201,6 @@ GetConnection(UserMapping *user, bool will_prep_stmt)
 	 */
 	if (entry->conn == NULL)
 	{
-		ForeignServer *server = GetForeignServer(user->serverid);
-
 		/* Reset all transient state fields, to be sure all are clean */
 		entry->xact_depth = 0;
 		entry->have_prep_stmt = false;
@@ -1019,9 +1036,9 @@ pgfdw_reject_incomplete_xact_state_change(ConnCacheEntry *entry)
 
 	/* find server name to be shown in the message below */
 	tup = SearchSysCache1(USERMAPPINGOID,
-						  ObjectIdGetDatum(entry->key));
+						  ObjectIdGetDatum(entry->key.umid));
 	if (!HeapTupleIsValid(tup))
-		elog(ERROR, "cache lookup failed for user mapping %u", entry->key);
+		elog(ERROR, "cache lookup failed for user mapping %u", entry->key.umid);
 	umform = (Form_pg_user_mapping) GETSTRUCT(tup);
 	server = GetForeignServer(umform->umserver);
 	ReleaseSysCache(tup);

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -1,0 +1,138 @@
+-- This file is used to test the feature that there are multiple remote postgres servers.
+-- ===================================================================
+-- create FDW objects
+-- ===================================================================
+SET timezone = 'PST8PDT';
+-- Clean
+-- start_ignore
+DROP EXTENSION IF EXISTS postgres_fdw CASCADE;
+-- end_ignore
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER pgserver FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host 'dummy', port '0',
+           dbname 'contrib_regression', multi_hosts 'localhost  localhost',
+           multi_ports '5432  5555', num_segments '2', mpp_execute 'all segments');
+CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver;
+-- ===================================================================
+-- create objects used through FDW pgserver server
+-- ===================================================================
+-- remote postgres server 1 -- listening port 5432
+\! env PGOPTIONS='' psql -p 5432 contrib_regression -f sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
+SET
+CREATE SCHEMA
+CREATE TABLE
+ALTER TABLE
+INSERT 0 5
+ANALYZE
+-- remote postgres server 2 -- listening port 5555
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -f sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
+SET
+CREATE SCHEMA
+CREATE TABLE
+ALTER TABLE
+INSERT 0 5
+ANALYZE
+-- ===================================================================
+-- create foreign tables
+-- ===================================================================
+CREATE FOREIGN TABLE mpp_ft1 (
+	c1 int,
+	c2 int
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
+-- ===================================================================
+-- tests for validator
+-- ===================================================================
+-- Error when the length of option multi_hosts and multi_ports is NOT same.
+CREATE SERVER testserver FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (dbname 'contrib_regression', multi_hosts 'localhost localhost',
+           multi_ports '5432', num_segments '2', mpp_execute 'all segments');
+ERROR:  The number of hosts and ports don't match in option 'multi_hosts' and 'multi_ports'.
+-- Error when specifying option multi_hosts and multi_ports but option mpp_execute is NOT 'all segments'.
+CREATE FOREIGN TABLE mpp_test (
+	c1 int,
+	c2 int
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1', mpp_execute 'coordinator');
+SELECT * FROM mpp_test;
+ERROR:  Only option mpp_execute is set to 'all segments', option multi_hosts and multi_ports is valid.
+ALTER FOREIGN TABLE mpp_test OPTIONS (drop mpp_execute);
+-- Error when the value of option num_segments is NOT same as the length of option multi_hosts and multi_ports.
+ALTER SERVER pgserver OPTIONS (set num_segments '1');
+SELECT * FROM mpp_test;
+ERROR:  server option num_segments, multi_hosts and multi_ports don't match. (postgres_fdw.c:1498)  (seg0 slice1 127.0.0.1:7002 pid=24510)
+ALTER SERVER pgserver OPTIONS (set num_segments '2');
+-- ===================================================================
+-- Simple queries
+-- ===================================================================
+EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=100.00..5558.20 rows=172200 width=8)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft1  (cost=100.00..2975.20 rows=86100 width=8)
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 1" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(8 rows)
+
+SELECT * FROM mpp_ft1 ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  0
+  3 |  1
+  4 |  0
+  5 |  1
+  6 |  0
+  7 |  1
+  8 |  0
+  9 |  1
+ 10 |  0
+(10 rows)
+
+ALTER FOREIGN TABLE mpp_ft1 OPTIONS (add use_remote_estimate 'true');
+EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=102.22..102.74 rows=20 width=8)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft1  (cost=102.22..102.44 rows=10 width=8)
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 1" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(8 rows)
+
+SELECT * FROM mpp_ft1 ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  0
+  3 |  1
+  4 |  0
+  5 |  1
+  6 |  0
+  7 |  1
+  8 |  0
+  9 |  1
+ 10 |  0
+(10 rows)
+
+ALTER FOREIGN TABLE mpp_ft1 OPTIONS (drop use_remote_estimate);
+-- ===================================================================
+-- When there are multiple remote servers, we don't support IMPORT FOREIGN SCHEMA
+-- ===================================================================
+CREATE SCHEMA mpp_import_dest;
+IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO mpp_import_dest;
+ERROR:  If there are multiple remote servers, gpdb doesn't support import foreign schema
+-- ===================================================================
+-- When there are multiple remote servers, we don't support INSERT/UPDATE/DELETE
+-- ===================================================================
+INSERT INTO mpp_ft1 VALUES (1, 1);
+ERROR:  foreign table "mpp_ft1" does not allow inserts
+UPDATE mpp_ft1 SET c1 = c1 + 1;
+ERROR:  foreign table "mpp_ft1" does not allow updates
+DELETE FROM mpp_ft1;
+ERROR:  foreign table "mpp_ft1" does not allow deletes

--- a/contrib/postgres_fdw/postgres_clean.bash
+++ b/contrib/postgres_fdw/postgres_clean.bash
@@ -2,6 +2,8 @@
 if [ -d "testdata/pgdata" ] && [ -d "testdata/pgsql" ] ; then
 	pgbin="testdata/pgsql"
 	${pgbin}/bin/pg_ctl -D testdata/pgdata  stop || true
+	${pgbin}/bin/pg_ctl -D testdara/pgdata2 -o "-p 5555"  stop || true
 	rm -rf testdata/pgdata
+	rm -rf testdara/pgdata2
 fi
 rm -rf testdata/pglog

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -127,7 +127,7 @@ extern int	set_transmission_modes(void);
 extern void reset_transmission_modes(int nestlevel);
 
 /* in connection.c */
-extern PGconn *GetConnection(UserMapping *user, bool will_prep_stmt);
+extern PGconn *GetConnection(ForeignServer *server, UserMapping *user, bool will_prep_stmt);
 extern void ReleaseConnection(PGconn *conn);
 extern unsigned int GetCursorNumber(PGconn *conn);
 extern unsigned int GetPrepStmtNumber(PGconn *conn);

--- a/contrib/postgres_fdw/postgres_setup.bash
+++ b/contrib/postgres_fdw/postgres_setup.bash
@@ -29,7 +29,7 @@ if [ ! -d "${pgbin}" ] ; then
 	popd
 fi
 
-# start postgres
+# start postgres 1
 # there may be already a postgres postgres running, anyway, stop it
 if [ -d "pgdata" ] ; then
 	${pgbin}/bin/pg_ctl -D pgdata  stop || true
@@ -38,9 +38,24 @@ fi
 ${pgbin}/bin/initdb -D pgdata
 ${pgbin}/bin/pg_ctl -D pgdata -l pglog start
 
-# init postgres
+# init postgres 1
 ${pgbin}/bin/dropdb --if-exists contrib_regression
 ${pgbin}/bin/createdb contrib_regression
+
+# start postgres 2
+# listening to port 5555
+# there may be already a postgres postgres running, anyway, stop it
+if [ -d "pgdata2" ] ; then
+    ${pgbin}/bin/pg_ctl -D pgdata2  stop || true
+    rm -r pgdata2
+fi
+${pgbin}/bin/initdb -D pgdata2
+${pgbin}/bin/pg_ctl -D pgdata2 -l pglog2 -o "-p 5555" start
+
+# init postgres 2
+${pgbin}/bin/dropdb -p 5555 --if-exists contrib_regression
+${pgbin}/bin/createdb -p 5555 contrib_regression
+
 export PGPORT=${GPPORT}
 # export PGOPTIONS=${GPOPTIONS}
 popd

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -1,0 +1,80 @@
+-- This file is used to test the feature that there are multiple remote postgres servers.
+
+-- ===================================================================
+-- create FDW objects
+-- ===================================================================
+SET timezone = 'PST8PDT';
+
+-- Clean
+-- start_ignore
+DROP EXTENSION IF EXISTS postgres_fdw CASCADE;
+-- end_ignore
+
+CREATE EXTENSION postgres_fdw;
+
+CREATE SERVER pgserver FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host 'dummy', port '0',
+           dbname 'contrib_regression', multi_hosts 'localhost  localhost',
+           multi_ports '5432  5555', num_segments '2', mpp_execute 'all segments');
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver;
+
+-- ===================================================================
+-- create objects used through FDW pgserver server
+-- ===================================================================
+-- remote postgres server 1 -- listening port 5432
+\! env PGOPTIONS='' psql -p 5432 contrib_regression -f sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
+-- remote postgres server 2 -- listening port 5555
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -f sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
+
+-- ===================================================================
+-- create foreign tables
+-- ===================================================================
+CREATE FOREIGN TABLE mpp_ft1 (
+	c1 int,
+	c2 int
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
+
+-- ===================================================================
+-- tests for validator
+-- ===================================================================
+-- Error when the length of option multi_hosts and multi_ports is NOT same.
+CREATE SERVER testserver FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (dbname 'contrib_regression', multi_hosts 'localhost localhost',
+           multi_ports '5432', num_segments '2', mpp_execute 'all segments');
+-- Error when specifying option multi_hosts and multi_ports but option mpp_execute is NOT 'all segments'.
+CREATE FOREIGN TABLE mpp_test (
+	c1 int,
+	c2 int
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1', mpp_execute 'coordinator');
+SELECT * FROM mpp_test;
+ALTER FOREIGN TABLE mpp_test OPTIONS (drop mpp_execute);
+-- Error when the value of option num_segments is NOT same as the length of option multi_hosts and multi_ports.
+ALTER SERVER pgserver OPTIONS (set num_segments '1');
+SELECT * FROM mpp_test;
+ALTER SERVER pgserver OPTIONS (set num_segments '2');
+-- ===================================================================
+-- Simple queries
+-- ===================================================================
+EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
+SELECT * FROM mpp_ft1 ORDER BY c1;
+
+ALTER FOREIGN TABLE mpp_ft1 OPTIONS (add use_remote_estimate 'true');
+EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
+SELECT * FROM mpp_ft1 ORDER BY c1;
+ALTER FOREIGN TABLE mpp_ft1 OPTIONS (drop use_remote_estimate);
+
+-- ===================================================================
+-- When there are multiple remote servers, we don't support IMPORT FOREIGN SCHEMA
+-- ===================================================================
+CREATE SCHEMA mpp_import_dest;
+IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO mpp_import_dest;
+
+-- ===================================================================
+-- When there are multiple remote servers, we don't support INSERT/UPDATE/DELETE
+-- ===================================================================
+INSERT INTO mpp_ft1 VALUES (1, 1);
+
+UPDATE mpp_ft1 SET c1 = c1 + 1;
+
+DELETE FROM mpp_ft1;

--- a/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
+++ b/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
@@ -1,0 +1,23 @@
+-- This sql file is used by mpp_gp2pg_postgres_fdw test, and it runs in
+-- postgres server.
+
+-- ===================================================================
+-- create objects used through FDW pgserver server
+-- ===================================================================
+SET timezone = 'PST8PDT';
+
+CREATE SCHEMA "MPP_S 1";
+CREATE TABLE "MPP_S 1"."T 1" (
+	c1 int,
+	c2 int
+);
+
+-- Disable autovacuum for these tables to avoid unexpected effects of that
+ALTER TABLE "MPP_S 1"."T 1" SET (autovacuum_enabled = 'false');
+
+INSERT INTO "MPP_S 1"."T 1"
+	SELECT id,
+	       id % 2
+	FROM generate_series(1, 5) id;
+
+ANALYZE "MPP_S 1"."T 1";

--- a/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
+++ b/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
@@ -1,0 +1,23 @@
+-- This sql file is used by mpp_gp2pg_postgres_fdw test, and it runs in
+-- postgres server.
+
+-- ===================================================================
+-- create objects used through FDW pgserver server
+-- ===================================================================
+SET timezone = 'PST8PDT';
+
+CREATE SCHEMA "MPP_S 1";
+CREATE TABLE "MPP_S 1"."T 1" (
+	c1 int,
+	c2 int
+);
+
+-- Disable autovacuum for these tables to avoid unexpected effects of that
+ALTER TABLE "MPP_S 1"."T 1" SET (autovacuum_enabled = 'false');
+
+INSERT INTO "MPP_S 1"."T 1"
+	SELECT id,
+	       id % 2
+	FROM generate_series(6, 10) id;
+
+ANALYZE "MPP_S 1"."T 1";


### PR DESCRIPTION
This PR is separated from https://github.com/greenplum-db/gpdb/pull/15525.

This feature is designed for scenes that the foreign table is a distributed foreign table which data stored on multiple remote servers.

The main commits are as follows:

#### 1. Support multi_hosts and multi_ports options for postgres_fdw server

```
CREATE SERVER pgserver
FOREIGN DATA WRAPPER postgres_fdw
OPTIONS (multi_hosts 'localhost localhost', multi_ports '5432 5555', num_segments '2', mpp_execute 'all segments');

CREATE USER MAPPING FOR gpadmin SERVER pgserver;

CREATE FOREIGN TABLE f_tbl (c1 int) SERVER pg_server OPTIONS (table_name 'l_tbl');
```

SQLs above create a foreign table f_tbl, which consists of l_tbl in two different remote postgres servers.

This feature supports creating and accessing such postgres_fdw foreign tables.

Now we only support read data from remote servers when there are multiple remote servers.

We plan to support write data to remote servers later.

Co-authored-by: zhaorui <zhaoru@vmware.com>