### PR TITLE
Add explain analyze detailed info of hash agg

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -3656,7 +3656,11 @@ show_hashagg_info(AggState *aggstate, ExplainState *es)
 							   aggstate->hash_planned_partitions, es);
 	}
 
-	if (!es->analyze)
+	/*
+	 * Greenplums outputs hash aggregate information in "Extra Text" via
+	 * cdbexplainbuf, hash_agg_update_metrics() is never called on QD.
+	 */
+	if (Gp_role != GP_ROLE_UTILITY || !es->analyze)
 		return;
 
 	/* EXPLAIN ANALYZE */

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -243,11 +243,6 @@
  *-------------------------------------------------------------------------
  */
 
-/*
- * GPDB_12_MERGE_FIXME: we lost the detailed cdb executor instruments to print
- * by explain, which were in execHHashagg.c
- */
-
 #include "postgres.h"
 
 #include "access/htup_details.h"
@@ -493,6 +488,8 @@ static int	find_compatible_pertrans(AggState *aggstate, Aggref *newagg,
 									 List *transnos);
 
 static void ExecEagerFreeAgg(AggState *node);
+
+void agg_hash_explain_extra_message(AggState *aggstate);
 
 /*
  * Select the current grouping set; affects current_set and
@@ -1547,6 +1544,16 @@ build_hash_tables(AggState *aggstate)
 			aggstate->hashentrysize, perhash->aggnode->numGroups, memory);
 
 		build_hash_table(aggstate, setno, nbuckets);
+
+		/* initialize some statistic info of hash table */
+		perhash->num_output_groups = 0;
+		perhash->num_spill_parts = 0;
+		perhash->num_expansions = 0;
+		perhash->bucket_total = 0;
+		perhash->bucket_used = 0;
+		perhash->chain_count = 0;
+		perhash->chain_length_total = 0;
+		perhash->chain_length_max = 0;
 	}
 
 	aggstate->hash_ngroups_current = 0;
@@ -1975,6 +1982,7 @@ hash_agg_enter_spill_mode(AggState *aggstate)
 			hashagg_spill_init(aggstate, spill, aggstate->hash_tapeinfo, 0,
 							   perhash->aggnode->numGroups,
 							   aggstate->hashentrysize);
+			perhash->num_spill_parts += spill->npartitions;
 		}
 
 		if (aggstate->ss.ps.instrument)
@@ -2029,6 +2037,12 @@ hash_agg_update_metrics(AggState *aggstate, bool from_tape, int npartitions)
 	}
 
 	/* update hashentrysize estimate based on contents */
+	/*
+	 * Greenplum doesn't use hashentrysize in the instrumentation, it will
+	 * calculate hash table chain length to get an accurate number.
+	 *
+	 * See the following code to collect hash table statistic info.
+	 */
 	if (aggstate->hash_ngroups_current > 0)
 	{
 		aggstate->hashentrysize =
@@ -2041,6 +2055,47 @@ hash_agg_update_metrics(AggState *aggstate, bool from_tape, int npartitions)
 		Instrumentation    *instrument = aggstate->ss.ps.instrument;
 
 		instrument->workmemused = aggstate->hash_mem_peak;
+
+		/*
+		 * workmemwanted to avoid scratch i/o, that how much memory is needed
+		 * if we want to load into the hashtable at once:
+		 *
+		 * 1. add meta_mem only when from_tape is false, because when we are
+		 *	  reading from tape/spilled file, we can reuse the existing hash
+		 *	  table's meta.
+		 * 2. add hash_mem every time.
+		 * 3. don't add buffer_mem since it's unnecessary when we can load into
+		 *    into the memory at once.
+		 */
+		if (!from_tape)
+			instrument->workmemwanted += meta_mem;
+		instrument->workmemwanted += hashkey_mem;
+
+		/* Scan all perhashs and collect hash table statistic info */
+		for (int setno = 0; setno < aggstate->num_hashes; setno++)
+		{
+			AggStatePerHash perhash = &aggstate->perhash[setno];
+			tuplehash_hash *hashtab = perhash->hashtable->hashtab;
+
+			Assert(hashtab);
+
+			perhash->num_expansions += hashtab->num_expansions;
+			perhash->bucket_total += hashtab->size;
+			perhash->bucket_used += hashtab->members;
+			if (hashtab->members > 0)
+			{
+				uint32  perht_chain_length_total = 0;
+				uint32  perht_chain_count = 0;
+
+				/* collect statistic info of chain length per hash table */
+				tuplehash_coll_stat(hashtab,
+									&(perhash->chain_length_max),
+									&perht_chain_length_total,
+									&perht_chain_count);
+				perhash->chain_count += perht_chain_count;
+				perhash->chain_length_total += perht_chain_length_total;
+			}
+		}
 	}
 }
 
