### PR TITLE
Remove function FinalizeDirectDispatchDataForSlice()

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -388,55 +388,6 @@ MergeDirectDispatchCalculationInfo(DirectDispatchInfo *to, DirectDispatchInfo *f
 	to->haveProcessedAnyCalculations = true;
 }
 
-/**
- * returns true if we should print test messages.  Note for clients: for multi-slice queries then messages will print in
- *   the order of processing which may not always be deterministic (single joins can be rearranged by the planner,
- *   for example).
- */
-static bool
-ShouldPrintTestMessages()
-{
-	return gp_test_options && strstr(gp_test_options, PRINT_DISPATCH_DECISIONS_STRING) != NULL;
-}
-
-void
-FinalizeDirectDispatchDataForSlice(PlanSlice *slice)
-{
-	DirectDispatchInfo *dd = &slice->directDispatch;
-
-	if (dd->haveProcessedAnyCalculations)
-	{
-		if (dd->isDirectDispatch)
-		{
-			if (dd->contentIds == NULL)
-			{
-				int			random_segno;
-
-				random_segno = cdbhashrandomseg(getgpsegmentCount());
-				dd->contentIds = list_make1_int(random_segno);
-				if (ShouldPrintTestMessages())
-					elog(INFO, "DDCR learned no content dispatch is required");
-			}
-			else
-			{
-				if (ShouldPrintTestMessages())
-					elog(INFO, "DDCR learned dispatch to content %d", linitial_int(dd->contentIds));
-			}
-		}
-		else
-		{
-			if (ShouldPrintTestMessages())
-				elog(INFO, "DDCR learned full dispatch is required");
-		}
-	}
-	else
-	{
-		if (ShouldPrintTestMessages())
-			elog(INFO, "DDCR learned no information: default to full dispatch");
-		dd->isDirectDispatch = false;
-	}
-}
-
 void
 DirectDispatchUpdateContentIdsFromPlan(PlannerInfo *root, Plan *plan)
 {

--- a/src/include/cdb/cdbtargeteddispatch.h
+++ b/src/include/cdb/cdbtargeteddispatch.h
@@ -25,7 +25,6 @@
 #include "nodes/pathnodes.h"
 #include "nodes/plannodes.h"
 
-extern void FinalizeDirectDispatchDataForSlice(PlanSlice *slice);
 extern void DirectDispatchUpdateContentIdsFromPlan(PlannerInfo *root, Plan *plan);
 extern void DirectDispatchUpdateContentIdsForInsert(PlannerInfo *root, Plan *plan,
 													GpPolicy *targetPolicy, Oid *hashfuncs);


### PR DESCRIPTION
Long log:

Funciton `FinalizeDirectDispatchDataForSlice()`  is applied to free 
and override direct dispatch data on the given node.
Before this commit [93abe74](https://github.com/greenplum-db/gpdb/commit/93abe741cd67f04958e2951edff02b45ab6e280f), 
the call chain of `FinalizeDirectDispatchDataForSlice()` is
`standard_planner() -> AssignContentIdsToPlanData() -> FinalizeDirectDispatchDataForSlice()`.

After this commit [93abe74](https://github.com/greenplum-db/gpdb/commit/93abe741cd67f04958e2951edff02b45ab6e280f), the logic of direct-dispatch was rewritten. 
Direct dispatch information is attached at `PlanSlice`, 
rather than struct `ContentIdAssignmentData`, function `AssignContentIdsToPlanData()` is  also deleted. 
Then `FinalizeDirectDispatchDataForSlice()` is never called now. So remove it and related code.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>