### PR TITLE
Collect statistics for root partitions during autoanalyze

### DIFF
--- a/src/backend/catalog/partition.c
+++ b/src/backend/catalog/partition.c
@@ -146,6 +146,25 @@ get_partition_ancestors_worker(Relation inhRel, Oid relid, List **ancestors)
 }
 
 /*
+ * Get the top-level partition root of a given relation. This is a convenience
+ * wrapper around get_partition_ancestors.
+ *
+ * This assumes that the given relation is a partition (i.e. relispartition is
+ * true)
+ *
+ * Note: we depend on the order of results returned by get_partition_ancestors
+ */
+Oid
+get_top_level_partition_root(Oid relid)
+{
+	List *ancestors;
+
+	Assert(OidIsValid(relid));
+	ancestors = get_partition_ancestors(relid);
+	return llast_oid(ancestors);
+}
+
+/*
  * index_get_partition
  *		Return the OID of index of the given partition that is a child
  *		of the given index, or InvalidOid if there isn't one.

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -700,6 +700,13 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	}
 
 	sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
+	/*
+	 * Do not sample partitioned tables during autovacuum for any reason.
+	 * It can take a long time and be IO intensive, and we'd only hit this case
+	 * for collecting extended stats
+	 */
+	if (onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && IsAutoVacuumWorkerProcess())
+		sample_needed = false;
 	if (ctx || sample_needed)
 	{
 		if (ctx)
@@ -822,6 +829,8 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 				MemoryContextResetAndDeleteChildren(col_context);
 				continue;
 			}
+			if (!sample_needed)
+				continue;
 			Assert(sample_needed);
 
 			Bitmapset  *rowIndexes = colLargeRowIndexes[stats->attr->attnum - 1];
@@ -989,8 +998,10 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		 *
 		 * For now we only build extended statistics on individual relations,
 		 * not for relations representing inheritance trees.
+		 *
+		 * Additionally, don't build external stats for partitioned tables during autovacuum
 		 */
-		if (build_ext_stats)
+		if (build_ext_stats && !(onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && IsAutoVacuumWorkerProcess()))
 			BuildRelationExtStatistics(onerel, totalrows, numrows, rows,
 									   attr_cnt, vacattrstats);
 	}

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -990,7 +990,12 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		 * always empty), so we store stats representing the whole tree.
 		 */
 
-		/*  Don't build external stats for partitioned tables during autovacuum */
+		/*
+		 * Don't build external stats for partitioned tables during autovacuum.
+		 * External stats cannot be merged and therefore would require sampling,
+		 * which is much more expensive. Users can instead explicitly run analyze
+		 * on the root partition to trigger sampling.
+		 */
 		if (onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 			build_ext_stats = IsAutoVacuumWorkerProcess() ? false : inh;
 		else

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -700,7 +700,6 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	}
 
 	sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
-
 	if (ctx || sample_needed)
 	{
 		if (ctx)
@@ -823,6 +822,11 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 				MemoryContextResetAndDeleteChildren(col_context);
 				continue;
 			}
+			/*
+			 * if merge_stats is not set, it is still possible that we don't want to sample
+			 * (eg: in the case of autoanalyze). In this case, don't populate statistics
+			 * for this attribute
+			 */
 			if (!sample_needed)
 				continue;
 			Assert(sample_needed);
@@ -996,8 +1000,6 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		 *
 		 * For now we only build extended statistics on individual relations,
 		 * not for relations representing inheritance trees.
-		 *
-		 *
 		 */
 		if (build_ext_stats)
 			BuildRelationExtStatistics(onerel, totalrows, numrows, rows,

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1043,6 +1043,7 @@ needs_sample(Relation rel, VacAttrStats **vacattrstats, int attr_cnt)
 	 */
 	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && IsAutoVacuumWorkerProcess())
 		return false;
