### PR TITLE
CREATE SCHEMA ... schema_element defeats protective search_path changes

### DIFF
--- a/contrib/sepgsql/expected/ddl.out
+++ b/contrib/sepgsql/expected/ddl.out
@@ -24,7 +24,6 @@ LOG:  SELinux: allowed { create } scontext=unconfined_u:unconfined_r:sepgsql_reg
 CREATE USER regtest_sepgsql_test_user;
 CREATE SCHEMA regtest_schema;
 LOG:  SELinux: allowed { create } scontext=unconfined_u:unconfined_r:sepgsql_regtest_superuser_t:s0 tcontext=unconfined_u:object_r:sepgsql_schema_t:s0 tclass=db_schema name="regtest_schema"
-LOG:  SELinux: allowed { search } scontext=unconfined_u:unconfined_r:sepgsql_regtest_superuser_t:s0 tcontext=system_u:object_r:sepgsql_schema_t:s0 tclass=db_schema name="public"
 GRANT ALL ON SCHEMA regtest_schema TO regtest_sepgsql_test_user;
 SET search_path = regtest_schema, public;
 CREATE TABLE regtest_table (x serial primary key, y text);

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3284,6 +3284,10 @@ OverrideSearchPathMatchesCurrent(OverrideSearchPath *path)
 /*
  * PushOverrideSearchPath - temporarily override the search path
  *
+ * Do not use this function; almost any usage introduces a security
+ * vulnerability.  It exists for the benefit of legacy code running in
+ * non-security-sensitive environments.
+ *
  * We allow nested overrides, hence the push/pop terminology.  The GUC
  * search_path variable is ignored while an override is active.
  *

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -30,6 +30,7 @@
 #include "commands/schemacmds.h"
 #include "miscadmin.h"
 #include "parser/parse_utilcmd.h"
+#include "parser/scansup.h"
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
@@ -53,14 +54,16 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 	const char *schemaName = stmt->schemaname;
 	const char *authId = stmt->authid;
 	Oid			namespaceId;
-	OverrideSearchPath *overridePath;
 	List	   *parsetree_list;
 	ListCell   *parsetree_item;
 	Oid			owner_uid;
 	Oid			saved_uid;
 	int			save_sec_context;
+	int			save_nestlevel;
+	char	   *nsp = namespace_search_path;
 	AclResult	aclresult;
 	ObjectAddress address;
+	StringInfoData pathbuf;
 	bool		shouldDispatch = (Gp_role == GP_ROLE_DISPATCH && 
 								  !IsBootstrapProcessingMode());
 
@@ -196,14 +199,26 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 	CommandCounterIncrement();
 
 	/*
-	 * Temporarily make the new namespace be the front of the search path, as
-	 * well as the default creation target namespace.  This will be undone at
-	 * the end of this routine, or upon error.
+	 * Prepend the new schema to the current search path.
+	 *
+	 * We use the equivalent of a function SET option to allow the setting to
+	 * persist for exactly the duration of the schema creation.  guc.c also
+	 * takes care of undoing the setting on error.
 	 */
-	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = lcons_oid(namespaceId, overridePath->schemas);
-	/* XXX should we clear overridePath->useTemp? */
-	PushOverrideSearchPath(overridePath);
+	save_nestlevel = NewGUCNestLevel();
+
+	initStringInfo(&pathbuf);
+	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
+
+	while (scanner_isspace(*nsp))
+		nsp++;
+
+	if (*nsp != '\0')
+		appendStringInfo(&pathbuf, ", %s", nsp);
+
+	(void) set_config_option("search_path", pathbuf.data,
+							 PGC_USERSET, PGC_S_SESSION,
+							 GUC_ACTION_SAVE, true, 0);
 
 	/*
 	 * Examine the list of commands embedded in the CREATE SCHEMA command, and
@@ -235,8 +250,10 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 		CommandCounterIncrement();
 	}
 
-	/* Reset search path to normal state */
-	PopOverrideSearchPath();
+	/*
+	 * Restore the GUC variable search_path we set above.
+	 */
+	AtEOXact_GUC(true, save_nestlevel);
 
 	/* Reset current user and security context */
 	SetUserIdAndSecContext(saved_uid, save_sec_context);

