### PR TITLE
Fix a flaky case in sysviews_gp

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -164,13 +164,15 @@ test: gp_covering_index
 test: pgstat_qd_tabstat
 # dispatch should always run seperately from other cases.
 test: dispatch
+# autoanalyze and autovacuum affects the analyze/vacuum related views in the sysviews_gp test
+test: sysviews_gp
 test: enable_autovacuum
 test: resource_group
 test: resource_group_cpuset
 test: resource_group_gucs
 
 # expand_table tests may affect the result of 'gp_explain', keep them below that
-test: trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression sysviews_gp
+test: trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression
 
 # direct dispatch tests
 test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types interrupt_holdoff_count


### PR DESCRIPTION
The test is flaky with diff:

```
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/sysviews_gp.out	2023-06-29 15:15:01.228910780 +0000 +++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/sysviews_gp.out	2023-06-29 15:15:01.236911545 +0000 @@ -137,7 +137,7 @@
 select count(*) = 0 or count(distinct gp_segment_id) = :segcount from gp_stat_progress_analyze;
  ?column?
 ----------
- t
+ f (1 row)
```

Autoanalyze can be run nondeterministically on some segment. So we cannot assume that we can see progress report on none-or-all segments. Similar to the vacuum progress view too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
