### PR TITLE
Fix another flaky aggregates ICW test

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -2731,6 +2731,7 @@ create aggregate my_half_sum(int4)
    sfunc = sum_transfn,
    finalfunc = halfsum_finalfn
 );
+discard plans;
 -- Agg state should be shared even though my_sum has no finalfn
 select my_sum(one),my_half_sum(one) from (values(1),(2),(3),(4)) t(one);
 NOTICE:  sum_transfn called with 1

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3008,6 +3008,7 @@ create aggregate my_half_sum(int4)
    sfunc = sum_transfn,
    finalfunc = halfsum_finalfn
 );
+discard plans;
 -- Agg state should be shared even though my_sum has no finalfn
 select my_sum(one),my_half_sum(one) from (values(1),(2),(3),(4)) t(one);
 INFO:  GPORCA failed to produce a plan, falling back to planner

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1126,6 +1126,7 @@ create aggregate my_half_sum(int4)
    finalfunc = halfsum_finalfn
 );
 
+discard plans;
 -- Agg state should be shared even though my_sum has no finalfn
 select my_sum(one),my_half_sum(one) from (values(1),(2),(3),(4)) t(one);
 


### PR DESCRIPTION
Sometimes these prepared statements would be replanned and log ORCA fallbacks, which are expected and ok. However, to make this more deterministic, reset the plan cache in the test. Hopefully this is the last one...

This uses the same approach as dee8ee04909f03e0aaa1e3def7c6fea4ab11778a and 8fa789e0cde3d6a6c158d6420fdd9c95603b2fd4