### PR TITLE
Fix intermittent pipeline failures

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -744,7 +744,6 @@ Feature: gprecoverseg tests
     And user can start transactions
     When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
-    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     Then verify if the gprecoverseg.lock directory is present in coordinator_data_directory
     When the user asynchronously sets up to end gprecoverseg process with SIGINT
     And the user waits until saved async process is completed

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -24,7 +24,7 @@ def impl(context):
 def impl(context):
     bg_pid = context.bg_pid
     if not unix.check_pid(bg_pid):
-        raise Exception("Postgres process {0} not killed.".format(bg_pid))
+        raise Exception("The background process with PID {} is not running.".format(bg_pid))
     gprecoverseg_lock_dir = os.path.join(get_coordinatordatadir() + '/gprecoverseg.lock')
     os.mkdir(gprecoverseg_lock_dir)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -6,6 +6,7 @@ from gppylib.db import dbconn
 from gppylib.gparray import GpArray, ROLE_MIRROR
 from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
 from gppylib.commands.gp import get_coordinatordatadir
+from gppylib.commands import unix
 
 @then('a sample recovery_progress.file is created from saved lines')
 def impl(context):
@@ -22,6 +23,8 @@ def impl(context):
 @given('a sample gprecoverseg.lock directory is created using the background pid in coordinator_data_directory')
 def impl(context):
     bg_pid = context.bg_pid
+    if not unix.check_pid(bg_pid):
+        raise Exception("Postgres process {0} not killed.".format(bg_pid))
     gprecoverseg_lock_dir = os.path.join(get_coordinatordatadir() + '/gprecoverseg.lock')
     os.mkdir(gprecoverseg_lock_dir)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1456,7 +1456,7 @@ def stop_segments_immediate(context, where_clause):
 @when('user can start transactions')
 @then('user can start transactions')
 def impl(context):
-    wait_for_unblocked_transactions(context)
+    wait_for_unblocked_transactions(context, 600)
 
 @given('below sql is executed in "{dbname}" db')
 @when('below sql is executed in "{dbname}" db')
@@ -1647,6 +1647,9 @@ def impl(context, seg):
         hostname = get_coordinator_hostname()[0][0]
 
     cmd = Command(name="killbg pid", cmdStr='kill -9 %s' % context.bg_pid, remoteHost=hostname, ctxt=REMOTE)
+    cmd.run(validateAfter=True)
+
+    cmd = Command(name="remove pid", cmdStr='rm -rf /tmp/bgpid', remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
 
 


### PR DESCRIPTION
gprecoverseg job has been failing recently on pipeline due to few testcase failures

Failure 1:
"HOOK-ERROR in after_scenario: OperationalError: ERROR:  tablespace "outerspace" is not empty" 
Testcase: differential recovery works with tablespaces -- @1.2 
Root cause: In after scenario during cleanup of tablespace, first database is dropped before dropping the tablespace. Looks like when we try to drop tablespace, database is not dropped yet as it is taking time to delete database. Hence the error
Solution:  while cleaning up the tablespace, after executing query to drop database added a check to verify that database has been dropped. If database has been dropped then only proceed to drop the tablespace.

Failure 2: 
Step "gpstate should print "Segments in recovery" to stdout" is failing 
Testcase: gprecoverseg creates recovery_progress.file in gpAdminLogs 
Root cause: It is taking old bg_pid to create gprecoverseg.lock directory in the coordinator_data_directory. 
Solution: In step "the background pid is killed on "{seg}" segment", while killing background pid added command to also remove /tmp/bgpid. Also added check to verify the existence of the pid  while creating gprecoverseg.lock directory in step "a sample gprecoverseg.lock directory is created using the background pid in coordinator_data_directory"

Failure 3: 
Step “And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs” is falling 
Testcase: SIGINT on gprecoverseg differential recovery should delete the progress file 
Root cause: Rsync keeps updating the progress of the segment so the progress gets overwritten in rsync progress file causing mismatch between rsync progress content and recovery_progress.file content. Hence the error occurs
Solution: We found that this step is not needed in this test case scenario. We will work on improving this step and add it to a suitable testcase in future

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
