### PR TITLE
Count number of removed rows in pg_stat* for AO/AOCS relations

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2511,6 +2511,8 @@ appendonly_delete(AppendOnlyDeleteDesc aoDeleteDesc,
 	/* tableName */
 #endif
 
+	pgstat_count_heap_delete(aoDeleteDesc->aod_rel);
+
 	return AppendOnlyVisimapDelete_Hide(&aoDeleteDesc->visiMapDelete, aoTupleId);
 }
 


### PR DESCRIPTION
pg_stat_*_tables relation in PostgreSQL/Greenplum contains statistic about relation inserted/updated/deleted rows number. However, for AO/AOCS relations only number of inserted rows is counted. This commit adds maintenance of deleted rows count, which can come in handy for manual vacuum purposes (autovac in 6X is not supported)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
