### PR TITLE
[6X] Fix url_curl.c headers handling

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -287,14 +287,19 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 	Assert(size == 1);
 
 	/*
-	 * parse the http response line (code and message) from
+	 * Parse the http response line (code and message) from
 	 * the http header that we get. Basically it's the whole
 	 * first line (e.g: "HTTP/1.0 400 time out"). We do this
 	 * in order to capture any error message that comes from
 	 * gpfdist, and later use it to report the error string in
 	 * check_response() to the database user.
+	 * As we can get multiple header blocks for multiple HTTP
+	 * messages, we need to parse all headers and get the last
+	 * one. First header may contain only successfull status and
+	 * no info about the error.
 	 */
-	if (url->http_response == 0)
+
+	if (len > 5 && *ptr == 'H' && 0 == strncmp("HTTP/", ptr, 5))
 	{
 		int 	n = nmemb;
 		char* 	p;
@@ -309,6 +314,9 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 
 			if (n > 0 && (p[n-1] == '\r' || p[n-1] == '\n'))
 				p[--n] = 0;
+
+			if (url->http_response)
+				pfree(url->http_response);
 
 			url->http_response = p;
 		}

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -484,7 +484,9 @@ COPY wet_region FROM STDIN DELIMITER '|';
 3|EUROPE|ly final courts cajole furiously final excuse
 \.
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
-
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -663,6 +663,10 @@ COPY reg_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region SELECT * from reg_region;
 COPY wet_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
+ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger


### PR DESCRIPTION
Backport of #14976
____________
Previously, header_callback(), used to get and parse HTTP headers, took only first status header from all header blocks to show it to user. The problem is that we can have multiple messages with multiple header blocks. In case of error, only first (successful) status is shown to user, which is not informative. This patch fixes header_callback(), which now process all status headers.
