### PR TITLE
Support partial aggregate functions pushdown to distributed postgres_fdw servers

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -1,7 +1,7 @@
 # contrib/postgres_fdw/Makefile
 
 MODULE_big = postgres_fdw
-OBJS = postgres_fdw.o option.o deparse.o connection.o shippable.o $(WIN32RES)
+OBJS = postgres_fdw.o option.o deparse.o connection.o shippable.o transcoding.o $(WIN32RES)
 PGFILEDESC = "postgres_fdw - foreign data wrapper for PostgreSQL"
 
 PG_CPPFLAGS = -I$(libpq_srcdir)

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -116,6 +116,7 @@ typedef struct deparse_expr_cxt
  * Functions to determine whether an expression can be evaluated safely on
  * remote server.
  */
+static bool partial_agg_pushdown(Aggref* agg, PgFdwRelationInfo *fpinfo);
 static bool foreign_expr_walker(Node *node,
 								foreign_glob_cxt *glob_cxt,
 								foreign_loc_cxt *outer_cxt);
@@ -181,6 +182,7 @@ static void deparseRangeTblRef(StringInfo buf, PlannerInfo *root,
 							   RelOptInfo *foreignrel, bool make_subquery,
 							   Index ignore_rel, List **ignore_conds, List **params_list);
 static void deparseAggref(Aggref *node, deparse_expr_cxt *context);
+static void deparsePartialAggref(Aggref *node, deparse_expr_cxt *context);
 static void appendGroupByClause(List *tlist, deparse_expr_cxt *context);
 static void appendOrderBySuffix(Oid sortop, Oid sortcoltype, bool nulls_first,
 								deparse_expr_cxt *context);
@@ -226,6 +228,92 @@ classifyConditions(PlannerInfo *root,
 		else
 			*local_conds = lappend(*local_conds, ri);
 	}
+}
+
+static bool supported_by_fdw(Oid target)
+{
+	/*
+	 * If aggregate functions have final functions or have internal transition
+	 * type, FDW need to handle them specifically to gurantee corrrect partial
+	 * aggregate pushdown.
+	 *
+	 * Those aggregate functions can be got by execute the SQL as follows.
+	 *     SELECT aggfnoid::oid, aggfnoid
+	 *     FROM pg_aggregate
+	 *     WHERE aggcombinefn::text != '-'
+	 *           and
+	 *           (aggfinalfn::text != '-' or aggtranstype = 2281);
+	 * Here 2281 is INTERNALOID.
+	 *
+	 * Array supported_partial_agg stores oid of such aggregate functions supported
+	 * currently.
+	 */
+	static Oid supported_partial_agg[] = {
+			2100, /* pg_catalog.avg int8|bigint */
+			2101, /* pg_catalog.avg int4|int */
+			2102, /* pg_catalog.avg int2|smallint */
+			2103, /* pg_catalog.avg numeric */
+			2104, /* pg_catalog.avg float4 */
+			2105, /* pg_catalog.avg float8 */
+			2107, /* pg_catalog.sum int8|bigint */
+			2114, /* pg_catalog.sum numeric */
+	};
+
+	for (int i = 0; i < sizeof(supported_partial_agg) / sizeof(Oid); ++i)
+	{
+		if (target == supported_partial_agg[i])
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+/*
+ * Check whether partial aggregate is safe to push down.
+ * condition1) agg is AGGKIND_NORMAL aggregate which contains no distinct
+ *   or order by clauses
+ * condition2) The aggtranstype is not internal and aggfinalfn is null.
+ *   In this case, nothing we need to do.
+ * condition3) The aggtranstype is not internal, but aggfinalfn is not null.
+ *   In this case, we only need to adjust the remote SQL.
+ * condition4) The aggtranstype is internal.
+ *   We may need to adjust the remote SQL, and then we need to do a trans-code
+ *   to transform the final-result from remote server into partial-result.
+ */
+static bool
+partial_agg_pushdown(Aggref *agg, PgFdwRelationInfo *fpinfo)
+{
+	HeapTuple	aggtup;
+	Form_pg_aggregate aggform;
+	bool        partial_agg_pushdown = true;
+
+	Assert(agg->aggsplit == AGGSPLIT_INITIAL_SERIAL);
+
+	/* We don't support complex partial aggregates */
+	if (agg->aggdistinct || agg->aggkind != AGGKIND_NORMAL || agg->aggorder != NIL)
+		return false;
+
+	aggtup = SearchSysCache1(AGGFNOID, ObjectIdGetDatum(agg->aggfnoid));
+	if (!HeapTupleIsValid(aggtup))
+		elog(ERROR, "cache lookup failed for aggregate %u", agg->aggfnoid);
+	aggform = (Form_pg_aggregate)GETSTRUCT(aggtup);
+
+	if ((aggform->aggtranstype != INTERNALOID) && (aggform->aggfinalfn == InvalidOid))
+	{
+		partial_agg_pushdown = true;
+	}
+	else if (supported_by_fdw(aggform->aggfnoid))
+	{
+		partial_agg_pushdown = true;
+	}
+	else
+	{
+		partial_agg_pushdown = false;
+	}
+
+	ReleaseSysCache(aggtup);
+	return partial_agg_pushdown;
 }
 
 /*
@@ -704,8 +792,11 @@ foreign_expr_walker(Node *node,
 				if (!IS_UPPER_REL(glob_cxt->foreignrel))
 					return false;
 
-				/* Only non-split aggregates are pushable. */
-				if (agg->aggsplit != AGGSPLIT_SIMPLE)
+				/* Only AGGSPLIT_SIMPLE and AGGSPLIT_INITIAL_SERIAL aggregates are pushable. */
+				if (agg->aggsplit != AGGSPLIT_SIMPLE &&
+					agg->aggsplit != AGGSPLIT_INITIAL_SERIAL)
+					return false;
+				if (agg->aggsplit == AGGSPLIT_INITIAL_SERIAL && !partial_agg_pushdown(agg, fpinfo))
 					return false;
 
 				/* As usual, it must be shippable. */
@@ -2416,7 +2507,10 @@ deparseExpr(Expr *node, deparse_expr_cxt *context)
 			deparseArrayExpr((ArrayExpr *) node, context);
 			break;
 		case T_Aggref:
-			deparseAggref((Aggref *) node, context);
+			if (((Aggref *) node)->aggsplit == AGGSPLIT_INITIAL_SERIAL)
+				deparsePartialAggref((Aggref *) node, context);
+			else
+				deparseAggref((Aggref *) node, context);
 			break;
 		default:
 			elog(ERROR, "unsupported expression type for deparse: %d",
@@ -2996,6 +3090,101 @@ deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context)
 						 deparse_type_name(node->array_typeid, -1));
 }
 
