### PR TITLE
Do not include unused system attributes for AO

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1752,6 +1752,11 @@ expand_all_col_privileges(Oid table_oid, Form_pg_class classForm,
 		if (classForm->relkind == RELKIND_VIEW && curr_att < 0)
 			continue;
 
+		/* AO rows and columns do not have system columns: cmin, cmax, xmin, and xmax */
+		if ((classForm->relam == AO_COLUMN_TABLE_AM_OID || classForm->relam == AO_ROW_TABLE_AM_OID) &&
+			(curr_att >= -5) && (curr_att <=-2))
+			continue;
+
 		attTuple = SearchSysCache2(ATTNUM,
 								   ObjectIdGetDatum(table_oid),
 								   Int16GetDatum(curr_att));

--- a/src/test/regress/expected/storage_pg_attributes.out
+++ b/src/test/regress/expected/storage_pg_attributes.out
@@ -1,0 +1,67 @@
+drop table if exists abuela;
+NOTICE:  table "abuela" does not exist, skipping
+CREATE TABLE abuela (a int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- verify that cmax, xmax, cmin, and xmin do not exist
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+ attrelid |    attname    | attnum 
+----------+---------------+--------
+ abuela   | gp_segment_id |     -7
+ abuela   | tableoid      |     -6
+ abuela   | ctid          |     -1
+ abuela   | a             |      1
+(4 rows)
+
+INSERT INTO abuela VALUES (0);
+-- show parser fails
+SELECT count(xmin) FROM abuela;
+ERROR:  column "xmin" does not exist
+LINE 1: SELECT count(xmin) FROM abuela;
+                     ^
+drop table if exists abuela;
+CREATE TABLE abuela (a int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- verify that cmax, xmax, cmin, and xmin do not exist
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+ attrelid |    attname    | attnum 
+----------+---------------+--------
+ abuela   | gp_segment_id |     -7
+ abuela   | tableoid      |     -6
+ abuela   | ctid          |     -1
+ abuela   | a             |      1
+(4 rows)
+
+INSERT INTO abuela VALUES (0);
+-- show parser fails
+SELECT count(xmin) FROM abuela;
+ERROR:  column "xmin" does not exist
+LINE 1: SELECT count(xmin) FROM abuela;
+                     ^
+drop table if exists abuela;
+CREATE TABLE abuela (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- verify that cmax, xmax, cmin, xmin exists
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+ attrelid |    attname    | attnum 
+----------+---------------+--------
+ abuela   | gp_segment_id |     -7
+ abuela   | tableoid      |     -6
+ abuela   | cmax          |     -5
+ abuela   | xmax          |     -4
+ abuela   | cmin          |     -3
+ abuela   | xmin          |     -2
+ abuela   | ctid          |     -1
+ abuela   | a             |      1
+(8 rows)
+
+INSERT INTO abuela VALUES (0);
+-- show parser pass
+SELECT count(xmin) FROM abuela;
+ count 
+-------
+     1
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -26,6 +26,8 @@ test: gp_dispatch_keepalives
 # copy form a file with different EOL
 test: copy_eol
 
+test: storage_pg_attributes
+
 test: disable_autovacuum
 # test gp_fastsequence allocation (early in schedule as log grepping is expensive)
 # These tests gp_log_system could have issue reading partial log that's generated

--- a/src/test/regress/sql/storage_pg_attributes.sql
+++ b/src/test/regress/sql/storage_pg_attributes.sql
@@ -1,0 +1,23 @@
+drop table if exists abuela;
+CREATE TABLE abuela (a int) USING ao_row;
+-- verify that cmax, xmax, cmin, and xmin do not exist
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+INSERT INTO abuela VALUES (0);
+-- show parser fails
+SELECT count(xmin) FROM abuela;
+
+drop table if exists abuela;
+CREATE TABLE abuela (a int) USING ao_column;
+-- verify that cmax, xmax, cmin, and xmin do not exist
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+INSERT INTO abuela VALUES (0);
+-- show parser fails
+SELECT count(xmin) FROM abuela;
+
+drop table if exists abuela;
+CREATE TABLE abuela (a int);
+-- verify that cmax, xmax, cmin, xmin exists
+SELECT attrelid::regclass, attname, attnum FROM pg_attribute WHERE attrelid = 'abuela'::regclass;
+INSERT INTO abuela VALUES (0);
+-- show parser pass
+SELECT count(xmin) FROM abuela;


### PR DESCRIPTION
AO tables do not use system columns `cmin`, `cmax`, `xmin`, and `xmax`, so do not include them when adding the system attributes. Not including the listed system columns above makes it possible to error out during parse analysis instead of getting a run-time error.


This addresses https://github.com/greenplum-db/gpdb/issues/11844

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
