### PR TITLE
Add latest tag to gpdb6-centos7-build image for orca pipeline

### DIFF
--- a/src/backend/gporca/concourse/test_orca_pipeline.yml
+++ b/src/backend/gporca/concourse/test_orca_pipeline.yml
@@ -20,6 +20,7 @@ resources:
   type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
+    tag: latest
 
 - name: gpdb6-centos7-test
   type: registry-image


### PR DESCRIPTION
Before adding the "latest" tag, we used an outdated image, where lib 'uuid' was missing. As a result, orca pipeline couldn't compile. Adding the "latest" tag allows us to access the required libraries.
