### PR TITLE
[6X] Update distribution policy for dropping distribution key dependency

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2175,6 +2175,41 @@ RemoveAttributeById(Oid relid, AttrNumber attnum)
 		/* We don't want to keep stats for it anymore */
 		attStruct->attstattarget = 0;
 
+		/* Update distribution policy for dropped distribution column */
+		if (GpPolicyIsHashPartitioned(rel->rd_cdbpolicy))
+		{
+			int            ia = 0;
+
+			for (ia = 0; ia < rel->rd_cdbpolicy->nattrs; ia++)
+			{
+				if (attnum == rel->rd_cdbpolicy->attrs[ia])
+				{
+					MemoryContext oldcontext;
+					GpPolicy *policy;
+
+					/* force a random distribution */
+					rel->rd_cdbpolicy->nattrs = 0;
+
+					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
+					policy = GpPolicyCopy(rel->rd_cdbpolicy);
+					MemoryContextSwitchTo(oldcontext);
+
+					/*
+					 * replace policy first in catalog and then assign to
+					 * rd_cdbpolicy to make sure we have intended policy in relcache
+					 * even with relcache invalidation. Otherwise rd_cdbpolicy can
+					 * become invalid soon after assignment.
+					 */
+					GpPolicyReplace(RelationGetRelid(rel), policy);
+					rel->rd_cdbpolicy = policy;
+					if (Gp_role != GP_ROLE_EXECUTE)
+						ereport(NOTICE,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									errmsg("dropping a column that is part of the distribution policy forces a NULL distribution policy")));
+				}
+			}
+		}
+
 		/*
 		 * Change the column name to something that isn't likely to conflict
 		 */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -8745,40 +8745,6 @@ ATExecDropColumn(List **wqueue, Relation rel, const char *colName,
 
 	ReleaseSysCache(tuple);
 
-	if (GpPolicyIsPartitioned(rel->rd_cdbpolicy))
-	{
-		int			ia = 0;
-
-		for (ia = 0; ia < rel->rd_cdbpolicy->nattrs; ia++)
-		{
-			if (attnum == rel->rd_cdbpolicy->attrs[ia])
-			{
-				MemoryContext oldcontext;
-				GpPolicy *policy;
-
-				/* force a random distribution */
-				rel->rd_cdbpolicy->nattrs = 0;
-
-				oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
-				policy = GpPolicyCopy(rel->rd_cdbpolicy);
-				MemoryContextSwitchTo(oldcontext);
-
-				/*
-				 * replace policy first in catalog and then assign to
-				 * rd_cdbpolicy to make sure we have intended policy in relcache
-				 * even with relcache invalidation. Otherwise rd_cdbpolicy can
-				 * become invalid soon after assignment.
-				 */
-				GpPolicyReplace(RelationGetRelid(rel), policy);
-				rel->rd_cdbpolicy = policy;
-				if (Gp_role != GP_ROLE_EXECUTE)
-				    ereport(NOTICE,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("dropping a column that is part of the distribution policy forces a NULL distribution policy")));
-			}
-		}
-	}
-
 	/*
 	 * Propagate to children as appropriate.  Unlike most other ALTER
 	 * routines, we have to do this one level of recursion at a time; we can't

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -570,24 +570,63 @@ select * from atsdb;
  j  | t  | n  
 ----+----+----
   2 | 3  |  4
-  3 | 4  |  5
-  4 | 5  |  6
-  5 | 6  |  7
-  6 | 7  |  8
-  7 | 8  |  9
-  8 | 9  | 10
   9 | 10 | 11
- 10 | 11 | 12
  11 | 12 | 13
  12 | 13 | 14
- 13 | 14 | 15
+ 21 | 22 | 23
+  4 | 5  |  6
+  7 | 8  |  9
+  8 | 9  | 10
+ 10 | 11 | 12
  14 | 15 | 16
  15 | 16 | 17
  16 | 17 | 18
- 17 | 18 | 19
  18 | 19 | 20
  19 | 20 | 21
  20 | 21 | 22
+  3 | 4  |  5
+  5 | 6  |  7
+  6 | 7  |  8
+ 13 | 14 | 15
+ 17 | 18 | 19
+(20 rows)
+
+select * from distcheck where rel = 'atsdb';
+ rel | attname 
+-----+---------
+(0 rows)
+
+drop table atsdb;
+-- check DROP TYPE..CASCADE updates distribution policy to random if
+-- any a dist key column is dropped for multi key distribution key columns
+create domain int_new as int;
+create table atsdb (i int_new, j int, t text, n numeric) distributed by (i, j);
+insert into atsdb select i, i+1, i+2, i+3 from generate_series(1, 20) i;
+drop type int_new cascade;
+NOTICE:  drop cascades to table atsdb column i
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+select * from atsdb;
+ j  | t  | n  
+----+----+----
+  4 | 5  |  6
+  7 | 8  |  9
+  8 | 9  | 10
+ 10 | 11 | 12
+ 14 | 15 | 16
+ 15 | 16 | 17
+ 16 | 17 | 18
+ 18 | 19 | 20
+ 19 | 20 | 21
+ 20 | 21 | 22
+  3 | 4  |  5
+  5 | 6  |  7
+  6 | 7  |  8
+ 13 | 14 | 15
+ 17 | 18 | 19
+  2 | 3  |  4
+  9 | 10 | 11
+ 11 | 12 | 13
+ 12 | 13 | 14
  21 | 22 | 23
 (20 rows)
 
@@ -702,6 +741,132 @@ select * from atsdb order by 1, 2, 3;
 (18 rows)
 
 drop table atsdb;
+-- check distribution correctly cascaded for inherited tables
+create table dropColumnCascade (a int, b int, e int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table dropColumnCascadeChild (c int) inherits (dropColumnCascade);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table dropColumnCascadeAnother (d int) inherits (dropColumnCascadeChild);
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into dropColumnCascadeAnother select i,i,i from generate_series(1,10)i;
+alter table dropColumnCascade drop column a;
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+select * from distcheck where rel like 'dropcolumnicascade%';
+ rel | attname 
+-----+---------
+(0 rows)
+
+drop table dropColumnCascade cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table dropcolumncascadechild
+drop cascades to table dropcolumncascadeanother
+-- check DROP TYPE..CASCADE for dist key type for inherited tables
+-- distribution should be set to randomly for base and inherited tables
+create domain int_new as int;
+create table dropColumnCascade (a int_new, b int, e int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table dropColumnCascadeChild (c int) inherits (dropColumnCascade);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table dropColumnCascadeAnother (d int) inherits (dropColumnCascadeChild);
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into dropColumnCascadeAnother select i,i,i from generate_series(1,10)i;
+drop type int_new cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table dropcolumncascade column a
+drop cascades to table dropcolumncascadechild column a
+drop cascades to table dropcolumncascadeanother column a
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+select * from distcheck where rel like 'dropcolumncascade%';
+ rel | attname 
+-----+---------
+(0 rows)
+
+drop table dropColumnCascade cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table dropcolumncascadechild
+drop cascades to table dropcolumncascadeanother
+-- Test corner cases in dropping distkey as inherited columns
+create table p1 (f1 int, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c1 (f1 int not null) inherits(p1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "f1" with inherited definition
+alter table p1 drop column f1;
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+-- only p1 is randomly distributed, c1 is still distributed by c1.f1
+select * from distcheck where rel in ('p1', 'c1');
+ rel | attname 
+-----+---------
+ c1  | f1
+(1 row)
+
+alter table c1 drop column f1;
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+-- both c1 and p1 randomly distributed
+select * from distcheck where rel in ('p1', 'c1');
+ rel | attname 
+-----+---------
+(0 rows)
+
+drop table p1 cascade;
+NOTICE:  drop cascades to table c1
+create table p1 (f1 int, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c1 () inherits(p1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+alter table only p1 drop column f1;
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+-- only p1 is randomly distributed, c1 is still distributed by c1.f1
+select * from distcheck where rel in ('p1', 'c1');
+ rel | attname 
+-----+---------
+ c1  | f1
+(1 row)
+
+drop table p1 cascade;
+NOTICE:  drop cascades to table c1
+-- check DROP TYPE..CASCADE for dist key type for inherited tables
+-- distribution should be set to randomly for base and inherited tables
+create domain int_new as int;
+create table p1 (f1 int_new, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c1 (f1 int_new not null) inherits(p1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+NOTICE:  merging column "f1" with inherited definition
+create table p1_inh (f1 int_new, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table c1_inh () inherits(p1_inh);
+NOTICE:  table has parent, setting distribution columns to match parent table
+drop type int_new cascade;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table p1 column f1
+drop cascades to table c1 column f1
+drop cascades to table p1_inh column f1
+drop cascades to table c1_inh column f1
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+-- all above tables set to randomly distributed
+select * from distcheck where rel in ('p1', 'c1');
+ rel | attname 
+-----+---------
+(0 rows)
+
+drop table p1 cascade;
+NOTICE:  drop cascades to table c1
+drop table p1_inh cascade;
+NOTICE:  drop cascades to table c1_inh
 drop view distcheck;
 -- MPP-5452
 -- Should succeed

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16271,6 +16271,90 @@ SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT
  8 | 9 | 10 | 10 | 11
 (8 rows)
 
+-- Test for dropping distribution column via DROP TYPE..CASCADE
+-- ensure the distribution policy for the table is updated
+-- and the DML queries on the table work as expected for both
+-- partitioned and non-partitioned tables
+CREATE DOMAIN int_new AS int;
+CREATE TABLE dist_key_dropped (a int_new, b int) DISTRIBUTED BY(a);
+CREATE TABLE dist_key_dropped_pt (a int_new, b int) DISTRIBUTED BY(a)
+PARTITION BY RANGE(b)
+  (PARTITION p1 START(0) END(5),
+   PARTITION p2 START(6) END(10));
+NOTICE:  CREATE TABLE will create partition "dist_key_dropped_pt_1_prt_p1" for table "dist_key_dropped_pt"
+NOTICE:  CREATE TABLE will create partition "dist_key_dropped_pt_1_prt_p2" for table "dist_key_dropped_pt"
+INSERT INTO dist_key_dropped VALUES(1, 1);
+INSERT INTO dist_key_dropped VALUES(2, 2);
+INSERT INTO dist_key_dropped_pt VALUES(1, 1);
+INSERT INTO dist_key_dropped_pt VALUES(2, 6);
+DROP TYPE int_new CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table dist_key_dropped column a
+drop cascades to table dist_key_dropped_pt column a
+drop cascades to table dist_key_dropped_pt_1_prt_p1 column a
+drop cascades to table dist_key_dropped_pt_1_prt_p2 column a
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+\d dist_key_dropped
+Table "qp_dropped_cols.dist_key_dropped"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Distributed randomly
+
+\d dist_key_dropped_pt
+Table "qp_dropped_cols.dist_key_dropped_pt"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Number of child tables: 2 (Use \d+ to list them.)
+Distributed randomly
+Partition by: (b)
+
+\d dist_key_dropped_pt_1_prt_p1
+Table "qp_dropped_cols.dist_key_dropped_pt_1_prt_p1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Check constraints:
+    "dist_key_dropped_pt_1_prt_p1_check" CHECK (b >= 0 AND b < 5)
+Inherits: dist_key_dropped_pt
+Distributed randomly
+
+\d dist_key_dropped_pt_1_prt_p2
+Table "qp_dropped_cols.dist_key_dropped_pt_1_prt_p2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Check constraints:
+    "dist_key_dropped_pt_1_prt_p2_check" CHECK (b >= 6 AND b < 10)
+Inherits: dist_key_dropped_pt
+Distributed randomly
+
+INSERT INTO dist_key_dropped VALUES(10);
+INSERT INTO dist_key_dropped_pt VALUES(7);
+UPDATE dist_key_dropped SET b=11 where b=1;
+UPDATE dist_key_dropped_pt SET b=2 where b=1;
+SELECT * FROM dist_key_dropped;
+ b  
+----
+  2
+ 10
+ 11
+(3 rows)
+
+SELECT * FROM dist_key_dropped_pt;
+ b 
+---
+ 6
+ 7
+ 2
+(3 rows)
+
+DELETE FROM dist_key_dropped WHERE b=2;
+DELETE FROM dist_key_dropped_pt WHERE b=6;
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16184,6 +16184,90 @@ SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT
  8 | 9 | 10 | 10 | 11
 (8 rows)
 
+-- Test for dropping distribution column via DROP TYPE..CASCADE
+-- ensure the distribution policy for the table is updated
+-- and the DML queries on the table work as expected for both
+-- partitioned and non-partitioned tables
+CREATE DOMAIN int_new AS int;
+CREATE TABLE dist_key_dropped (a int_new, b int) DISTRIBUTED BY(a);
+CREATE TABLE dist_key_dropped_pt (a int_new, b int) DISTRIBUTED BY(a)
+PARTITION BY RANGE(b)
+  (PARTITION p1 START(0) END(5),
+   PARTITION p2 START(6) END(10));
+NOTICE:  CREATE TABLE will create partition "dist_key_dropped_pt_1_prt_p1" for table "dist_key_dropped_pt"
+NOTICE:  CREATE TABLE will create partition "dist_key_dropped_pt_1_prt_p2" for table "dist_key_dropped_pt"
+INSERT INTO dist_key_dropped VALUES(1, 1);
+INSERT INTO dist_key_dropped VALUES(2, 2);
+INSERT INTO dist_key_dropped_pt VALUES(1, 1);
+INSERT INTO dist_key_dropped_pt VALUES(2, 6);
+DROP TYPE int_new CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table dist_key_dropped column a
+drop cascades to table dist_key_dropped_pt column a
+drop cascades to table dist_key_dropped_pt_1_prt_p1 column a
+drop cascades to table dist_key_dropped_pt_1_prt_p2 column a
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
+\d dist_key_dropped
+Table "qp_dropped_cols.dist_key_dropped"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Distributed randomly
+
+\d dist_key_dropped_pt
+Table "qp_dropped_cols.dist_key_dropped_pt"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Number of child tables: 2 (Use \d+ to list them.)
+Distributed randomly
+Partition by: (b)
+
+\d dist_key_dropped_pt_1_prt_p1
+Table "qp_dropped_cols.dist_key_dropped_pt_1_prt_p1"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Check constraints:
+    "dist_key_dropped_pt_1_prt_p1_check" CHECK (b >= 0 AND b < 5)
+Inherits: dist_key_dropped_pt
+Distributed randomly
+
+\d dist_key_dropped_pt_1_prt_p2
+Table "qp_dropped_cols.dist_key_dropped_pt_1_prt_p2"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ b      | integer | 
+Check constraints:
+    "dist_key_dropped_pt_1_prt_p2_check" CHECK (b >= 6 AND b < 10)
+Inherits: dist_key_dropped_pt
+Distributed randomly
+
+INSERT INTO dist_key_dropped VALUES(10);
+INSERT INTO dist_key_dropped_pt VALUES(7);
+UPDATE dist_key_dropped SET b=11 where b=1;
+UPDATE dist_key_dropped_pt SET b=2 where b=1;
+SELECT * FROM dist_key_dropped;
+ b  
+----
+  2
+ 10
+ 11
+(3 rows)
+
+SELECT * FROM dist_key_dropped_pt;
+ b 
+---
+ 6
+ 7
+ 2
+(3 rows)
+
+DELETE FROM dist_key_dropped WHERE b=2;
+DELETE FROM dist_key_dropped_pt WHERE b=6;
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -134,6 +134,16 @@ select * from atsdb;
 select * from distcheck where rel = 'atsdb';
 drop table atsdb;
 
+-- check DROP TYPE..CASCADE updates distribution policy to random if
+-- any a dist key column is dropped for multi key distribution key columns
+create domain int_new as int;
+create table atsdb (i int_new, j int, t text, n numeric) distributed by (i, j);
+insert into atsdb select i, i+1, i+2, i+3 from generate_series(1, 20) i;
+drop type int_new cascade;
+select * from atsdb;
+select * from distcheck where rel = 'atsdb';
+drop table atsdb;
+
 -- Check that we correctly cascade for partitioned tables
 create table atsdb (i int, j int, k int) distributed by (i) partition by range(k)
 (start(1) end(10) every(1));
@@ -149,6 +159,57 @@ select * from atsdb order by 1, 2, 3;
 insert into atsdb select i+2, i+1, i from generate_series(1, 9) i;
 select * from atsdb order by 1, 2, 3;
 drop table atsdb;
+
+-- check distribution correctly cascaded for inherited tables
+create table dropColumnCascade (a int, b int, e int);
+create table dropColumnCascadeChild (c int) inherits (dropColumnCascade);
+create table dropColumnCascadeAnother (d int) inherits (dropColumnCascadeChild);
+insert into dropColumnCascadeAnother select i,i,i from generate_series(1,10)i;
+alter table dropColumnCascade drop column a;
+select * from distcheck where rel like 'dropcolumnicascade%';
+drop table dropColumnCascade cascade;
+
+-- check DROP TYPE..CASCADE for dist key type for inherited tables
+-- distribution should be set to randomly for base and inherited tables
+create domain int_new as int;
+create table dropColumnCascade (a int_new, b int, e int);
+create table dropColumnCascadeChild (c int) inherits (dropColumnCascade);
+create table dropColumnCascadeAnother (d int) inherits (dropColumnCascadeChild);
+insert into dropColumnCascadeAnother select i,i,i from generate_series(1,10)i;
+drop type int_new cascade;
+select * from distcheck where rel like 'dropcolumncascade%';
+drop table dropColumnCascade cascade;
+
+-- Test corner cases in dropping distkey as inherited columns
+create table p1 (f1 int, f2 int);
+create table c1 (f1 int not null) inherits(p1);
+alter table p1 drop column f1;
+-- only p1 is randomly distributed, c1 is still distributed by c1.f1
+select * from distcheck where rel in ('p1', 'c1');
+alter table c1 drop column f1;
+-- both c1 and p1 randomly distributed
+select * from distcheck where rel in ('p1', 'c1');
+drop table p1 cascade;
+
+create table p1 (f1 int, f2 int);
+create table c1 () inherits(p1);
+alter table only p1 drop column f1;
+-- only p1 is randomly distributed, c1 is still distributed by c1.f1
+select * from distcheck where rel in ('p1', 'c1');
+drop table p1 cascade;
+
+-- check DROP TYPE..CASCADE for dist key type for inherited tables
+-- distribution should be set to randomly for base and inherited tables
+create domain int_new as int;
+create table p1 (f1 int_new, f2 int);
+create table c1 (f1 int_new not null) inherits(p1);
+create table p1_inh (f1 int_new, f2 int);
+create table c1_inh () inherits(p1_inh);
+drop type int_new cascade;
+-- all above tables set to randomly distributed
+select * from distcheck where rel in ('p1', 'c1');
+drop table p1 cascade;
+drop table p1_inh cascade;
 drop view distcheck;
 
 -- MPP-5452

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8654,6 +8654,34 @@ analyze non_part2;
 EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
 SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
 
+-- Test for dropping distribution column via DROP TYPE..CASCADE
+-- ensure the distribution policy for the table is updated
+-- and the DML queries on the table work as expected for both
+-- partitioned and non-partitioned tables
+CREATE DOMAIN int_new AS int;
+CREATE TABLE dist_key_dropped (a int_new, b int) DISTRIBUTED BY(a);
+CREATE TABLE dist_key_dropped_pt (a int_new, b int) DISTRIBUTED BY(a)
+PARTITION BY RANGE(b)
+  (PARTITION p1 START(0) END(5),
+   PARTITION p2 START(6) END(10));
+INSERT INTO dist_key_dropped VALUES(1, 1);
+INSERT INTO dist_key_dropped VALUES(2, 2);
+INSERT INTO dist_key_dropped_pt VALUES(1, 1);
+INSERT INTO dist_key_dropped_pt VALUES(2, 6);
+DROP TYPE int_new CASCADE;
+\d dist_key_dropped
+\d dist_key_dropped_pt
+\d dist_key_dropped_pt_1_prt_p1
+\d dist_key_dropped_pt_1_prt_p2
+INSERT INTO dist_key_dropped VALUES(10);
+INSERT INTO dist_key_dropped_pt VALUES(7);
+UPDATE dist_key_dropped SET b=11 where b=1;
+UPDATE dist_key_dropped_pt SET b=2 where b=1;
+SELECT * FROM dist_key_dropped;
+SELECT * FROM dist_key_dropped_pt;
+DELETE FROM dist_key_dropped WHERE b=2;
+DELETE FROM dist_key_dropped_pt WHERE b=6;
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.


### PR DESCRIPTION
Prior to this commit, if DROP TYPE..CASCADE finds a distribution key column dependent on the type being dropped it would go ahead and drop the column without updating catalog for table's distribution policy leading to invalid distribution policy in gp_distribution_policy and when trying to describe the table it would reference dropped distribution column that would lead to a crash. To avoid landing in this state, this commit aligns the behavior of DROP TYPE..CASCADE with that of a direct drop (ALTER ... DROP COLUMN) for a distribution key column and update the distribution policy of the table to random.  This commit adds tests and distributions policy asserts for few existing tests.

Note: did not change the NOTICE message for 6X.
6X:  `NOTICE: dropping a column that is part of the distribution policy forces a NULL distribution policy` 
7X:  `NOTICE: dropping a column that is part of the distribution policy forces a random distribution policy` 
(cherry picked from commit 0f7927ac3bbc497d4c74736063965a0f7af3b8bc)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
