### PR TITLE
Docs: added libcgroup-tools to platform requirements page

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -30,6 +30,7 @@ Greenplum Database 7 requires the following software packages on RHEL systems. T
 -   bzip2
 -   curl
 -   krb5
+-   libcgroup-tools
 -   libcurl
 -   libevent
 -   libxml2

--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -30,6 +30,7 @@ Greenplum Database 7 requires the following software packages on RHEL systems. T
 -   bzip2
 -   curl
 -   krb5
+-   libcgroup
 -   libcgroup-tools
 -   libcurl
 -   libevent

--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -30,7 +30,6 @@ Greenplum Database 7 requires the following software packages on RHEL systems. T
 -   bzip2
 -   curl
 -   krb5
--   libcgroup
 -   libcgroup-tools
 -   libcurl
 -   libevent


### PR DESCRIPTION
Resource Groups are a core piece of functionality in Greenplum. Resource Groups requires certain OS packages to be installed. When users are installing the Greenplum Server, that is the appropriate time to require those packages.
Adding libcgroup-tools dependency to Platform Requirements page for GPDB 7.X.