### PR TITLE
fix bitmap index

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -1033,6 +1033,7 @@ _bitmap_log_bitmapwords(Relation rel,
 	ListCell   *lcb;
 	bool		init_page;
 	int			num_bm_pages = list_length(xl_bm_bitmapword_pages);
+	int 		current_page = 0;
 
 	Assert(list_length(bitmapBuffers) == num_bm_pages);
 	if (num_bm_pages > MAX_BITMAP_PAGES_PER_INSERT)
@@ -1041,7 +1042,7 @@ _bitmap_log_bitmapwords(Relation rel,
 	MemSet(&xlBitmapWords, 0, sizeof(xlBitmapWords));
 
 	xlBitmapWords.bm_node = rel->rd_node;
-	xlBitmapWords.bm_num_pages = list_length(xl_bm_bitmapword_pages);
+	xlBitmapWords.bm_num_pages = num_bm_pages;
 	xlBitmapWords.bm_init_first_page = init_first_page;
 
 	xlBitmapWords.bm_lov_blkno = BufferGetBlockNumber(lovBuffer);
@@ -1071,6 +1072,13 @@ _bitmap_log_bitmapwords(Relation rel,
 
 		Assert(BufferIsValid(bitmapBuffer));
 
+		/* fill bm_next_blkno field */
+		if (current_page + 1 < num_bm_pages)
+		{
+			xl_bm_bitmapwords_perpage *next_xl_bm_bitmapwords_perpage = lfirst(lnext(lcp));
+			xlBitmapwordsPage->bm_next_blkno = next_xl_bm_bitmapwords_perpage->bmp_blkno;
+		}
+
 		XLogRegisterBuffer(rdata_no, bitmapBuffer, 0);
 
 		XLogRegisterBufData(rdata_no, (char *) xlBitmapwordsPage, sizeof(xl_bm_bitmapwords_perpage));
@@ -1079,6 +1087,7 @@ _bitmap_log_bitmapwords(Relation rel,
 		XLogRegisterBufData(rdata_no, (char *) &bitmap->cwords[xlBitmapwordsPage->bmp_start_cword_no],
 							xlBitmapwordsPage->bmp_num_cwords * sizeof(BM_HRL_WORD));
 		rdata_no++;
+		current_page++;
 	}
 
 	recptr = XLogInsert(RM_BITMAP_ID, XLOG_BITMAP_INSERT_WORDS);

--- a/src/include/access/bitmap_xlog.h
+++ b/src/include/access/bitmap_xlog.h
@@ -93,6 +93,9 @@ typedef struct xl_bm_bitmapwords_perpage
 	uint16			bmp_start_cword_no;
 	uint16			bmp_num_cwords;
 
+	/* The next page number for the page. */
+	BlockNumber		bm_next_blkno;
+
 	/*
 	 * The following are arrays of content words and header
 	 * words, at next MAXALIGN boundary. They are located one after the other.

--- a/src/test/isolation2/expected/bitmap_index_crash.out
+++ b/src/test/isolation2/expected/bitmap_index_crash.out
@@ -98,3 +98,32 @@ ALTER SYSTEM
 -----------------
  Success:        
 (1 row)
+
+-- Test bitmap index replay XLog after crash
+-- More details could be found at https://github.com/greenplum-db/gpdb/issues/13517
+drop table if exists test_bitmap;
+DROP TABLE
+create table test_bitmap( id int, type int ) distributed by (id);
+CREATE TABLE
+insert into test_bitmap (id, type) select 1, g % 1000 from generate_series(1, 3000000) g;
+INSERT 0 3000000
+create index on test_bitmap using bitmap(type);
+CREATE INDEX
+select count(*) from test_bitmap where type = 520;
+ count 
+-------
+ 3000  
+(1 row)
+
+-- start_ignore
+! gpstop -rai;
+-- end_ignore
+
+0: select count(*) from test_bitmap where type = 520;
+ count 
+-------
+ 3000  
+(1 row)
+0: drop table test_bitmap;
+DROP TABLE
+


### PR DESCRIPTION
This PR is trying to fix the issue of #13517. The RCA could be found at [huansong's comments](https://github.com/greenplum-db/gpdb/issues/13517#issuecomment-1601716547).

The data registered by `XLogRegisterBufData()` could be replaced by Full Image, and the value 
of `bm_next_blkno` in special data is page data too, if we change that, we should record it in XLog, 
instead of predicting it in the replay process.
