### PR TITLE
Fix warning configure: WARNING: unrecognized options: --without-docdir

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -65,7 +65,7 @@ run_resgroup_test() {
         cd /home/gpadmin/gpdb_src
         PYTHON=python3.9 ./configure --prefix=/usr/local/greenplum-db-devel \
             --without-zlib --without-rt --without-libcurl \
-            --without-libedit-preferred --without-docdir --without-readline \
+            --without-libedit-preferred --without-readline \
             --disable-gpcloud --disable-gpfdist --disable-orca \
             --without-python PKG_CONFIG_PATH="\${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 

--- a/concourse/scripts/ic_gpdb_resgroup_v2.bash
+++ b/concourse/scripts/ic_gpdb_resgroup_v2.bash
@@ -40,7 +40,7 @@ run_resgroup_test() {
         cd /home/gpadmin/gpdb_src
         PYTHON=python3.9 ./configure --prefix=/usr/local/greenplum-db-devel \
             --without-zlib --without-rt --without-libcurl \
-            --without-libedit-preferred --without-docdir --without-readline \
+            --without-libedit-preferred --without-readline \
             --disable-gpcloud --disable-gpfdist --disable-orca \
             --without-python PKG_CONFIG_PATH="\${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 


### PR DESCRIPTION
Long log:

Fix warning about resgroup CI test, remove a useless configure paramater.
```
+ ./configure --prefix=/usr/local/greenplum-db-devel --without-zlib --without-rt --without-libcurl --without-libedit-preferred --without-docdir --without-readline --disable-gpcloud --disable-gpfdist --disable-orca --without-python PKG_CONFIG_PATH=/usr/local/greenplum-db-devel/lib/pkgconfig
configure: WARNING: unrecognized options: --without-docdir
```

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>