### PR TITLE
Fixing crash in ORCA with skip-level correlated query with exhaustive2 join order

### DIFF
--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3798,6 +3798,118 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
+--------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should
+-- not cause segfault on ORCA. Currently ORCA is falling back to planner which
+-- is undesired. Github Issue #15693
+--------------------------------------------------------------------------------
+set optimizer_join_order to exhaustive2;
+set optimizer_trace_fallback to on;
+CREATE TABLE skip_correlated_t1 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t2 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t3 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t4 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON EXISTS (
+        SELECT skip_correlated_t1.b
+        FROM skip_correlated_t2
+    )
+);
+ERROR:  correlated subquery with skip-level correlations is not supported
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON (
+        EXISTS (
+            SELECT 1
+            FROM skip_correlated_t2
+            WHERE a > skip_correlated_t1.b
+        )
+        )
+);
+ERROR:  correlated subquery with skip-level correlations is not supported
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             INNER JOIN skip_correlated_t3 ON skip_correlated_t2.a = skip_correlated_t3.a
+             LEFT JOIN skip_correlated_t4 ON (
+        EXISTS (
+            SELECT skip_correlated_t1.b
+            FROM skip_correlated_t2
+        )
+        )
+);
+ERROR:  correlated subquery with skip-level correlations is not supported
+--------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA. Will fallback to planner as no plan
+-- is computed by ORCA. Github Issue #15693
+--------------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON skip_correlated_t3.a = ALL (
+        SELECT skip_correlated_t1.a
+        FROM skip_correlated_t2
+    )
+);
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Seq Scan on skip_correlated_t1
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice4; segments: 3)
+           ->  Nested Loop Left Join
+                 ->  Result
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                   ->  Seq Scan on skip_correlated_t2
+                 ->  Materialize
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
+                             ->  Result
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Seq Scan on skip_correlated_t3
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                     ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+DROP TABLE skip_correlated_t1;
+DROP TABLE skip_correlated_t2;
+DROP TABLE skip_correlated_t3;
+DROP TABLE skip_correlated_t4;
+reset optimizer_join_order;
+reset optimizer_trace_fallback;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3930,6 +3930,126 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
+--------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should
+-- not cause segfault on ORCA. Currently ORCA is falling back to planner which
+-- is undesired. Github Issue #15693
+--------------------------------------------------------------------------------
+set optimizer_join_order to exhaustive2;
+set optimizer_trace_fallback to on;
+CREATE TABLE skip_correlated_t1 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t2 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t3 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t4 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON EXISTS (
+        SELECT skip_correlated_t1.b
+        FROM skip_correlated_t2
+    )
+);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON (
+        EXISTS (
+            SELECT 1
+            FROM skip_correlated_t2
+            WHERE a > skip_correlated_t1.b
+        )
+        )
+);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             INNER JOIN skip_correlated_t3 ON skip_correlated_t2.a = skip_correlated_t3.a
+             LEFT JOIN skip_correlated_t4 ON (
+        EXISTS (
+            SELECT skip_correlated_t1.b
+            FROM skip_correlated_t2
+        )
+        )
+);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
+--------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA. Will fallback to planner as no plan
+-- is computed by ORCA. Github Issue #15693
+--------------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON skip_correlated_t3.a = ALL (
+        SELECT skip_correlated_t1.a
+        FROM skip_correlated_t2
+    )
+);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Seq Scan on skip_correlated_t1
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice4; segments: 3)
+           ->  Nested Loop Left Join
+                 ->  Result
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                   ->  Seq Scan on skip_correlated_t2
+                 ->  Materialize
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
+                             ->  Result
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Seq Scan on skip_correlated_t3
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                     ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+DROP TABLE skip_correlated_t1;
+DROP TABLE skip_correlated_t2;
+DROP TABLE skip_correlated_t3;
+DROP TABLE skip_correlated_t4;
+reset optimizer_join_order;
+reset optimizer_trace_fallback;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -741,6 +741,99 @@ reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
 
