### PR TITLE
Docs: added failedHostname column to gprecoverseg input file

### DIFF
--- a/gpdb-doc/markdown/admin_guide/highavail/topics/g-recovering-from-segment-failures.html.md
+++ b/gpdb-doc/markdown/admin_guide/highavail/topics/g-recovering-from-segment-failures.html.md
@@ -61,15 +61,24 @@ Follow these steps for incremental recovery:
     ```
 
 2.  To recover a subset of segments:
-    1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with format `failedHostname|failedAddress|failedPort|failedDataDirectory`
+    1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with format `failedAddress|failedPort|failedDataDirectory` or `failedHostname|failedAddress|failedPort|failedDataDirectory`
 
-        For multiple segments, create a new line for each segment you want to recover, specifying the hostname, the address, port number and data directory for each down segment. For example:
+        For multiple segments, create a new line for each segment you want to recover, specifying the hostname (optional), the address, port number and data directory for each down segment. For example:
+
+        ```
+        failedAddress1|failedPort1|failedDataDirectory1
+        failedAddress2|failedPort2|failedDataDirectory2
+        failedAddress3|failedPort3|failedDataDirectory3
+        ```
+       
+        or
 
         ```
         failedHostname1|failedAddress1|failedPort1|failedDataDirectory1
         failedHostname2|failedAddress2|failedPort2|failedDataDirectory2
         failedHostname3|failedAddress3|failedPort3|failedDataDirectory3
         ```
+
 
     2.  Alternatively, generate a sample recovery file using the following command; you may edit the resulting file if necessary:
 
@@ -97,7 +106,13 @@ Follow these steps for incremental recovery:
     1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with following format:
 
         ```
-        failedHostname1|failedAddress1|failedPort1|failedDataDirectory1<SPACE>failedAddress2|failedPort2|failedDataDirectory2
+        failedAddress1|failedPort1|failedDataDirectory1<SPACE>failedAddress2|failedPort2|failedDataDirectory2
+        ```
+
+        or
+
+        ```
+        failedHostname1|failedAddress1|failedPort1|failedDataDirectory1<SPACE>failedHostname2|failedAddress2|failedPort2|failedDataDirectory2
         ```
 
         Note the literal **SPACE** separating the lines.
@@ -132,7 +147,13 @@ Follow these steps to recover all segments or just a subset of segments to a dif
 1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with following format:
 
     ```
-    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|newPort|newDataDirectory
+    failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|newPort|newDataDirectory
+    ```
+
+    or
+
+    ```
+    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newHostname|newAddress|newPort|newDataDirectory
     ```
 
     Note the literal **SPACE** separating the details of the down segment from the details of where the segment will be recovered to.

--- a/gpdb-doc/markdown/admin_guide/highavail/topics/g-recovering-from-segment-failures.html.md
+++ b/gpdb-doc/markdown/admin_guide/highavail/topics/g-recovering-from-segment-failures.html.md
@@ -61,14 +61,14 @@ Follow these steps for incremental recovery:
     ```
 
 2.  To recover a subset of segments:
-    1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with format `failedAddress|failedPort|failedDataDirectory`
+    1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with format `failedHostname|failedAddress|failedPort|failedDataDirectory`
 
-        For multiple segments, create a new line for each segment you want to recover, specifying the address, port number and data directory for each down segment. For example:
+        For multiple segments, create a new line for each segment you want to recover, specifying the hostname, the address, port number and data directory for each down segment. For example:
 
         ```
-        failedAddress1|failedPort1|failedDataDirectory1
-        failedAddress2|failedPort2|failedDataDirectory2
-        failedAddress3|failedPort3|failedDataDirectory3
+        failedHostname1|failedAddress1|failedPort1|failedDataDirectory1
+        failedHostname2|failedAddress2|failedPort2|failedDataDirectory2
+        failedHostname3|failedAddress3|failedPort3|failedDataDirectory3
         ```
 
     2.  Alternatively, generate a sample recovery file using the following command; you may edit the resulting file if necessary:
@@ -97,7 +97,7 @@ Follow these steps for incremental recovery:
     1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with following format:
 
         ```
-        failedAddress1|failedPort1|failedDataDirectory1<SPACE>failedAddress2|failedPort2|failedDataDirectory2
+        failedHostname1|failedAddress1|failedPort1|failedDataDirectory1<SPACE>failedAddress2|failedPort2|failedDataDirectory2
         ```
 
         Note the literal **SPACE** separating the lines.
@@ -132,7 +132,7 @@ Follow these steps to recover all segments or just a subset of segments to a dif
 1.  Manually create a `recover_config_file` file in a location of your choice, where each segment to recover has its own line with following format:
 
     ```
-    failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|newPort|newDataDirectory
+    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|newPort|newDataDirectory
     ```
 
     Note the literal **SPACE** separating the details of the down segment from the details of where the segment will be recovered to.

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -39,17 +39,16 @@ Segment recovery using `gprecoverseg` requires that you have an active mirror to
 gpstop -r
 ```
 
-By default, a failed segment is recovered in place, meaning that the system brings the segment back online on the same host and data directory location on which it was originally configured. In this case, use the following format for the recovery configuration file \(using `-i`\).
+By default, a failed segment is recovered in place, meaning that the system brings the segment back online on the same host and data directory location on which it was originally configured. In this case, use the following format for the recovery configuration file \(using `-i`\). Note that `failed_hostname` is an optional parameter.
 
 ```
 <failed_hostname>|<failed_host_address>|<port>|<data_directory> 
 ```
 
-In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces.
+In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces. The parameter `failed_hostname` is optional.
 
 ```