@@ -2232,6 +2287,7 @@ lookup_hash_entries(AggState *aggstate)
 				hashagg_spill_init(aggstate, spill, aggstate->hash_tapeinfo, 0,
 								   perhash->aggnode->numGroups,
 								   aggstate->hashentrysize);
+			perhash->num_spill_parts += spill->npartitions;
 
 			hashagg_spill_tuple(aggstate, spill, slot, hash);
 			pergroup[setno] = NULL;
@@ -2283,6 +2339,13 @@ ExecAgg(PlanState *pstate)
 		if (!TupIsNull(result))
 			return result;
 	}
+
+	/* Save statistics into the cdbexplainbuf for EXPLAIN ANALYZE */
+	if (node->ss.ps.instrument &&
+			(node->ss.ps.instrument)->need_cdb &&
+			(node->phase->aggstrategy == AGG_HASHED ||
+			node->phase->aggstrategy == AGG_MIXED))
+		agg_hash_explain_extra_message(node);
 
 	return NULL;
 }
@@ -2813,6 +2876,7 @@ agg_refill_hash_table(AggState *aggstate)
 				spill_initialized = true;
 				hashagg_spill_init(aggstate, &spill, tapeinfo, batch->used_bits,
 								   batch->input_card, aggstate->hashentrysize);
+				aggstate->perhash[aggstate->current_set].num_spill_parts += spill.npartitions;
 			}
 			/* no memory for a new group, spill */
 			hashagg_spill_tuple(aggstate, &spill, spillslot, hash);
@@ -2986,6 +3050,8 @@ agg_retrieve_hash_table_in_memory(AggState *aggstate)
 				return NULL;
 			}
 		}