+static void
+deparsePartialAggFunctionParamFilter(Aggref *node, deparse_expr_cxt *context,
+	StringInfo agg_param, StringInfo agg_filter)
+{
+	StringInfo buf = context->buf;
+
+	switch (node->aggfnoid)
+	{
+		case 2100:
+			/* int8 AVG */
+			/* Fall through */
+		case 2101:
+			/* int4 AVG function */
+			/* Fall through */
+		case 2102:
+			/* int2 AVG function */
+			/* Fall through */
+		case 2103:
+			/* numeric AVG function */
+			/* According to aggcombinefn, those aggregate functions need to fetch same columns from remote server. */
+			appendStringInfo(buf, "array[count(%s)%s, sum(%s)%s]", agg_param->data, agg_filter->data,
+				agg_param->data, agg_filter->data);
+			break;
+		case 2104:
+			/* float4 AVG function */
+			/* Fall through */
+		case 2105:
+			/* float8 AVG function */
+			appendStringInfo(buf, "array[count(%s)%s, sum(%s)%s, count(%s)*var_pop(%s)%s]",
+				agg_param->data, agg_filter->data, agg_param->data, agg_filter->data,
+				agg_param->data, agg_param->data, agg_filter->data);
+			break;
+		default:
+			/* Find aggregate name from aggfnoid which is a pg_proc entry */
+			appendFunctionName(node->aggfnoid, context);
+			appendStringInfo(buf, "(%s)%s", agg_param->data, agg_filter->data);
+			break;
+	}
+}
+/* Deparse an Partial Aggref node. */
+static void
+deparsePartialAggref(Aggref *node, deparse_expr_cxt *context)
+{
+	StringInfoData agg_param;
+	StringInfoData agg_filter;
+	bool		use_variadic;
+	StringInfo origin_buf = context->buf;
+
+	/* Check if need to print VARIADIC (cf. ruleutils.c) */
+	use_variadic = node->aggvariadic;
+	initStringInfo(&agg_param);
+	initStringInfo(&agg_filter);
+
+	context->buf = &agg_param;
+	/* aggstar can be set only in zero-argument aggregates */
+	if (node->aggstar)
+		appendStringInfoChar(&agg_param, '*');
+	else
+	{
+		ListCell   *arg;
+		bool		first = true;
+
+		/* Add all the arguments */
+		foreach(arg, node->args)
+		{
+			TargetEntry *tle = (TargetEntry *) lfirst(arg);
+			Node	   *n = (Node *) tle->expr;
+
+			if (tle->resjunk)
+				continue;
+
+			if (!first)
+				appendStringInfoString(&agg_param, ", ");
+			first = false;
+
+			/* Add VARIADIC */
+			if (use_variadic && lnext(arg) == NULL)
+				appendStringInfoString(&agg_param, "VARIADIC ");
+
+			deparseExpr((Expr *) n, context);
+		}
+	}
+
+	context->buf = &agg_filter;
+	/* Add FILTER (WHERE ..) */
+	if (node->aggfilter != NULL)
+	{
+		appendStringInfoString(&agg_filter, " FILTER (WHERE ");
+		deparseExpr((Expr *) node->aggfilter, context);
+		appendStringInfoChar(&agg_filter, ')');
+	}
+
+	context->buf = origin_buf;
+	deparsePartialAggFunctionParamFilter(node, context, &agg_param, &agg_filter);
+}
 /*
  * Deparse an Aggref node.
  */

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -141,28 +141,47 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 (7 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
-                           QUERY PLAN                            
------------------------------------------------------------------
- Gather Motion 4:1  (slice1; segments: 4)
-   Output: (count(*))
-   ->  Foreign Scan
-         Output: (count(*))
-         Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
-         Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather Motion 4:1  (slice1; segments: 4)
+         Output: (PARTIAL count(*))
+         ->  Foreign Scan
+               Output: (PARTIAL count(*))
+               Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
+               Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 4:1  (slice1; segments: 4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
-   ->  Foreign Scan
+   ->  Gather Motion 4:1  (slice1; segments: 4)
          Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
-         Relations: (postgres_fdw_gp.gp_ft1 t1) INNER JOIN (postgres_fdw_gp.gp_ft1 t2)
-         Remote SQL: SELECT r1.f1, r1.f2, r1.f3, r2.f1, r2.f2, r2.f3 FROM (postgres_fdw_gp."GP 1" r1 INNER JOIN postgres_fdw_gp."GP 1" r2 ON (((r1.f1 = r2.f1)))) LIMIT 3::bigint
+         ->  Limit
+               Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+               ->  Hash Join
+                     Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+                     Hash Cond: (t1.f1 = t2.f1)
+                     ->  Redistribute Motion 4:4  (slice2; segments: 4)
+                           Output: t1.f1, t1.f2, t1.f3
+                           Hash Key: t1.f1
+                           ->  Foreign Scan on postgres_fdw_gp.gp_ft1 t1
+                                 Output: t1.f1, t1.f2, t1.f3
+                                 Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
+                     ->  Hash
+                           Output: t2.f1, t2.f2, t2.f3
+                           ->  Redistribute Motion 4:4  (slice3; segments: 4)
+                                 Output: t2.f1, t2.f2, t2.f3
+                                 Hash Key: t2.f1
+                                 ->  Foreign Scan on postgres_fdw_gp.gp_ft1 t2
+                                       Output: t2.f1, t2.f2, t2.f3
+                                       Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
  Optimizer: Postgres query optimizer
-(7 rows)
+(24 rows)
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -140,28 +140,47 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 (6 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
-                           QUERY PLAN                            
------------------------------------------------------------------
- Gather Motion 4:1  (slice1; segments: 4)
-   Output: (count(*))
-   ->  Foreign Scan
-         Output: (count(*))
-         Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
-         Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather Motion 4:1  (slice1; segments: 4)
+         Output: (PARTIAL count(*))
+         ->  Foreign Scan
+               Output: (PARTIAL count(*))
+               Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
+               Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 4:1  (slice1; segments: 4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
    Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
-   ->  Foreign Scan
+   ->  Gather Motion 4:1  (slice1; segments: 4)
          Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
-         Relations: (postgres_fdw_gp.gp_ft1 t1) INNER JOIN (postgres_fdw_gp.gp_ft1 t2)
-         Remote SQL: SELECT r1.f1, r1.f2, r1.f3, r2.f1, r2.f2, r2.f3 FROM (postgres_fdw_gp."GP 1" r1 INNER JOIN postgres_fdw_gp."GP 1" r2 ON (((r1.f1 = r2.f1)))) LIMIT 3::bigint
+         ->  Limit
+               Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+               ->  Hash Join
+                     Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+                     Hash Cond: (t1.f1 = t2.f1)
+                     ->  Redistribute Motion 4:4  (slice2; segments: 4)
+                           Output: t1.f1, t1.f2, t1.f3
+                           Hash Key: t1.f1
+                           ->  Foreign Scan on postgres_fdw_gp.gp_ft1 t1
+                                 Output: t1.f1, t1.f2, t1.f3
+                                 Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
+                     ->  Hash
+                           Output: t2.f1, t2.f2, t2.f3
+                           ->  Redistribute Motion 4:4  (slice3; segments: 4)
+                                 Output: t2.f1, t2.f2, t2.f3
+                                 Hash Key: t2.f1
+                                 ->  Foreign Scan on postgres_fdw_gp.gp_ft1 t2
+                                       Output: t2.f1, t2.f2, t2.f3
+                                       Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
  Optimizer: Postgres query optimizer
-(7 rows)
+(24 rows)
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -3,6 +3,8 @@
 -- create FDW objects
 -- ===================================================================
 SET timezone = 'PST8PDT';
+-- If gp_enable_minmax_optimization is on, it won't generate aggregate functions pushdown plan.
+SET gp_enable_minmax_optimization = off;
 -- Clean
 -- start_ignore
 DROP EXTENSION IF EXISTS postgres_fdw CASCADE;
@@ -21,16 +23,26 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver;
 SET
 CREATE SCHEMA
 CREATE TABLE
+CREATE TABLE
+ALTER TABLE
 ALTER TABLE
 INSERT 0 5
+INSERT 0 500
+UPDATE 500
+ANALYZE
 ANALYZE
 -- remote postgres server 2 -- listening port 5555
 \! env PGOPTIONS='' psql -p 5555 contrib_regression -f sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
 SET
 CREATE SCHEMA
 CREATE TABLE
+CREATE TABLE
+ALTER TABLE
 ALTER TABLE
 INSERT 0 5
+INSERT 0 500
+UPDATE 500
+ANALYZE
 ANALYZE
 -- ===================================================================
 -- create foreign tables
@@ -39,6 +51,15 @@ CREATE FOREIGN TABLE mpp_ft1 (
 	c1 int,
 	c2 int
 ) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
+CREATE FOREIGN TABLE mpp_ft2 (
+	c1 int,
+	c2 int,
+	c3 smallint,
+	c4 bigint,
+	c5 real,
+	c6 double precision,
+	c7 numeric
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 2');
 -- ===================================================================
 -- tests for validator
 -- ===================================================================
@@ -58,7 +79,7 @@ ALTER FOREIGN TABLE mpp_test OPTIONS (drop mpp_execute);
 -- Error when the value of option num_segments is NOT same as the length of option multi_hosts and multi_ports.
 ALTER SERVER pgserver OPTIONS (set num_segments '1');
 SELECT * FROM mpp_test;
-ERROR:  server option num_segments, multi_hosts and multi_ports don't match. (postgres_fdw.c:1498)  (seg0 slice1 127.0.0.1:7002 pid=24510)
+ERROR:  server option num_segments, multi_hosts and multi_ports don't match. (postgres_fdw.c:1502)  (seg0 slice1 127.0.0.1:7002 pid=24510)
 ALTER SERVER pgserver OPTIONS (set num_segments '2');
 -- ===================================================================
 -- Simple queries
@@ -136,3 +157,843 @@ UPDATE mpp_ft1 SET c1 = c1 + 1;
 ERROR:  foreign table "mpp_ft1" does not allow updates
 DELETE FROM mpp_ft1;
 ERROR:  foreign table "mpp_ft1" does not allow deletes
+-- ===================================================================
+-- Aggregate and grouping queries
+-- ===================================================================
+-- Simple aggregates with different data types
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), count(c3), count(c4), count(c5), count(c6), count(c7) FROM mpp_ft2;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(c1), count(c3), count(c4), count(c5), count(c6), count(c7)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL count(c1)), (PARTIAL count(c3)), (PARTIAL count(c4)), (PARTIAL count(c5)), (PARTIAL count(c6)), (PARTIAL count(c7))
+         ->  Foreign Scan
+               Output: (PARTIAL count(c1)), (PARTIAL count(c3)), (PARTIAL count(c4)), (PARTIAL count(c5)), (PARTIAL count(c6)), (PARTIAL count(c7))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT count(c1), count(c3), count(c4), count(c5), count(c6), count(c7) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT count(c1), count(c3), count(c4), count(c5), count(c6), count(c7) FROM mpp_ft2;
+ count | count | count | count | count | count 
+-------+-------+-------+-------+-------+-------
+  1000 |  1000 |  1000 |  1000 |  1000 |  1000
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7) FROM mpp_ft2;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL sum(c1)), (PARTIAL sum(c3)), (PARTIAL sum(c4)), (PARTIAL sum(c5)), (PARTIAL sum(c6)), (PARTIAL sum(c7))
+         ->  Foreign Scan
+               Output: (PARTIAL sum(c1)), (PARTIAL sum(c3)), (PARTIAL sum(c4)), (PARTIAL sum(c5)), (PARTIAL sum(c6)), (PARTIAL sum(c7))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7) FROM mpp_ft2;
+  sum   |  sum   |  sum   |  sum  |        sum        |   sum   
+--------+--------+--------+-------+-------------------+---------
+ 500500 | 500500 | 500500 | 500.5 | 500.5000000000001 | 500.500
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT avg(c1), avg(c3), avg(c4), avg(c5), avg(c6), avg(c7) FROM mpp_ft2;
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: avg(c1), avg(c3), avg(c4), avg(c5), avg(c6), avg(c7)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL avg(c1)), (PARTIAL avg(c3)), (PARTIAL avg(c4)), (PARTIAL avg(c5)), (PARTIAL avg(c6)), (PARTIAL avg(c7))
+         ->  Foreign Scan
+               Output: (PARTIAL avg(c1)), (PARTIAL avg(c3)), (PARTIAL avg(c4)), (PARTIAL avg(c5)), (PARTIAL avg(c6)), (PARTIAL avg(c7))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT array[count(c1), sum(c1)], array[count(c3), sum(c3)], array[count(c4), sum(c4)], array[count(c5), sum(c5), count(c5)*var_pop(c5)], array[count(c6), sum(c6), count(c6)*var_pop(c6)], array[count(c7), sum(c7)] FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT avg(c1), avg(c3), avg(c4), avg(c5), avg(c6), avg(c7) FROM mpp_ft2;
+         avg          |         avg          |         avg          |  avg   |        avg         |          avg           
+----------------------+----------------------+----------------------+--------+--------------------+------------------------
+ 500.5000000000000000 | 500.5000000000000000 | 500.5000000000000000 | 0.5005 | 0.5005000000000002 | 0.50050000000000000000
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT min(c1), min(c3), min(c4), min(c5), min(c6), min(c7) FROM mpp_ft2;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: min(c1), min(c3), min(c4), min(c5), min(c6), min(c7)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL min(c1)), (PARTIAL min(c3)), (PARTIAL min(c4)), (PARTIAL min(c5)), (PARTIAL min(c6)), (PARTIAL min(c7))
+         ->  Foreign Scan
+               Output: (PARTIAL min(c1)), (PARTIAL min(c3)), (PARTIAL min(c4)), (PARTIAL min(c5)), (PARTIAL min(c6)), (PARTIAL min(c7))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT min(c1), min(c3), min(c4), min(c5), min(c6), min(c7) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT min(c1), min(c3), min(c4), min(c5), min(c6), min(c7) FROM mpp_ft2;
+ min | min | min |  min  |  min  |  min  
+-----+-----+-----+-------+-------+-------
+   1 |   1 |   1 | 0.001 | 0.001 | 0.001
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT max(c1), max(c3), max(c4), max(c5), max(c6), max(c7) FROM mpp_ft2;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: max(c1), max(c3), max(c4), max(c5), max(c6), max(c7)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL max(c1)), (PARTIAL max(c3)), (PARTIAL max(c4)), (PARTIAL max(c5)), (PARTIAL max(c6)), (PARTIAL max(c7))
+         ->  Foreign Scan
+               Output: (PARTIAL max(c1)), (PARTIAL max(c3)), (PARTIAL max(c4)), (PARTIAL max(c5)), (PARTIAL max(c6)), (PARTIAL max(c7))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT max(c1), max(c3), max(c4), max(c5), max(c6), max(c7) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT max(c1), max(c3), max(c4), max(c5), max(c6), max(c7) FROM mpp_ft2;
+ max  | max  | max  | max | max |  max  
+------+------+------+-----+-----+-------
+ 1000 | 1000 | 1000 |   1 |   1 | 1.000
+(1 row)
+
+-- Simple Aggregates with GROUP BY clause
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (count(c1)), (sum(c3)), (avg(c4)), (min(c5)), (max(c6)), (((count(c1)) * ((random() <= '1'::double precision))::integer)), c2
+   Merge Key: c2
+   ->  Result
+         Output: (count(c1)), (sum(c3)), (avg(c4)), (min(c5)), (max(c6)), ((count(c1)) * ((random() <= '1'::double precision))::integer), c2
+         ->  Sort
+               Output: (count(c1)), (sum(c3)), (avg(c4)), (min(c5)), (max(c6)), c2
+               Sort Key: mpp_ft2.c2
+               ->  Finalize HashAggregate
+                     Output: count(c1), sum(c3), avg(c4), min(c5), max(c6), c2
+                     Group Key: mpp_ft2.c2
+                     ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                           Output: c2, (PARTIAL count(c1)), (PARTIAL sum(c3)), (PARTIAL avg(c4)), (PARTIAL min(c5)), (PARTIAL max(c6))
+                           Hash Key: c2
+                           ->  Foreign Scan
+                                 Output: c2, (PARTIAL count(c1)), (PARTIAL sum(c3)), (PARTIAL avg(c4)), (PARTIAL min(c5)), (PARTIAL max(c6))
+                                 Relations: Aggregate on (public.mpp_ft2)
+                                 Remote SQL: SELECT c2, count(c1), sum(c3), array[count(c4), sum(c4)], min(c5), max(c6) FROM "MPP_S 1"."T 2" GROUP BY 1
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(20 rows)
+
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+ count |  sum  |         avg          |  min  |  max  | count2 
+-------+-------+----------------------+-------+-------+--------
+   100 | 50500 | 505.0000000000000000 |  0.01 |     1 |    100
+   100 | 49600 | 496.0000000000000000 | 0.001 | 0.991 |    100
+   100 | 49700 | 497.0000000000000000 | 0.002 | 0.992 |    100
+   100 | 49800 | 498.0000000000000000 | 0.003 | 0.993 |    100
+   100 | 49900 | 499.0000000000000000 | 0.004 | 0.994 |    100
+   100 | 50000 | 500.0000000000000000 | 0.005 | 0.995 |    100
+   100 | 50100 | 501.0000000000000000 | 0.006 | 0.996 |    100
+   100 | 50200 | 502.0000000000000000 | 0.007 | 0.997 |    100
+   100 | 50300 | 503.0000000000000000 | 0.008 | 0.998 |    100
+   100 | 50400 | 504.0000000000000000 | 0.009 | 0.999 |    100
+(10 rows)
+
+-- Aggregate is not pushed down as aggregation contains random()
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1 * (random() <= 1)::int) as sum, avg(c1) FROM mpp_ft2;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum((c1 * ((random() <= '1'::double precision))::integer)), avg(c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL sum((c1 * ((random() <= '1'::double precision))::integer))), (PARTIAL avg(c1))
+         ->  Partial Aggregate
+               Output: PARTIAL sum((c1 * ((random() <= '1'::double precision))::integer)), PARTIAL avg(c1)
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c1, c2, c3, c4, c5, c6, c7
+                     Remote SQL: SELECT c1 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(11 rows)
+
+SELECT sum(c1 * (random() <= 1)::int) as sum, avg(c1) FROM mpp_ft2;
+  sum   |         avg          
+--------+----------------------
+ 500500 | 500.5000000000000000
+(1 row)
+
+-- GROUP BY clause having expressions
+/* FIXME: Aggregates are not pushed down.
+          Because for Remote SQL of partial agg, non-grouping columns 
+		  might neither appear in the GROUP BY clause nor be used in 
+		  an aggregate function.
+		  This is unsafe to make foreign grouping.
+*/
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2/2, sum(c2) * (c2/2) FROM mpp_ft2 GROUP BY c2/2 ORDER BY c2/2;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((c2 / 2)), ((sum(c2) * ((c2 / 2))))
+   Merge Key: ((c2 / 2))
+   ->  Sort
+         Output: ((c2 / 2)), ((sum(c2) * ((c2 / 2))))
+         Sort Key: ((mpp_ft2.c2 / 2))
+         ->  Finalize HashAggregate
+               Output: ((c2 / 2)), (sum(c2) * ((c2 / 2)))
+               Group Key: ((mpp_ft2.c2 / 2))
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: ((c2 / 2)), (PARTIAL sum(c2)), c2
+                     Hash Key: ((c2 / 2))
+                     ->  Partial HashAggregate
+                           Output: ((c2 / 2)), PARTIAL sum(c2), c2
+                           Group Key: (mpp_ft2.c2 / 2)
+                           ->  Foreign Scan on public.mpp_ft2
+                                 Output: (c2 / 2), c2
+                                 Remote SQL: SELECT c2 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(20 rows)
+
+SELECT c2/2, sum(c2) * (c2/2) FROM mpp_ft2 GROUP BY c2/2 ORDER BY c2/2;
+ ?column? | ?column? 
+----------+----------
+        0 |        0
+        1 |      500
+        2 |     1800
+        3 |     3900
+        4 |     6800
+(5 rows)
+
+-- Aggregates in subquery are pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(x.a), sum(x.a) FROM (SELECT c2 a, sum(c1) b FROM mpp_ft2 GROUP BY c2, sqrt(c1) ORDER BY 1, 2) x;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(mpp_ft2.c2), sum(mpp_ft2.c2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(mpp_ft2.c2)), (PARTIAL sum(mpp_ft2.c2))
+         ->  Partial Aggregate
+               Output: PARTIAL count(mpp_ft2.c2), PARTIAL sum(mpp_ft2.c2)
+               ->  Sort
+                     Output: mpp_ft2.c2, (sum(mpp_ft2.c1)), (sqrt((mpp_ft2.c1)::double precision))
+                     Sort Key: mpp_ft2.c2, (sum(mpp_ft2.c1))
+                     ->  Finalize HashAggregate
+                           Output: mpp_ft2.c2, sum(mpp_ft2.c1), (sqrt((mpp_ft2.c1)::double precision))
+                           Group Key: mpp_ft2.c2, (sqrt((mpp_ft2.c1)::double precision))
+                           ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                                 Output: mpp_ft2.c2, (sqrt((mpp_ft2.c1)::double precision)), (PARTIAL sum(mpp_ft2.c1))
+                                 Hash Key: mpp_ft2.c2, (sqrt((mpp_ft2.c1)::double precision))
+                                 ->  Foreign Scan
+                                       Output: mpp_ft2.c2, (sqrt((mpp_ft2.c1)::double precision)), (PARTIAL sum(mpp_ft2.c1))
+                                       Relations: Aggregate on (public.mpp_ft2)
+                                       Remote SQL: SELECT c2, sqrt(c1), sum(c1) FROM "MPP_S 1"."T 2" GROUP BY 1, 2
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(21 rows)
+
+SELECT count(x.a), sum(x.a) FROM (SELECT c2 a, sum(c1) b FROM mpp_ft2 GROUP BY c2, sqrt(c1) ORDER BY 1, 2) x;
+ count | sum  
+-------+------
+  1000 | 4500
+(1 row)
+
+-- Aggregate is still pushed down by taking unshippable expression out
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 FROM mpp_ft2 GROUP BY c2 ORDER BY 1, 2;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((c2 * ((random() <= '1'::double precision))::integer)), ((sum(c1) * c2)), c2
+   Merge Key: ((c2 * ((random() <= '1'::double precision))::integer)), ((sum(c1) * c2))
+   ->  Sort
+         Output: ((c2 * ((random() <= '1'::double precision))::integer)), ((sum(c1) * c2)), c2
+         Sort Key: ((mpp_ft2.c2 * ((random() <= '1'::double precision))::integer)), ((sum(mpp_ft2.c1) * mpp_ft2.c2))
+         ->  Finalize HashAggregate
+               Output: (c2 * ((random() <= '1'::double precision))::integer), (sum(c1) * c2), c2
+               Group Key: mpp_ft2.c2
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, (PARTIAL sum(c1))
+                     Hash Key: c2
+                     ->  Foreign Scan
+                           Output: c2, (PARTIAL sum(c1))
+                           Relations: Aggregate on (public.mpp_ft2)
+                           Remote SQL: SELECT c2, sum(c1) FROM "MPP_S 1"."T 2" GROUP BY 1
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(18 rows)
+
+SELECT c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 FROM mpp_ft2 GROUP BY c2 ORDER BY 1, 2;
+ sum1 |  sum2  
+------+--------
+    0 |      0
+    1 |  49600
+    2 |  99400
+    3 | 149400
+    4 | 199600
+    5 | 250000
+    6 | 300600
+    7 | 351400
+    8 | 402400
+    9 | 453600
+(10 rows)
+
+-- Aggregate with unshippable GROUP BY clause are not pushed
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2 * (random() <= 1)::int as c2 FROM mpp_ft2 GROUP BY c2 * (random() <= 1)::int ORDER BY 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((c2 * ((random() <= '1'::double precision))::integer))
+   Merge Key: ((c2 * ((random() <= '1'::double precision))::integer))
+   ->  Sort
+         Output: ((c2 * ((random() <= '1'::double precision))::integer))
+         Sort Key: ((mpp_ft2.c2 * ((random() <= '1'::double precision))::integer))
+         ->  HashAggregate
+               Output: ((c2 * ((random() <= '1'::double precision))::integer))
+               Group Key: ((mpp_ft2.c2 * ((random() <= '1'::double precision))::integer))
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: ((c2 * ((random() <= '1'::double precision))::integer))
+                     Hash Key: ((c2 * ((random() <= '1'::double precision))::integer))
+                     ->  HashAggregate
+                           Output: ((c2 * ((random() <= '1'::double precision))::integer))
+                           Group Key: (mpp_ft2.c2 * ((random() <= '1'::double precision))::integer)
+                           ->  Foreign Scan on public.mpp_ft2
+                                 Output: (c2 * ((random() <= '1'::double precision))::integer)
+                                 Remote SQL: SELECT c2 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(20 rows)
+
+SELECT c2 * (random() <= 1)::int as c2 FROM mpp_ft2 GROUP BY c2 * (random() <= 1)::int ORDER BY 1;
+ c2 
+----
+  0
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+(10 rows)
+
+-- GROUP BY clause in various forms, cardinal, alias and constant expression
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c2) w, c2 x, 5 y, 7.0 z FROM mpp_ft2 GROUP BY 2, y, 9.0::int ORDER BY 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (count(c2)), c2, 5, 7.0, 9
+   Merge Key: c2
+   ->  Sort
+         Output: (count(c2)), c2, 5, 7.0, 9
+         Sort Key: mpp_ft2.c2
+         ->  Finalize HashAggregate
+               Output: count(c2), c2, (5), 7.0, (9)
+               Group Key: mpp_ft2.c2, 5, 9
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, 5, 9, (PARTIAL count(c2))
+                     Hash Key: c2, 5, 9
+                     ->  Foreign Scan
+                           Output: c2, 5, 9, (PARTIAL count(c2))
+                           Relations: Aggregate on (public.mpp_ft2)
+                           Remote SQL: SELECT c2, 5, 9, count(c2) FROM "MPP_S 1"."T 2" GROUP BY 1, 2, 3
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(18 rows)
+
+SELECT count(c2) w, c2 x, 5 y, 7.0 z FROM mpp_ft2 GROUP BY 2, y, 9.0::int ORDER BY 2;
+  w  | x | y |  z  
+-----+---+---+-----
+ 100 | 0 | 5 | 7.0
+ 100 | 1 | 5 | 7.0
+ 100 | 2 | 5 | 7.0
+ 100 | 3 | 5 | 7.0
+ 100 | 4 | 5 | 7.0
+ 100 | 5 | 5 | 7.0
+ 100 | 6 | 5 | 7.0
+ 100 | 7 | 5 | 7.0
+ 100 | 8 | 5 | 7.0
+ 100 | 9 | 5 | 7.0
+(10 rows)
+
+-- GROUP BY clause referring to same column multiple times
+-- Also, ORDER BY contains an aggregate function
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2, c2 FROM mpp_ft2 WHERE c2 > 6 GROUP BY 1, 2 ORDER BY sum(c1);
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: c2, c2, (sum(c1))
+   Merge Key: (sum(c1))
+   ->  Sort
+         Output: c2, c2, (sum(c1))
+         Sort Key: (sum(mpp_ft2.c1))
+         ->  Finalize HashAggregate
+               Output: c2, c2, sum(c1)
+               Group Key: mpp_ft2.c2, mpp_ft2.c2
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, c2, (PARTIAL sum(c1))
+                     Hash Key: c2, c2
+                     ->  Foreign Scan
+                           Output: c2, c2, (PARTIAL sum(c1))
+                           Relations: Aggregate on (public.mpp_ft2)
+                           Remote SQL: SELECT c2, c2, sum(c1) FROM "MPP_S 1"."T 2" WHERE ((c2 > 6)) GROUP BY 1, 2
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(18 rows)
+
+SELECT c2, c2 FROM mpp_ft2 WHERE c2 > 6 GROUP BY 1, 2 ORDER BY sum(c1);
+ c2 | c2 
+----+----
+  7 |  7
+  8 |  8
+  9 |  9
+(3 rows)
+
+-- Testing HAVING clause
+-- It's unsafe for partial agg to push down HAVING clause.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2, sum(c1) FROM mpp_ft2 GROUP BY c2 HAVING avg(c1) < 500 AND sum(c1) < 49800 ORDER BY c2;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: c2, (sum(c1))
+   Merge Key: c2
+   ->  Sort
+         Output: c2, (sum(c1))
+         Sort Key: mpp_ft2.c2
+         ->  Finalize HashAggregate
+               Output: c2, sum(c1)
+               Group Key: mpp_ft2.c2
+               Filter: ((avg(mpp_ft2.c1) < '500'::numeric) AND (sum(mpp_ft2.c1) < 49800))
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, (PARTIAL sum(c1)), (PARTIAL avg(c1))
+                     Hash Key: c2
+                     ->  Partial HashAggregate
+                           Output: c2, PARTIAL sum(c1), PARTIAL avg(c1)
+                           Group Key: mpp_ft2.c2
+                           ->  Foreign Scan on public.mpp_ft2
+                                 Output: c1, c2, c3, c4, c5, c6, c7
+                                 Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(21 rows)
+
+SELECT c2, sum(c1) FROM mpp_ft2 GROUP BY c2 HAVING avg(c1) < 500 AND sum(c1) < 49800 ORDER BY c2;
+ c2 |  sum  
+----+-------
+  1 | 49600
+  2 | 49700
+(2 rows)
+
+-- Remote aggregate in combination with a local Param (for the output
+-- of an initplan) can be trouble, per bug #15781
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Finalize Aggregate
+   Output: $0, sum(mpp_ft2.c1)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Seq Scan on pg_catalog.pg_aggregate
+           Output: 1
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL sum(mpp_ft2.c1))
+         ->  Foreign Scan
+               Output: (PARTIAL sum(mpp_ft2.c1))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT sum(c1) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(13 rows)
+
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2;
+ exists |  sum   
+--------+--------
+ t      | 500500
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2 group by 1;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: ($0), sum(mpp_ft2.c1)
+   Group Key: ($0)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Seq Scan on pg_catalog.pg_aggregate
+           Output: 1
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: ($0), (PARTIAL sum(mpp_ft2.c1))
+         ->  Partial GroupAggregate
+               Output: ($0), PARTIAL sum(mpp_ft2.c1)
+               Group Key: $0
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: $0, mpp_ft2.c1
+                     Remote SQL: SELECT c1 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(16 rows)
+
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2 group by 1;
+ exists |  sum   
+--------+--------
+ t      | 500500
+(1 row)
+
+-- Testing ORDER BY, DISTINCT, FILTER within aggregates
+-- ORDER BY within aggregate, same column used to order
+-- TODO: Now we don't support array_agg mpp pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT array_agg(c1 ORDER BY c1) FROM mpp_ft2 WHERE c1 < 100 GROUP BY c2 ORDER BY 1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: (array_agg(c1 ORDER BY c1)), c2
+   Sort Key: (array_agg(mpp_ft2.c1 ORDER BY mpp_ft2.c1))
+   ->  GroupAggregate
+         Output: array_agg(c1 ORDER BY c1), c2
+         Group Key: mpp_ft2.c2
+         ->  Gather Motion 2:1  (slice1; segments: 2)
+               Output: c2, c1
+               Merge Key: c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c2, c1
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" WHERE ((c1 < 100)) ORDER BY c2 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(14 rows)
+
+SELECT array_agg(c1 ORDER BY c1) FROM mpp_ft2 WHERE c1 < 100 GROUP BY c2 ORDER BY 1;
+           array_agg            
+--------------------------------
+ {1,11,21,31,41,51,61,71,81,91}
+ {2,12,22,32,42,52,62,72,82,92}
+ {3,13,23,33,43,53,63,73,83,93}
+ {4,14,24,34,44,54,64,74,84,94}
+ {5,15,25,35,45,55,65,75,85,95}
+ {6,16,26,36,46,56,66,76,86,96}
+ {7,17,27,37,47,57,67,77,87,97}
+ {8,18,28,38,48,58,68,78,88,98}
+ {9,19,29,39,49,59,69,79,89,99}
+ {10,20,30,40,50,60,70,80,90}
+(10 rows)
+
+-- FILTER within aggregate
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1) FILTER (WHERE c1 < 100 AND c2 > 5) FROM mpp_ft2 GROUP BY c2 ORDER BY 1 nulls last;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5)))), c2
+   Merge Key: (sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5))))
+   ->  Sort
+         Output: (sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5)))), c2
+         Sort Key: (sum(mpp_ft2.c1) FILTER (WHERE ((mpp_ft2.c1 < 100) AND (mpp_ft2.c2 > 5))))
+         ->  Finalize HashAggregate
+               Output: sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5))), c2
+               Group Key: mpp_ft2.c2
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, (PARTIAL sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5))))
+                     Hash Key: c2
+                     ->  Foreign Scan
+                           Output: c2, (PARTIAL sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5))))
+                           Relations: Aggregate on (public.mpp_ft2)
+                           Remote SQL: SELECT c2, sum(c1) FILTER (WHERE ((c1 < 100) AND (c2 > 5))) FROM "MPP_S 1"."T 2" GROUP BY 1
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(18 rows)
+
+SELECT sum(c1) FILTER (WHERE c1 < 100 AND c2 > 5) FROM mpp_ft2 GROUP BY c2 ORDER BY 1 nulls last;
+ sum 
+-----
+ 510
+ 520
+ 530
+ 540
+    
+    
+    
+    
+    
+    
+(10 rows)
+
+-- DISTINCT, ORDER BY and FILTER within aggregate
+-- It's unsafe to push down DISTINCT within aggregates when there are multiple remote servers.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1%3), sum(DISTINCT c1%3 ORDER BY c1%3) FILTER (WHERE c1%3 < 2), c2 FROM mpp_ft2 WHERE c2 = 6 GROUP BY c2;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum((c1 % 3))), (sum(DISTINCT (c1 % 3) ORDER BY (c1 % 3)) FILTER (WHERE ((c1 % 3) < 2))), c2
+   ->  GroupAggregate
+         Output: sum((c1 % 3)), sum(DISTINCT (c1 % 3) ORDER BY (c1 % 3)) FILTER (WHERE ((c1 % 3) < 2)), c2
+         Group Key: mpp_ft2.c2
+         ->  Redistribute Motion 2:3  (slice2; segments: 2)
+               Output: c2, c1
+               Hash Key: c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c2, c1
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" WHERE ((c2 = 6))
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(13 rows)
+
+SELECT sum(c1%3), sum(DISTINCT c1%3 ORDER BY c1%3) FILTER (WHERE c1%3 < 2), c2 FROM mpp_ft2 WHERE c2 = 6 GROUP BY c2;
+ sum | sum | c2 
+-----+-----+----
+  99 |   1 |  6
+(1 row)
+
+-- Aggregate not pushed down as FILTER condition is not pushable
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1) FILTER (WHERE (c1 / c1) * random() <= 1) FROM mpp_ft2 GROUP BY c2 ORDER BY 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision))), c2
+   Merge Key: (sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision)))
+   ->  Sort
+         Output: (sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision))), c2
+         Sort Key: (sum(mpp_ft2.c1) FILTER (WHERE ((((mpp_ft2.c1 / mpp_ft2.c1))::double precision * random()) <= '1'::double precision)))
+         ->  Finalize HashAggregate
+               Output: sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision)), c2
+               Group Key: mpp_ft2.c2
+               ->  Redistribute Motion 2:3  (slice2; segments: 2)
+                     Output: c2, (PARTIAL sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision)))
+                     Hash Key: c2
+                     ->  Partial HashAggregate
+                           Output: c2, PARTIAL sum(c1) FILTER (WHERE ((((c1 / c1))::double precision * random()) <= '1'::double precision))
+                           Group Key: mpp_ft2.c2
+                           ->  Foreign Scan on public.mpp_ft2
+                                 Output: c1, c2, c3, c4, c5, c6, c7
+                                 Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(20 rows)
+
+SELECT sum(c1) FILTER (WHERE (c1 / c1) * random() <= 1) FROM mpp_ft2 GROUP BY c2 ORDER BY 1;
+  sum  
+-------
+ 49600
+ 49700
+ 49800
+ 49900
+ 50000
+ 50100
+ 50200
+ 50300
+ 50400
+ 50500
+(10 rows)
+
+-- Set use_remote_estimate to true
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(add use_remote_estimate 'true');
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT min(c5) FROM mpp_ft2;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Finalize Aggregate
+   Output: min(c5)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL min(c5))
+         ->  Foreign Scan
+               Output: (PARTIAL min(c5))
+               Relations: Aggregate on (public.mpp_ft2)
+               Remote SQL: SELECT min(c5) FROM "MPP_S 1"."T 2"
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(10 rows)
+
+SELECT min(c5) FROM mpp_ft2;
+  min  
+-------
+ 0.001
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: count(c1), max(c6), c2
+   Group Key: mpp_ft2.c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c2, (PARTIAL count(c1)), (PARTIAL max(c6))
+         Merge Key: c2
+         ->  Sort
+               Output: c2, (PARTIAL count(c1)), (PARTIAL max(c6))
+               Sort Key: mpp_ft2.c2
+               ->  Foreign Scan
+                     Output: c2, (PARTIAL count(c1)), (PARTIAL max(c6))
+                     Relations: Aggregate on (public.mpp_ft2)
+                     Remote SQL: SELECT c2, count(c1), max(c6) FROM "MPP_S 1"."T 2" GROUP BY 1
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(15 rows)
+
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2;
+ count |  max  
+-------+-------
+   100 |     1
+   100 | 0.991
+   100 | 0.992
+   100 | 0.993
+   100 | 0.994
+   100 | 0.995
+   100 | 0.996
+   100 | 0.997
+   100 | 0.998
+   100 | 0.999
+(10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: count(c1), sum(c3), avg(c4), min(c5), max(c6), (count(c1) * ((random() <= '1'::double precision))::integer), c2
+   Group Key: mpp_ft2.c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c2, (PARTIAL count(c1)), (PARTIAL sum(c3)), (PARTIAL avg(c4)), (PARTIAL min(c5)), (PARTIAL max(c6))
+         Merge Key: c2
+         ->  Sort
+               Output: c2, (PARTIAL count(c1)), (PARTIAL sum(c3)), (PARTIAL avg(c4)), (PARTIAL min(c5)), (PARTIAL max(c6))
+               Sort Key: mpp_ft2.c2
+               ->  Foreign Scan
+                     Output: c2, (PARTIAL count(c1)), (PARTIAL sum(c3)), (PARTIAL avg(c4)), (PARTIAL min(c5)), (PARTIAL max(c6))
+                     Relations: Aggregate on (public.mpp_ft2)
+                     Remote SQL: SELECT c2, count(c1), sum(c3), array[count(c4), sum(c4)], min(c5), max(c6) FROM "MPP_S 1"."T 2" GROUP BY 1
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(15 rows)
+
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+ count |  sum  |         avg          |  min  |  max  | count2 
+-------+-------+----------------------+-------+-------+--------
+   100 | 50500 | 505.0000000000000000 |  0.01 |     1 |    100
+   100 | 49600 | 496.0000000000000000 | 0.001 | 0.991 |    100
+   100 | 49700 | 497.0000000000000000 | 0.002 | 0.992 |    100
+   100 | 49800 | 498.0000000000000000 | 0.003 | 0.993 |    100
+   100 | 49900 | 499.0000000000000000 | 0.004 | 0.994 |    100
+   100 | 50000 | 500.0000000000000000 | 0.005 | 0.995 |    100
+   100 | 50100 | 501.0000000000000000 | 0.006 | 0.996 |    100
+   100 | 50200 | 502.0000000000000000 | 0.007 | 0.997 |    100
+   100 | 50300 | 503.0000000000000000 | 0.008 | 0.998 |    100
+   100 | 50400 | 504.0000000000000000 | 0.009 | 0.999 |    100
+(10 rows)
+
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
+-- limit is not pushed down when there are multiple remote servers
+-- limit with agg functions
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit
+   Output: (count(c1)), (max(c6)), c2
+   ->  Finalize GroupAggregate
+         Output: count(c1), max(c6), c2
+         Group Key: mpp_ft2.c2
+         ->  Gather Motion 2:1  (slice1; segments: 2)
+               Output: c2, (PARTIAL count(c1)), (PARTIAL max(c6))
+               Merge Key: c2
+               ->  Partial GroupAggregate
+                     Output: c2, PARTIAL count(c1), PARTIAL max(c6)
+                     Group Key: mpp_ft2.c2
+                     ->  Foreign Scan on public.mpp_ft2
+                           Output: c1, c2, c3, c4, c5, c6, c7
+                           Remote SQL: SELECT c1, c2, c6 FROM "MPP_S 1"."T 2" ORDER BY c2 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(16 rows)
+
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
+ count |  max  
+-------+-------
+   100 |     1
+   100 | 0.991
+   100 | 0.992
+(3 rows)
+
+-- limit with normal scan without agg functions
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Limit
+               Output: c1, c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c1, c2
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(12 rows)
+
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+(3 rows)
+
+-- join is not safe to pushed down when there are multiple remote servers
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*), sum(t1.c1), avg(t2.c2)
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: (PARTIAL count(*)), (PARTIAL sum(t1.c1)), (PARTIAL avg(t2.c2))
+         ->  Partial Aggregate
+               Output: PARTIAL count(*), PARTIAL sum(t1.c1), PARTIAL avg(t2.c2)
+               ->  Nested Loop
+                     Output: t1.c1, t2.c2
+                     ->  Broadcast Motion 2:2  (slice2; segments: 2)
+                           Output: t1.c1
+                           ->  Foreign Scan on public.mpp_ft2 t1
+                                 Output: t1.c1
+                                 Remote SQL: SELECT c1 FROM "MPP_S 1"."T 2" WHERE ((c1 = 2))
+                     ->  Materialize
+                           Output: t2.c2, t2.c1
+                           ->  Foreign Scan on public.mpp_ft2 t2
+                                 Output: t2.c2, t2.c1
+                                 Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" WHERE ((c1 = 2))
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+(20 rows)
+
+SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;
+ count | sum |        avg         
+-------+-----+--------------------
+     1 |   2 | 2.0000000000000000
+(1 row)
+

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -211,4 +211,5 @@ extern const char *get_jointype_name(JoinType jointype);
 extern bool is_builtin(Oid objectId);
 extern bool is_shippable(Oid objectId, Oid classId, PgFdwRelationInfo *fpinfo);
 
