### PR TITLE
[6X]Added host-name parameter in recovery configuration

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -6,7 +6,7 @@ from gppylib import gplog
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 from gppylib.parseutils import line_reader, check_values, canonicalize_address
-from gppylib.utils import checkNotNone, normalizeAndValidateInputPath
+from gppylib.utils import checkNotNone, normalizeAndValidateInputPath, validateHostnameAddress
 from gppylib.gparray import GpArray, Segment
 from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
 from gppylib.commands.gp import RECOVERY_REWIND_APPNAME
@@ -143,10 +143,11 @@ class RecoveryTriplet:
 
 
 class RecoveryTripletRequest:
-    def __init__(self, failed, failover_host=None, failover_port=None, failover_datadir=None, is_new_host=False):
+    def __init__(self, failed, failover_host_name=None, failover_host_address=None, failover_port=None, failover_datadir=None, is_new_host=False):
         self.failed = failed
 
-        self.failover_host = failover_host
+        self.failover_host_name = failover_host_name
+        self.failover_host_address = failover_host_address
         self.failover_port = failover_port
         self.failover_datadir = failover_datadir
         self.failover_to_new_host = is_new_host
@@ -243,17 +244,29 @@ class RecoveryTriplets:
             # TODO: These 2 cases have different behavior which might be confusing to the user.
             # "<failed_address>|<failed_port>|<failed_data_dir> <failed_address>|<failed_port>|<failed_data_dir>" does full recovery
             # "<failed_address>|<failed_port>|<failed_data_dir>" does incremental recovery
+            # Changes made to support hostname in input configuration file jira# GPCM-207
+            # Full recovery: "<failed_hostname|<failed_address>|<failed_port>|<failed_data_dir> SPACE <failed_hostname>|<failed_address>|<failed_port>|<failed_data_dir>"
+            # Incremental recovery: "<failed_hostname>|<failed_address>|<failed_port>|<failed_data_dir>"
             failover = None
-            if req.failover_host:
 
+            if req.failover_host_address:
                 # these two lines make it so that failover points to the object that is registered in gparray
                 #   as the failed segment(!).
                 failover = req.failed
                 req.failed = failover.copy()
 
                 # now update values in failover segment
-                failover.setSegmentAddress(req.failover_host)
-                failover.setSegmentHostName(req.failover_host)
+                if req.failover_host_name != req.failover_host_address:
+                    # Validate if the hostname and address are of the same host
+                    if not validateHostnameAddress(req.failover_host_name, req.failover_host_address):
+                        logger.warning(
+                            "Not able to co-relate hostname:{0} with address:{1}. "
+                            "Skipping recovery for segments with contentId {2}"
+                            .format(req.failover_host_name, req.failover_host_address, peer_contentid))
+                        continue
+
+                failover.setSegmentHostName(req.failover_host_name)
+                failover.setSegmentAddress(req.failover_host_address)
                 failover.setSegmentPort(int(req.failover_port))
                 failover.setSegmentDataDirectory(req.failover_datadir)
                 failover.unreachable = False if req.failover_to_new_host else failover.unreachable
@@ -334,7 +347,8 @@ class RecoveryTripletsNewHosts(RecoveryTriplets):
         for failedHost, failoverHost in zip(sorted(failedSegments.keys()), self.newHosts):
             for failed in failedSegments[failedHost]:
                 failoverPort = self.portAssigner.findAndReservePort(failoverHost, failoverHost)
-                req = RecoveryTripletRequest(failed, failoverHost, failoverPort, failed.getSegmentDataDirectory(), True)
+                req = RecoveryTripletRequest(failed, failover_host_name=failoverHost, failover_host_address=failoverHost,
+                      failover_port=failoverPort, failover_datadir=failed.getSegmentDataDirectory(), is_new_host=True)
                 requests.append(req)
 
         return self._convert_requests_to_triplets(requests)
@@ -397,6 +411,10 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
         def _find_failed_from_row():
             failed = None
             for segment in self.gpArray.getDbList():
+                # In case the input configuration file contains 4 parameters then hostname provided should match
+                # with the hostname in segment configuration table, if it does not match an exception will be thrown
+                if row['hostname_check_required'] and segment.getSegmentHostName() != row['failedHostname']:
+                    continue
                 if (segment.getSegmentAddress() == row['failedAddress']
                         and str(segment.getSegmentPort()) == row['failedPort']
                         and segment.getSegmentDataDirectory() == row['failedDataDirectory']):