+
+		perhash->num_output_groups++;
 
 		/*
 		 * Clear the per-output-tuple context for each group
@@ -5200,4 +5266,78 @@ ReuseHashTable(AggState *node)
 			!node->hash_ever_spilled &&
 			!node->streaming &&
 			!bms_overlap(node->ss.ps.chgParam, aggnode->aggParams));
+}
+
+/*
+ * Save statistics into the cdbexplainbuf for EXPLAIN ANALYZE
+ */
+void
+agg_hash_explain_extra_message(AggState *aggstate)
+{
+	/*
+	 * Check cdbexplain_depositStatsToNode(), Greenplum only saves extra
+	 * message text for the most interesting winning qExecs.
+	 */
+	StringInfo hbuf = aggstate->ss.ps.cdbexplainbuf;
+	uint64	sum_num_expansions = 0;
+	uint64	sum_output_groups = 0;
+	uint64	sum_spill_parts = 0;
+	uint64	sum_chain_length_total = 0;
+	uint64	sum_chain_count = 0;
+	uint32	chain_length_max = 0;
+	uint64	sum_bucket_used = 0;
+	uint64	sum_bucket_total = 0;
+
+	Assert(hbuf);
+
+	appendStringInfo(hbuf, "hash table(s): %d", aggstate->num_hashes);
+
+	/* Scan all perhashs and collect statistic info */
+	for (int setno = 0; setno < aggstate->num_hashes; setno++)
+	{
+		AggStatePerHash perhash = &aggstate->perhash[setno];
+
+		/* spill statistic info */
+		if (aggstate->hash_ever_spilled)
+		{
+			sum_output_groups += perhash->num_output_groups;
+			sum_spill_parts += perhash->num_spill_parts;
+		}
+
+		/* inner hash table statistic info */
+		if (perhash->chain_count > 0)
+		{
+			sum_chain_length_total += perhash->chain_length_total;
+			sum_chain_count += perhash->chain_count;
+			if (perhash->chain_length_max > chain_length_max)
+				chain_length_max = perhash->chain_length_max;
+			sum_bucket_used = perhash->bucket_used;
+			sum_bucket_total = perhash->bucket_total;
+			sum_num_expansions += perhash->num_expansions;
+		}
+	}
+
+	if (aggstate->hash_ever_spilled)
+	{
+		appendStringInfo(hbuf,
+			"; " UINT64_FORMAT " groups total in %d batches, " UINT64_FORMAT
+			" spill partitions; disk usage: " INT64_FORMAT "KB",
+			sum_output_groups,
+			aggstate->hash_batches_used,
+			sum_spill_parts,
+			aggstate->hash_disk_used);
+	}
+
+	if (sum_chain_count > 0)
+	{
+		appendStringInfo(hbuf,
+				"; chain length %.1f avg, %d max;"
+				" using " INT64_FORMAT " of " INT64_FORMAT " buckets;"
+				" total " INT64_FORMAT " expansions.\n",
+				(double)sum_chain_length_total / sum_chain_count,
+				chain_length_max,
+				sum_bucket_used,
+				sum_bucket_total,
+				sum_num_expansions);
+	}
 }

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -310,6 +310,29 @@ typedef struct AggStatePerHashData
 	AttrNumber *hashGrpColIdxInput; /* hash col indices in input slot */
 	AttrNumber *hashGrpColIdxHash;	/* indices in hashtbl tuples */
 	Agg		   *aggnode;		/* original Agg node, for numGroups etc. */
+
+	/*
+	 * Some statistic info of hash table, used for EXPLAIN ANALYZE.
+	 * Note that they are accumulated info and will not be reset even
+	 * after the hash table is reset.
+	 */
+
+	/* number of groups/entries output by the iterator */
+	uint64		num_output_groups;
+	/* number of spilled partitions */
+	uint64		num_spill_parts;
+	/* number of hash table expansions */
+	uint32		num_expansions;
+	/* total number of buckets */
+	uint64      bucket_total;
+	/* number of used buckets */
+	uint64      bucket_used;
+	/* number of all chains */
+	uint64      chain_count;
+	/* total length of all chains */
+	uint64      chain_length_total;
+	/* max chain length */
+	uint32      chain_length_max;
 }			AggStatePerHashData;
 
 

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -21,6 +21,8 @@
 -- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- m/Memory Usage: \d+\w?B/
 -- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory wanted:  \d+\w?kB/
