### PR TITLE
Fix incorrect function arguments call in row lock extension.

### DIFF
--- a/contrib/pgrowlocks/pgrowlocks.c
+++ b/contrib/pgrowlocks/pgrowlocks.c
@@ -153,7 +153,8 @@ pgrowlocks(PG_FUNCTION_ARGS)
 		/* must hold a buffer lock to call HeapTupleSatisfiesUpdate */
 		LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_SHARE);
 
-		htsu = HeapTupleSatisfiesUpdate(tuple,
+		htsu = HeapTupleSatisfiesUpdate(rel,
+										tuple,
 										GetCurrentCommandId(false),
 										hscan->rs_cbuf);
 		xmax = HeapTupleHeaderGetRawXmax(tuple->t_data);


### PR DESCRIPTION
Hi, there:
HeapTupleSatisfiesUpdate has been changed from 3 parameters to 4 parameters. Function call should also be changed.
You can test it by `make` in directory `contrib/pgrowlocks`