@@ -404,15 +422,22 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
                     break
 
             if failed is None:
-                raise Exception("A segment to recover was not found in configuration.  " \
-                                "This segment is described by address|port|directory '%s|%s|%s'" %
-                                (row['failedAddress'], row['failedPort'], row['failedDataDirectory']))
+                msg =  "A segment to recover was not found in configuration. This segment is described by "
 
+                if row['hostname_check_required']:
+                    msg += "hostname|address|port|directory '{}|{}|{}|{}'".format(
+                          row['failedHostname'], row['failedAddress'], row['failedPort'], row['failedDataDirectory'])
+
+
+                else:
+                    msg += "address|port|directory '{}|{}|{}'".format(row['failedAddress'],
+                                                                      row['failedPort'], row['failedDataDirectory'])
+                raise Exception(msg)
             return failed
 
         requests = []
         for row in self.rows:
-            req = RecoveryTripletRequest(_find_failed_from_row(), row.get('newAddress'), row.get('newPort'), row.get('newDataDirectory'))
+            req = RecoveryTripletRequest(_find_failed_from_row(), row.get('newHostname'), row.get('newAddress'), row.get('newPort'), row.get('newDataDirectory'))
             requests.append(req)
 
         return self._convert_requests_to_triplets(requests)
@@ -422,43 +447,61 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
     def _parseConfigFile(config_file):
         """
         Parse the config file
+
+        Note: if the hostname is not mentioned, the provided address will be populated as host-name
+
         :param config_file:
         :return: List of dictionaries with each dictionary containing the failed and failover information??
         """
         rows = []
         with open(config_file) as f:
             for lineno, line in line_reader(f):
-
+                hostname_check_required = False
                 groups = line.split()  # NOT line.split(' ') due to MPP-15675
                 if len(groups) not in [1, 2]:
                     msg = "line %d of file %s: expected 1 or 2 groups but found %d" % (lineno, config_file, len(groups))
                     raise ExceptionNoStackTraceNeeded(msg)
                 parts = groups[0].split('|')
-                if len(parts) != 3:
-                    msg = "line %d of file %s: expected 3 parts on failed segment group, obtained %d" % (
+
+                if len(parts) not in [3, 4]:
+                    msg = "line {0} of file {1}: expected 3 or 4 parts on failed segment group, obtained {2}" .format(
                         lineno, config_file, len(parts))
                     raise ExceptionNoStackTraceNeeded(msg)
-                address, port, datadir = parts
-                check_values(lineno, address=address, port=port, datadir=datadir)
+                if len(parts) == 4:
+                    hostname, address, port, datadir = parts
+                    hostname_check_required = True
+                else:
+                    address, port, datadir = parts
+                    hostname = address
+                check_values(lineno, hostname=hostname, address=address, port=port, datadir=datadir)
                 datadir = normalizeAndValidateInputPath(datadir, f.name, lineno)
 
                 row = {
+                    'failedHostname': hostname,
                     'failedAddress': address,
                     'failedPort': port,
                     'failedDataDirectory': datadir,
-                    'lineno': lineno
+                    'lineno': lineno,
+                    'hostname_check_required': hostname_check_required
                 }
                 if len(groups) == 2:
                     parts2 = groups[1].split('|')
-                    if len(parts2) != 3:
-                        msg = "line %d of file %s: expected 3 parts on new segment group, obtained %d" % (
-                            lineno, config_file, len(parts2))
+                    if len(parts2) not in [3, 4] or len(parts) != len(parts2):
+                        msg = "line {0} of file {1}: expected equal parts, either 3 or 4 on both segment group, obtained {2} on " \
+                              "group1 and {3} on group2" .format(
+                            lineno, config_file, len(parts), len(parts2))
                         raise ExceptionNoStackTraceNeeded(msg)
-                    address2, port2, datadir2 = parts2
-                    check_values(lineno, address=address2, port=port2, datadir=datadir2)
+                    if len(parts2) == 4:
+                        hostname2, address2, port2, datadir2 = parts2
+                    else:
+                        address2, port2, datadir2 = parts2
+                        hostname2 = address2
+
+                    check_values(lineno, hostname=hostname2, address=address2, port=port2, datadir=datadir2)
                     datadir2 = normalizeAndValidateInputPath(datadir2, f.name, lineno)
 
                     row.update({
+                        'newHostname': hostname2,
                         'newAddress': address2,
                         'newPort': port2,
                         'newDataDirectory': datadir2

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -215,6 +215,14 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                            '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
                                            None)]
             },