+-- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
 -- m/Peak Memory Usage: \d+/
 -- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
 -- m/Buckets: \d+/

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -900,9 +900,82 @@ RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
+-- start_matchsubs
+-- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
+-- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
+-- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
+-- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
+-- end_matchsubs
+-- Greenplum hash table extra message
+CREATE TABLE test_src_tbl AS
+SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
+ANALYZE test_src_tbl;
+-- Enable optimizer_enable_hashagg, and set statement_mem to a small value to force spilling
+set optimizer_enable_hashagg = on;
+SET statement_mem = '1000kB';
+-- Hashagg with spilling
+CREATE TABLE test_hashagg_spill AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3) (actual time=8.948..21.656 rows=10000 loops=1)
+  ->  HashAggregate (actual time=13.950..15.183 rows=3386 loops=1)
+        Group Key: a
+        Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 1024KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
+
+        ->  HashAggregate (actual time=12.113..12.658 rows=3386 loops=1)
+              Group Key: a, b
+              Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
+
+              ->  Seq Scan on test_src_tbl (actual time=0.015..1.748 rows=16930 loops=1)
+Optimizer: Postgres query optimizer
+Planning Time: 0.167 ms
+  (slice0)    Executor memory: 236K bytes.
+* (slice1)    Executor memory: 657K bytes avg x 3 workers, 722K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
+Memory used:  1000kB
+Memory wanted:  1640kB
+Execution Time: 22.346 ms
+(17 rows)
+-- Hashagg with grouping sets
+CREATE TABLE test_hashagg_groupingsets AS
+SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- The planner generates multiple hash tables but ORCA uses Shared Scan.
+EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3) (actual time=57.360..82.135 rows=20000 loops=1)
+  ->  Finalize HashAggregate (actual time=57.788..78.873 rows=6769 loops=1)
+        Group Key: a, b, (GROUPINGSET_ID())
+        Extra Text: (seg0)   hash table(s): 1; 6570 groups total in 16 batches, 20604 spill partitions; disk usage: 1824KB; chain length 2.7 avg, 10 max; using 6570 of 34816 buckets; total 0 expansions.
+
+        ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=14.477..54.576 rows=6769 loops=1)
+              Hash Key: a, b, (GROUPINGSET_ID())
+              ->  Partial HashAggregate (actual time=21.224..38.700 rows=6772 loops=1)
+                    Hash Key: a
+                    Hash Key: b
+                    Extra Text: (seg1)   hash table(s): 2; 6772 groups total in 40 batches, 121260 spill partitions; disk usage: 2912KB; chain length 2.1 avg, 6 max; using 3386 of 83968 buckets; total 0 expansions.
+
+                    ->  Seq Scan on test_src_tbl (actual time=0.043..3.471 rows=16930 loops=1)
+Optimizer: Postgres query optimizer
+Planning Time: 0.202 ms
+  (slice0)    Executor memory: 205K bytes.
+* (slice1)    Executor memory: 467K bytes avg x 3 workers, 467K bytes max (seg1).  Work_mem: 705K bytes max, 1921K bytes wanted.
+* (slice2)    Executor memory: 610K bytes avg x 3 workers, 631K bytes max (seg0).  Work_mem: 633K bytes max, 2377K bytes wanted.
+Memory used:  1000kB
+Memory wanted:  5052kB
+Execution Time: 84.367 ms
+(21 rows)
+RESET optimizer_enable_hashagg;
+RESET statement_mem;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
 DROP TABLE jsonexplaintest;
 DROP TABLE jit_explain_output;
+DROP TABLE test_src_tbl;
+DROP TABLE test_hashagg_spill;
+DROP TABLE test_hashagg_groupingsets;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -21,6 +21,8 @@
 -- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- m/Memory Usage: \d+\w?B/
 -- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory wanted:  \d+\w?kB/
+-- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
 -- m/Peak Memory Usage: \d+/
 -- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
 -- m/Buckets: \d+/
@@ -864,16 +866,13 @@ Gather Motion 3:1  (slice1; segments: 3) (actual time=66.084..124.823 rows=20000
         ->  Shared Scan (share slice:id 1:0) (actual time=10.481..17.729 rows=16930 loops=1)
               ->  Seq Scan on test_src_tbl (actual time=0.020..1.319 rows=16930 loops=1)
         ->  Append (actual time=45.590..84.119 rows=6771 loops=1)
-              ->  Finalize HashAggregate (actual time=45.590..61.530 rows=3385 loops=1)
+              ->  HashAggregate (actual time=14.125..27.481 rows=3385 loops=1)
                     Group Key: share0_ref2.b
                     Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 2016KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
 
                     ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=0.023..38.616 rows=16925 loops=1)
                           Hash Key: share0_ref2.b
-                          ->  Streaming Partial HashAggregate (actual time=10.905..33.798 rows=16930 loops=1)
-                                Group Key: share0_ref2.b
-                                Extra Text: (seg1)   hash table(s): 1; chain length 2.0 avg, 4 max; using 16930 of 98304 buckets; total 0 expansions.
-
+                          ->  Result (actual time=7.251..15.668 rows=16930 loops=1)
                                 ->  Shared Scan (share slice:id 2:0) (actual time=10.668..14.900 rows=16930 loops=1)
               ->  HashAggregate (actual time=11.722..22.117 rows=3386 loops=1)
                     Group Key: share0_ref3.a
