### PR TITLE
Add assert cases for the attributes of GpSegmentId

### DIFF
--- a/src/test/regress/expected/misc_sanity.out
+++ b/src/test/regress/expected/misc_sanity.out
@@ -122,3 +122,21 @@ ORDER BY 1, 2;
  pg_stat_last_shoperation | stasubtype         | text
 (19 rows)
 
+-- **************** others ****************
+-- For better performance, we hardcode some attribute values of gp_segment_id in
+-- GetContentIdsFromPlanForSingleRelation() of src/backend/cdb/cdbtargeteddispatch.c
+-- PR: https://github.com/greenplum-db/gpdb/pull/15659
+-- Normally, they shouldn't change in a major version. But just in case, add tests
+-- to notice the possible changes in future.
+select distinct atttypmod, atttypid from pg_attribute where attname='gp_segment_id';
+ atttypmod | atttypid 
+-----------+----------
+        -1 |       23
+(1 row)
+
+select oid, opfname from pg_opfamily where oid=1977;
+ oid  |   opfname   
+------+-------------
+ 1977 | integer_ops
+(1 row)
+

--- a/src/test/regress/sql/misc_sanity.sql
+++ b/src/test/regress/sql/misc_sanity.sql
@@ -98,3 +98,14 @@ WHERE c.oid < 16384 AND
       relkind = 'r' AND
       attstorage != 'p'
 ORDER BY 1, 2;
+
+-- **************** others ****************
+
+-- For better performance, we hardcode some attribute values of gp_segment_id in
+-- GetContentIdsFromPlanForSingleRelation() of src/backend/cdb/cdbtargeteddispatch.c
+-- PR: https://github.com/greenplum-db/gpdb/pull/15659
+
+-- Normally, they shouldn't change in a major version. But just in case, add tests
+-- to notice the possible changes in future.
+select distinct atttypmod, atttypid from pg_attribute where attname='gp_segment_id';
+select oid, opfname from pg_opfamily where oid=1977;


### PR DESCRIPTION
This PR add assert case for https://github.com/greenplum-db/gpdb/pull/15659, to resolve https://github.com/greenplum-db/gpdb/pull/15659#discussion_r1227616967

(no need to backport to 6x since the catalog is stable)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
