### PR TITLE
resqueue test: Close holdable cursor instead

### DIFF
--- a/src/test/isolation2/expected/resource_queue.out
+++ b/src/test/isolation2/expected/resource_queue.out
@@ -99,7 +99,8 @@ DECLARE CURSOR
  t       | resource queue | ExclusiveLock 
 (1 row)
 
-4q: ... <quitting>
+4:CLOSE c_hold;
+CLOSE CURSOR
 
 -- Sanity check: Ensure that all locks were released.
 0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();

--- a/src/test/isolation2/sql/resource_queue.sql
+++ b/src/test/isolation2/sql/resource_queue.sql
@@ -47,7 +47,7 @@
 -- Sanity check: The holdable cursor should be accounted for in pg_locks.
 0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();
 
-4q:
+4:CLOSE c_hold;
 
 -- Sanity check: Ensure that all locks were released.
 0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();


### PR DESCRIPTION
Quitting the session is non-blocking and can cause diffs like:

```diff
 -- Sanity check: Ensure that all locks were released.
 0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();
- granted | locktype | mode
----------+----------+------
-(0 rows)
+ granted | locktype       | mode
+---------+----------------+---------------
+ t       | resource queue | ExclusiveLock
+(1 row)

 -- Sanity check: Ensure that the resource queue is now empty.
 0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_concurrency_test';
```
CLOSE the cursor instead, which will be a blocking operation, and will
exercise the same code path.

Co-authored-by: Jimmy Yih <jyih@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_resq_test