### PR TITLE
add gp version to pg_config

### DIFF
--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -64,7 +64,7 @@ static const InfoItem info_items[] = {
 	{"--ldflags_sl", "LDFLAGS_SL"},
 	{"--libs", "LIBS"},
 	{"--version", "VERSION"},
-	{"--gp_version", "GP_VERSION"},
+	{"--gpversion", "GPVERSION"},
 	{NULL, NULL}
 };
 
@@ -101,7 +101,7 @@ help(void)
 	printf(_("  --ldflags_sl          show LDFLAGS_SL value used when PostgreSQL was built\n"));
 	printf(_("  --libs                show LIBS value used when PostgreSQL was built\n"));
 	printf(_("  --version             show the PostgreSQL version\n"));
-	printf(_("  --gp_version          show the Greenplum version\n"));
+	printf(_("  --gpversion           show the Greenplum version\n"));
 	printf(_("  -?, --help            show this help, then exit\n"));
 	printf(_("\nWith no arguments, all known items are shown.\n\n"));
 	printf(_("Report bugs to <bugs@greenplum.org>.\n"));

--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -64,7 +64,7 @@ static const InfoItem info_items[] = {
 	{"--ldflags_sl", "LDFLAGS_SL"},
 	{"--libs", "LIBS"},
 	{"--version", "VERSION"},
-	{"--gpversion", "GPVERSION"},
+	{"--gp_version", "GP_VERSION"},
 	{NULL, NULL}
 };
 
@@ -101,7 +101,7 @@ help(void)
 	printf(_("  --ldflags_sl          show LDFLAGS_SL value used when PostgreSQL was built\n"));
 	printf(_("  --libs                show LIBS value used when PostgreSQL was built\n"));
 	printf(_("  --version             show the PostgreSQL version\n"));
-	printf(_("  --gpversion           show the Greenplum version\n"));
+	printf(_("  --gp_version          show the Greenplum version\n"));
 	printf(_("  -?, --help            show this help, then exit\n"));
 	printf(_("\nWith no arguments, all known items are shown.\n\n"));
 	printf(_("Report bugs to <bugs@greenplum.org>.\n"));

--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -64,6 +64,7 @@ static const InfoItem info_items[] = {
 	{"--ldflags_sl", "LDFLAGS_SL"},
 	{"--libs", "LIBS"},
 	{"--version", "VERSION"},
+	{"--gp_version", "GP_VERSION"},
 	{NULL, NULL}
 };
 
@@ -100,6 +101,7 @@ help(void)
 	printf(_("  --ldflags_sl          show LDFLAGS_SL value used when PostgreSQL was built\n"));
 	printf(_("  --libs                show LIBS value used when PostgreSQL was built\n"));
 	printf(_("  --version             show the PostgreSQL version\n"));
+	printf(_("  --gp_version          show the Greenplum version\n"));
 	printf(_("  -?, --help            show this help, then exit\n"));
 	printf(_("\nWith no arguments, all known items are shown.\n\n"));
 	printf(_("Report bugs to <bugs@greenplum.org>.\n"));

--- a/src/common/config_info.c
+++ b/src/common/config_info.c
@@ -199,7 +199,7 @@ get_configdata(const char *my_exec_path, size_t *configdata_len)
 	configdata[i].setting = pstrdup("PostgreSQL " PG_VERSION);
 	i++;
 
-	configdata[i].name = pstrdup("GP_VERSION");
+	configdata[i].name = pstrdup("GPVERSION");
 	configdata[i].setting = pstrdup("Greenplum " GP_VERSION);
 	i++;
 

--- a/src/common/config_info.c
+++ b/src/common/config_info.c
@@ -199,7 +199,7 @@ get_configdata(const char *my_exec_path, size_t *configdata_len)
 	configdata[i].setting = pstrdup("PostgreSQL " PG_VERSION);
 	i++;
 
