### PR TITLE
Change GPVARS_VERBOSITY_DEBUG logging level

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -452,59 +452,14 @@ show_gp_role(void)
 }
 
 
-
 /* --------------------------------------------------------------------------------------------------
  * Logging
  */
 
-
-/*
- * gp_log_gangs (string)
- *
- * Should creation, reallocation and cleanup of gangs of QE processes be logged?
- * "OFF"	 -> only errors are logged
- * "TERSE"	 -> terse logging of routine events, e.g. creation of new qExecs
- * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 int gp_log_gang;
-
-/*
- * gp_log_fts (string)
- *
- * What kind of messages should the fault-prober log ?
- * "OFF"	 -> only errors are logged
- * "TERSE"	 -> terse logging of routine events
- * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 int gp_log_fts;
-
-/*
- * gp_log_interconnect (string)
- *
- * Should connections between internal processes be logged?  (qDisp/qExec/etc)
- * "OFF"	 -> connection errors are logged
- * "TERSE"	 -> terse logging of routine events, e.g. successful connections
- * "VERBOSE" -> most interconnect setup events are logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5.
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 int gp_log_interconnect;
 
-/*
- * gpvars_check_gp_resource_manager_policy
- * gpvars_assign_gp_resource_manager_policy
- * gpvars_show_gp_resource_manager_policy
- */
 bool
 gpvars_check_gp_resource_manager_policy(char **newval, void **extra, GucSource source)
 {

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -754,7 +754,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 				gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			{
 				/* Print chunk-sorter entry statistics. */
-				elog(DEBUG4, "Chunk-sorter entry [route=%d,node=%d] statistics:\n"
+				elog(LOG, "Chunk-sorter entry [route=%d,node=%d] statistics:\n"
 					 "\tAvailable Tuples High-Watermark: " UINT64_FORMAT,
 					 i, pMNEntry->motion_node_id,
 					 pMNEntry->stat_tuples_available_hwm);

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -254,7 +254,7 @@ void
 CleanUpMotionLayerIPC(void)
 {
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-		elog(DEBUG3, "Cleaning Up Motion Layer IPC...");
+		elog(LOG, "Cleaning Up Motion Layer IPC...");
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
 		Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
@@ -482,7 +482,7 @@ DeregisterReadInterest(ChunkTransportState *transportStates,
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 	{
-		elog(DEBUG3, "Interconnect finished receiving "
+		elog(LOG, "Interconnect finished receiving "
 			 "from seg%d slice%d %s pid=%d sockfd=%d; %s",
 			 conn->remoteContentId,
 			 pEntry->sendSlice->sliceIndex,

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -154,7 +154,7 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 		/* UV_EOF is expected */
 		if (nread == UV_EOF)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: backend %s: received EOF while receiving HELLO ACK.",
 				   ic_proxy_key_to_str(&backend->key));
 		}
@@ -186,7 +186,7 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: backend %s: received %s, dropping the invalid package (magic number mismatch)",
 					ic_proxy_key_to_str(&backend->key), ic_proxy_pkt_to_str(pkt));
 		return;
@@ -244,7 +244,7 @@ ic_proxy_backend_on_sent_hello(uv_write_t *req, int status)
 
 	if (status < 0)
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: backend %s: backend failed to send HELLO: %s",
 					 ic_proxy_key_to_str(&backend->key), uv_strerror(status));
 		uv_close((uv_handle_t *) &backend->pipe, ic_proxy_backend_on_close);
@@ -252,7 +252,7 @@ ic_proxy_backend_on_sent_hello(uv_write_t *req, int status)
 	}
 
 	/* receive hello ack */
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: backend %s: backend connected, receiving HELLO ACK",
 				 ic_proxy_key_to_str(&backend->key));
 
@@ -300,7 +300,7 @@ ic_proxy_backend_on_connected(uv_connect_t *conn, int status)
 	if (status < 0)
 	{
 		/* the proxy might just not get ready yet, retry later */
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: backend %s: backend failed to connect: %s",
 					 ic_proxy_key_to_str(&backend->key), uv_strerror(status));
 
@@ -317,7 +317,7 @@ ic_proxy_backend_on_connected(uv_connect_t *conn, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: backend %s: backend connected, sending HELLO message.",
 				 ic_proxy_key_to_str(&backend->key));
 

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -293,7 +293,7 @@ ic_proxy_client_register(ICProxyClient *client)
 		}
 
 		/* it's a placeholder, this happens if the pkts arrived before me */
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: replace my placeholder %s",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_client_get_name(placeholder));
@@ -304,7 +304,7 @@ ic_proxy_client_register(ICProxyClient *client)
 		 * it really happens, don't panic, nothing serious.
 		 */
 		if (placeholder->pkts == NIL)
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: no cached pkts in the placeholder %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_client_get_name(placeholder));
@@ -324,7 +324,7 @@ ic_proxy_client_register(ICProxyClient *client)
 			 * itself, so free it directly.
 			 */
 			ic_proxy_free(placeholder);
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: freed my placeholder",
 						 ic_proxy_client_get_name(client));
 		}