+--------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should
+-- not cause segfault on ORCA. Currently ORCA is falling back to planner which
+-- is undesired. Github Issue #15693
+--------------------------------------------------------------------------------
+set optimizer_join_order to exhaustive2;
+set optimizer_trace_fallback to on;
+
+CREATE TABLE skip_correlated_t1 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+
+CREATE TABLE skip_correlated_t2 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+
+CREATE TABLE skip_correlated_t3 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+
+CREATE TABLE skip_correlated_t4 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON EXISTS (
+        SELECT skip_correlated_t1.b
+        FROM skip_correlated_t2
+    )
+);
+
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON (
+        EXISTS (
+            SELECT 1
+            FROM skip_correlated_t2
+            WHERE a > skip_correlated_t1.b
+        )
+        )
+);
+
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             INNER JOIN skip_correlated_t3 ON skip_correlated_t2.a = skip_correlated_t3.a
+             LEFT JOIN skip_correlated_t4 ON (
+        EXISTS (
+            SELECT skip_correlated_t1.b
+            FROM skip_correlated_t2
+        )
+        )
+);
+
+--------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA. Will fallback to planner as no plan
+-- is computed by ORCA. Github Issue #15693
+--------------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON skip_correlated_t3.a = ALL (
+        SELECT skip_correlated_t1.a
+        FROM skip_correlated_t2
+    )
+);
+
+DROP TABLE skip_correlated_t1;
+DROP TABLE skip_correlated_t2;
+DROP TABLE skip_correlated_t3;
+DROP TABLE skip_correlated_t4;
+reset optimizer_join_order;
+reset optimizer_trace_fallback;
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
This PR is a backport of #15648
This PR fixes the crash in ORCA observed with skip-level correlated query containing a subquery with exhaustive2 join order.

Setup:
-------
```
create table t1(a int, b int);
create table t2(a int, b int);
create table t3(a int, b int);
```

Query:
-------
```
explain select * from t1 where ( EXISTS ( select t2.a from t2 left join t3 on (
EXISTS ( select t1.b from t2))));
```

Detailed RCA:
-------------
In 6X the optimizer_join_order is exhaustive by default. On setting the optimizer_join_order to exhaustive2 trace flag EopttraceEnableLOJInNAryJoin is enabled. Due to this CLogicalLeftOuterJoin is converted to CLogicalNAryJoin in the preprocessing stage. For the above query while deriving the join stats using method CJoinStatsProcessor::DeriveJoinStats the subquery present in the join condition is replaced by a CScalarConst by method PexprScalarRepChild. After this the code seperates out the join predicate into local predicates and predicates involving outer references using method CPredicateUtils::SeparateOuterRefs. The predicate involving outer references is returned as a CScalarConst from SeparateOuterRefs method because the columns in the join predicate are disjoint to outer references (Since subquery is already replaced with CScalarConst by PexprScalarRepChild). Now since outer references are present in the query we try to derive the stats with outer references using CScalarConst as the join predicate. Due to this we hit a assert in CJoinStatsProcessor::CalcAllJoinStats method which checks if the join operator is CLogicalNAryJoin then the join predicate should have EopScalarNAryJoinPredList as its parent which is not the case for CScalarConst. The issue is in CPredicateUtils::SeparateOuterRefs method. The predicate involving outer references is returned as a CScalarConst and it's parent operator CScalarNAryJoinPredList is not preserved.

Fix:
----
In the method CPredicateUtils::SeparateOuterRefs, the first step is to assess the derived used columns of the scalar expression and verify if they overlap with the outer reference. However, due to the transformation of the subquery containing the outer reference into a CScalarConst, the disjoint check results in a true evaluation. Consequently, a CScalarConst is returned for the predicate involving outer references, which is incorrect when the parent operator is CScalarNAryJoinPredList. To resolve this issue, the disjoint check should only be evaluated when the parent operator is not CScalarNAryJoinPredList in order to preserve this operator.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
