### PR TITLE
BRIN changes to user interface

### DIFF
--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -1193,7 +1193,7 @@ brin_summarize_range_internal(PG_FUNCTION_ARGS)
  * SQL-callable interface to mark a range as no longer summarized
  */
 Datum
-brin_desummarize_range(PG_FUNCTION_ARGS)
+brin_desummarize_range_internal(PG_FUNCTION_ARGS)
 {
 	Oid			indexoid = PG_GETARG_OID(0);
 	int64		heapBlk64 = PG_GETARG_INT64(1);

--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -41,6 +41,7 @@
 #include "utils/rel.h"
 
 /* GPDB includes */
+#include "cdb/cdbvars.h"
 #include "storage/procarray.h"
 #include "utils/faultinjector.h"
 
@@ -1060,6 +1061,15 @@ brinoptions(Datum reloptions, bool validate)
 
 	fillRelOptions((void *) rdopts, sizeof(BrinOptions), options, numoptions,
 				   validate, tab, lengthof(tab));
+
+	/*
+	 * GPDB: We don't support autosummarize yet, as we don't support user-table
+	 * autovacuum. So, ERROR out accordingly.
+	 */
+	if (IS_QUERY_DISPATCHER() && validate && rdopts->autosummarize)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("autosummarize is not supported")));
 
 	free_options_deep(options, numoptions);
 

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1798,6 +1798,13 @@ $$
 $$
 LANGUAGE sql READS SQL DATA EXECUTE ON COORDINATOR;
 
+create or replace function brin_desummarize_range(t regclass, block_number int8) returns setof void as
+$$
+  -- brin_desummarize_range_internal is marked as EXECUTE ON ALL SEGMENTS.
+select brin_desummarize_range_internal(t, block_number);
+$$
+LANGUAGE SQL READS SQL DATA EXECUTE ON COORDINATOR;
+
 ------------------------------------------------------------------
 -- GPDB endpoint related views and functions
 ------------------------------------------------------------------

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302306121
+#define CATALOG_VERSION_NO	302306211
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -918,9 +918,10 @@
   prorettype => 'int4', proargtypes => 'regclass int8',
   prosrc => 'brin_summarize_range_internal' },
 { oid => '4014', descr => 'brin: desummarize page range',
-  proname => 'brin_desummarize_range', provolatile => 'v', proparallel => 'u',
+  proname => 'brin_desummarize_range_internal', provolatile => 'v', proparallel => 'u',
+  proexeclocation => 's',
   prorettype => 'void', proargtypes => 'regclass int8',
-  prosrc => 'brin_desummarize_range' },
+  prosrc => 'brin_desummarize_range_internal' },
 
 { oid => '338', descr => 'validate an operator class',
   proname => 'amvalidate', provolatile => 'v', prorettype => 'bool',

--- a/src/test/isolation2/expected/ao_partial_scan.out
+++ b/src/test/isolation2/expected/ao_partial_scan.out
@@ -82,23 +82,19 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('ao_partial_scan1_j_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('ao_partial_scan1_j_idx', 33554438);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('ao_partial_scan1_j_idx', 33554441);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('ao_partial_scan1_j_idx', 67108867);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Now summarize these desummarized ranges piecemeal and check that we scan only
 -- a subset of the blocks each time.
@@ -408,8 +404,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('ao_partial_scan2_i_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing the first range now should only scan the committed rows. (same
 -- as the index build). In other words, we will scan an equal number of
@@ -589,8 +584,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('ao_partial_scan3_i_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing this range should scan blocks corresponding to the 2 final logical
 -- heap blocks in the range only. This means that we will restrict our scan to
@@ -744,8 +738,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('ao_partial_scan4_i_idx', 33554433);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing 33554433 will map to a hole between block directory entries, so
 -- we will start our scan from the entry preceding the hole. So, we will scan
@@ -907,23 +900,19 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('aoco_partial_scan1_i_j_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('aoco_partial_scan1_i_j_idx', 33554438);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('aoco_partial_scan1_i_j_idx', 33554471);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 1U: SELECT brin_desummarize_range('aoco_partial_scan1_i_j_idx', 67108867);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Range scans beginning at 33554432 and 33554438 will span 13 block directory
 -- entries (13 varblocks) for col i and 7 entries (7 varblocks) for col j.
@@ -1363,8 +1352,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('aoco_partial_scan2_i_j_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing the first range now should only scan the committed rows. (same
 -- as the index build). In other words, we will scan an equal number of
@@ -1513,8 +1501,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('aoco_partial_scan3_i_j_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing this range should scan blocks corresponding to the 2 final logical
 -- heap blocks in the range only. This means that we will restrict our scan to
@@ -1636,8 +1623,7 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 1U: SELECT brin_desummarize_range('aoco_partial_scan4_i_idx', 33554433);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Summarizing 33554433 will map to a hole between block directory entries, so
 -- we will start our scan from the entry preceding the hole. So, we will scan

--- a/src/test/isolation2/input/uao/brin.source
+++ b/src/test/isolation2/input/uao/brin.source
@@ -230,9 +230,6 @@ SELECT brin_summarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
 1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_specific_@amname@_i_idx', 2),
   'brin_ao_specific_@amname@_i_idx') ORDER BY blknum, attnum;
 
--- Now test desummarization
--- XXX: We currently use utility mode as brin_desummarize_range() is not MPPized yet.
-
 -- Desummarization of a block falling beyond the end of aoseg1 should be a no-op.
 SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554436);
 -- Desummarization of a block falling in aoseg0 should be a no-op (as aoseg0 doesn't exist).
@@ -251,9 +248,9 @@ SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
   'brin_ao_specific_@amname@_i_idx') ORDER BY blknum, attnum;
 
 -- Should be able to desummarize all existing blocks in aoseg1.
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554432);
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554433);
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554435);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554432);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554433);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554435);
 
 -- Sanity: All revmap entries corresponding to aoseg1 have been set to invalid
 -- and all their data page tuples have been deleted (marked unused).