-<failed_hostname>|<failed_host_address>|<port>|<data_directory><SPACE>
-<recovery_host_address>|<port>|<data_directory>
+<failed_hostname>|<failed_host_address>|<port>|<data_directory><SPACE><recovery_host_address>|<port>|<data_directory>
 
 ```
 
@@ -106,14 +105,25 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     Each line in the config file specifies a segment to recover. This line can have one of two formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
 
     ```
-    failedHostname|failedAddress|failedPort|failedDataDirectory
+    failedAddress|failedPort|failedDataDirectory
     ```
+
+    or
+
+    ```
+    failedHostname|failedAddress|failedPort|failedDataDirectory
+    ``` 
 
     For recovery to a new location, enter two groups of fields separated by a space in the line. The required space is indicated by <SPACE\>. Do not add additional spaces.
 
     ```
-    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|
-    newPort|newDataDirectory
+    failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|newPort|newDataDirectory
+    ```
+
+    or
+
+    ```
+    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newHostname|newAddress|newPort|newDataDirectory
     ```
 
     > **Note** Lines beginning with `#` are treated as comments and ignored.

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -48,7 +48,7 @@ By default, a failed segment is recovered in place, meaning that the system brin
 In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces. The parameter `failed_host_name` is optional.
 
 ```
-<failed_host_name>|<failed_host_address>|<port>|<data_directory><SPACE><recovery_host_address>|<port>|<data_directory>
+<failed_host_name>|<failed_host_address>|<port>|<data_directory><SPACE><recovery_host_name>|<recovery_host_address>|<port>|<data_directory>
 
 ```
 

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -42,13 +42,13 @@ gpstop -r
 By default, a failed segment is recovered in place, meaning that the system brings the segment back online on the same host and data directory location on which it was originally configured. In this case, use the following format for the recovery configuration file \(using `-i`\).
 
 ```
-<failed_host_address>|<port>|<data_directory> 
+<failed_hostname>|<failed_host_address>|<port>|<data_directory> 
 ```
 
 In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces.
 
 ```
-<failed_host_address>|<port>|<data_directory><SPACE>
+<failed_hostname>|<failed_host_address>|<port>|<data_directory><SPACE>
 <recovery_host_address>|<port>|<data_directory>
 
 ```
@@ -106,13 +106,13 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     Each line in the config file specifies a segment to recover. This line can have one of two formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
 
     ```
-    failedAddress|failedPort|failedDataDirectory
+    failedHostname|failedAddress|failedPort|failedDataDirectory
     ```
 
     For recovery to a new location, enter two groups of fields separated by a space in the line. The required space is indicated by <SPACE\>. Do not add additional spaces.
 
     ```
-    failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|
+    failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newAddress|
     newPort|newDataDirectory
     ```
 

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -39,16 +39,16 @@ Segment recovery using `gprecoverseg` requires that you have an active mirror to
 gpstop -r
 ```
 
-By default, a failed segment is recovered in place, meaning that the system brings the segment back online on the same host and data directory location on which it was originally configured. In this case, use the following format for the recovery configuration file \(using `-i`\). Note that `failed_hostname` is an optional parameter.
+By default, a failed segment is recovered in place, meaning that the system brings the segment back online on the same host and data directory location on which it was originally configured. In this case, use the following format for the recovery configuration file \(using `-i`\). Note that `failed_host_name` is an optional parameter.
 
 ```
-<failed_hostname>|<failed_host_address>|<port>|<data_directory> 
+<failed_host_name>|<failed_host_address>|<port>|<data_directory> 
 ```
 
-In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces. The parameter `failed_hostname` is optional.
+In some cases, this may not be possible \(for example, if a host was physically damaged and cannot be recovered\). In this situation, `gprecoverseg` allows you to recover failed segments to a completely new host \(using `-p`\), on an alternative data directory location on your remaining live segment hosts \(using `-s`\), or by supplying a recovery configuration file \(using `-i`\) in the following format. The word <SPACE\> indicates the location of a required space. Do not add additional spaces. The parameter `failed_host_name` is optional.
 
 ```
-<failed_hostname>|<failed_host_address>|<port>|<data_directory><SPACE><recovery_host_address>|<port>|<data_directory>
+<failed_host_name>|<failed_host_address>|<port>|<data_directory><SPACE><recovery_host_address>|<port>|<data_directory>
 
 ```
 


### PR DESCRIPTION
PR https://github.com/greenplum-db/gpdb/pull/15566 introduces a new column `failedHostfile` to the input file for gprecoverseg. This PR modifies the documentation so the new column is introduced.