### PR TITLE
[7X] Fix isolation2 tests for PR15840.

### DIFF
--- a/src/test/isolation2/expected/resource_queue.out
+++ b/src/test/isolation2/expected/resource_queue.out
@@ -90,7 +90,7 @@ COMMIT
 4:SET role role_concurrency_test;
 SET
 4:DECLARE c_hold CURSOR WITH HOLD FOR SELECT 1;
-DECLARE
+DECLARE CURSOR
 
 -- Sanity check: The holdable cursor should be accounted for in pg_locks.
 0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();


### PR DESCRIPTION
In 52c7e0a, we fixed the status message for the isolation2 test driver. The test case should be updated accordingly.

- [x] Pass `make installcheck`
