### PR TITLE
Added libcgroup dependency to Platform Requirements page

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
@@ -44,7 +44,7 @@ Greenplum Database 6 requires the following software packages on RHEL/CentOS 6/7
 -   bzip2
 -   curl
 -   krb5
--   libcgrop (RHEL/CentOS 6)
+-   libcgroup (RHEL/CentOS 6)
 -   libcgroup-tools (RHEL/CentOS 7)
 -   libcurl
 -   libevent

--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
@@ -44,6 +44,8 @@ Greenplum Database 6 requires the following software packages on RHEL/CentOS 6/7
 -   bzip2
 -   curl
 -   krb5
+-   libcgrop (RHEL/CentOS 6)
+-   libcgroup-tools (RHEL/CentOS 7)
 -   libcurl
 -   libevent
 -   libxml2


### PR DESCRIPTION
Resource Groups are a core piece of functionality in Greenplum. Resource Groups requires certain OS packages to be installed. When users are installing the Greenplum Server, that is the appropriate time to require those packages.
Adding libcgroup/libcgroup-tools dependency to Platform Requirements page for GPDB 6.x