+            {
+                "name": "in_place_1_part_with_4_parameter",
+                "gparray": self.all_up_gparray_str,
+                "config": "sdw2|sdw2|21000|/mirror/gpseg0",
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           None)]
+            },
         ]
         self.run_pass_tests(tests, self.run_single_ConfigFile_test)
 
@@ -224,13 +232,13 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "name": "invalid_failed_address",
                 "gparray": self.three_failedover_segs_gparray_str,
                 "config": "seg_does_not_exist|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5",
-                "expected": "segment to recover was not found in configuration.*described by.*seg_does_not_exist"
+                "expected": "A segment to recover was not found in configuration.*segment is described by.*seg_does_not_exist.*"
             },
             {
                 "name": "invalid_failed_port1",
                 "gparray": self.three_failedover_segs_gparray_str,
                 "config": "sdw1|99999|/primary/gpseg0 sdw3|20001|/primary/gpseg5",
-                "expected": "segment to recover was not found in configuration.*described by.*99999"
+                "expected": "A segment to recover was not found in configuration.*segment is described by.*99999"
             },
             {
                 "name": "invalid_failed_port2",
@@ -282,6 +290,12 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3""",
                 "config": "sdw1|20000|/primary/gpseg0 sdw3|20000|/primary/gpseg5",
                 "expected": "For content 2, the dbid values are the same.  A segment may not be recovered from itself"
+            },
+            {
+                "name": "invalid_failed_hostname_with_4_parameter",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "config": "sdw2_invalid_hostname|sdw2|21000|/primary/gpseg0 ",
+                "expected": "segment to recover was not found in configuration.*described by.*sdw2_invalid_hostname"
             },
             #
             #
@@ -851,7 +865,9 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
             "config": """sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5
                       sdw1|20001|/primary/gpseg1 sdw1|40001|/primary/gpseg_new
                       sdw3|20000|/primary/gpseg4
-                      sdw4|20000|/primary/gpseg6 sdw4|20000|/primary/gpseg6"""
+                      sdw4|20000|/primary/gpseg6 sdw4|20000|/primary/gpseg6
+                      sdw5|sdw5|20000|/primary/gpseg0 sdw3|10.0.34.5|20001|/primary/gpseg5
+                      sdw6|sdw6|20000|/primary/gpseg4"""
         },
         {
             "name": "6X_web_doc",
@@ -896,7 +912,7 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
                 """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
                    sdw1|20000 sdw3|20001|/mirror/gpseg5""",
             "expected":
-                "line 2 of file .*: expected 3 parts on failed segment group, obtained 2"
+                "line 2 of file .*: expected 3 or 4 parts on failed segment group, obtained 2"
         },
         {
             "name":
@@ -904,7 +920,7 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
             "config": """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
                          sdw2|50001|/data2/mirror/gpseg1 sdw4|50001""",
             "expected":
-                "line 2 of file .*: expected 3 parts on new segment group, obtained 2"
+                "line 2 of file .*: expected equal parts, either 3 or 4 on both segment group, obtained 3 on group1 and 2 on group2"
         },
         {
             "name":
@@ -1011,7 +1027,25 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
             "name": "new_port_invalid",
             "config": """sdw2|50001|/data2/mirror/gpseg1 sdw4|new_invalid_port|relative/new/mirror/gpseg1""",
             "expected": "Invalid port on line 1"
-        }
+        },
+        {
+            "name":
+                "invalid_parts_present_in_group_1",
+            "config":
+                """sdw1|10.0.34.2|20000|/primary/gpseg0 sdw3|10.0.34.5|20001|/primary/gpseg5
+                   sdw1|20000|/primary/gpseg0 sdw3|10.0.34.5|20001|/primary/gpseg5""",
+            "expected":
+                "line 2 of file .*: expected equal parts, either 3 or 4 on both segment group, obtained 3 on group1 and 4 on group2"
+        },
+        {
+            "name":
+                "invalid_parts_present_in_group_2",
+            "config":
+                """sdw1|10.0.34.2|20000|/primary/gpseg0 sdw3|10.0.34.5|20001|/primary/gpseg5
+                   sdw1|10.0.34.2|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5""",
+            "expected":
+                "line 2 of file .*: expected equal parts, either 3 or 4 on both segment group, obtained 4 on group1 and 3 on group2"
+        },
     ]
 
     def test_parsing_should_fail(self):