+extern PGFunction GetTranscodingFnFromOid(Oid aggfnoid);
 #endif							/* POSTGRES_FDW_H */

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -4,6 +4,8 @@
 -- create FDW objects
 -- ===================================================================
 SET timezone = 'PST8PDT';
+-- If gp_enable_minmax_optimization is on, it won't generate aggregate functions pushdown plan.
+SET gp_enable_minmax_optimization = off;
 
 -- Clean
 -- start_ignore
@@ -34,6 +36,16 @@ CREATE FOREIGN TABLE mpp_ft1 (
 	c1 int,
 	c2 int
 ) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
+
+CREATE FOREIGN TABLE mpp_ft2 (
+	c1 int,
+	c2 int,
+	c3 smallint,
+	c4 bigint,
+	c5 real,
+	c6 double precision,
+	c7 numeric
+) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 2');
 
 -- ===================================================================
 -- tests for validator
@@ -78,3 +90,144 @@ INSERT INTO mpp_ft1 VALUES (1, 1);
 UPDATE mpp_ft1 SET c1 = c1 + 1;
 
 DELETE FROM mpp_ft1;
+
+-- ===================================================================
+-- Aggregate and grouping queries
+-- ===================================================================
+-- Simple aggregates with different data types
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), count(c3), count(c4), count(c5), count(c6), count(c7) FROM mpp_ft2;
+SELECT count(c1), count(c3), count(c4), count(c5), count(c6), count(c7) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7) FROM mpp_ft2;
+SELECT sum(c1), sum(c3), sum(c4), sum(c5), sum(c6), sum(c7) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT avg(c1), avg(c3), avg(c4), avg(c5), avg(c6), avg(c7) FROM mpp_ft2;
+SELECT avg(c1), avg(c3), avg(c4), avg(c5), avg(c6), avg(c7) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT min(c1), min(c3), min(c4), min(c5), min(c6), min(c7) FROM mpp_ft2;
+SELECT min(c1), min(c3), min(c4), min(c5), min(c6), min(c7) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT max(c1), max(c3), max(c4), max(c5), max(c6), max(c7) FROM mpp_ft2;
+SELECT max(c1), max(c3), max(c4), max(c5), max(c6), max(c7) FROM mpp_ft2;
+
+-- Simple Aggregates with GROUP BY clause
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+
+-- Aggregate is not pushed down as aggregation contains random()
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1 * (random() <= 1)::int) as sum, avg(c1) FROM mpp_ft2;
+SELECT sum(c1 * (random() <= 1)::int) as sum, avg(c1) FROM mpp_ft2;
+
+-- GROUP BY clause having expressions
+/* FIXME: Aggregates are not pushed down.
+          Because for Remote SQL of partial agg, non-grouping columns 
+		  might neither appear in the GROUP BY clause nor be used in 
+		  an aggregate function.
+		  This is unsafe to make foreign grouping.
+*/
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2/2, sum(c2) * (c2/2) FROM mpp_ft2 GROUP BY c2/2 ORDER BY c2/2;
+SELECT c2/2, sum(c2) * (c2/2) FROM mpp_ft2 GROUP BY c2/2 ORDER BY c2/2;
+
+-- Aggregates in subquery are pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(x.a), sum(x.a) FROM (SELECT c2 a, sum(c1) b FROM mpp_ft2 GROUP BY c2, sqrt(c1) ORDER BY 1, 2) x;
+SELECT count(x.a), sum(x.a) FROM (SELECT c2 a, sum(c1) b FROM mpp_ft2 GROUP BY c2, sqrt(c1) ORDER BY 1, 2) x;
+
+-- Aggregate is still pushed down by taking unshippable expression out
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 FROM mpp_ft2 GROUP BY c2 ORDER BY 1, 2;
+SELECT c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 FROM mpp_ft2 GROUP BY c2 ORDER BY 1, 2;
+
+-- Aggregate with unshippable GROUP BY clause are not pushed
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2 * (random() <= 1)::int as c2 FROM mpp_ft2 GROUP BY c2 * (random() <= 1)::int ORDER BY 1;
+SELECT c2 * (random() <= 1)::int as c2 FROM mpp_ft2 GROUP BY c2 * (random() <= 1)::int ORDER BY 1;
+
+-- GROUP BY clause in various forms, cardinal, alias and constant expression
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c2) w, c2 x, 5 y, 7.0 z FROM mpp_ft2 GROUP BY 2, y, 9.0::int ORDER BY 2;
+SELECT count(c2) w, c2 x, 5 y, 7.0 z FROM mpp_ft2 GROUP BY 2, y, 9.0::int ORDER BY 2;
+
+-- GROUP BY clause referring to same column multiple times
+-- Also, ORDER BY contains an aggregate function
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2, c2 FROM mpp_ft2 WHERE c2 > 6 GROUP BY 1, 2 ORDER BY sum(c1);
+SELECT c2, c2 FROM mpp_ft2 WHERE c2 > 6 GROUP BY 1, 2 ORDER BY sum(c1);
+
+-- Testing HAVING clause
+-- It's unsafe for partial agg to push down HAVING clause.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c2, sum(c1) FROM mpp_ft2 GROUP BY c2 HAVING avg(c1) < 500 AND sum(c1) < 49800 ORDER BY c2;
+SELECT c2, sum(c1) FROM mpp_ft2 GROUP BY c2 HAVING avg(c1) < 500 AND sum(c1) < 49800 ORDER BY c2;
+
+-- Remote aggregate in combination with a local Param (for the output
+-- of an initplan) can be trouble, per bug #15781
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2;
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2 group by 1;
+SELECT exists(SELECT 1 FROM pg_aggregate), sum(c1) FROM mpp_ft2 group by 1;
+
+-- Testing ORDER BY, DISTINCT, FILTER within aggregates
+-- ORDER BY within aggregate, same column used to order
+-- TODO: Now we don't support array_agg mpp pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT array_agg(c1 ORDER BY c1) FROM mpp_ft2 WHERE c1 < 100 GROUP BY c2 ORDER BY 1;
+SELECT array_agg(c1 ORDER BY c1) FROM mpp_ft2 WHERE c1 < 100 GROUP BY c2 ORDER BY 1;
+
+-- FILTER within aggregate
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1) FILTER (WHERE c1 < 100 AND c2 > 5) FROM mpp_ft2 GROUP BY c2 ORDER BY 1 nulls last;
+SELECT sum(c1) FILTER (WHERE c1 < 100 AND c2 > 5) FROM mpp_ft2 GROUP BY c2 ORDER BY 1 nulls last;
+
+-- DISTINCT, ORDER BY and FILTER within aggregate
+-- It's unsafe to push down DISTINCT within aggregates when there are multiple remote servers.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1%3), sum(DISTINCT c1%3 ORDER BY c1%3) FILTER (WHERE c1%3 < 2), c2 FROM mpp_ft2 WHERE c2 = 6 GROUP BY c2;
+SELECT sum(c1%3), sum(DISTINCT c1%3 ORDER BY c1%3) FILTER (WHERE c1%3 < 2), c2 FROM mpp_ft2 WHERE c2 = 6 GROUP BY c2;
+
+-- Aggregate not pushed down as FILTER condition is not pushable
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT sum(c1) FILTER (WHERE (c1 / c1) * random() <= 1) FROM mpp_ft2 GROUP BY c2 ORDER BY 1;
+SELECT sum(c1) FILTER (WHERE (c1 / c1) * random() <= 1) FROM mpp_ft2 GROUP BY c2 ORDER BY 1;
+
+-- Set use_remote_estimate to true
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(add use_remote_estimate 'true');
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT min(c5) FROM mpp_ft2;
+SELECT min(c5) FROM mpp_ft2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2;
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1)::int as count2 FROM mpp_ft2 GROUP BY c2 ORDER BY c2;
+
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
+
+-- limit is not pushed down when there are multiple remote servers
+-- limit with agg functions
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
+SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
+-- limit with normal scan without agg functions
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+-- join is not safe to pushed down when there are multiple remote servers
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;
+SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;