+
 	for (i = 0; i < attr_cnt; i++)
 	{
 		Assert(vacattrstats[i] != NULL);

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -22,6 +22,7 @@
 #include "lib/binaryheap.h"
 #include "miscadmin.h"
 #include "parser/parse_oper.h"
+#include "postmaster/autovacuum.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
 #include "utils/fmgroids.h"
@@ -1031,10 +1032,18 @@ getBucketSizes(const HeapTuple *heaptupleStats, const float4 *relTuples, int nPa
 bool
 needs_sample(Relation rel, VacAttrStats **vacattrstats, int attr_cnt)
 {
+
 	Assert(vacattrstats != NULL);
 	List *statext_oids;
 	int			i;
 
+	/*
+	 * Do not sample partitioned tables during autovacuum for any reason.
+	 * It can take a long time and is IO intensive, and we'd only hit this case
+	 * for collecting extended stats
+	 */
+	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && IsAutoVacuumWorkerProcess())
+		return false;
 	for (i = 0; i < attr_cnt; i++)
 	{
 		Assert(vacattrstats[i] != NULL);

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1032,7 +1032,6 @@ getBucketSizes(const HeapTuple *heaptupleStats, const float4 *relTuples, int nPa
 bool
 needs_sample(Relation rel, VacAttrStats **vacattrstats, int attr_cnt)
 {
-
 	Assert(vacattrstats != NULL);
 	List *statext_oids;
 	int			i;

--- a/src/include/catalog/partition.h
+++ b/src/include/catalog/partition.h
@@ -21,6 +21,7 @@
 
 extern Oid	get_partition_parent(Oid relid);
 extern List *get_partition_ancestors(Oid relid);
+extern Oid	get_top_level_partition_root(Oid relid);
 extern Oid	index_get_partition(Relation partition, Oid indexId);
 extern List *map_partition_varattnos(List *expr, int fromrel_varno,
 									 Relation to_rel, Relation from_rel,

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -117,8 +117,6 @@ SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
 select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
--- Ensure root partition was only merged once, num_times_hit should be 1
-SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'status', '', '', 'rankpart', 1, -1, 0, 1);
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
 
 -- Wait until autovacuum worker updates pg_database

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -324,7 +324,7 @@ SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'p3', 1,
 -- Suspend the autovacuum worker from analyze before
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'p3', 1, -1, 0, 1);
 
-1&: insert into multipart select i%20 from generate_series(1, 1000)i;
+1&: insert into multipart select i%20 from generate_series(1, 10000)i;
 
 -- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -106,7 +106,7 @@ SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpar
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
 
 -- Insert data into final partition to trigger stats collection for root partition
-1&: insert into rankpart select i, 9, i from generate_series(1,200)i;
+1&: insert into rankpart select i, (i%2)+8, i from generate_series(1,8000)i;
 
 -- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
@@ -117,6 +117,8 @@ SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
 select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
+-- Ensure root partition was only merged once, num_times_hit should be 1
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'status', '', '', 'rankpart', 1, -1, 0, 1);
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
 
 -- Wait until autovacuum worker updates pg_database
@@ -125,8 +127,11 @@ SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
 
 -- Once all partitions are analyzed, statistics should have been collected for root
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_5'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_2'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
 SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_6'::regclass;
+SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_5'::regclass;
 SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
 -- Extended stats should not have been collected
 SELECT d.stxddependencies FROM pg_statistic_ext s, pg_statistic_ext_data d WHERE s.stxrelid = 'rankpart'::regclass AND d.stxoid = s.oid;
@@ -343,7 +348,7 @@ SELECT count(*) FROM pg_statistic where starelid = 'multipart'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'part2'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'part3'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
-- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
+-- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
 select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
 select relpages, reltuples from pg_class where oid = 'part2'::regclass;
 select relpages, reltuples from pg_class where oid = 'part3'::regclass;

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -343,6 +343,7 @@ SELECT count(*) FROM pg_statistic where starelid = 'multipart'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'part2'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'part3'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
+- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
 select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
 select relpages, reltuples from pg_class where oid = 'part2'::regclass;
 select relpages, reltuples from pg_class where oid = 'part3'::regclass;

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -123,12 +123,12 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
 SELECT gp_wait_until_triggered_fault('analyze_finished_one_relation', 1, 1);
 SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
 
--- Once all partitions are analyzed, statistics should be collected for root
+-- Once all partitions are analyzed, statistics should have been collected for root
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
 SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_6'::regclass;
 SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
--- Extended stats should not be collected
+-- Extended stats should not have been collected
 SELECT d.stxddependencies FROM pg_statistic_ext s, pg_statistic_ext_data d WHERE s.stxrelid = 'rankpart'::regclass AND d.stxoid = s.oid;
 
 

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -54,7 +54,7 @@ select relpages, reltuples from pg_class where oid = 'anatest'::regclass;
 
 -- Prepare the table to be ANALYZEd
 1: CREATE TABLE rankpart (id int, rank int, product int) DISTRIBUTED BY (id) PARTITION BY RANGE (rank) ( START (1) END (10) EVERY (2), DEFAULT PARTITION extra );
-
+1: CREATE STATISTICS dep(dependencies) on rank, product from rankpart;
 -- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_extra', 1, -1, 0, 1);
 -- Track that we have updated the attributes stats in pg_statistic when finished
@@ -95,6 +95,41 @@ select relpages, reltuples from pg_class where oid = 'rankpart_1_prt_4'::regclas
 select relpages, reltuples from pg_class where oid = 'rankpart_1_prt_5'::regclass;
 select relpages, reltuples from pg_class where oid = 'rankpart_1_prt_6'::regclass;
 select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
+
+-- Insert data into rankpart_1_prt_6, check that root partition stats are updated
+
+-- Track report gpstat on coordinator
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+-- Track that we have updated the attributes stats in pg_statistic when finished
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+-- Suspend the autovacuum worker from analyze before
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+
+-- Insert data into final partition to trigger stats collection for root partition
+1&: insert into rankpart select i, 9, i from generate_series(1,200)i;
+
+-- Wait until report pgstat on coordinator
+SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
+
+1<:
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+
+-- Wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('analyze_finished_one_relation', 1, 1);
+SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
+
+-- Once all partitions are analyzed, statistics should be collected for root
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
+SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_6'::regclass;
+SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
+-- Extended stats should not be collected
+SELECT d.stxddependencies FROM pg_statistic_ext s, pg_statistic_ext_data d WHERE s.stxrelid = 'rankpart'::regclass AND d.stxoid = s.oid;
 
 
 --
@@ -259,6 +294,59 @@ SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
 select relpages, reltuples from pg_class where oid = 'autostatstbl'::regclass;
 -- expect analyze_count = 2, autoanalyze_count = 3, and n_mod_since_analyze = 0 since ANALYZE executed
 select analyze_count, autoanalyze_count, n_mod_since_analyze from pg_stat_all_tables where relname = 'autostatstbl';
+
+-- Case 4 --
+-- Multi-level partition case
+
+-- Prepare the table to be ANALYZEd
+1: RESET gp_autostats_mode;
+1: create table multipart(a int)  partition by range(a);
+1: create table part2(a int) partition by range(a);
+1: create table part3(a int) partition by range(a);
+1: create table p1(a int);
+1: create table p2(a int);
+1: create table p3(a int);
+1: create table p4(a int);
+1: alter table multipart attach partition part2 for values from (0) to (10);
+1: alter table multipart attach partition part3 for values from (10) to (20);
+1: alter table part2 attach partition p1 for values from (0) to (5);
+1: alter table part2 attach partition p2 for values from (5) to (10);
+1: alter table part3 attach partition p3 for values from (10) to (15);
+1: alter table part3 attach partition p4 for values from (15) to (20);
+
+-- Track report gpstat on coordinator
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'p3', 1, -1, 0, 1);
+-- Track that we have updated the attributes stats in pg_statistic when finished
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'p3', 1, -1, 0, 1);
+-- Suspend the autovacuum worker from analyze before
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'p3', 1, -1, 0, 1);
+
+1&: insert into multipart select i%20 from generate_series(1, 1000)i;
+
+-- Wait until report pgstat on coordinator
+SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
+
+1<:
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+
+-- Wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('analyze_finished_one_relation', 1, 1);
+SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
+
+-- Root and leaves should have statistic updated. Intermediate partitions should not
+SELECT count(*) FROM pg_statistic where starelid = 'multipart'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'part2'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'part3'::regclass;
+SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
+select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
+select relpages, reltuples from pg_class where oid = 'part2'::regclass;
+select relpages, reltuples from pg_class where oid = 'part3'::regclass;
+select relpages, reltuples from pg_class where oid = 'p4'::regclass;
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -792,7 +792,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
  Success:        
 (1 row)
 