@@ -263,7 +260,7 @@ SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
   'brin_ao_specific_@amname@_i_idx') ORDER BY blknum, attnum;
 
 -- Now desummarize the last remaining range in the data page (from aoseg2).
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 67108864);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 67108864);
 
 -- Sanity: The revmap entry should be marked invalid.
 -- Also, this time instead of looking up the data page, look at the data page
@@ -648,7 +645,7 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid)
   FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 
 -- Desummarize the last block (test iteration to target range across chain)
-1U: SELECT brin_desummarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
+SELECT brin_desummarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
 
 -- Sanity: The revmap entry for the last block should be marked invalid.
 -- Also, this time instead of looking up the data page, look at the data page

--- a/src/test/isolation2/output/uao/brin.source
+++ b/src/test/isolation2/output/uao/brin.source
@@ -562,27 +562,21 @@ SELECT brin_summarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
  4          | 67108864 | 1      | f        | f        | f           | f     | {1 .. 1} 
 (4 rows)
 
--- Now test desummarization
--- XXX: We currently use utility mode as brin_desummarize_range() is not MPPized yet.
-
 -- Desummarization of a block falling beyond the end of aoseg1 should be a no-op.
 SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554436);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 -- Desummarization of a block falling in aoseg0 should be a no-op (as aoseg0 doesn't exist).
 SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 1);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 -- Desummarization of a block falling in aoseg3 should be a no-op (as aoseg3 doesn't exist).
 SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Sanity: Nothing should have changed.
 1U: SELECT blkno, brin_page_type(get_raw_page('brin_ao_specific_@amname@_i_idx', blkno)) FROM generate_series(0, nblocks('brin_ao_specific_@amname@_i_idx') - 1) blkno;
@@ -615,21 +609,18 @@ SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
 (4 rows)
 
 -- Should be able to desummarize all existing blocks in aoseg1.
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554432);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554432);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554433);
+(0 rows)
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554433);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554435);
+(0 rows)
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 33554435);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Sanity: All revmap entries corresponding to aoseg1 have been set to invalid
 -- and all their data page tuples have been deleted (marked unused).
@@ -650,11 +641,10 @@ SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 100663296);
 (4 rows)
 
 -- Now desummarize the last remaining range in the data page (from aoseg2).
-1U: SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 67108864);
+SELECT brin_desummarize_range('brin_ao_specific_@amname@_i_idx', 67108864);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Sanity: The revmap entry should be marked invalid.
 -- Also, this time instead of looking up the data page, look at the data page
@@ -1460,11 +1450,10 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid) FROM gp_segment_
 (1 row)
 
 -- Desummarize the last block (test iteration to target range across chain)
