### PR TITLE
Make sure database-wide VACUUM FREEZE don't leave unfrozen rows in pg_stat_last_operation/pg_stat_last_shoperation

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -40,6 +40,8 @@
 #include "catalog/pg_database.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_stat_last_operation_d.h"
+#include "catalog/pg_stat_last_shoperation_d.h"
 #include "commands/cluster.h"
 #include "commands/defrem.h"
 #include "commands/tablecmds.h"
@@ -381,7 +383,42 @@ vacuum(List *relations, VacuumParams *params,
 		relations = newrels;
 	}
 	else
+	{
 		relations = get_all_vacuum_rels(params->options);
+
+		/*
+		 * GPDB: for a database-wide VACUUM FREEZE (relations==NIL), make sure 
+		 * pg_stat_last_operation and pg_stat_last_shoperation are the last tables
+		 * to be frozen, so that all the meta-tracking rows that we are inserting 
+		 * into pg_stat_last_operation/pg_stat_last_shoperation during VACUUM FREEZE
+		 * can be frozen too. In addition, we will skip the meta-tracking of 
+		 * pg_stat_last_operation/pg_stat_last_shoperation itself. All of these will
+		 * make sure that we do not leave any unfrozen row after database-wide VACUUM FREEZE.
+		 */
+		if (params->options & VACOPT_FREEZE)
+		{
+			ListCell 		*lc;
+			ListCell 		*prev = NULL;
+			ListCell 		*original_tail = list_tail(relations);
+
+			/* go through the original table list and move the two tables to the end */
+			for (lc = list_head(relations); lc != original_tail; )
+			{
+				VacuumRelation *vrel = lfirst_node(VacuumRelation, lc);
+				ListCell *next = lnext(lc);
+
+				if (vrel->oid == StatLastOpRelationId || vrel->oid == StatLastShOpRelationId)
+				{
+					relations = list_delete_cell(relations, lc, prev);
+					relations = lappend(relations, vrel);
+					lc = NULL;
+				}
+				if (lc)
+					prev = lc;
+				lc = next;
+			}
+		}
+	}
 
 	/*
 	 * Decide whether we need to start/commit our own transactions.
@@ -2567,26 +2604,34 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		dispatchVacuum(params, relid, &stats_context);
 		vac_update_relstats_from_list(&stats_context);
 
-		/* Also update pg_stat_last_operation */
-		if (IsAutoVacuumWorkerProcess())
-			vsubtype = "AUTO";
-		else
+		/*
+		 * Also update pg_stat_last_operation/pg_stat_last_shoperation. Unless
+		 * we are freezing those two tables themselves, because we do not want
+		 * to create new unfrozen row in them.
+		 */
+		if (!(params->options & VACOPT_FREEZE && 
+					(relid == StatLastOpRelationId || relid == StatLastShOpRelationId)))
 		{
-			if ((params->options & VACOPT_FULL) &&
-				(0 == params->freeze_min_age))
-				vsubtype = "FULL FREEZE";
-			else if ((params->options & VACOPT_FULL))
-				vsubtype = "FULL";
-			else if (0 == params->freeze_min_age)
-				vsubtype = "FREEZE";
+			if (IsAutoVacuumWorkerProcess())
+				vsubtype = "AUTO";
 			else
-				vsubtype = "";
+			{
+				if ((params->options & VACOPT_FULL) &&
+					(0 == params->freeze_min_age))
+					vsubtype = "FULL FREEZE";
+				else if ((params->options & VACOPT_FULL))
+					vsubtype = "FULL";
+				else if (0 == params->freeze_min_age)
+					vsubtype = "FREEZE";
+				else
+					vsubtype = "";
+			}
+			MetaTrackUpdObject(RelationRelationId,
+							   relid,
+							   GetUserId(),
+							   "VACUUM",
+							   vsubtype);
 		}
-		MetaTrackUpdObject(RelationRelationId,
-						   relid,
-						   GetUserId(),
-						   "VACUUM",
-						   vsubtype);
 
 		/* Restore userid and security context */
 		SetUserIdAndSecContext(save_userid, save_sec_context);

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -415,3 +415,96 @@ drop function clean_roles();
 -- end_ignore
 -- free pg_global space, otherwise it fails db_size_functions
 VACUUM FULL pg_authid, pg_database;