-1&: insert into multipart select i%20 from generate_series(1, 1000)i;  <waiting ...>
+1&: insert into multipart select i%20 from generate_series(1, 10000)i;  <waiting ...>
 
 -- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
@@ -807,7 +807,7 @@ SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 (1 row)
 
 1<:  <... completed>
-INSERT 0 1000
+INSERT 0 10000
 
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
@@ -879,7 +879,7 @@ select relpages, reltuples from pg_class where oid = 'part3'::regclass;
 select relpages, reltuples from pg_class where oid = 'p4'::regclass;
  relpages | reltuples 
 ----------+-----------
- 3        | 250       
+ 4        | 2500      
 (1 row)
 
 -- Reset GUCs.

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -114,6 +114,8 @@ select relpages, reltuples from pg_class where oid = 'anatest'::regclass;
 1: CREATE TABLE rankpart (id int, rank int, product int) DISTRIBUTED BY (id) PARTITION BY RANGE (rank) ( START (1) END (10) EVERY (2), DEFAULT PARTITION extra );
 CREATE TABLE
 
+1: CREATE STATISTICS dep(dependencies) on rank, product from rankpart;
+CREATE STATISTICS
 -- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_extra', 1, -1, 0, 1);
  gp_inject_fault 
@@ -251,6 +253,103 @@ select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
  relpages | reltuples 
 ----------+-----------
  0        | 0         