@@ -379,7 +379,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 
 		if (client->pkts)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: transfer %d unhandled pkts to my successor",
 						 ic_proxy_client_get_name(client),
 						 list_length(client->pkts));
@@ -406,7 +406,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 	{
 		ICProxyClient *placeholder;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: transfer %d unhandled pkts to my placeholder",
 					 ic_proxy_client_get_name(client),
 					 list_length(client->pkts));
@@ -449,7 +449,7 @@ ic_proxy_client_blessed_lookup(uv_loop_t *loop, const ICProxyKey *key)
 		client->key = *key;
 		ic_proxy_client_register(client);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: registered as a placeholder",
 					 ic_proxy_client_get_name(client));
 	}
@@ -480,7 +480,7 @@ ic_proxy_client_on_c2p_data_pkt(void *opaque, const void *data, uint16 size)
 {
 	ICProxyClient *client = opaque;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received B2C PKT [%d bytes] from the backend",
 				 ic_proxy_client_get_name(client), size);
 
@@ -564,7 +564,7 @@ ic_proxy_client_on_c2p_data(uv_stream_t *stream,
 					 "ic-proxy: %s: paused already, but still received DATA[%zd bytes] from the backend, state is 0x%08x",
 					 ic_proxy_client_get_name(client), nread, client->state);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received DATA[%zd bytes] from the backend",
 				 ic_proxy_client_get_name(client), nread);
 
@@ -590,7 +590,7 @@ ic_proxy_client_maybe_start_read_data(ICProxyClient *client)
 		 */
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA",
 				 ic_proxy_client_get_name(client));
 
@@ -668,7 +668,7 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
 					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
