### PR TITLE
Removed ambiguous step

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4080,8 +4080,3 @@ def impl(context):
     else:
         return
 
-
-@when('the user asynchronously sets up to end {process_name} process with SIGHUP')
-def impl(context, process_name):
-    command = "ps ux | grep bin/%s | awk '{print $2}' | xargs kill -9" % (process_name)
-    run_async_command(context, command)


### PR DESCRIPTION
Due to changes made in https://github.com/greenplum-db/gpdb/pull/15504 step 'the user asynchronously sets up to end {process_name} process with SIGHUP' was defined twice, so removed the ambiguity

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
