### PR TITLE
[6X] starting segments in default mode post recovery 

### DIFF
--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -296,7 +296,7 @@ def start_segment(recovery_info, logger, era):
         , numContentsInCluster=0
         , era=era
         , mirrormode="mirror"
-        , utilityMode=True)
+        , utilityMode=False)
     logger.info(str(cmd))
     cmd.run(validateAfter=True)
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -10,6 +10,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And the database segments are in execute mode
 
         Given another tablespace is created with data
          When the user runs "gprecoverseg -ra"
@@ -17,6 +18,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And the database segments are in execute mode
       Examples:
         | scenario     | args               |
         | incremental  | -a                 |
@@ -646,6 +648,7 @@ Feature: gprecoverseg tests
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
     And the tablespace is valid
+    And the database segments are in execute mode
 
     Given another tablespace is created with data
     When the user runs "gprecoverseg -ra"
@@ -653,6 +656,7 @@ Feature: gprecoverseg tests
     And the segments are synchronized
     And the tablespace is valid
     And the other tablespace is valid
+    And the database segments are in execute mode
     Examples:
         | scenario     | args               |
         | incremental  | -a                 |


### PR DESCRIPTION
**Problem:** After recovery, the segment should start in the default mode of dispatch for 6x. Currently, gprecoverseg starts the segment in utility mode after the recovery. Before recovery, all segments are in dispatch mode (gp_role_string). With this PR we are making sure that after the recovery, we are not changing the gp_role of the segment.
In the case of 6X, we do not pass any parameter/role value when starting the segment. Here's how the segment looks on a newly created cluster: 
`/usr/local/gpdb6/bin/postgres -D /data/dbfast1/demoDataDir0 -p 6002`

After the recovery, before this PR, gprecoverseg adds execute parameter in the command line. Here's how the command line looks: 
`/usr/local/gpdb6/bin/postgres -D /data/dbfast1/demoDataDir0 -p 6002-c gp_role=utility`

**Solution:**
With this PR, make sure that the default mode of the segment remains unchanged even after recovery. 

This is cherry-pick of 7x commit: 91c5a30007dc4f7e270770a0c663a8fb5d1674e4
7X PR: https://github.com/greenplum-db/gpdb/pull/15599

*Testing done*: 
- Manually ran the gprecoverseg and checked the command line for the segment. 
- Verified gp_role_string by connecting to Postgres process using gdb
- Ran gpaddmirrors and gpmovemirrors to confirm segments are not in utility mode. 

Manual Testing : 
- Check gp_role value on a primary when the cluster is initialized: 
- Connect to existing segment postgres process: 
```
$ lldb -p 83089
(lldb) process attach --pid 83089
Process 83089 stopped
```
- Print gp_role_string variable: 
```
(lldb) p gp_role_string
(char *) $0 = 0x0000600003dd8090 "dispatch"
```

- Primary instance is stopped: 
```
pg_ctl stop -D /data/datadirs/dbfast1/demoDataDir0
waiting for server to shut down.... done
server stopped
```
- Recover instance in-place
```
$ gprecoverseg -a
.
.
[INFO]:-Segments successfully recovered.
```
- Connect to the recovered segment Postgres process and verify gp_role value:
```
$ lldb -p 85926
(lldb) process attach --pid 85926
Process 85926 stopped
(lldb) p gp_role_string
(char *) $0 = 0x0000600000c2c0e0 "dispatch"
```
Expected: 
- gp_role_string value of Postgres process is unchanged
- The command line of each segment instance should not have any extra parameters after recovery
  Before recovery, PS output:
   `/usr/local/gpdb6/bin/postgres -D /data/datadirs/dbfast1/demoDataDir0 -p 6002`
  Post Recovery PS output: 
   `/usr/local/gpdb6/bin/postgres -D /data/datadirs/dbfast1/demoDataDir0 -p 6002`
  
Automation tests are added to check if primary segments are in execute mode by parsing the error 
string returned when trying to connect to a segment. Could not add check for mirrors as error message 
returned is same even if a mirror is in execute mode or utility mode

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
