### PR TITLE
docs: fixed two typos on Greenplum name

### DIFF
--- a/gpdb-doc/markdown/analytics/postgis-upgrade.html.md
+++ b/gpdb-doc/markdown/analytics/postgis-upgrade.html.md
@@ -96,7 +96,7 @@ When upgrading PostGIS you must check the version of the Greenplum PostGIS packa
 
     If PostGIS is not enabled for the database, Greenplum returns a `function does not exist` error.
 
--   For the Geenplum PostGIS package `postgis-2.5.4+pivotal.2` and later, you can display the PostGIS extension version and state in a database with this query.
+-   For the Greenplum PostGIS package `postgis-2.5.4+pivotal.2` and later, you can display the PostGIS extension version and state in a database with this query.
 
     ```
     # SELECT * FROM pg_available_extensions WHERE name = 'postgis' ;

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -194,7 +194,7 @@ The `vm.overcommit_memory` Linux kernel parameter is used by the OS to determine
 
 `vm.overcommit_ratio` is the percent of RAM that is used for application processes and the remainder is reserved for the operating system. The default is 50 on Red Hat Enterprise Linux.
 
-For `vm.overcommit_ratio` tuning and calculation recommendations with resource group-based resource management or resource queue-based resource management, refer to [Options for Configuring Segment Host Memory](../admin_guide/wlmgmt_intro.html) in the *Geenplum Database Administrator Guide*.
+For `vm.overcommit_ratio` tuning and calculation recommendations with resource group-based resource management or resource queue-based resource management, refer to [Options for Configuring Segment Host Memory](../admin_guide/wlmgmt_intro.html) in the *Greenplum Database Administrator Guide*.
 
 **Port Settings**
 


### PR DESCRIPTION
Reported by user via bugzilla. It probably needs to be cherry-picked to 6.x