+-- Test that VACUUM FREEZE should leave no unfrozen rows in pg_stat_last_operation and pg_stat_last_shoperation
+drop table if exists vacfrzt;
+drop database if exists vacfrzdb;
+create extension if not exists pageinspect;
+-- autovacuum needs to be turned off for this test
+show autovacuum;
+ autovacuum 
+------------
+ off
+(1 row)
+
+-- helper function to get the number of unfrozen rows in a table
+-- as of GPDB7/PG12, we don't have a convenient function to decode the infomask bits like
+-- heap_tuple_infomask_flags which only comes after PG13, so just manually checking if it
+-- is marked frozen which is (HEAP_XMIN_COMMITTED | HEAP_XMIN_INVALID)=(0x0100 | 0x0200)=768
+CREATE OR REPLACE FUNCTION count_unfrozen_rows(rel text)
+RETURNS INT AS
+$$
+DECLARE
+    i INTEGER;
+    num_pages INTEGER;
+    total_count BIGINT := 0;
+BEGIN
+    SELECT relpages INTO num_pages
+    FROM pg_class
+    WHERE relname = rel;
+
+    FOR i IN 0..num_pages - 1 LOOP
+        total_count := total_count +
+        (SELECT count(*)
+        FROM heap_page_items(get_raw_page(rel, i))
+        WHERE t_infomask & 768 = 0);
+    END LOOP;
+
+    RETURN total_count;
+END;
+$$
+LANGUAGE plpgsql;
+-- start off cleanly
+vacuum freeze;
+-- these will create an unfrozen row in pg_stat_last_operation and pg_stat_last_shoperation, respectively
+create table vacfrzt(a int);
+create database vacfrzdb;
+-- we should see unfrozen rows created above.
+select count_unfrozen_rows('pg_stat_last_operation');
+ count_unfrozen_rows 
+---------------------
+                   1
+(1 row)
+
+select count_unfrozen_rows('pg_stat_last_shoperation');
+ count_unfrozen_rows 
+---------------------
+                   1
+(1 row)
+
+vacuum freeze;
+-- now should have zero unfrozen rows
+select count_unfrozen_rows('pg_stat_last_operation');
+ count_unfrozen_rows 
+---------------------
+                   0
+(1 row)
+
+select count_unfrozen_rows('pg_stat_last_shoperation');
+ count_unfrozen_rows 
+---------------------
+                   0
+(1 row)
+
+-- per-table vacuum freeze of normal table will leave an unfrozen row in pg_stat_last_operation
+vacuum freeze vacfrzt;
+select count_unfrozen_rows('pg_stat_last_operation');
+ count_unfrozen_rows 
+---------------------
+                   1
+(1 row)
+
+-- per-table vacuum freeze of the lastop/lastshop won't leave unfrozen rows
+vacuum freeze pg_stat_last_operation;
+vacuum freeze pg_stat_last_shoperation;
+select count_unfrozen_rows('pg_stat_last_operation');
+ count_unfrozen_rows 
+---------------------
+                   0
+(1 row)
+
+select count_unfrozen_rows('pg_stat_last_shoperation');
+ count_unfrozen_rows 
+---------------------
+                   0
+(1 row)
+


### PR DESCRIPTION
IN GPDB, VACUUM FREEZE of any table, like many other operations, will leave tracking info in pg_stat_last_operation/pg_stat_last_shoperation. Those rows in pg_stat_last_operation/pg_stat_last_shoperation are unfrozen until we freeze those two tables themselves. Therefore, a database-wide VACUUM FREEZE could leave a lot of unfrozen rows in those two tables.

That doesn't hurt until we try to import collations at gpinitsystem time and we want to freeze template0 before going into pg_upgrade (#15667). But the unfrozen rows generated during VACUUM FREEZE would defeat the purpose of VACUUM FREEZE.

So now we try to not leave unfrozen rows in those two catalogs. We do that by moving pg_stat_last_operation and pg_stat_last_shoperation to the end of the list of relations to be vacuumed during a database-wide VACUUM FREEZE. So that all the meta-tracking rows that we just inserted can be frozen. Then, we opt to skip the VACUUM FREEZE-tracking of those two catalogs themselves to make sure no more unfrozen rows.

P.S. practically pg_stat_last_shoperation didn't cause a problem for us (probably because it was frozen after the shared catalogs are frozen), but it should be addressed with pg_stat_last_operation nonetheless. 

gpdb-dev discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/qG-wJfVzeQI

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/vacuum-freeze-fix

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