@@ -684,7 +684,7 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s from the backend",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 
@@ -875,7 +875,7 @@ ic_proxy_client_new(uv_loop_t *loop, bool placeholder)
 static void
 ic_proxy_client_free(ICProxyClient *client)
 {
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: freeing", ic_proxy_client_get_name(client));
 
 	/*
@@ -1143,7 +1143,7 @@ ic_proxy_client_on_p2c_message(ICProxyClient *client, const ICProxyPkt *pkt,
 {
 	if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_BYE))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: received %s",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_pkt_to_str(pkt));
@@ -1154,7 +1154,7 @@ ic_proxy_client_on_p2c_message(ICProxyClient *client, const ICProxyPkt *pkt,
 	}
 	else if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_DATA_ACK))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: received %s, with %d existing unack packets",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_pkt_to_str(pkt),
@@ -1191,7 +1191,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
 					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
@@ -1217,7 +1217,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 	{
 		if (ic_proxy_pkt_is_out_of_date(pkt, &client->key))
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: drop out-of-date %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_pkt_to_str(pkt));
@@ -1228,7 +1228,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 		{
 			Assert(ic_proxy_pkt_is_in_the_future(pkt, &client->key));
 
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: future %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_pkt_to_str(pkt));
@@ -1281,7 +1281,7 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 
 	client->pkts = lappend(client->pkts, pkt);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: cached a %s for future use, %d in the list",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
 				 list_length(client->pkts));
@@ -1301,7 +1301,7 @@ ic_proxy_client_cache_p2c_pkts(ICProxyClient *client, List *pkts)
 
 	client->pkts = list_concat(client->pkts, pkts);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				 "ic-proxy: %s: cached %d pkts for future use, %d in the list",
 				 ic_proxy_client_get_name(client),
 				 list_length(pkts), list_length(client->pkts));
@@ -1354,7 +1354,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 	if (client->pkts == NIL)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: trying to consume the %d cached pkts",
 				 ic_proxy_client_get_name(client), list_length(client->pkts));
 
@@ -1379,7 +1379,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 		ic_proxy_client_on_p2c_data(client, pkt, NULL, NULL);
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: consumed %d cached pkts",
 				 ic_proxy_client_get_name(client), count);
 }
@@ -1390,7 +1390,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 static void
 ic_proxy_client_maybe_send_ack_message(ICProxyClient *client)
 {
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: %d unconsumed packets to the backend",
 				 ic_proxy_client_get_name(client), client->unconsumed);
 
@@ -1430,7 +1430,7 @@ ic_proxy_client_maybe_pause(ICProxyClient *client)
 		client->state |= IC_PROXY_CLIENT_STATE_PAUSED;
 		uv_read_stop((uv_stream_t *) &client->pipe);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: paused", ic_proxy_client_get_name(client));
 	}
 }
@@ -1448,7 +1448,7 @@ ic_proxy_client_maybe_resume(ICProxyClient *client)
 
 		client->state &= ~IC_PROXY_CLIENT_STATE_PAUSED;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: resumed", ic_proxy_client_get_name(client));
 	}
 }

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -344,7 +344,7 @@ ic_proxy_obuf_push(ICProxyOBuf *obuf,
 		/* TODO: should we flush if no data in the packet? */
 		if (obuf->len == obuf->header_size)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: no data to flush");
 		}
 		else

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -316,7 +316,7 @@ ic_proxy_server_client_listener_init(uv_loop_t *loop)
 	ic_proxy_build_server_sock_path(path, sizeof(path));
 
 	/* FIXME: do not unlink here */
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: unlink(%s) ...", path);
 	unlink(path);
 

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -220,7 +220,7 @@ ic_proxy_peer_register(ICProxyPeer *peer)
 		else
 		{
 			/* This is an actual placeholder */
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s(state=0x%08x): found my placeholder %s(state=0x%08x)",
 						 peer->name, peer->state,
 						 placeholder->name, placeholder->state);
@@ -290,13 +290,13 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 	const ICProxyPkt *pkt = data;
 	ICProxyPeer *peer = opaque;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
 					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
@@ -386,7 +386,7 @@ ic_proxy_peer_free(ICProxyPeer *peer)
 {
 	ListCell   *cell;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: freeing", peer->name);
 
 	foreach(cell, peer->reqs)
@@ -513,7 +513,7 @@ ic_proxy_peer_on_sent_hello_ack(void *opaque, const ICProxyPkt *pkt, int status)
 
 	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO_ACK;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA", peer->name);
 
 	/* it's unlikely that the ibuf is non-empty, but clear it for sure */
@@ -547,7 +547,7 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
 					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
@@ -568,7 +568,7 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	 */
 	ic_proxy_peer_register(peer);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s, sending HELLO ACK",
 				 peer->name, ic_proxy_pkt_to_str(pkt));
 
