### PR TITLE
Fix warning: missing braces around initializer [-Wmissing-braces]

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1902,7 +1902,7 @@ aoco_index_build_range_scan(Relation heapRelation,
 		 */
 		bool	*proj;
 		int		relnatts = RelationGetNumberOfAttributes(heapRelation);
-		AppendOnlyBlockDirectoryEntry dirEntry = {0};
+		AppendOnlyBlockDirectoryEntry dirEntry = {{0}};
 
 		/* The range is contained within one seg. */
 		Assert(AOSegmentGet_segno(start_blockno) ==

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1663,7 +1663,7 @@ appendonly_index_build_range_scan(Relation heapRelation,
 		 * have a non-empty blkdir to help guide our partial scan.
 		 */
 		int 							fsInfoIdx;
-		AppendOnlyBlockDirectoryEntry 	dirEntry = {0};
+		AppendOnlyBlockDirectoryEntry 	dirEntry = {{0}};
 
 		/* The range is contained within one seg. */
 		Assert(AOSegmentGet_segno(start_blockno) ==


### PR DESCRIPTION
Long log:

We met these warnings
```
appendonlyam_handler.c: In function 'appendonly_index_build_range_scan':
appendonlyam_handler.c:1666:3: warning: missing braces around initializer [-Wmissing-braces]
   AppendOnlyBlockDirectoryEntry  dirEntry = {0};
   ^
appendonlyam_handler.c:1666:3: warning: (near initialization for 'dirEntry.range') [-Wmissing-braces]
aocsam_handler.c: In function 'aoco_index_build_range_scan':
aocsam_handler.c:1905:3: warning: missing braces around initializer [-Wmissing-braces]
   AppendOnlyBlockDirectoryEntry dirEntry = {0};
   ^
aocsam_handler.c:1905:3: warning: (near initialization for 'dirEntry.range') [-Wmissing-braces]
```
`AppendOnlyBlockDirectoryEntry` is a nested struct with `range` inside.
```
typedef struct AppendOnlyBlockDirectoryEntry
{
	struct range
	{
		int64		fileOffset;
		int64		firstRowNum;
		int64		afterFileOffset;
		int64		lastRowNum;
	} range;

} AppendOnlyBlockDirectoryEntry;
```
So we need `{{}}`, outer braces are for the struct `AppendOnlyBlockDirectoryEntry`, 
and inner braces are for the inside struct `range`. 

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
## Here are some reminders before you submit the pull request
- [OK] Pass `make installcheck`
