### PR TITLE
Fix warning of unused variable

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -670,8 +670,6 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 	TransactionId frozenXid;
 	MultiXactId cutoffMulti;
 
-    bool		is_ao = RelationStorageIsAO(OldHeap);
-
 	/* Mark the correct index as clustered */
 	if (OidIsValid(indexOid))
 		mark_index_clustered(OldHeap, indexOid, true);


### PR DESCRIPTION
```
cluster.c: In function ‘rebuild_relation’:
cluster.c:673:11: warning: unused variable ‘is_ao’ [-Wunused-variable]
  673 |     bool  is_ao = RelationStorageIsAO(OldHeap);
      |           ^~~~~
```

Probably this was a conflict mismerge between 0c942b968d and 569de03c2c.