### PR TITLE
[6X] Don't initialize ORCA on query executors

### DIFF
--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -652,14 +652,17 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	GPMemoryProtect_Init();
 
 #ifdef USE_ORCA
-	/* Initialize GPOPT */
-	OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
-												   "GPORCA Top-level Memory Context",
-												   ALLOCSET_DEFAULT_MINSIZE,
-												   ALLOCSET_DEFAULT_INITSIZE,
-												   ALLOCSET_DEFAULT_MAXSIZE);
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		/* Initialize GPOPT */
+		OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
+													"GPORCA Top-level Memory Context",
+													ALLOCSET_DEFAULT_MINSIZE,
+													ALLOCSET_DEFAULT_INITSIZE,
+													ALLOCSET_DEFAULT_MAXSIZE);
 
-	InitGPOPT();
+		InitGPOPT();
+	}
 #endif
 
 	/*
@@ -1407,10 +1410,13 @@ ShutdownPostgres(int code, Datum arg)
 	ReportOOMConsumption();
 
 #ifdef USE_ORCA
-	TerminateGPOPT();
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		TerminateGPOPT();
 
-	if (OptimizerMemoryContext != NULL)
-		MemoryContextDelete(OptimizerMemoryContext);
+		if (OptimizerMemoryContext != NULL)
+			MemoryContextDelete(OptimizerMemoryContext);
+	}
 #endif
 
 	/* Disable memory protection */


### PR DESCRIPTION
Currently, the ORCA optimizer is initialized unconditionally in all backends. But we can reduce memory consumption by avoiding ORCA initialization on query executors where ORCA is never used.
This can be done using the Gp_role variable, which is set to GP_ROLE_EXECUTE on the executors, and this happens before ORCA is initialized.