@@ -1030,23 +1064,38 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
         lineno = 0
 
         for line in config_str.splitlines():
+            hostname_check_required = False
             lineno += 1
             groups = line.split()
-
-            address, port, datadir = groups[0].split('|')
+            parts = groups[0].split('|')
+            if len(parts) == 4:
+                hostname, address, port, datadir = parts
+                hostname_check_required = True
+            else:
+                address, port, datadir = parts
+                hostname = address
             row = {
+                'failedHostname': hostname,
                 'failedAddress': address,
                 'failedPort': port,
                 'failedDataDirectory': datadir,
-                'lineno': lineno
+                'lineno': lineno,
+                'hostname_check_required': hostname_check_required
+
             }
 
             if len(groups) > 1:
-                address, port, datadir = groups[1].split('|')
+                parts2 = groups[1].split('|')
+                if len(parts2) == 4:
+                    hostname2, address2, port2, datadir2 = parts2
+                else:
+                    address2, port2, datadir2 = parts2
+                    hostname2 = address2
                 row.update({
-                    'newAddress': address,
-                    'newPort': port,
-                    'newDataDirectory': datadir
+                    'newHostname': hostname2,
+                    'newAddress': address2,
+                    'newPort': port2,
+                    'newDataDirectory': datadir2
                 })
 
             rows.append(row)

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -10,6 +10,7 @@ from xml.dom import minidom
 from xml.dom import Node
 
 from gppylib.gplog import *
+from socket import gethostbyaddr
 
 logger = get_default_logger()
 
@@ -529,3 +530,30 @@ def escapeDoubleQuoteInSQLString(string, forceDoubleQuote=True):
     if forceDoubleQuote:
         string = '"' + string + '"'
     return string