--- a/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
+++ b/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_1.sql
@@ -12,12 +12,36 @@ CREATE TABLE "MPP_S 1"."T 1" (
 	c2 int
 );
 
+CREATE TABLE "MPP_S 1"."T 2" (
+	c1 int,
+	c2 int,
+	c3 smallint,
+	c4 bigint,
+	c5 real,
+	c6 double precision,
+	c7 numeric
+);
+
 -- Disable autovacuum for these tables to avoid unexpected effects of that
 ALTER TABLE "MPP_S 1"."T 1" SET (autovacuum_enabled = 'false');
+ALTER TABLE "MPP_S 1"."T 2" SET (autovacuum_enabled = 'false');
 
 INSERT INTO "MPP_S 1"."T 1"
 	SELECT id,
 	       id % 2
 	FROM generate_series(1, 5) id;
 
+INSERT INTO "MPP_S 1"."T 2" (c1, c2, c3, c4)
+	SELECT id,
+	       id % 10,
+	       id,
+	       id
+	FROM generate_series(1, 500) id;
+
+UPDATE "MPP_S 1"."T 2"
+  SET c5 = c1 * 0.001,
+      c6 = c1 * 0.001,
+      c7 = c1 * 0.001;
+
 ANALYZE "MPP_S 1"."T 1";