@@ -884,11 +883,11 @@ Optimizer: Pivotal Optimizer (GPORCA)
 Planning Time: 11.209 ms
   (slice0)    Executor memory: 224K bytes.
 * (slice1)    Executor memory: 574K bytes avg x 3 workers, 576K bytes max (seg2).  Work_mem: 353K bytes max, 1137K bytes wanted.
-* (slice2)    Executor memory: 161K bytes avg x 3 workers, 161K bytes max (seg0).  Work_mem: 193K bytes max, 9155K bytes wanted.
+  (slice2)    Executor memory: 161K bytes avg x 3 workers, 161K bytes max (seg0).
 Memory used:  1000kB
-Memory wanted:  55430kB
+Memory wanted:  6600kB
 Execution Time: 126.275 ms
-(29 rows)
+(26 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Cleanup

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -815,9 +815,88 @@ RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
+-- start_matchsubs
+-- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
+-- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
+-- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
+-- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
+-- end_matchsubs
+-- Greenplum hash table extra message
+CREATE TABLE test_src_tbl AS
+SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
+ANALYZE test_src_tbl;
+-- Enable optimizer_enable_hashagg, and set statement_mem to a small value to force spilling
+set optimizer_enable_hashagg = on;
+SET statement_mem = '1000kB';
+-- Hashagg with spilling
+CREATE TABLE test_hashagg_spill AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3) (actual time=9.551..21.820 rows=10000 loops=1)
+  ->  HashAggregate (actual time=9.028..10.280 rows=3386 loops=1)
+        Group Key: a
+        Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 1024KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
+
+        ->  HashAggregate (actual time=7.066..7.628 rows=3386 loops=1)
+              Group Key: a, b
+              Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 1024KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
+
+              ->  Seq Scan on test_src_tbl (actual time=0.020..1.349 rows=16930 loops=1)
+Optimizer: Pivotal Optimizer (GPORCA)
+Planning Time: 5.518 ms
+  (slice0)    Executor memory: 236K bytes.
+* (slice1)    Executor memory: 709K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
+Memory used:  1000kB
+Memory wanted:  1640kB
+Execution Time: 22.843 ms
+(17 rows)
+-- Hashagg with grouping sets
+CREATE TABLE test_hashagg_groupingsets AS
+SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+-- The planner generates multiple hash tables but ORCA uses Shared Scan.
+EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3) (actual time=66.084..124.823 rows=20000 loops=1)
+  ->  Sequence (actual time=63.808..102.762 rows=6771 loops=1)
+        ->  Shared Scan (share slice:id 1:0) (actual time=10.481..17.729 rows=16930 loops=1)
+              ->  Seq Scan on test_src_tbl (actual time=0.020..1.319 rows=16930 loops=1)
+        ->  Append (actual time=45.590..84.119 rows=6771 loops=1)
+              ->  Finalize HashAggregate (actual time=45.590..61.530 rows=3385 loops=1)
+                    Group Key: share0_ref2.b
+                    Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 2016KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
+
+                    ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=0.023..38.616 rows=16925 loops=1)
+                          Hash Key: share0_ref2.b
+                          ->  Streaming Partial HashAggregate (actual time=10.905..33.798 rows=16930 loops=1)
+                                Group Key: share0_ref2.b
+                                Extra Text: (seg1)   hash table(s): 1; chain length 2.0 avg, 4 max; using 16930 of 98304 buckets; total 0 expansions.
+
+                                ->  Shared Scan (share slice:id 2:0) (actual time=10.668..14.900 rows=16930 loops=1)
+              ->  HashAggregate (actual time=11.722..22.117 rows=3386 loops=1)
+                    Group Key: share0_ref3.a
+                    Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 1888KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
+
+                    ->  Shared Scan (share slice:id 1:0) (actual time=0.009..5.775 rows=16930 loops=1)
+Optimizer: Pivotal Optimizer (GPORCA)
+Planning Time: 11.209 ms
+  (slice0)    Executor memory: 224K bytes.
+* (slice1)    Executor memory: 574K bytes avg x 3 workers, 576K bytes max (seg2).  Work_mem: 353K bytes max, 1137K bytes wanted.
+* (slice2)    Executor memory: 161K bytes avg x 3 workers, 161K bytes max (seg0).  Work_mem: 193K bytes max, 9155K bytes wanted.
+Memory used:  1000kB
+Memory wanted:  55430kB
+Execution Time: 126.275 ms
+(29 rows)
+RESET optimizer_enable_hashagg;
+RESET statement_mem;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
 DROP TABLE jsonexplaintest;
 DROP TABLE jit_explain_output;