@@ -635,7 +635,7 @@ ic_proxy_peer_read_hello(ICProxyPeer *peer)
 	if (peer->state & IC_PROXY_PEER_STATE_RECEIVING_HELLO)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: waiting for HELLO", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_RECEIVING_HELLO;
@@ -680,7 +680,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
 					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
@@ -694,7 +694,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 		elog(ERROR, "ic-proxy: %s: received invalid HELLO ACK: %s",
 					 peer->name, ic_proxy_pkt_to_str(pkt));
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
 	peer->state |= IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK;
@@ -708,7 +708,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	 */
 	ic_proxy_peer_handle_out_cache(peer);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA", peer->name);
 
 	/* now it's time to receive the normal data */
@@ -769,7 +769,7 @@ ic_proxy_peer_on_sent_hello(void *opaque, const ICProxyPkt *pkt, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: waiting for HELLO ACK", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO;
@@ -803,7 +803,7 @@ ic_proxy_peer_on_connected(uv_connect_t *conn, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: connected, sending HELLO", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_CONNECTED;
@@ -850,7 +850,7 @@ ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
 	peer->state |= IC_PROXY_PEER_STATE_CONNECTING;
 
 	uv_ip4_name(dest, name, sizeof(name));
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: connecting to %s:%d",
 				 peer->name, name, ntohs(dest->sin_port));
 
@@ -881,7 +881,7 @@ ic_proxy_peer_disconnect(ICProxyPeer *peer)
 	if (!(peer->state & IC_PROXY_PEER_STATE_CONNECTING))
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: disconnecting", peer->name);
 	ic_proxy_peer_shutdown(peer);
 }
@@ -897,7 +897,7 @@ ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
 	{
 		ICProxyDelay *delay;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: caching outgoing %s",
 					 peer->name, ic_proxy_pkt_to_str(pkt));
 
@@ -949,7 +949,7 @@ ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
 	if (peer->reqs == NIL)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: trying to consume the %d cached outgoing pkts",
 				 peer->name, list_length(peer->reqs));
 
@@ -969,7 +969,7 @@ ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
 		ic_proxy_free(delay);
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: consumed %d cached pkts",
 				 peer->name, list_length(reqs) - list_length(peer->reqs));
 

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -112,7 +112,7 @@ ic_proxy_pkt_cache_alloc(size_t *pkt_size)
 	memset(cpkt, 0, ic_proxy_pkt_cache.pkt_size);
 #endif
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: pkt-cache: allocated, %d free, %d total",
 				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	return cpkt;
@@ -159,7 +159,7 @@ ic_proxy_pkt_cache_free(void *pkt)
 		ic_proxy_pkt_cache.freelist = cpkt;
 		ic_proxy_pkt_cache.n_free++;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: pkt-cache: recycled, %d free, %d total",
 					 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	}

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -104,7 +104,7 @@ ic_proxy_router_loopback_on_check(uv_check_t *handle)
 		ic_proxy_key_from_p2c_pkt(&key, delay->pkt);
 		client = ic_proxy_client_blessed_lookup(handle->loop, &key);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: router: looped back %s to %s",
 					 ic_proxy_pkt_to_str(delay->pkt),
 					 ic_proxy_client_get_name(client));
@@ -132,7 +132,7 @@ ic_proxy_router_loopback_push(ICProxyPkt *pkt,
 {
 	ICProxyDelay *delay;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: router: looping back %s",
 				 ic_proxy_pkt_to_str(pkt));
 
@@ -224,7 +224,7 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		ic_proxy_key_from_p2c_pkt(&key, pkt);
 		client = ic_proxy_client_blessed_lookup(loop, &key);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt),
 					 ic_proxy_client_get_name(client));
@@ -238,7 +238,7 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		peer = ic_proxy_peer_blessed_lookup(loop,
 											pkt->dstContentId, pkt->dstDbid);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt), peer->name);
 