+ANALYZE "MPP_S 1"."T 2";

--- a/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
+++ b/contrib/postgres_fdw/sql/postgres_sql/mpp_gp2pg_postgres_init_2.sql
@@ -12,12 +12,36 @@ CREATE TABLE "MPP_S 1"."T 1" (
 	c2 int
 );
 
+CREATE TABLE "MPP_S 1"."T 2" (
+	c1 int,
+	c2 int,
+	c3 smallint,
+	c4 bigint,
+	c5 real,
+	c6 double precision,
+	c7 numeric
+);
+
 -- Disable autovacuum for these tables to avoid unexpected effects of that
 ALTER TABLE "MPP_S 1"."T 1" SET (autovacuum_enabled = 'false');
+ALTER TABLE "MPP_S 1"."T 2" SET (autovacuum_enabled = 'false');
 
 INSERT INTO "MPP_S 1"."T 1"
 	SELECT id,
 	       id % 2
 	FROM generate_series(6, 10) id;
 
+INSERT INTO "MPP_S 1"."T 2" (c1, c2, c3, c4)
+	SELECT id,
+	       id % 10,
+	       id,
+	       id
+	FROM generate_series(501, 1000) id;
+
+UPDATE "MPP_S 1"."T 2"
+  SET c5 = c1 * 0.001,
+      c6 = c1 * 0.001,
+      c7 = c1 * 0.001;
+
 ANALYZE "MPP_S 1"."T 1";
