### PR TITLE
Docs: Replaced gp_role with gp_session_role for GPDB 6

### DIFF
--- a/gpdb-doc/markdown/admin_guide/managing/startstop.html.md
+++ b/gpdb-doc/markdown/admin_guide/managing/startstop.html.md
@@ -68,7 +68,7 @@ Maintenance mode should only be used with direction from VMware Technical Suppor
 
      <a id="kg155401"></a>
      ``` 
-     $ PGOPTIONS='-c gp_role=utility' psql postgres
+     $ PGOPTIONS='-c gp_session_role=utility' psql postgres
      ```
 
 3.  After completing your administrative tasks, stop the master in maintenance mode. Then, restart it in production mode.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1482,14 +1482,6 @@ The default value is `false`.
 |-----------|-------|-------------------|
 |Boolean|false|read only|
 
-## <a id="gp_role"></a>gp\_role 
-
-The role of this server process is set to *dispatch* for the master and *execute* for a segment.
-
-|Value Range|Default|Set Classifications|
-|-----------|-------|-------------------|
-|dispatch<br/><br/>execute<br/><br/>utility| |read only|
-
 ## <a id="gp_safefswritesize"></a>gp\_safefswritesize 
 
 Specifies a minimum size for safe write operations to append-optimized tables in a non-mature file system. When a number of bytes greater than zero is specified, the append-optimized writer adds padding data up to that number in order to prevent data corruption due to file system errors. Each non-mature file system has a known safe write size that must be specified here when using Greenplum Database with that type of file system. This is commonly set to a multiple of the extent size of the file system; for example, Linux ext3 is 4096 bytes, so a value of 32768 is commonly used.
@@ -1537,6 +1529,14 @@ A system assigned ID number for a client session. Starts counting from 1 when th
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
 |1-*n*|14|read only|
+
+## <a id="gp_session_role"></a>gp_session_role
+
+The role of this server process is set to *dispatch* for the master and *execute* for a segment.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|dispatch<br/><br/>execute<br/><br/>utility| |read only|
 
 ## <a id="gp_set_proc_affinity"></a>gp\_set\_proc\_affinity 
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -513,8 +513,8 @@ The parameters in this topic control the configuration of the Greenplum Database
 - [gp_content](guc-list.html#gp_content)
 - [gp_dbid](guc-list.html#gp_dbid)
 - [gp_retrieve_conn](guc-list.html#gp_retrieve_conn)
-- [gp_role](guc-list.html#gp_role)
 - [gp_session_id](guc-list.html#gp_session_id)
+- [gp_session_role](guc-list.html#gp_session_role)
 - [gp_server_version](guc-list.html#gp_server_version)
 - [gp_server_version_num](guc-list.html#gp_server_version_num)
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpstart.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpstart.html.md
@@ -64,7 +64,7 @@ If the standby master is not accessible, you can start the system and troublesho
 -m
 :   Optional. Starts the master instance only, which may be useful for maintenance tasks. This mode only allows connections to the master in utility mode. For example:
 
-:   `PGOPTIONS='-c gp_role=utility' psql`
+:   `PGOPTIONS='-c gp_session_role=utility' psql`
 
 :   The consistency of the heap checksum setting on master and segment instances is not checked.
 
@@ -112,7 +112,7 @@ Start the Greenplum master instance only and connect in utility mode:
 
 ```
 gpstart -m 
-PGOPTIONS='-c gp_role=utility' psql
+PGOPTIONS='-c gp_session_role=utility' psql
 ```
 
 ## <a id="section6"></a>See Also 


### PR DESCRIPTION
Greenplum 6 documentation should still refer to gp_session_role and not gp_role. Modifying some documentation pages to address this.
