### PR TITLE
6X: Open parallel cursors on behalf of the current user

### DIFF
--- a/gpcontrib/gp_parallel_retrieve_cursor/gp_parallel_retrieve_cursor.c
+++ b/gpcontrib/gp_parallel_retrieve_cursor/gp_parallel_retrieve_cursor.c
@@ -330,8 +330,8 @@ gp_get_segment_endpoints(PG_FUNCTION_ARGS)
 		MemSet(nulls, 0, sizeof(nulls));
 
 		/*
-		 * Only allow current user to list his/her own endpoints, or let
-		 * superuser list all endpoints.
+		 * Only allow the current user to list own endpoints, or let superuser
+		 * list all endpoints.
 		 */
 		if (!entry->empty && entry->databaseID == MyDatabaseId && (superuser() || entry->userID == GetUserId()))
 		{

--- a/src/backend/cdb/endpoint/README
+++ b/src/backend/cdb/endpoint/README
@@ -102,7 +102,7 @@ gp_get_endpoints() Columns:
 | port        | integer   | The port number to start the retrieve    |
 |             |           | session                                  |
 |-------------+-----------+------------------------------------------|
-| userid      | oid       | The oid of the session user              |
+| userid      | oid       | The oid of the user                      |
 |-------------+-----------+------------------------------------------|
 | state       | text      | One of the following state for this      |
 |             |           | endpoint:                                |
@@ -132,24 +132,15 @@ postgres=# select * from gp_get_endpoints();
     4 | 97a8eeee337798f718319c5234ea1440 | c3         |       105 | host67   | 6004 |     10 | READY | c30000006900000005
 (3 rows)
 
-The userid of the endpoint is the session user, not the current user. For
-example, if a user logs in to the database as user1, then uses set role to
-switch to another user (e.g., user2) and declare a parallel retrieve cursor.
-The userid of these endpoints is user1's oid, not user2's oid. The session user
-(i.e., user1) should be used to start a retrieve connection. This is typically
-due to the security concern, e.g. if user2 is nologin, we should not be able to
-retrieve using user2.
-
 There is another similar gp_get_session_endpoints() that shows the endpoint
-informations that belong to this session only.
+information that belong to this session only.
 
 Start A Retrieve Session
 ========================
 
 Once a parallel retrieve cursor has been declared, retrieve sessions can be
 started on each endpoint's host by using the endpoint's token as the session
-authentication password. The user of this retrieve session is the session user
-who declares this parallel retrieve cursor.
+authentication password.
 
 gp_retrieve_conn=true needs to be set to start retrieve session.
 

--- a/src/backend/cdb/endpoint/cdbendpoint.c
+++ b/src/backend/cdb/endpoint/cdbendpoint.c
@@ -436,7 +436,7 @@ static Endpoint
 				sharedEndpoints[i].databaseID = MyDatabaseId;
 				sharedEndpoints[i].mqDsmHandle = DSM_HANDLE_INVALID;
 				sharedEndpoints[i].sessionID = gp_session_id;
-				sharedEndpoints[i].userID = GetSessionUserId();
+				sharedEndpoints[i].userID = GetUserId();
 				sharedEndpoints[i].senderPid = InvalidPid;
 				sharedEndpoints[i].receiverPid = InvalidPid;
 				sharedEndpoints[i].empty = false;
@@ -476,7 +476,7 @@ static Endpoint
 	StrNCpy(sharedEndpoints[i].cursorName, cursorName, NAMEDATALEN);
 	sharedEndpoints[i].databaseID = MyDatabaseId;
 	sharedEndpoints[i].sessionID = gp_session_id;
-	sharedEndpoints[i].userID = GetSessionUserId();
+	sharedEndpoints[i].userID = GetUserId();
 	sharedEndpoints[i].senderPid = MyProcPid;
 	sharedEndpoints[i].receiverPid = InvalidPid;
 	sharedEndpoints[i].state = ENDPOINTSTATE_READY;
@@ -566,7 +566,7 @@ setup_endpoint_token_entry()
 	const int8 *token = NULL;
 
 	tag.sessionID = gp_session_id;
-	tag.userID = GetSessionUserId();
+	tag.userID = GetUserId();
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
 	infoEntry = (EndpointTokenEntry *) hash_search(EndpointTokenHash, &tag, HASH_ENTER, &found);

--- a/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
@@ -60,6 +60,7 @@ RESET SESSION AUTHORIZATION;
 1: SELECT SESSION_USER, CURRENT_USER;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 --- u1 can not see uu1's endpoints.
 1: SET ROLE u1;
 1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();

--- a/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
@@ -60,13 +60,13 @@ RESET SESSION AUTHORIZATION;
 1: SELECT SESSION_USER, CURRENT_USER;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
---- uu1 can not see u1's endpoints.
+--- u1 can not see uu1's endpoints.
+1: SET ROLE u1;
 1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 
 3: @pre_run 'export RETRIEVE_USER="uu1"; echo $RAW_STR ' : SELECT 1;
---- Login as uu1 and retrieve, only u1 can retrieve
-3R: SELECT SESSION_USER, CURRENT_USER;
+--- Login as uu1 and retrieve
 3R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 
 --- Retrieve c2(which belongs to u1) but current user is uu1.

--- a/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
@@ -167,18 +167,22 @@ DECLARE
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
 (3 rows)
---- uu1 can not see u1's endpoints.
+--- u1 can not see uu1's endpoints.
+1: SET ROLE u1;
+SET
 1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
  cursorname | username 
 ------------+----------
-(0 rows)
+ c2         | u1       
+ c12        | u1       
+(2 rows)
 2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
  cursorname | username  
 ------------+-----------
  c1         | adminuser 
  c12        | u1        
  c2         | u1        
- c3         | u1        
+ c3         | uu1       
 (4 rows)
 
 3: @pre_run 'export RETRIEVE_USER="uu1"; echo $RAW_STR ' : SELECT 1;
@@ -186,15 +190,21 @@ DECLARE
 ----------
  1        
 (1 row)
---- Login as uu1 and retrieve, only u1 can retrieve
-3R: SELECT SESSION_USER, CURRENT_USER;
-#3retrieve> FATAL:  Authentication failure (Wrong password or no endpoint for the user)
+--- Login as uu1 and retrieve
 3R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
-#3retrieve> FATAL:  Authentication failure (Wrong password or no endpoint for the user)
+ a 
+---
+ 2 
+ 3 
+ 4 
+ 7 
+ 8 
+(5 rows)
 
 --- Retrieve c2(which belongs to u1) but current user is uu1.
 3R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#3retrieve> FATAL:  Authentication failure (Wrong password or no endpoint for the user)
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 0Rq: ... <quitting>
 3Rq: ... <quitting>
 1<:  <... completed>

--- a/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
@@ -167,6 +167,11 @@ DECLARE
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
 (3 rows)
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+ cursorname | username 
+------------+----------
+ c3         | uu1      
+(1 row)
 --- u1 can not see uu1's endpoints.
 1: SET ROLE u1;
 SET


### PR DESCRIPTION
It's a weird behavior that parallel retrieve cursors are opened on behalf of the session user no matter who the current user is, and it confuses the database users.

This commit changes the behavior to open parallel retrieve cursors on behalf of the current user, just as how these parallel retrieve cursor functions check permissions.