--- a/src/test/regress/expected/namespace.out
+++ b/src/test/regress/expected/namespace.out
@@ -1,7 +1,15 @@
 --
 -- Regression tests for schemas (namespaces)
 --
-CREATE SCHEMA test_schema_1
+-- set the whitespace-only search_path to test that the
+-- GUC list syntax is preserved during a schema creation
+SELECT pg_catalog.set_config('search_path', ' ', false);
+ set_config 
+------------
+  
+(1 row)
+
+CREATE SCHEMA test_ns_schema_1
        CREATE INDEX abc_a_idx ON abc (a)
        CREATE VIEW abc_view AS
               SELECT a+1 AS a, b+1 AS b FROM abc
@@ -9,18 +17,55 @@ CREATE SCHEMA test_schema_1
               a serial,
               b int UNIQUE
        ) DISTRIBUTED BY (b);
+-- verify that the correct search_path restored on abort
+SET search_path to public;
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT c FROM abc;
+ERROR:  column "c" does not exist
+LINE 2:        CREATE VIEW abc_view AS SELECT c FROM abc;
+                                              ^
+COMMIT;
+SHOW search_path;
+ search_path 
+-------------
+ public
+(1 row)
+
+-- verify that the correct search_path preserved
+-- after creating the schema and on commit
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT a FROM abc;
+SHOW search_path;
+       search_path        
+--------------------------
+ public, test_ns_schema_1
+(1 row)
+
+COMMIT;
+SHOW search_path;
+       search_path        
+--------------------------
+ public, test_ns_schema_1
+(1 row)
+
+DROP SCHEMA test_ns_schema_2 CASCADE;
+NOTICE:  drop cascades to view test_ns_schema_2.abc_view
 -- verify that the objects were created
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_1');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');
  count 
 -------
      5
 (1 row)
 
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
-SELECT * FROM test_schema_1.abc;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+SELECT * FROM test_ns_schema_1.abc;
  a | b 
 ---+---
  1 |  
@@ -28,7 +73,7 @@ SELECT * FROM test_schema_1.abc;
  3 |  
 (3 rows)
 
-SELECT * FROM test_schema_1.abc_view;
+SELECT * FROM test_ns_schema_1.abc_view;
  a | b 
 ---+---
  2 |  
@@ -36,20 +81,20 @@ SELECT * FROM test_schema_1.abc_view;
  4 |  
 (3 rows)
 
-ALTER SCHEMA test_schema_1 RENAME TO test_schema_renamed;
+ALTER SCHEMA test_ns_schema_1 RENAME TO test_ns_schema_renamed;
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_1');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');
  count 
 -------
      0
 (1 row)
 
 -- test IF NOT EXISTS cases
-CREATE SCHEMA test_schema_renamed; -- fail, already exists
-ERROR:  schema "test_schema_renamed" already exists
-CREATE SCHEMA IF NOT EXISTS test_schema_renamed; -- ok with notice
-NOTICE:  schema "test_schema_renamed" already exists, skipping
-CREATE SCHEMA IF NOT EXISTS test_schema_renamed -- fail, disallowed
+CREATE SCHEMA test_ns_schema_renamed; -- fail, already exists
+ERROR:  schema "test_ns_schema_renamed" already exists
+CREATE SCHEMA IF NOT EXISTS test_ns_schema_renamed; -- ok with notice
+NOTICE:  schema "test_ns_schema_renamed" already exists, skipping
+CREATE SCHEMA IF NOT EXISTS test_ns_schema_renamed -- fail, disallowed
        CREATE TABLE abc (
               a serial,
               b int UNIQUE
@@ -57,13 +102,13 @@ CREATE SCHEMA IF NOT EXISTS test_schema_renamed -- fail, disallowed
 ERROR:  CREATE SCHEMA IF NOT EXISTS cannot include schema elements
 LINE 2:        CREATE TABLE abc (
                ^
-DROP SCHEMA test_schema_renamed CASCADE;
+DROP SCHEMA test_ns_schema_renamed CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table test_schema_renamed.abc
-drop cascades to view test_schema_renamed.abc_view
+DETAIL:  drop cascades to table test_ns_schema_renamed.abc
+drop cascades to view test_ns_schema_renamed.abc_view
 -- verify that the objects were dropped
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_renamed');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_renamed');
  count 
 -------
      0

--- a/src/test/regress/sql/namespace.sql
+++ b/src/test/regress/sql/namespace.sql
@@ -2,7 +2,11 @@
 -- Regression tests for schemas (namespaces)
 --
 
-CREATE SCHEMA test_schema_1
+-- set the whitespace-only search_path to test that the
+-- GUC list syntax is preserved during a schema creation
+SELECT pg_catalog.set_config('search_path', ' ', false);
+
+CREATE SCHEMA test_ns_schema_1
        CREATE INDEX abc_a_idx ON abc (a)
 
        CREATE VIEW abc_view AS
@@ -13,32 +17,52 @@ CREATE SCHEMA test_schema_1
               b int UNIQUE
        ) DISTRIBUTED BY (b);
 