+ANALYZE "MPP_S 1"."T 2";

--- a/contrib/postgres_fdw/transcoding.c
+++ b/contrib/postgres_fdw/transcoding.c
@@ -1,0 +1,241 @@
+/*-------------------------------------------------------------------------
+ *
+ * transcoding.c
+ *		  Transcoding implementation for postgres.
+ * When "mpp_execute" is set to "all segments", postgres_fdw will try to
+ * run on MPP mode, the server option "number_of_segments" will set the
+ * executing QE numbers of the MPP mode.
+ * Postgres FDW is not designed to be executed on multi-QEs, however it
+ * is the first FDW extension which can give examples of other following
+ * FDW extensions.
+ * 
+ * So we want to add support MPP AGG push down for postgres FDW to give 
+ * an example to other FDWs which need to run on multiple QEs.
+ * 
+ * In order to push down MPP AGG functions to multiple remote PGs, we 
+ * have to deparse the partial agg sqls to form the result of partial 
+ * AGG. However, if the transtype of the AGG function is internal, we
+ * have to do the transcoding from the result of the Partial Agg push 
+ * down which is a final result into an internal result which is what 
+ * combine function of the 2-staged AGG function wants.
+ * 
+ * Take AVG(column) function for example, we have to deparse 
+ * array[count(column), sum(column)] sql to remote, then the returned 
+ * value is a final result string, but the combine AGG function wants
+ * an internal struct like PolyNumAggState. So we need to do a transcoding
+ * to meet the needs for input format of combine AGG function.
+ * 
+ * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *			contrib/postgres_fdw/transcoding.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+#include "postgres_fdw.h"
+
+#include "fmgr.h"
+#include "utils/array.h"
+#include "utils/fmgrprotos.h"
+#include "utils/numeric.h"
+#include "nodes/execnodes.h"
+
+/* Initialize fake AggState to call agg functions */
+static void init_aggstate(AggState *aggstate)
+{
+	Node *node = (Node *)aggstate;
+	memset(aggstate, 0, sizeof(AggState));
+	node->type = T_AggState;
+}
+static Datum call_agg_function1(FmgrInfo *flinfo, Datum arg1, fmNodePtr *context)
+{
+	LOCAL_FCINFO(fcinfo, 1);
+
+	InitFunctionCallInfoData(*fcinfo, flinfo, 1, InvalidOid, (Node *)context, NULL);
+	fcinfo->args[0].value = arg1;
+	fcinfo->args[0].isnull = false;
+
+	return FunctionCallInvoke(fcinfo);
+}
+
+/* 
+ * Handle trancoding for aggregate function -- avg(bigint), aggfnoid = 2100
+ * The input str is formatted like {$count, $sum} 
+ * 1. Transcode the input str into ArrayType whose data type is int64
+ * 2. Construct internal type PolyNumAggState
+ * 3. Serialize PolyNumAggState into bytea
+ */
+static Datum transfn_for_avg_bigint(PG_FUNCTION_ARGS)
+{
+	ArrayType	*internal_array = NULL;
+	char		*str = PG_GETARG_CSTRING(0);
+	Oid			element_type = INT8OID;
+	int32		typmod = PG_GETARG_INT32(2);
+	Int8TransTypeData *transdata = NULL;
+	PolyNumAggState *internal_polynum;
+	FmgrInfo flinfo;
+	AggState aggstate;
+
+
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("array_in"), &flinfo, CurrentMemoryContext);
+	internal_array = (ArrayType *)InputFunctionCall(&flinfo, str, element_type, typmod);
+
+	transdata = (Int8TransTypeData *) ARR_DATA_PTR (internal_array);
+	internal_polynum = makePolyNumAggStateCurrentContext(false);
+	internal_polynum->N = transdata->count;
+#ifdef HAVE_INT128
+	internal_polynum->sumX = (int128)transdata->sum;
+#else
+	Datum sumd;
+	sumd = DirectFunctionCall1(int8_numeric,
+							   Int64GetDatumFast(transdata->sum));
+	do_numeric_accum(internal_polynum, (Numeric)sumd);
+	internal_polynum->N--;
+#endif
+    
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("int8_avg_serialize"), &flinfo, CurrentMemoryContext);
+	init_aggstate(&aggstate);
+	return call_agg_function1(&flinfo, (Datum)internal_polynum, (fmNodePtr *)&aggstate);
+}
+
+/* 
+ * Handle trancoding for aggregate function -- avg(numeric), aggfnoid = 2103
+ * The input str is formatted like {$count, $sum} 
+ * 1. Transcode the input str into ArrayType whose data type is numeric
+ * 2. Construct internal type NumericAggState
+ * 3. Serialize NumericAggState into bytea
+ */
+static Datum transfn_for_avg_numeric(PG_FUNCTION_ARGS)
+{
+	ArrayType	*internal_array = NULL;
+	char		*str = PG_GETARG_CSTRING(0);
+	Oid			element_type = NUMERICOID;
+	int32		typmod = PG_GETARG_INT32(2);
+	int64		countd;
+	Datum		sumd;
+	Datum		*internal_numeric;
+	int			num_numeric;
+	NumericAggState *target_state;
+	AggState aggstate;
+
+	FmgrInfo flinfo;
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("array_in"), &flinfo, CurrentMemoryContext);
+	internal_array = (ArrayType *)InputFunctionCall(&flinfo, str, element_type, typmod);
+
+	deconstruct_array(internal_array, NUMERICOID, -1, false, 'i',
+					  &internal_numeric, NULL, &num_numeric);
+
+	countd = (int64)DirectFunctionCall1(numeric_int8, internal_numeric[0]);
+	sumd = internal_numeric[1];
+	target_state = makeNumericAggStateCurrentContext(false);
+	target_state->N = countd;
+	do_numeric_accum(target_state, (Numeric)sumd);
+	target_state->N--;
+
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("numeric_avg_serialize"), &flinfo, CurrentMemoryContext);
+	init_aggstate(&aggstate);
+	return call_agg_function1(&flinfo, (Datum)target_state, (fmNodePtr *)&aggstate);
+}
+
+/*
+ * Handle trancoding for aggregate function -- sum(bigint), aggfnoid = 2107
+ * The input str is formatted like {$sum}
+ * 1. Transcode the input str into int8/numeric
+ * 2. Construct internal type PolyNumAggState
+ * 3. Serialize PolyNumAggState into bytea
+ */
+static Datum transfn_for_sum_bigint(PG_FUNCTION_ARGS)
+{
+	char		*str = PG_GETARG_CSTRING(0);
+	int32		typmod = PG_GETARG_INT32(2);
+	FmgrInfo	flinfo;
+	Datum		newval;
+	AggState	aggstate;
+	PolyNumAggState	*internal_polynum = makePolyNumAggStateCurrentContext(false);
+
+#ifdef HAVE_INT128
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("int8in"), &flinfo, CurrentMemoryContext);
+	newval = InputFunctionCall(&flinfo, str, INT8OID, typmod);
+	internal_polynum->sumX = (int128)newval;
+#else
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("int8_numeric"), &flinfo, CurrentMemoryContext);
+	newval = InputFunctionCall(&flinfo, str, NUMERICOID, typmod);
+	do_numeric_accum(internal_polynum, (Numeric)newval);
+#endif
+
+	/* N(count) is not used for sum(), so here we set N = 1 as default value. */
+	internal_polynum->N = 1;
+
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("int8_avg_serialize"), &flinfo, CurrentMemoryContext);
+	init_aggstate(&aggstate);
+	return call_agg_function1(&flinfo, (Datum)internal_polynum, (fmNodePtr *)&aggstate);
+}
+
+/*
+ * Handle trancoding for aggregate function -- avg(numeric), aggfnoid = 2114
+ * The input str is formatted like {$sum}
+ * 1. Transcode the input str into numeric
+ * 2. Construct internal type NumericAggState
+ * 3. Serialize NumericAggState into bytea
+ */
+static Datum transfn_for_sum_numeric(PG_FUNCTION_ARGS)
+{
+	char		*str = PG_GETARG_CSTRING(0);
+	int32		typmod = PG_GETARG_INT32(2);
+	FmgrInfo	flinfo;
+	Datum		sumd;
+	NumericAggState *target_state;
+	AggState 	aggstate;
+
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("numeric_in"), &flinfo, CurrentMemoryContext);
+	sumd = InputFunctionCall(&flinfo, str, NUMERICOID, typmod);
+
+	target_state = makeNumericAggStateCurrentContext(false);
+	do_numeric_accum(target_state, (Numeric)sumd);
+	/* N(count) is not used for sum(), so here we set N = 1 as default value. */
+	target_state->N = 1;
+
+	memset(&flinfo, 0, sizeof(FmgrInfo));
+	fmgr_info_cxt(fmgr_internal_function("numeric_avg_serialize"), &flinfo, CurrentMemoryContext);
+	init_aggstate(&aggstate);
+	return call_agg_function1(&flinfo, (Datum)target_state, (fmNodePtr *)&aggstate);
+}
+
+PGFunction GetTranscodingFnFromOid(Oid aggfnoid) {
+	PGFunction refnaddr = NULL;
+	if (aggfnoid == InvalidOid) 
+	{
+		return NULL;
+	}
+	switch (aggfnoid) 
+	{
+		case 2100:
+			/* 2100 pg_catalog.avg int8|bigint */
+			refnaddr = transfn_for_avg_bigint;
+			break;
+		case 2103:
+			/* 2103 pg_catalog.avg numeric */
+			refnaddr = transfn_for_avg_numeric;
+			break;
+		case 2107:
+			/* 2107 pg_catalog.sum int8|bigint */
+			refnaddr = transfn_for_sum_bigint;
+			break;
+		case 2114:
+			/* 2114 pg_catalog.sum numeric */
+			refnaddr = transfn_for_sum_numeric;
+			break;
+		default:
+			break;
+	}
+	return refnaddr;
+}

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -69,6 +69,7 @@
 #include "parser/parse_oper.h"
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
+#include "foreign/fdwapi.h"
 
 typedef enum
 {
@@ -161,7 +162,7 @@ typedef struct
 } cdb_multi_dqas_info;
 
 static void create_two_stage_paths(PlannerInfo *root, cdb_agg_planning_context *ctx,
-								   RelOptInfo *input_rel, RelOptInfo *output_rel);
+								   RelOptInfo *input_rel, RelOptInfo *output_rel, GroupPathExtraData *extra);
 static List *get_common_group_tles(PathTarget *target,
 								   List *groupClause,
 								   List *rollups);