-1U: SELECT brin_desummarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
+SELECT brin_desummarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
  brin_desummarize_range 
 ------------------------
-                        
-(1 row)
+(0 rows)
 
 -- Sanity: The revmap entry for the last block should be marked invalid.
 -- Also, this time instead of looking up the data page, look at the data page

--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -436,8 +436,7 @@ FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 VACUUM brintest;  -- force a summarization cycle in brinidx
 UPDATE brintest SET int8col = int8col * int4col;
@@ -459,20 +458,17 @@ ERROR:  block number out of range: -1
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 SELECT brin_desummarize_range('brinidx', 100000000);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 -- Test brin_summarize_range
 CREATE TABLE brin_summarize (

--- a/src/test/regress/expected/brin_interface.out
+++ b/src/test/regress/expected/brin_interface.out
@@ -1,0 +1,148 @@
+-- Additional tests that exercise the BRIN user interface
+CREATE EXTENSION pageinspect;
+CREATE TABLE brin_interface(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO brin_interface SELECT * FROM generate_series(1, 5000);
+CREATE INDEX ON brin_interface USING brin(i) WITH (pages_per_range=1);
+-- Helper view to see revmap page contents.
+CREATE VIEW revmap_page1 AS (SELECT * FROM
+    brin_revmap_data(get_raw_page('brin_interface_i_idx', 1)) WHERE pages != '(0,0)' ORDER BY 1);
+-- Sanity: there are 2 ranges on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+ gp_execution_segment | pages 
+----------------------+-------
+                    0 | (2,1)
+                    0 | (2,2)
+                    1 | (2,1)
+                    1 | (2,2)
+                    2 | (2,1)
+                    2 | (2,2)
+(6 rows)
+
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+ gp_execution_segment | itemoffset | blknum | attnum | allnulls | hasnulls | placeholder | empty |     value      
+----------------------+------------+--------+--------+----------+----------+-------------+-------+----------------
+                    0 |          1 |      0 |      1 | f        | f        | f           | f     | {2 .. 2703}
+                    0 |          2 |      1 |      1 | f        | f        | f           | f     | {2705 .. 4997}
+                    1 |          1 |      0 |      1 | f        | f        | f           | f     | {1 .. 2777}
+                    1 |          2 |      1 |      1 | f        | f        | f           | f     | {2779 .. 5000}
+                    2 |          1 |      0 |      1 | f        | f        | f           | f     | {5 .. 2698}
+                    2 |          2 |      1 |      1 | f        | f        | f           | f     | {2699 .. 4999}
+(6 rows)
+
+-- Now desummarize the 1st range on each QE.
+SELECT brin_desummarize_range('brin_interface_i_idx', 0);
+ brin_desummarize_range 
+------------------------
+(0 rows)
+
+-- Sanity: the 1st range is desummarized on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+ gp_execution_segment |     pages      
+----------------------+----------------
+                    0 | (2,2)
+                    0 | (4294967295,0)
+                    1 | (2,2)
+                    1 | (4294967295,0)
+                    2 | (2,2)
+                    2 | (4294967295,0)
+(6 rows)
+
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+ gp_execution_segment | itemoffset | blknum | attnum | allnulls | hasnulls | placeholder | empty |     value      
+----------------------+------------+--------+--------+----------+----------+-------------+-------+----------------
+                    0 |          1 |        |        |          |          |             |       | 
+                    0 |          2 |      1 |      1 | f        | f        | f           | f     | {2705 .. 4997}
+                    1 |          1 |        |        |          |          |             |       | 
+                    1 |          2 |      1 |      1 | f        | f        | f           | f     | {2779 .. 5000}
+                    2 |          1 |        |        |          |          |             |       | 
+                    2 |          2 |      1 |      1 | f        | f        | f           | f     | {2699 .. 4999}
+(6 rows)
+
+-- Now re-summarize the 1st range on each QE.
+SELECT brin_summarize_range('brin_interface_i_idx', 0);
+ brin_summarize_range 
+----------------------
+                    3
+(1 row)
+
+-- Sanity: the 1st range is desummarized on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+ gp_execution_segment | pages 
+----------------------+-------
+                    0 | (2,2)
+                    0 | (2,3)
+                    1 | (2,2)
+                    1 | (2,3)
+                    2 | (2,2)
+                    2 | (2,3)
+(6 rows)
+
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+     'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+ gp_execution_segment | itemoffset | blknum | attnum | allnulls | hasnulls | placeholder | empty |     value      
+----------------------+------------+--------+--------+----------+----------+-------------+-------+----------------
+                    0 |          1 |        |        |          |          |             |       | 
+                    0 |          2 |      1 |      1 | f        | f        | f           | f     | {2705 .. 4997}
+                    0 |          3 |      0 |      1 | f        | f        | f           | f     | {2 .. 2703}
+                    1 |          1 |        |        |          |          |             |       | 
+                    1 |          2 |      1 |      1 | f        | f        | f           | f     | {2779 .. 5000}
+                    1 |          3 |      0 |      1 | f        | f        | f           | f     | {1 .. 2777}
+                    2 |          1 |        |        |          |          |             |       | 
+                    2 |          2 |      1 |      1 | f        | f        | f           | f     | {2699 .. 4999}
+                    2 |          3 |      0 |      1 | f        | f        | f           | f     | {5 .. 2698}
+(9 rows)
+
+-- Insert some more rows
+INSERT INTO brin_interface SELECT * FROM generate_series(5001, 10000);
+-- Summarize new ranges on all QEs (2 for each QE)
+SELECT brin_summarize_new_values('brin_interface_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         6
+(1 row)
+
+-- Sanity: all ranges are summarized on all QEs.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+ gp_execution_segment | pages 
+----------------------+-------
+                    0 | (2,2)
+                    0 | (2,3)
+                    0 | (2,4)
+                    0 | (2,5)
+                    1 | (2,2)
+                    1 | (2,3)
+                    1 | (2,4)
+                    1 | (2,5)
+                    2 | (2,2)
+                    2 | (2,3)
+                    2 | (2,4)
+                    2 | (2,5)
+(12 rows)
+
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+ gp_execution_segment | itemoffset | blknum | attnum | allnulls | hasnulls | placeholder | empty |      value      
+----------------------+------------+--------+--------+----------+----------+-------------+-------+-----------------
+                    0 |          1 |        |        |          |          |             |       | 
+                    0 |          2 |      1 |      1 | f        | f        | f           | f     | {2705 .. 5472}
+                    0 |          3 |      0 |      1 | f        | f        | f           | f     | {2 .. 2703}
+                    0 |          4 |      2 |      1 | f        | f        | f           | f     | {5477 .. 8199}
+                    0 |          5 |      3 |      1 | f        | f        | f           | f     | {8200 .. 9998}
+                    1 |          1 |        |        |          |          |             |       | 
+                    1 |          2 |      1 |      1 | f        | f        | f           | f     | {2779 .. 5442}
+                    1 |          3 |      0 |      1 | f        | f        | f           | f     | {1 .. 2777}
+                    1 |          4 |      2 |      1 | f        | f        | f           | f     | {5444 .. 8142}
+                    1 |          5 |      3 |      1 | f        | f        | f           | f     | {8145 .. 9990}
+                    2 |          1 |        |        |          |          |             |       | 
+                    2 |          2 |      1 |      1 | f        | f        | f           | f     | {2699 .. 5452}
+                    2 |          3 |      0 |      1 | f        | f        | f           | f     | {5 .. 2698}
+                    2 |          4 |      2 |      1 | f        | f        | f           | f     | {5456 .. 8214}
+                    2 |          5 |      3 |      1 | f        | f        | f           | f     | {8218 .. 10000}
+(15 rows)
+
+DROP EXTENSION pageinspect CASCADE;
+NOTICE:  drop cascades to view revmap_page1

--- a/src/test/regress/expected/brin_interface.out
+++ b/src/test/regress/expected/brin_interface.out
@@ -144,5 +144,15 @@ SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_i
                     2 |          5 |      3 |      1 | f        | f        | f           | f     | {8218 .. 10000}
 (15 rows)
 
+-- Error out when autosummarize is specified as true during index build.
+CREATE INDEX brin_interface_error_idx ON brin_interface USING brin(i) WITH (autosummarize=true);
+ERROR:  autosummarize is not supported
+-- Don't error out when autosummarize is specified as false during index build.
+CREATE INDEX brin_interface_idx ON brin_interface USING brin(i) WITH (autosummarize=false);
+-- Altering it to false should not result in an error.
+ALTER INDEX brin_interface_idx SET (autosummarize=false);
+-- Altering it to true should result in an error.
+ALTER INDEX brin_interface_idx SET (autosummarize=true);
+ERROR:  autosummarize is not supported
 DROP EXTENSION pageinspect CASCADE;
 NOTICE:  drop cascades to view revmap_page1

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -454,8 +454,7 @@ FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 VACUUM brintest;  -- force a summarization cycle in brinidx
 UPDATE brintest SET int8col = int8col * int4col;
@@ -477,20 +476,17 @@ ERROR:  block number out of range: -1
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 SELECT brin_desummarize_range('brinidx', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 SELECT brin_desummarize_range('brinidx', 100000000);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 -- Test brin_summarize_range
 CREATE TABLE brin_summarize (

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1420,13 +1420,12 @@ CREATE INDEX sro_brin ON sro_tab USING brin ((sro_ifun(a) + sro_ifun(0)));
 SELECT brin_desummarize_range('sro_brin', 0);
  brin_desummarize_range 
 ------------------------
- 
-(1 row)
+(0 rows)
 
 SELECT brin_summarize_range('sro_brin', 0);
  brin_summarize_range 
 ----------------------
-                    0
+                    2
 (1 row)
 
 DROP TABLE sro_tab;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -123,7 +123,7 @@ test: partition partition1 partition_indexing partition_storage partition_ddl pa
 
 test: index_constraint_naming index_constraint_naming_partition index_constraint_naming_upgrade
 
-test: brin_ao brin_aocs
+test: brin_ao brin_aocs brin_interface
 
 test: sreh
 

--- a/src/test/regress/sql/brin_interface.sql
+++ b/src/test/regress/sql/brin_interface.sql
@@ -41,5 +41,14 @@ SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
 SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
     'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
 
+-- Error out when autosummarize is specified as true during index build.
+CREATE INDEX brin_interface_error_idx ON brin_interface USING brin(i) WITH (autosummarize=true);
+-- Don't error out when autosummarize is specified as false during index build.
+CREATE INDEX brin_interface_idx ON brin_interface USING brin(i) WITH (autosummarize=false);
+-- Altering it to false should not result in an error.
+ALTER INDEX brin_interface_idx SET (autosummarize=false);
+-- Altering it to true should result in an error.
+ALTER INDEX brin_interface_idx SET (autosummarize=true);
+
 DROP EXTENSION pageinspect CASCADE;
 

--- a/src/test/regress/sql/brin_interface.sql
+++ b/src/test/regress/sql/brin_interface.sql
@@ -1,0 +1,45 @@
+-- Additional tests that exercise the BRIN user interface
+CREATE EXTENSION pageinspect;
+
+CREATE TABLE brin_interface(i int);
+INSERT INTO brin_interface SELECT * FROM generate_series(1, 5000);
+CREATE INDEX ON brin_interface USING brin(i) WITH (pages_per_range=1);
+
+-- Helper view to see revmap page contents.
+CREATE VIEW revmap_page1 AS (SELECT * FROM
+    brin_revmap_data(get_raw_page('brin_interface_i_idx', 1)) WHERE pages != '(0,0)' ORDER BY 1);
+
+-- Sanity: there are 2 ranges on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+
+-- Now desummarize the 1st range on each QE.
+SELECT brin_desummarize_range('brin_interface_i_idx', 0);
+
+-- Sanity: the 1st range is desummarized on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+
+-- Now re-summarize the 1st range on each QE.
+SELECT brin_summarize_range('brin_interface_i_idx', 0);
+
+-- Sanity: the 1st range is desummarized on each QE.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+     'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+
+-- Insert some more rows
+INSERT INTO brin_interface SELECT * FROM generate_series(5001, 10000);
+
+-- Summarize new ranges on all QEs (2 for each QE)
+SELECT brin_summarize_new_values('brin_interface_i_idx');
+
+-- Sanity: all ranges are summarized on all QEs.
+SELECT gp_execution_segment(), * FROM gp_dist_random('revmap_page1') ORDER BY 1;
+SELECT gp_execution_segment(), (brin_page_items(get_raw_page('brin_interface_i_idx', 2),
+    'brin_interface_i_idx')).* from gp_dist_random('gp_id') ORDER BY 1;
+
+DROP EXTENSION pageinspect CASCADE;
+


### PR DESCRIPTION
Please review commits individually. Mainly consists of 2 changes:
1. Making brin_desummarize_range MPP aware.
2. Warning users when the autosummarize reloption is set for BRIN indexes.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/brin_interface