+DROP TABLE test_src_tbl;
+DROP TABLE test_hashagg_spill;
+DROP TABLE test_hashagg_groupingsets;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -21,6 +21,8 @@
 -- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- m/Memory Usage: \d+\w?B/
 -- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory wanted:  \d+\w?kB/
+-- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
 -- m/Peak Memory Usage: \d+/
 -- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
 -- m/Buckets: \d+/

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -216,9 +216,42 @@ RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
+
+-- start_matchsubs
+-- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
+-- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
+-- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
+-- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
+-- end_matchsubs
+-- Greenplum hash table extra message
+CREATE TABLE test_src_tbl AS
+SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
+ANALYZE test_src_tbl;
+
+-- Enable optimizer_enable_hashagg, and set statement_mem to a small value to force spilling
+set optimizer_enable_hashagg = on;
+SET statement_mem = '1000kB';
+
+-- Hashagg with spilling
+CREATE TABLE test_hashagg_spill AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+
+-- Hashagg with grouping sets
+CREATE TABLE test_hashagg_groupingsets AS
+SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+-- The planner generates multiple hash tables but ORCA uses Shared Scan.
+EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+
+RESET optimizer_enable_hashagg;
+RESET statement_mem;
+
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
 DROP TABLE jsonexplaintest;
 DROP TABLE jit_explain_output;
+DROP TABLE test_src_tbl;
+DROP TABLE test_hashagg_spill;
+DROP TABLE test_hashagg_groupingsets;


### PR DESCRIPTION
### Summary

After upgrading to GPDB7, we lost the detailed cdb executor instruments of hashagg since the code base has been changed in a large size. The patch is to re-implement explain analyze related code of hashagg to provide more critical info for troubleshooting issues.

### Example

We use a script to create the hashagg scenario:
```
create table streaming_t1 (d int, i int, c int, dt date);
insert into streaming_t1 select i/10, i/10, i/100, '2009-06-10'::date + ( (i%34) || ' days')::interval from generate_series(0, 99999999) i;

analyze streaming_t1;

SET statement_mem='1000kB';
SET optimizer=off;

explain analyze select count(distinct i) from streaming_t1 group by c;
```

Result in GPDB6:

```
testdb=# explain analyze select count(distinct i) from streaming_t1 group by c;
                                                                                 QUERY PLAN                                                      
                           
-------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=3117970.90..3122369.13 rows=439823 width=12) (actual time=15782.991..16337.777 rows=1000000 loop
s=1)
   ->  HashAggregate  (cost=3117970.90..3122369.13 rows=146608 width=12) (actual time=15785.477..16234.622 rows=334042 loops=1)
         Group Key: streaming_t1.c
         Extra Text: (seg2)   334042 groups total in 32 batches; 1 overflows; 2999062 spill groups.
 (seg2)   Hash chain length 1.5 avg, 11 max, using 277170 of 557056 buckets; total 1 expansions.
 
         ->  HashAggregate  (cost=2838677.18..2967972.60 rows=3333296 width=8) (actual time=13428.779..14403.499 rows=3340420 loops=1)
               Group Key: streaming_t1.c, streaming_t1.i
               Extra Text: (seg2)   3340420 groups total in 32 batches; 1 overflows; 3340420 spill groups.
 (seg2)   Hash chain length 3.3 avg, 16 max, using 1036832 of 1081344 buckets; total 1 expansions.
 
               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1884391.12..2634382.62 rows=3333296 width=8) (actual time=320.177..11683
.206 rows=3340420 loops=1)
                     Hash Key: streaming_t1.c
                     ->  HashAggregate  (cost=1884391.12..2434384.88 rows=3333296 width=8) (actual time=1074.721..11839.608 rows=3334839 loops=1)
                           Group Key: streaming_t1.c, streaming_t1.i
                           Extra Text: (seg2)   Hash chain length 3.5 avg, 15 max, using 949145 of 983040 buckets; total 1 expansions.
 
                           ->  Seq Scan on streaming_t1  (cost=0.00..1134399.64 rows=33332955 width=8) (actual time=1.521..6235.343 rows=33348390
 loops=1)
 Planning time: 0.380 ms
   (slice0)    Executor memory: 151K bytes.
   (slice1)    Executor memory: 5031K bytes avg x 3 workers, 5031K bytes max (seg0).
 * (slice2)    Executor memory: 10905K bytes avg x 3 workers, 10905K bytes max (seg0).  Work_mem: 5001K bytes max, 132225K bytes wanted.
 Memory used:  10000kB
 Memory wanted:  396972kB
 Optimizer: Postgres query optimizer
 Execution time: 16406.703 ms
(26 rows) 
```