@@ -255,7 +256,8 @@ cdb_create_multistage_grouping_paths(PlannerInfo *root,
 								   const AggClauseCosts *agg_final_costs,
 								   List *rollups,
 								   List *new_rollups,
-								   AggStrategy strat)
+								   AggStrategy strat,
+								   GroupPathExtraData *extra)
 {
 	Query	   *parse = root->parse;
 	Path	   *cheapest_path = input_rel->cheapest_total_path;
@@ -440,7 +442,7 @@ cdb_create_multistage_grouping_paths(PlannerInfo *root,
 	/*
 	 * All set, generate the two-stage paths.
 	 */
-	create_two_stage_paths(root, &ctx, input_rel, output_rel);
+	create_two_stage_paths(root, &ctx, input_rel, output_rel, extra);
 
 	/*
 	 * Aggregates with DISTINCT arguments are more complicated, and are not
@@ -618,7 +620,7 @@ cdb_create_twostage_distinct_paths(PlannerInfo *root,
 	/*
 	 * All set, generate the two-stage paths.
 	 */
-	create_two_stage_paths(root, &ctx, input_rel, output_rel);
+	create_two_stage_paths(root, &ctx, input_rel, output_rel, NULL);
 }
 
 /*
@@ -626,7 +628,7 @@ cdb_create_twostage_distinct_paths(PlannerInfo *root,
  */
 static void
 create_two_stage_paths(PlannerInfo *root, cdb_agg_planning_context *ctx,
-					   RelOptInfo *input_rel, RelOptInfo *output_rel)
+					   RelOptInfo *input_rel, RelOptInfo *output_rel, GroupPathExtraData *extra)
 {
 	Path	   *cheapest_path = input_rel->cheapest_total_path;
 
@@ -683,6 +685,28 @@ create_two_stage_paths(PlannerInfo *root, cdb_agg_planning_context *ctx,
 		 */
 		if (!cdbpathlocus_collocates_tlist(root, cheapest_path->locus, ctx->group_tles))
 			add_first_stage_hash_agg_path(root, cheapest_path, ctx);
+	}
+
+	/*
+	 * Only when option mpp_execute is set to 'all segments',
+	 * we try to add two-phase aggregate path for foreign table
+	 * and call FDW routine to consider partial aggregate pushdown.
+	 */
+	if (input_rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
+	{
+		ctx->partial_rel->serverid = input_rel->serverid;
+		ctx->partial_rel->userid = input_rel->userid;
+		ctx->partial_rel->useridiscurrent = input_rel->useridiscurrent;
+		ctx->partial_rel->fdwroutine = input_rel->fdwroutine;
+		ctx->partial_rel->exec_location = input_rel->exec_location;
+		ctx->partial_rel->cdbpolicy = input_rel->cdbpolicy;
+		if (ctx->partial_rel->fdwroutine &&
+		    (ctx->partial_rel->fdwroutine->IsMPPPlanNeeded && ctx->partial_rel->fdwroutine->IsMPPPlanNeeded()) &&
+		    ctx->partial_rel->fdwroutine->GetForeignUpperPaths)
+		{
+			ctx->partial_rel->fdwroutine->GetForeignUpperPaths(root, UPPERREL_CDB_FIRST_STAGE_GROUP_AGG,
+																input_rel, ctx->partial_rel, extra);
+		}
 	}
 
 	/*

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -359,9 +359,15 @@ add_paths_to_joinrel(PlannerInfo *root,
 	 */
 	if (joinrel->fdwroutine &&
 		joinrel->fdwroutine->GetForeignJoinPaths)
-		joinrel->fdwroutine->GetForeignJoinPaths(root, joinrel,
-												 outerrel, innerrel,
-												 jointype, &extra);
+	{
+		if(joinrel->exec_location != FTEXECLOCATION_ALL_SEGMENTS ||
+		   !joinrel->fdwroutine->IsMPPPlanNeeded || joinrel->fdwroutine->IsMPPPlanNeeded() == 0)
+		{
+			joinrel->fdwroutine->GetForeignJoinPaths(root, joinrel,
+													 outerrel, innerrel,
+													 jointype, &extra);
+		}
+	}
 
 	/*
 	 * 6. Finally, give extensions a chance to manipulate the path list.

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3006,9 +3006,15 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 	 */
 	if (final_rel->fdwroutine &&
 		final_rel->fdwroutine->GetForeignUpperPaths)
-		final_rel->fdwroutine->GetForeignUpperPaths(root, UPPERREL_FINAL,
-													current_rel, final_rel,
-													&extra);
+	{
+		if(final_rel->exec_location != FTEXECLOCATION_ALL_SEGMENTS ||
+		   !final_rel->fdwroutine->IsMPPPlanNeeded || final_rel->fdwroutine->IsMPPPlanNeeded() == 0)
+		{
+			final_rel->fdwroutine->GetForeignUpperPaths(root, UPPERREL_FINAL,
+														current_rel, final_rel,
+														&extra);
+		}
+	}
 
 	/* Let extensions possibly add some more paths */
 	if (create_upper_paths_hook)
@@ -4788,9 +4794,15 @@ create_ordinary_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	 */
 	if (grouped_rel->fdwroutine &&
 		grouped_rel->fdwroutine->GetForeignUpperPaths)
-		grouped_rel->fdwroutine->GetForeignUpperPaths(root, UPPERREL_GROUP_AGG,
-													  input_rel, grouped_rel,
-													  extra);
+	{
+		if(grouped_rel->exec_location != FTEXECLOCATION_ALL_SEGMENTS ||
+		   !grouped_rel->fdwroutine->IsMPPPlanNeeded || grouped_rel->fdwroutine->IsMPPPlanNeeded() == 0)
+		{
+			grouped_rel->fdwroutine->GetForeignUpperPaths(root, UPPERREL_GROUP_AGG,
+														  input_rel, grouped_rel,
+														  extra);
+		}
+	}
 
 	/* Let extensions possibly add some more paths */
 	if (create_upper_paths_hook)
@@ -7611,7 +7623,8 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 										   &extra->agg_final_costs,
 										   gd ? gd->rollups : NIL,
 										   new_rollups,
-										   strat);
+										   strat,
+										   extra);
 	}
 }
 