+
+def validateHostnameAddress(hostname, address):
+    """
+    validateHostnameAddress : validates that given hostname and address are for the same host
+    Address can be hostname/alias also. Resolves hostname and address both to get the associated addresses.
+
+    @param hostname Name of the host to be validated
+    @param address Address of the host to be validated. Can be hostname/alias also
+    @return if the address and hostname are of the same host
+    """
+    try:
+        resolved_hostname, _, resolved_address_list = gethostbyaddr(hostname)
+        resolved_hostname_2, _, resolved_address_list_2 = gethostbyaddr(address)
+    except Exception as e:
+        # This means given hostname or address is not reachable
+        logger.warning(
+            "Could not resolve hostname:{0}."
+                .format(hostname))
+        return False
+
+    # Resolved address and hostname should have at least one IP address common if they are of same host
+    if not bool(set(resolved_address_list).intersection(resolved_address_list_2)):
+        logger.warning(
+            "Given address:{0} not present in resolved hostname:{1} address list we got:{2}".format(
+                address, hostname, resolved_address_list))
+        return False
+    return True

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -70,6 +70,13 @@ add additional spaces.
 <failed_host_address>|<port>|<data_directory>SPACE
 [<recovery_host_address>|<port>|<data_directory>
 
+If hostname is not provided, host-address will be populated in the
+configuration. In case you want to have different hostname and address,
+hostname can be specified in the recovery configuration, the format
+for the config file is as follows:
+<failed_host_name>|<failed_host_address>|<port>|<data_directory>SPACE
+[<recovery_host_name>|<recovery_host_address>|<port>|<data_directory>]
+
 See the -i option below for details and examples of a recovery
 configuration file.
 
@@ -180,6 +187,11 @@ sdw1-1|50001|/data1/mirror/gpseg16
 Recovery of a single mirror to a new host
 
 sdw1-1|50001|/data1/mirror/gpseg16SPACE sdw4-1|50001|51001|/data1/recover1/gpseg16
+
+Recovery of a single mirror to a new host with hostname specified:
+sdw1|sdw1-1|50001|/data1/mirror/gpseg16 SPACE
+sdw4|sdw4-1|50001|51001|/data1/recover1/gpseg16
+
 
 Obtaining a Sample File
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1703,3 +1703,164 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And all the segments are running
           And the segments are synchronized
+
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg recovery to new host populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with added parameter hostname to recover the failed segment on new host
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+         Then gprecoverseg should return a return code of 0
+         When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg recovery to same host (full inplace) populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with hostname parameter to recover the failed segment on same host
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 0
+          When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg recovery with invalid format with hostname in config file
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config-invalid.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config-invalid.conf" is created with invalid format for inplace full recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config-invalid.conf -a -v"
+          Then gprecoverseg should return a return code of 2
+          And gprecoverseg should print "line 1 of file /tmp/recover-config-invalid.conf: expected equal parts, either 3 or 4 on both segment group, obtained 4 on group1 and 3 on group2" to stdout
+          Then the user runs "gprecoverseg -a"
+          Then gprecoverseg should return a return code of 0
+          And the cluster is rebalanced
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg incremental recovery populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with hostname parameter matches with segment configuration table for incremental recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 0
+          When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg recovery with and without hostname parameter in config file
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all primary processes
+          And user can start transactions
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When a gprecoverseg input file "recover-config.conf" is created with and without parameter hostname to recover all the failed segments
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -F -v"
+          Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg throws warning and skips recovery if provided hostname and address can not be resolved to same host
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And user stops all primary processes
+          And user can start transactions
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When a gprecoverseg input file "recover-config.conf" created with invalid failover hostname for full recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -F -v"
+          Then gprecoverseg should return a return code of 0
+          And gprecoverseg should print a "Not able to co-relate hostname:.* with address.*Skipping recovery for segments with contentId" warning
+          Then the user runs "gprecoverseg -a"
+          Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg incremental recovery with config file and wrong hostname
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with invalid hostname parameter that does not matches with the segment configuration table hostname
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 2
+          And gprecoverseg should print "A segment to recover was not found in configuration.  This segment is described by hostname|address|port|directory .*'" to stdout
+          Then the user runs "gprecoverseg -a"
+          And gprecoverseg should return a return code of 0
+          And the cluster is rebalanced
+
+  @demo_cluster
+  Scenario: gprecoverseg recovers segment when config file contains hostname on demo cluster
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0
+    And user can start transactions
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the hostsname input file to recover segment with content 0 full inplace
+    And update /etc/hosts file with address for the localhost
+    When the user runs gprecoverseg with input file and additional args "-a"
+    And gprecoverseg should return a return code of 0
+    And restore /etc/hosts file and cleanup hostlist file
+    And the cluster configuration has no segments where "content=0 and status='d'"
+    Then the cluster is rebalanced
+
+  @demo_cluster
+  Scenario: gprecoverseg skips recovery when config file contains invalid hostname on demo cluster
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0
+    And user can start transactions
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the hostsname input file to recover segment with content 0 with invalid hostname
+    When the user runs gprecoverseg with input file and additional args "-a"
+    And gprecoverseg should print a "Could not resolve hostname:invalid_host" warning
+    And gprecoverseg should print a "Not able to co-relate hostname:invalid_host with address:.*Skipping recovery for segments with contentId" warning
+    And gprecoverseg should print "No segments to recover" to stdout
+    And gprecoverseg should return a return code of 0
+    And the user runs "gprecoverseg -a -v"
+    Then gprecoverseg should return a return code of 0
+    And the cluster is rebalanced

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -817,6 +817,7 @@ def impl(context, command, out_msg):
 @when('{command} should print "{out_msg}" to stdout')
 @then('{command} should print "{out_msg}" to stdout')
 @then('{command} should print a "{out_msg}" warning')
+@when('{command} should print a "{out_msg}" warning')
 def impl(context, command, out_msg):
     check_stdout_msg(context, out_msg)
 
@@ -1539,6 +1540,7 @@ def impl(context, content_ids, expected_status):
 
 
 @given('the cluster configuration has no segments where "{filter}"')
+@when('the cluster configuration has no segments where "{filter}"')
 def impl(context, filter):
     SLEEP_PERIOD = 5
     MAX_DURATION = 300
@@ -4004,7 +4006,8 @@ def impl(context, contentids):
 
     if not no_basebackup:
         raise Exception("pg_basebackup entry was found for contents %s in gp_stat_replication after %d retries" % (contentids, retries))
-    
+
+
 @given('backup /etc/hosts file and update hostname entry for localhost')
 def impl(context):
      # Backup current /etc/hosts file
@@ -4018,6 +4021,18 @@ def impl(context):
      cmd = Command(name='update hostlist with new hostname', cmdStr="sudo sed 's/%s/%s__1 %s/g' </etc/hosts >> /tmp/hosts; sudo cp -f /tmp/hosts /etc/hosts;rm /tmp/hosts"
                                                         %(hostname, hostname, hostname))
      cmd.run(validateAfter=True)
+
+
+@given('update /etc/hosts file with address for the localhost')
+def impt(context):
+    hostname = context.hostname
+    # Backup current /etc/hosts file
+    cmd = Command(name='backup the hosts file', cmdStr='sudo cp /etc/hosts /tmp/hosts_orig')
+    cmd.run(validateAfter=True)
+    # Update the address
+    cmdStr = "echo \"127.0.0.1 {}\" | sudo tee -a /etc/hosts".format(hostname)
+    cmd = Command(name="update /etc/hosts file with hostname entry", cmdStr=cmdStr)
+    cmd.run(validateAfter=True)
 
 @given('update hostlist file with updated host-address')
 def impl(context):
@@ -4074,8 +4089,9 @@ def impl(context):
      cmd.run(validateAfter=True)
 
 @then('restore /etc/hosts file and cleanup hostlist file')
+@when('restore /etc/hosts file and cleanup hostlist file')
 def impl(context):
-    cmd =  "sudo mv -f /tmp/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"
+    cmd = "sudo mv -f /tmp/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"
     context.execute_steps(u'''Then the user runs command "%s"''' % cmd)
 
 @given('create a gpcheckperf input host file')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -518,6 +518,45 @@ def impl(context, content):
                 fd.write('{} {}\n'.format(valid_config, valid_config))
             break
 
+@given("edit the hostsname input file to recover segment with content {content} full inplace")
+def impl(context,  content):
+    content = int(content)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    for seg in segments:
+        if seg.mirrorDB.getSegmentContentId() == content:
+            mirror = seg.mirrorDB
+            valid_config = '{}|{}|{}|{} localhost|{}|{}|{}'.format(mirror.getSegmentHostName(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory())
+            context.hostname = mirror.getSegmentHostName()
+
+            with open(context.mirror_context.input_file_path(), 'a') as fd:
+                fd.write('{}'.format(valid_config))
+            break
+
+@given("edit the hostsname input file to recover segment with content {content} with invalid hostname")
+def impl(context,  content):
+    content = int(content)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    for seg in segments:
+        if seg.mirrorDB.getSegmentContentId() == content:
+            mirror = seg.mirrorDB
+            valid_config = '{}|{}|{}|{} invalid_host|{}|{}|{}'.format(mirror.getSegmentHostName(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory())
+
+            with open(context.mirror_context.input_file_path(), 'a') as fd:
+                fd.write('{}'.format(valid_config))
+            break
+
 
 @given("edit the input file to recover mirror with content {content} incremental")
 def impl(context, content):

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -10,6 +10,7 @@ from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from test.behave_utils.utils import *
 import platform, shutil
 from behave import given, when, then
+from gppylib.utils import writeLinesToFile
 
 
 #TODO remove duplication of these functions
@@ -85,6 +86,8 @@ def impl(context, seg):
         context.remote_pair_primary_segcid = primary_segs[0].getSegmentContentId()
         context.remote_pair_primary_host = primary_segs[0].getSegmentHostName()
         context.remote_pair_primary_datadir = primary_segs[0].getSegmentDataDirectory()
+        context.remote_pair_primary_port = primary_segs[0].getSegmentPort()
+        context.remote_pair_primary_address = primary_segs[0].getSegmentAddress()
     elif seg == "mirror":
         mirror_segs = [seg for seg in gparray.getDbList()
                        if seg.isSegmentMirror() and seg.getSegmentHostName() != platform.node()]
@@ -629,3 +632,130 @@ def impl(context, expected_additional_entries):
     if actual_backout_entries != expected_total_entries:
         raise Exception("Expected configuration history table to have {} backout entries, found {}".format(
             context.original_config_history_backout_count + expected_additional_entries, actual_backout_entries))
+
+
+@when('a gprecoverseg input file "{filename}" is created with added parameter hostname to recover the failed segment on new host')
+def impl(context, filename):
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
+        failed_port, failed_hostname, failed_datadir, failed_address = context.remote_pair_primary_port, \
+            context.remote_pair_primary_host, context.remote_pair_primary_datadir, context.remote_pair_primary_address
+        result = dbconn.execSQL(conn,"SELECT hostname FROM gp_segment_configuration WHERE preferred_role='p' and status = 'u' and content != -1;").fetchall()
+        failover_port, failover_hostname, failover_datadir = 23000, result[0][0], failed_datadir
+
+        failover_host_address = get_host_address(failover_hostname)
+        context.recovery_host_address = failover_host_address
+        context.recovery_host_name = failover_hostname
+
+        line = "{0}|{1}|{2}|{3} {4}|{5}|{6}|{7}" .format(failed_hostname, failed_address, failed_port, failed_datadir,
+                                            failover_hostname, failover_host_address, failover_port, failover_datadir)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+
+@when('check hostname and address updated on segment configuration with the saved information')
+def impl(context):
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
+        result = dbconn.execSQL(conn, "SELECT content, hostname, address FROM gp_segment_configuration WHERE dbid = {};" .format(context.remote_pair_primary_segdbId)).fetchall()
+        content, hostname, address = result[0][0], result[0][1], result[0][2]
+
+        if address != context.recovery_host_address or hostname != context.recovery_host_name:
+            raise Exception(
+                'Host name and address could not updated on segment configuration for dbId {0}'.format(context.remote_pair_primary_segdbId))
+
+
+@when('a gprecoverseg input file "{filename}" is created with hostname parameter to recover the failed segment on same host')
+def impl(context, filename):
+    port, hostname, datadir, address = context.remote_pair_primary_port, context.remote_pair_primary_host,\
+                              context.remote_pair_primary_datadir, context.remote_pair_primary_address
+
+    host_address = get_host_address(hostname)
+    context.recovery_host_address = host_address
+    context.recovery_host_name = hostname
+
+    line = "{0}|{1}|{2}|{3} {4}|{5}|{6}|/tmp/newdir" .format(hostname, address, port, datadir, hostname,
+                                                             host_address, port)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+
+@when('a gprecoverseg input file "{filename}" is created with hostname parameter matches with segment configuration table for incremental recovery of failed segment')
+def impl(context, filename):
+    port, hostname, datadir, address = context.remote_pair_primary_port, context.remote_pair_primary_host, \
+        context.remote_pair_primary_datadir, context.remote_pair_primary_address
+    context.recovery_host_address = address
+    context.recovery_host_name = hostname
+
+    line = "{0}|{1}|{2}|{3}" .format(hostname, address, port, datadir)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+
+@when('a gprecoverseg input file "{filename}" is created with invalid format for inplace full recovery of failed segment')
+def impl(context, filename):
+    port, hostname, datadir, address = context.remote_pair_primary_port, context.remote_pair_primary_host,\
+                              context.remote_pair_primary_datadir, context.remote_pair_primary_address
+
+    host_address = get_host_address(hostname)
+
+    line = "{0}|{1}|{2}|{3} {4}|{5}|/tmp/newdir" .format(hostname, address, port, datadir, host_address, port)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+
+@when('a gprecoverseg input file "{filename}" created with invalid failover hostname for full recovery of failed segment')
+def impl(context, filename):
+    port, hostname, datadir, address = context.remote_pair_primary_port, context.remote_pair_primary_host,\
+                              context.remote_pair_primary_datadir, context.remote_pair_primary_address
+
+    host_address = get_host_address(hostname)
+
+    line = "{0}|{1}|{2}|{3} {4}_1|{5}|{6}|/tmp/newdir" .format(hostname, address, port, datadir, hostname, host_address, port)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+
+@when('a gprecoverseg input file "{filename}" is created with and without parameter hostname to recover all the failed segments')
+def impl(context, filename):
+    lines = []
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
+        rows = dbconn.execSQL(conn,"SELECT port, hostname, datadir, content, address FROM gp_segment_configuration WHERE  status = 'd' and content != -1;").fetchall()
+    for i, row in enumerate(rows):
+        output_str = ""
+        hostname = row[1]
+        host_address = get_host_address(hostname)
+        port = row[0]
+        address = row[4]
+        datadir = row[2]
+        content = row[3]
+
+        if content == 0:
+            output_str += "{0}|{1}|{2}".format(address, port, datadir)
+        elif content == 1:
+            output_str += "{0}|{1}|{2} {3}|{4}|/tmp/newdir{5}".format(address, port, datadir, address, port, i)
+        else:
+            output_str += "{0}|{1}|{2}|{3} {4}|{5}|{6}|/tmp/newdir{7}".format(hostname, address, port, datadir,
+                                                                              hostname, host_address, port, i)
+
+        lines.append(output_str)
+    writeLinesToFile("/tmp/%s" % filename, lines)
+
+@when('a gprecoverseg input file "{filename}" is created with invalid hostname parameter that does not matches with the segment configuration table hostname')
+def impl(context, filename):
+    port, hostname, datadir, address = context.remote_pair_primary_port, context.remote_pair_primary_host, \
+        context.remote_pair_primary_datadir, context.remote_pair_primary_address
+
+    line = "{0}|{1}|{2}|{3}" .format("invalid_hostname", address, port, datadir)
+
+    with open("/tmp/%s" % filename, "w") as fd:
+        fd.write("%s\n" % line)
+
+def get_host_address(hostname):
+    cmd = Command("get the address of the host", cmdStr="hostname -I", ctxt=REMOTE, remoteHost=hostname)
+    cmd.run(validateAfter=True)
+    return cmd.get_stdout().strip()
+


### PR DESCRIPTION
This is a cherry-pick of https://github.com/greenplum-db/gpdb/pull/15566
Problem: During gprecoverseg host-name and host-address fields are getting populated with the same value(host-address) in the gp_segment_configuration table after recovery. The reason being the recovery input configuration file can have only three parameters host-address, port, data-directory and host-name field is not there. In previous versions of gpdb, the hostname was resolved using the provided host-address but the functionality used to resolve the hostname was not stable and faulty. So, It was removed in https://github.com/greenplum-db/gpdb/commit/f61d35cdeacc2f97e234648e06788207fb9e53fc with the reason provided "The hostname resolution from address was incorrect and faulty in its logic - an IP address never requires a hostname associated with it. However, the hostname field in gp_segment_configuration should be populated somehow - we recommend a "hostname" field addition to any configuration files that require it"

Solution: We should provide control to the user to also specify host-name and host-address separately in the gprecoverseg input config file. At present input config file has the option to specify host-address, port, data-directory  only and we added code changes to support the 4th parameter host-name as well. The option to provide host-name currently will be available only in case of recovery using config file and hostname value will be switched on the basis of the number of parameters provided in config file. If a host-name is not mentioned behavior remains unchanged and provided address will be populated as host-name in the configuration

Implementation: Added support to have the 4th parameter host-name field in the recovery config file. This host-name field will be used just to populate the hostname field in the recovery when converting a request to triplet

The new input format of gprecoverseg input config file will look as follows: 
- Full recovery: `<failed_host_name>|<failed_host_address>|<port>|<data_directory>SPACE<failover_host_name>|<recovery_host_address>|<port>|<data_directory>`
- Incremental Recovery:  `<failed_host_name>|<failed_host_address>|<port>|<data_directory>`

Also, we are supporting previous formats for recovery i.e. 
- Full Recovery: `<failed_host_address>|<port>|<data_directory>SPACE <recovery_host_address>|<port>|<data_directory>`
- Incremental Recovery: <failed_host_address>|<port>|<data_directory>

Future Scope :
The addition of the 4th parameter host-name also impacts gpaddmirrors, gpexpand, gpmovemirror and we will create stories to track those utilities to support host-name in their input configuration file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