Result in GPDB7 without the patch:
```
testdb=# explain analyze select count(distinct i) from streaming_t1 group by c;
                                                                               QUERY PLAN--------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1257397.71..1264900.21 rows=450150 width=12) (actual ti
me=17254.426..19779.878 rows=1000000 loops=1)
   ->  HashAggregate  (cost=1257397.71..1258898.21 rows=150050 width=12) (actual time=17273.667..19759.6
68 rows=334042 loops=1)
         Group Key: c
         Planned Partitions: 4
         Peak Memory Usage: 0 kB
         ->  HashAggregate  (cost=1197800.36..1240730.74 rows=3333393 width=8) (actual time=12139.638..1
6350.869 rows=3340420 loops=1)
               Group Key: c, i
               Planned Partitions: 4
               Peak Memory Usage: 0 kB
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=758358.40..1085713.88 rows=9826
761 width=8) (actual time=8.817..11453.585 rows=3341861 loops=1)
                     Hash Key: c
                     ->  Streaming HashAggregate  (cost=758358.40..889178.67 rows=9826761 width=8) (actu
al time=7.587..11070.286 rows=3336270 loops=1)
                           Group Key: c, i
                           Planned Partitions: 4
                           Peak Memory Usage: 0 kB
                           ->  Seq Scan on streaming_t1  (cost=0.00..378143.28 rows=33333928 width=8) (a
ctual time=0.074..3261.548 rows=33348390 loops=1)
 Optimizer: Postgres query optimizer
 Planning Time: 1.224 ms
   (slice0)    Executor memory: 349K bytes.
   (slice1)    Executor memory: 1181K bytes avg x 3 workers, 1181K bytes max (seg0).  Work_mem: 785K byt
es max.
   (slice2)    Executor memory: 198K bytes avg x 3 workers, 199K bytes max (seg1).  Work_mem: 369K bytes
 max.
 Memory used:  1000kB
 Execution Time: 19873.473 ms
(23 rows) 
```
Result in GPDB7 with the patch:
```
testdb=# explain analyze select count(distinct i) from streaming_t1 group by c;
                                                                                                           QUERY PLA
N
--------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1257397.71..1264859.84 rows=447728 width=12) (actual time=37990.820
..43252.288 rows=1000000 loops=1)
   ->  HashAggregate  (cost=1257397.71..1258890.13 rows=149243 width=12) (actual time=38041.124..43104.985 rows=3340
42 loops=1)
         Group Key: c
         Planned Partitions: 4
         Extra Text: (seg2)   hash table(s): 1; 334042 groups total in 340 batches, 13253020 spill partitions; disk
usage: 111584KB; chain length 2.6 avg, 13 max; using 334042 of 1396736 buckets; total 0 expansions.

         ->  HashAggregate  (cost=1197800.36..1240730.74 rows=3333393 width=8) (actual time=27682.691..36143.712 row
s=3340420 loops=1)
               Group Key: c, i
               Planned Partitions: 4
               Extra Text: (seg2)   hash table(s): 1; 3340420 groups total in 1364 batches, 13359480 spill partition
s; disk usage: 112128KB; chain length 2.7 avg, 16 max; using 3340420 of 5591040 buckets; total 0 expansions.

               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=758358.40..1085713.88 rows=9826761 width=8)
 (actual time=20.442..26186.948 rows=3341861 loops=1)
                     Hash Key: c
                     ->  Streaming HashAggregate  (cost=758358.40..889178.67 rows=9826761 width=8) (actual time=17.5
70..25616.621 rows=3336270 loops=1)
                           Group Key: c, i
                           Planned Partitions: 4
                           Extra Text: (seg2)   hash table(s): 1; chain length 2.6 avg, 15 max; using 3336270 of 586
5472 buckets; total 0 expansions.

                           ->  Seq Scan on streaming_t1  (cost=0.00..378143.28 rows=33333928 width=8) (actual time=0
.098..6420.498 rows=33348390 loops=1)
 Optimizer: Postgres query optimizer
 Planning Time: 0.717 ms
   (slice0)    Executor memory: 349K bytes.
 * (slice1)    Executor memory: 1181K bytes avg x 3 workers, 1181K bytes max (seg0).  Work_mem: 785K bytes max, 3379
05K bytes wanted.
 * (slice2)    Executor memory: 198K bytes avg x 3 workers, 199K bytes max (seg1).  Work_mem: 369K bytes max, 526874
K bytes wanted.
 Memory used:  1000kB
 Memory wanted:  1580920kB
 Execution Time: 43408.876 ms
(27 rows)
```
In a brief, the patch updated some info which are different between GPDB6 and GPDB7 (without the patch):

