### PR TITLE
[Releng]Fix the test_sections option is always set to full pipeline

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -373,8 +373,10 @@ def main():
 
     # use_ICW_workers adds tags to the specified concourse definitions which
     # correspond to dedicated concourse workers to increase performance.
-    if args.pipeline_target in ['prod', 'dev', 'cm'] and args.os_type not in ["rhel9", "oel9"]:
+    if args.pipeline_target in ['prod', 'dev', 'cm']:
         args.use_ICW_workers = True
+
+    if args.pipeline_target in ['prod'] and args.os_type not in ["rhel9", "oel9"]:
         args.test_sections = [
             'ICW',
             'CLI',


### PR DESCRIPTION
test_sections is a option for users to set what job groups to run, when it's prod concourse, it should set to all test sections: ICW, CLI, AA, Release, but when it's non prod concourse, user can specify which job groups to run.

The error is when it's prod, dev, cm concourse, the test_sections is always set to ICW, CLI, AA, Release, which is not expected.

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