+-- verify that the correct search_path restored on abort
+SET search_path to public;
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT c FROM abc;
+COMMIT;
+SHOW search_path;
+
+-- verify that the correct search_path preserved
+-- after creating the schema and on commit
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT a FROM abc;
+SHOW search_path;
+COMMIT;
+SHOW search_path;
+DROP SCHEMA test_ns_schema_2 CASCADE;
+
 -- verify that the objects were created
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_1');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');
 
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
-INSERT INTO test_schema_1.abc DEFAULT VALUES;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
 
-SELECT * FROM test_schema_1.abc;
-SELECT * FROM test_schema_1.abc_view;
+SELECT * FROM test_ns_schema_1.abc;
+SELECT * FROM test_ns_schema_1.abc_view;
 
-ALTER SCHEMA test_schema_1 RENAME TO test_schema_renamed;
+ALTER SCHEMA test_ns_schema_1 RENAME TO test_ns_schema_renamed;
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_1');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');
 
 -- test IF NOT EXISTS cases
-CREATE SCHEMA test_schema_renamed; -- fail, already exists
-CREATE SCHEMA IF NOT EXISTS test_schema_renamed; -- ok with notice
-CREATE SCHEMA IF NOT EXISTS test_schema_renamed -- fail, disallowed
+CREATE SCHEMA test_ns_schema_renamed; -- fail, already exists
+CREATE SCHEMA IF NOT EXISTS test_ns_schema_renamed; -- ok with notice
+CREATE SCHEMA IF NOT EXISTS test_ns_schema_renamed -- fail, disallowed
        CREATE TABLE abc (
               a serial,
               b int UNIQUE
        );
 
-DROP SCHEMA test_schema_renamed CASCADE;
+DROP SCHEMA test_ns_schema_renamed CASCADE;
 
 -- verify that the objects were dropped
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
-    (SELECT oid FROM pg_namespace WHERE nspname = 'test_schema_renamed');
+    (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_renamed');


### PR DESCRIPTION
The two methods don't cooperate, so set_config_option("search_path", ...) has been ineffective under non-empty overrideStack.  This defect enabled an attacker having database-level CREATE privilege to execute arbitrary code as the bootstrap superuser.  While that particular attack requires v13+ for the trusted extension attribute, other attacks are feasible in all supported versions.

Standardize on the combination of NewGUCNestLevel() and set_config_option("search_path", ...).  It is newer than PushOverrideSearchPath(), more-prevalent, and has no known disadvantages.  The "override" mechanism remains for now, for compatibility with out-of-tree code.  Users should update such code, which likely suffers from the same sort of vulnerability closed here. Back-patch to v11 (all supported versions).

Alexander Lakhin.  Reported by Alexander Lakhin.


(cherry-picked from 78119a0bf98edb13e7f79c6402378376cc6b6ca4 with conflicts pg:REL_12_STABLE)

Additional changes:
- Since the file is out-of-date compared to the cherry-pick, rename test_schema to test_ns_schema to use the new convention.
- Remove extra argument last argument for `set_config_option` "false". This is a new change that is not in 6X; the introduction of the argument (in the future releases) removed the `#ifdef EXEC_BACKEND ...` for from `guc.c`. The argument `is_reload` being false is equivalent to going to the `EXEC_BACKEND`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
