### PR TITLE
Add latest tag to gpdb6-centos7-build image

### DIFF
--- a/src/backend/gporca/concourse/test_explain_pipeline.yml
+++ b/src/backend/gporca/concourse/test_explain_pipeline.yml
@@ -31,6 +31,7 @@ resources:
   type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
+    tag: latest
 
 - name: libquicklz-centos7
   type: gcs


### PR DESCRIPTION
Before adding the "latest" tag, we used an outdated image, where lib 'uuid' was missing. As a result, explain pipeline couldn't compile. Adding the "latest" tag allows us to access the required libraries.