@@ -259,13 +259,13 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 
 	if (status < 0)
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: router: failed to send %s: %s",
 					 ic_proxy_pkt_to_str(pkt), uv_strerror(status));
 	}
 	else
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: router: sent %s",
 					 ic_proxy_pkt_to_str(pkt));
 	}
@@ -302,7 +302,7 @@ ic_proxy_router_write(uv_stream_t *stream, ICProxyPkt *pkt, int32 offset,
 	ICProxyWriteReq *wreq;
 	uv_buf_t	wbuf;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: router: sending %s", ic_proxy_pkt_to_str(pkt));
 
 	wreq = ic_proxy_new(ICProxyWriteReq);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -573,7 +573,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				elog_node_display(DEBUG3, "slice table", estate->es_sliceTable, true);
 
 			if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-				elog(DEBUG1, "seg%d executing slice%d under root slice%d",
+				elog(LOG, "seg%d executing slice%d under root slice%d",
 					 GpIdentity.segindex,
 					 LocallyExecutingSliceIndex(estate),
 					 RootSliceIndex(estate));

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -356,7 +356,7 @@ execMotionUnsortedReceiver(MotionState *node)
 	{
 #ifdef CDB_MOTION_DEBUG
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			elog(DEBUG4, "motionID=%d saw end of stream", motion->motionID);
+			elog(LOG, "motionID=%d saw end of stream", motion->motionID);
 #endif
 		Assert(node->numTuplesFromAMS == node->numTuplesToParent);
 		Assert(node->numTuplesFromChild == 0);

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -417,10 +417,10 @@ extern uint32 gp_interconnect_id;
 typedef enum GpVars_Verbosity
 {
 	GPVARS_VERBOSITY_UNDEFINED = 0,
-    GPVARS_VERBOSITY_OFF,
+	GPVARS_VERBOSITY_OFF,
 	GPVARS_VERBOSITY_TERSE,
 	GPVARS_VERBOSITY_VERBOSE,
-    GPVARS_VERBOSITY_DEBUG,
+	GPVARS_VERBOSITY_DEBUG,
 } GpVars_Verbosity;
 
 /* Enable single-slice single-row inserts. */
@@ -439,10 +439,7 @@ extern bool gp_enable_direct_dispatch;
  * "OFF"     -> only errors are logged
  * "TERSE"   -> terse logging of routine events, e.g. creation of new qExecs
  * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * "DEBUG"   -> additional events are logged
  */
 extern int gp_log_gang;
 
@@ -453,10 +450,7 @@ extern int gp_log_gang;
  * "OFF"     -> only errors are logged
  * "TERSE"   -> terse logging of routine events
  * "VERBOSE" -> more messages
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * "DEBUG"   -> additional events are logged
  */
 extern int gp_log_fts;
 
@@ -467,10 +461,7 @@ extern int gp_log_fts;
  * "OFF"     -> connection errors are logged
  * "TERSE"   -> terse logging of routine events, e.g. successful connections
  * "VERBOSE" -> most interconnect setup events are logged
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5.
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * "DEBUG"   -> additional events are logged
  */
 extern int gp_log_interconnect;
 


### PR DESCRIPTION
The current implementation had a dependency on log_min_messages for DEBUG level
logs. This facility is used for three GUCs gp_log_fts, gp_log_gang, and
gp_log_interconnect. The intent is to use these GUCs to be able to control the
logging to triage issues for these components. TERSE and VERBOSE modes emitted
messages with LOG level. Though DEBUG emitted messages with DEBUG* levels. This
poses a problem as if wish to enable DEBUG logging for let's say
gp_log_interconnect, need to also set log_min_messages to DEBUG* level. Setting
log_min_messages to DEBUG* has the side effect of enabling logging for more
other components which don't use GPVARS_VERBOSITY facility. Which becomes a
hurdle for enabling in production deployments.

Hence, for simplicity and ease let a single GUC control the logging extent for
these components and decouple the need for setting log_min_messages to DEBUG*
levels. Changed messages to all be logged now at LOG level.