+(1 row)
+
+-- Insert data into rankpart_1_prt_6, check that root partition stats are updated
+
+-- Track report gpstat on coordinator
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Track that we have updated the attributes stats in pg_statistic when finished
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Suspend the autovacuum worker from analyze before
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Insert data into final partition to trigger stats collection for root partition
+1&: insert into rankpart select i, 9, i from generate_series(1,200)i;  <waiting ...>
+
+-- Wait until report pgstat on coordinator
+SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+INSERT 0 200
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
+ datname        | query                                                                                                    
+----------------+----------------------------------------------------------------------------------------------------------
+ isolation2test | select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database(); 
+ isolation2test | autovacuum: ANALYZE public.rankpart_1_prt_6                                                              
+(2 rows)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('analyze_finished_one_relation', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Once all partitions are analyzed, statistics should be collected for root
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
+ count 
+-------
+ 3     
+(1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
+ count 
+-------
+ 3     
+(1 row)
+SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_6'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 3        | 200       
+(1 row)
+SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 0        | 0         
+(1 row)
+-- Extended stats should not be collected
+SELECT d.stxddependencies FROM pg_statistic_ext s, pg_statistic_ext_data d WHERE s.stxrelid = 'rankpart'::regclass AND d.stxoid = s.oid;
+ stxddependencies 
+------------------
+                  
 (1 row)
 
 
@@ -625,6 +724,147 @@ select analyze_count, autoanalyze_count, n_mod_since_analyze from pg_stat_all_ta
  analyze_count | autoanalyze_count | n_mod_since_analyze 
 ---------------+-------------------+---------------------
  2             | 3                 | 0                   
+(1 row)
+
+-- Case 4 --
+-- Multi-level partition case
+
+-- Prepare the table to be ANALYZEd
+1: RESET gp_autostats_mode;
+RESET
+1: create table multipart(a int)  partition by range(a);
+CREATE TABLE
+1: create table part2(a int) partition by range(a);
+CREATE TABLE
+1: create table part3(a int) partition by range(a);
+CREATE TABLE
+1: create table p1(a int);
+CREATE TABLE
+1: create table p2(a int);
+CREATE TABLE
+1: create table p3(a int);
+CREATE TABLE
+1: create table p4(a int);
+CREATE TABLE
+1: alter table multipart attach partition part2 for values from (0) to (10);
+ALTER TABLE
+1: alter table multipart attach partition part3 for values from (10) to (20);
+ALTER TABLE
+1: alter table part2 attach partition p1 for values from (0) to (5);
+ALTER TABLE
+1: alter table part2 attach partition p2 for values from (5) to (10);
+ALTER TABLE
+1: alter table part3 attach partition p3 for values from (10) to (15);
+ALTER TABLE
+1: alter table part3 attach partition p4 for values from (15) to (20);
+ALTER TABLE
+
+-- Track report gpstat on coordinator
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'p3', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Track that we have updated the attributes stats in pg_statistic when finished
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'p3', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Suspend the autovacuum worker from analyze before
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'p3', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1&: insert into multipart select i%20 from generate_series(1, 1000)i;  <waiting ...>
+
+-- Wait until report pgstat on coordinator
+SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+INSERT 0 1000
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database();
+ datname        | query                                                                                                    
+----------------+----------------------------------------------------------------------------------------------------------
+ isolation2test | select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database(); 
+ isolation2test | autovacuum: ANALYZE public.p3                                                                            
+(2 rows)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('analyze_finished_one_relation', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Root and leaves should have statistic updated. Intermediate partitions should not
+SELECT count(*) FROM pg_statistic where starelid = 'multipart'::regclass;
+ count 
+-------
+ 1     
+(1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'part2'::regclass;
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'part3'::regclass;
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
+ count 
+-------
+ 1     
+(1 row)
+select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 0        | 0         
+(1 row)
+select relpages, reltuples from pg_class where oid = 'part2'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 0        | 0         
+(1 row)
+select relpages, reltuples from pg_class where oid = 'part3'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 0        | 0         
+(1 row)
+select relpages, reltuples from pg_class where oid = 'p4'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 3        | 250       
 (1 row)
 
 -- Reset GUCs.

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -113,7 +113,6 @@ select relpages, reltuples from pg_class where oid = 'anatest'::regclass;
 -- Prepare the table to be ANALYZEd
 1: CREATE TABLE rankpart (id int, rank int, product int) DISTRIBUTED BY (id) PARTITION BY RANGE (rank) ( START (1) END (10) EVERY (2), DEFAULT PARTITION extra );
 CREATE TABLE
-
 1: CREATE STATISTICS dep(dependencies) on rank, product from rankpart;
 CREATE STATISTICS
 -- Track report gpstat on coordinator
@@ -277,7 +276,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
 (1 row)
 
 -- Insert data into final partition to trigger stats collection for root partition
-1&: insert into rankpart select i, 9, i from generate_series(1,200)i;  <waiting ...>
+1&: insert into rankpart select i, (i%2)+8, i from generate_series(1,8000)i;  <waiting ...>
 
 -- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
@@ -292,7 +291,7 @@ SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 (1 row)
 
 1<:  <... completed>
-INSERT 0 200
+INSERT 0 8000
 
 -- Wait until autovacuum is triggered
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
@@ -306,6 +305,13 @@ select datname, query from pg_stat_activity where query like '%ANALYZE%' and dat
  isolation2test | select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database(); 
  isolation2test | autovacuum: ANALYZE public.rankpart_1_prt_6                                                              
 (2 rows)
+-- Ensure root partition was only merged once, num_times_hit should be 1
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'status', '', '', 'rankpart', 1, -1, 0, 1);
+ gp_inject_fault                                                                                                                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'auto_vac_worker_after_report_activity' fault type:'suspend' ddl statement:'' database name:'' table name:'rankpart_1_prt_6' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
+ 
+(1 row)
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
  gp_inject_fault 
 -----------------
@@ -330,6 +336,16 @@ SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
 -------
  3     
 (1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_5'::regclass;
+ count 
+-------
+ 3     
+(1 row)
+SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_2'::regclass;
+ count 
+-------
+ 3     
+(1 row)
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
  count 
 -------
@@ -338,7 +354,12 @@ SELECT count(*) FROM pg_statistic where starelid = 'rankpart'::regclass;
 SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_6'::regclass;
  relpages | reltuples 
 ----------+-----------
- 3        | 200       
+ 6        | 4000      
+(1 row)
+SELECT relpages, reltuples FROM pg_class WHERE oid = 'rankpart_1_prt_5'::regclass;
+ relpages | reltuples 
+----------+-----------
+ 6        | 4125      
 (1 row)
 SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
  relpages | reltuples 
@@ -846,7 +867,7 @@ SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
 -------
  1     
 (1 row)
-- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
+-- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
 select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
  relpages | reltuples 
 ----------+-----------

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -846,6 +846,7 @@ SELECT count(*) FROM pg_statistic where starelid = 'p4'::regclass;
 -------
  1     
 (1 row)
+- relpages/reltuples for root partitions are retrieved at planning time, not during analyze
 select relpages, reltuples from pg_class where oid = 'multipart'::regclass;
  relpages | reltuples 
 ----------+-----------

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -324,7 +324,7 @@ SELECT gp_inject_fault('analyze_finished_one_relation', 'reset', 1);
  Success:        
 (1 row)
 
--- Once all partitions are analyzed, statistics should be collected for root
+-- Once all partitions are analyzed, statistics should have been collected for root
 SELECT count(*) FROM pg_statistic where starelid = 'rankpart_1_prt_6'::regclass;
  count 
 -------
@@ -345,7 +345,7 @@ SELECT relpages, reltuples FROM pg_class where oid = 'rankpart'::regclass;
 ----------+-----------
  0        | 0         
 (1 row)
--- Extended stats should not be collected
+-- Extended stats should not have been collected
 SELECT d.stxddependencies FROM pg_statistic_ext s, pg_statistic_ext_data d WHERE s.stxrelid = 'rankpart'::regclass AND d.stxoid = s.oid;
  stxddependencies 
 ------------------

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -305,13 +305,6 @@ select datname, query from pg_stat_activity where query like '%ANALYZE%' and dat
  isolation2test | select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database(); 
  isolation2test | autovacuum: ANALYZE public.rankpart_1_prt_6                                                              
 (2 rows)
--- Ensure root partition was only merged once, num_times_hit should be 1
-SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'status', '', '', 'rankpart', 1, -1, 0, 1);
- gp_inject_fault                                                                                                                                                                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'auto_vac_worker_after_report_activity' fault type:'suspend' ddl statement:'' database name:'' table name:'rankpart_1_prt_6' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
- 
-(1 row)
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
Currently, autoanalyze will simply ignore intermediate/root partitions and only sample data from partition leaves. However, the Orca and Planner optimizers rely on root partition statistics in order to generate performent plans, and GPDB heavily uses partitioned tables. One of the main concerns in upstream Postgres is the sampling time to resample the entire partition hierarchy.

GPDB supports merging leaf partition statistics, and this PR utilizes this feature in order to significantly speed up populating root stats. When analyzing a leaf partition, if all other leaves are analyzed, the root partition stats will be populated by merging statistics. To prevent redundant merging of statistics (which can take non-insignificant time with many partitions and columns), we only merge stats at the end of the autoanalyze iteration and only merge stats once per root partition.

Extended stats are not mergeable and therefore also won't be populated in the root partition. Users will need to explicitly analyze the root partition in order to trigger sampling and statistics collection if they want extended stats. Other data types, such as json or non-hashable data types will only have trivial statistics such as non-null ratios and average width merged, but won't be sampled. (see 1bfd25a9)

Some nice to haves for the future:

1) When attaching/detaching partitions, signal to autoanalyze to merge stats for the root partition
2) Improved monitoring around autoanalyze and partitioned tables. Eg: pg_stat_get_autoanalyze_count and others

Discussion thread: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/q9csN98T2B8