--- a/src/include/cdb/cdbgroupingpaths.h
+++ b/src/include/cdb/cdbgroupingpaths.h
@@ -28,7 +28,8 @@ extern void cdb_create_multistage_grouping_paths(PlannerInfo *root,
 												 const AggClauseCosts *agg_final_costs,
 												 List *rollups,
 												 List *new_rollups,
-												 AggStrategy strat);
+												 AggStrategy strat,
+												 GroupPathExtraData *extra);
 
 
 extern void cdb_create_twostage_distinct_paths(PlannerInfo *root,

--- a/src/include/foreign/fdwapi.h
+++ b/src/include/foreign/fdwapi.h
@@ -180,6 +180,8 @@ typedef List *(*ReparameterizeForeignPathByChild_function) (PlannerInfo *root,
 															List *fdw_private,
 															RelOptInfo *child_rel);
 
+typedef int (*IsMPPPlanNeeded_function) ();
+
 /*
  * FdwRoutine is the struct returned by a foreign-data wrapper's handler
  * function.  It provides pointers to the callback functions needed by the
@@ -268,6 +270,9 @@ typedef struct FdwRoutine
 	 */
 	AcquireSampleRowsFunc AcquireSampleRowsOnSegment;
 	ForeignTableSize_function GetRelationSizeOnSegment;
+
+	/* Functions for MPP plan generation */
+	IsMPPPlanNeeded_function IsMPPPlanNeeded;
 } FdwRoutine;
 
 

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -41,6 +41,86 @@
 /* The actual contents of Numeric are private to numeric.c */
 struct NumericData;
 typedef struct NumericData *Numeric;
+typedef struct Int8TransTypeData
+{
+	int64		count;
+	int64		sum;
+} Int8TransTypeData;
+
+/* ----------
+ * Fast sum accumulator.
+ *
+ * NumericSumAccum is used to implement SUM(), and other standard aggregates
+ * that track the sum of input values.  It uses 32-bit integers to store the
+ * digits, instead of the normal 16-bit integers (with NBASE=10000).  This
+ * way, we can safely accumulate up to NBASE - 1 values without propagating
+ * carry, before risking overflow of any of the digits.  'num_uncarried'
+ * tracks how many values have been accumulated without propagating carry.
+ *
+ * Positive and negative values are accumulated separately, in 'pos_digits'
+ * and 'neg_digits'.  This is simpler and faster than deciding whether to add
+ * or subtract from the current value, for each new value (see sub_var() for
+ * the logic we avoid by doing this).  Both buffers are of same size, and
+ * have the same weight and scale.  In accum_sum_final(), the positive and
+ * negative sums are added together to produce the final result.
+ *
+ * When a new value has a larger ndigits or weight than the accumulator
+ * currently does, the accumulator is enlarged to accommodate the new value.
+ * We normally have one zero digit reserved for carry propagation, and that
+ * is indicated by the 'have_carry_space' flag.  When accum_sum_carry() uses
+ * up the reserved digit, it clears the 'have_carry_space' flag.  The next
+ * call to accum_sum_add() will enlarge the buffer, to make room for the
+ * extra digit, and set the flag again.
+ *
+ * To initialize a new accumulator, simply reset all fields to zeros.
+ *
+ * The accumulator does not handle NaNs.
+ * ----------
+ */
+typedef struct NumericSumAccum
+{
+	int			ndigits;
+	int			weight;
+	int			dscale;
+	int			num_uncarried;
+	bool		have_carry_space;
+	int32	   *pos_digits;
+	int32	   *neg_digits;
+} NumericSumAccum;
+
+typedef struct NumericAggState
+{
+	bool		calcSumX2;		/* if true, calculate sumX2 */
+	MemoryContext agg_context;	/* context we're calculating in */
+	int64		N;				/* count of processed numbers */
+	NumericSumAccum sumX;		/* sum of processed numbers */
+	NumericSumAccum sumX2;		/* sum of squares of processed numbers */
+	int			maxScale;		/* maximum scale seen so far */
+	int64		maxScaleCount;	/* number of values seen with maximum scale */
+	int64		NaNcount;		/* count of NaN values (not included in N!) */
+} NumericAggState;
+
+extern NumericAggState *makeNumericAggState(FunctionCallInfo fcinfo, bool calcSumX2);
+extern NumericAggState *makeNumericAggStateCurrentContext(bool calcSumX2);
+
+#ifdef HAVE_INT128
+typedef struct Int128AggState
+{
+	bool		calcSumX2;		/* if true, calculate sumX2 */
+	int64		N;				/* count of processed numbers */
+	int128		sumX;			/* sum of processed numbers */
+	int128		sumX2;			/* sum of squares of processed numbers */
+} Int128AggState;
+extern Int128AggState *makeInt128AggState(FunctionCallInfo fcinfo, bool calcSumX2);
+extern Int128AggState *makeInt128AggStateCurrentContext(bool calcSumX2);
+typedef Int128AggState PolyNumAggState;
+#define makePolyNumAggState makeInt128AggState
+#define makePolyNumAggStateCurrentContext makeInt128AggStateCurrentContext
+#else
+typedef NumericAggState PolyNumAggState;
+#define makePolyNumAggState makeNumericAggState
+#define makePolyNumAggStateCurrentContext makeNumericAggStateCurrentContext
+#endif
 
 /*
  * fmgr interface macros
@@ -57,7 +137,7 @@ extern int cmp_numerics(Numeric num1, Numeric num2);
 extern float8 numeric_li_fraction(Numeric x, Numeric x0, Numeric x1, 
 								  bool *eq_bounds, bool *eq_abscissas);
 extern Numeric numeric_li_value(float8 f, Numeric y0, Numeric y1);
-
+extern void do_numeric_accum(NumericAggState *state, Numeric newval);
 /*
  * Utility functions in numeric.c
  */

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1086,6 +1086,7 @@ IpcSemaphoreId
 IpcSemaphoreKey
 IsForeignRelUpdatable_function
 IsForeignScanParallelSafe_function
+IsMPPPlanNeeded_function
 IspellDict
 Item
 ItemId


### PR DESCRIPTION
### 1. Background
This PR is separated from https://github.com/greenplum-db/gpdb/pull/15525.

For the convenience of review, https://github.com/greenplum-db/gpdb/pull/15525 is split into multiple sub-PRs.
- sub-PR 1:    https://github.com/greenplum-db/gpdb/pull/15821 (**Merged**)
- sub-PR 2:   https://github.com/greenplum-db/gpdb/pull/15824 (**Merged**)
- sub-PR 3:   current PR

### 2. Scenario using this feature
We consider such scenario -- foreign table demo_f_tbl is distributed randomly across multiple remote postgres server.
```
CREATE EXTENSION postgres_fdw;

CREATE SERVER multi_pg_servers
FOREIGN DATA WRAPPER postgres_fdw
OPTIONS (mpp_execute 'all segments', num_segments '2', multi_hosts '127.0.0.1 127.0.0.1', multi_ports '5432 5555', dbname 'postgres');

CREATE USER MAPPING FOR gpadmin 
SERVER multi_pg_servers OPTIONS (user 'postgres');

CREATE FOREIGN TABLE demo_f_tbl(a int, b int) 
SERVER multi_pg_servers
OPTIONS(table_name 'demo_local_tbl');
```
- We set option `mpp_execute` to `all segments` for server `multi_pg_server`. So when select something from postgres_fdw foreign table, the scan will be executed in a distributed way.
- The number of executors is controlled by the server option `num_segments`. If this option is not set, the number of executors will be the default number of segments in GPDB. 
- Options `multi_hosts` and `multi_ports` can specify multiple remote postgres server. The number of remote postgres server **MUST** be same as the option `num_segments`.

By doing so, we build the scenario that the foreign table is a distributed foreign table which data stored on multiple remote servers. 

There are some customers who have the need to scan data from distributed foreign servers. The basic need is to make the result correct and make some basic aggregate functions pushed down to remote distributed servers and keep the result correct.

### 3. Results
As FDW is designed for Postgres which is not a distributed system database, we have to change the plan and executors for distributed scenario. 

The result of sequence scan is correct by default, but it does **NOT** work for aggregate functions.

Looking at the example below:
```
demodb=# explain verbose select sum(c1) from demo_f_tbl;
                                   QUERY PLAN
--------------------------------------------------------------------------------
 Gather Motion 2:1  (slice1; segments: 2)  (cost=100.02..101.15 rows=2 width=8)
   Output: (sum(c1))
   ->  Foreign Scan  (cost=100.02..101.12 rows=1 width=8)
         Output: (sum(c1))
         Relations: Aggregate on (public.demo_f_tbl)
         Remote SQL: SELECT sum(c1) FROM public.demo_local_table
 Optimizer: Postgres query optimizer
(7 rows)

demodb=# select sum(c1) from demo_f_tbl;
 sum
-----
  36
  90
(2 rows)
```
The plan after this PR will be like:
```
demodb=# explain verbose select sum(c1) from demo_f_tbl;
                                      QUERY PLAN
--------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=101.15..101.16 rows=1 width=8)
   Output: sum(c1)
   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=100.02..101.15 rows=2 width=8)
         Output: (PARTIAL sum(c1))
         ->  Foreign Scan  (cost=100.02..101.12 rows=1 width=8)
               Output: (PARTIAL sum(c1))
               Relations: Aggregate on (public.demo_f_tbl)
               Remote SQL: SELECT sum(c1) FROM public.demo_local_table
 Optimizer: Postgres query optimizer
(9 rows)

demodb=# select sum(c1) from demo_f_tbl;
 sum
-----
 126
(1 row)
```

### 4. Main modifications
We have made the following modification to make this happen:
- We modify the GPDB planner to generate two-stage AGG plan.
  When adding paths to grouped_rel, we try to generate two-stage aggregate path and add it.

- We adjust AGG functions pushdown conditions for postgres_fdw APIs.

- We adjust deparsed remote SQLs for partial AGG functions.
  If aggregate function state value is different from final result, we need adjust deparsed remote SQLs.
  For example, avg(c1) state value is [sum(c1), count(c1)] and final result is avg(c1).

- We transform data coming from remote servers to internal data which final AGG needs.
  If aggregate function transition type is internal, we need to transform data coming from remote servers.
  For example, avg(c1::numeric) transition type is internal. We need to build internal data struct using data coming from remote servers.

- Add testing cases to test this feature.

As postgres_fdw is the first Foreign Data Wrapper, many other FDWs need to add new features according to the implementations of postgres_fdw. 
So we want to make a template for MPP AGG push down scenarios.
Currently we try our best to make as small as modifications to postgres_fdw so that it is not difficult for future merging work from upstream. 

Co-authered-by: zhaorui <zhaoru@vmware.com>
Co-authored-by: jingwen-yang-yjw <jingweny1@vmware.com>