1. Added extra lines of "Extra Text" about more details.
2. Added extra lines of "Memory wanted".
3. Removed the info of "Peak Memory Usage" of GPDB7 (which was always 0 without the patch) since we can get it in "Executor memory". See code in `hash_agg_update_metrics()`:
```
2002         instrument->workmemused = aggstate->hash_mem_peak;
```
### Details in "Extra Text"
1. On GPDB6, there is only one hash table. But on GPDB7, because of group set, there might be multiple hash tables. We must collect statistic info of all of them. 
2. The hash table implementation was rewritten completely on GPDB7, so some concepts are meaningless and were removed. e.g. `num_overflows` is used to count `SpillSet` ever created on GPDB6, but there is no `SpillSet` on GPDB7 at all.
3. The behavior of hash table was changed greatly. On GPDB6, when there is no space for a new entry, the hash table will be spilled to disk to make room (see `spill_hash_table()`). On GPDB7, a new group will be spilled to disk in spill mode, and the hash table itself will not (see `lookup_hash_entry()`). Thus, `num_spill_groups` which indicates number of spilled groups in `spill_hash_table()` is meaningless and removed.
4. To measure the spilled data to replace `num_spill_groups`, on GPDB7 I used `num_spill_parts` to indicate the number of spilled partitions. When entering spill mode, a number of partitions will be allocated and assigned to tape set, which measures the spilled data in some degree (see `hashagg_spill_init()`). Not very sure if it's proper. Or we can still count the spilled branches on GPDB7?
5. Some concepts with same names have different meanings. e.g. on GPDB6 `num_batches` means "number of batch files" on GPDB6 (see `spill_hash_table()`), but on GPDB7 batch means "work to be done for one pass of hash aggregation (with only one grouping set)" (see definition of `HashAggBatch`). So we have "batches" output in "Extra Text" on both versions, but they have different meanings.
6. The calculation of hash chain is totally different. Please see details in `SH_COLL_STAT`().

### Memory wanted

On GPDB6, the calculation of "Memory wanted" is based on hash table implementation and not applicable on GPDB7. I used a different way (with similar theory). Please see `hash_agg_update_metrics().`

### Test

The impact for test cases is smaller than estimated because the extra explain info is available when ANALYZE is enabled. Actually all existing test cases are not impacted, and I just need a test case to cover the scenario. A candidate is src/test/regress/sql/workfile/hashagg_spill.sql, but it focuses on work file status under various spilling cases and not so good for the scenarios. So I chose src/test/isolation2/sql/spilling_hashagg.sql as a simple example, and enlarged the test data to create spilling scenario.