-	configdata[i].name = pstrdup("GPVERSION");
+	configdata[i].name = pstrdup("GP_VERSION");
 	configdata[i].setting = pstrdup("Greenplum " GP_VERSION);
 	i++;
 

--- a/src/common/config_info.c
+++ b/src/common/config_info.c
@@ -38,7 +38,7 @@ get_configdata(const char *my_exec_path, size_t *configdata_len)
 	int			i = 0;
 
 	/* Adjust this to match the number of items filled below */
-	*configdata_len = 23;
+	*configdata_len = 24;
 	configdata = (ConfigData *) palloc(*configdata_len * sizeof(ConfigData));
 
 	configdata[i].name = pstrdup("BINDIR");
@@ -197,6 +197,10 @@ get_configdata(const char *my_exec_path, size_t *configdata_len)
 
 	configdata[i].name = pstrdup("VERSION");
 	configdata[i].setting = pstrdup("PostgreSQL " PG_VERSION);
+	i++;
+
+	configdata[i].name = pstrdup("GP_VERSION");
+	configdata[i].setting = pstrdup("Greenplum " GP_VERSION);
 	i++;
 
 	Assert(i == *configdata_len);


### PR DESCRIPTION
Some [extension development framework](https://github.com/tcdi/pgrx/issues/1179) need to read pg_config at compile time to determine the Postgresql version.

We have an ABI incompatibility with Postgresql, but the output of pg_config is identical.

 Modify the output of pg_config to allow such tools to determine the version of gp before compiling.

```
~/GPDB/gpdb_7X sa/gp_config ❯ ../install_7x/bin/pg_config                                                                                                                                                      15s ⎈ default 18:38:39
BINDIR = /home/sa/GPDB/install_7x/bin
DOCDIR = /home/sa/GPDB/install_7x/share/doc/postgresql
HTMLDIR = /home/sa/GPDB/install_7x/share/doc/postgresql
INCLUDEDIR = /home/sa/GPDB/install_7x/include
PKGINCLUDEDIR = /home/sa/GPDB/install_7x/include/postgresql
INCLUDEDIR-SERVER = /home/sa/GPDB/install_7x/include/postgresql/server
LIBDIR = /home/sa/GPDB/install_7x/lib
PKGLIBDIR = /home/sa/GPDB/install_7x/lib/postgresql
LOCALEDIR = /home/sa/GPDB/install_7x/share/locale
MANDIR = /home/sa/GPDB/install_7x/share/man
SHAREDIR = /home/sa/GPDB/install_7x/share/postgresql
SYSCONFDIR = /home/sa/GPDB/install_7x/etc/postgresql
PGXS = /home/sa/GPDB/install_7x/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--prefix=/home/sa/GPDB/install_7x' '--with-python' '--enable-cassert' '--enable-debug' 'CFLAGS=-ggdb -fno-inline -O0 -g3' '--disable-orca' '--disable-gpcloud' '--with-openssl' '--with-uuid=e2fs' '--disable-debug-extensions' 'CC=/usr/bin/clang' 'CXX=/usr/bin/clang++'
CC = /usr/bin/clang
CPPFLAGS = -D_GNU_SOURCE
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-but-set-variable -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -Wno-deprecated-non-prototype -g -ggdb -fno-inline -O0 -g3  -Werror=uninitialized -Werror=implicit-function-declaration
CFLAGS_SL = -fPIC
LDFLAGS = -Wl,--as-needed -Wl,-rpath,'/home/sa/GPDB/install_7x/lib',--enable-new-dtags
LDFLAGS_EX =
LDFLAGS_SL =
LIBS = -lpgcommon -lpgport -lnuma -lbz2 -lrt -lssl -lcrypto -lz -lreadline -lcrypt -lm  -lcurl -lzstd
VERSION = PostgreSQL 12.12
GP_VERSION = Greenplum 7.0.0-beta.4+dev.83.g81a762b664 build dev
```