### PR TITLE
[6X] Fix: Redundant indexes cause partition split failed

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -20588,7 +20588,7 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 
 	/*
 	 * For each index on the partitioned table, find a matching one in the
-	 * partition-to-be; if one is not found, create one.
+	 * partition-to-be; if one is not found, error out.
 	 */
 	foreach(cell, idxes)
 	{
@@ -20627,10 +20627,6 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 			Oid			cldIdxId = RelationGetRelid(attachrelIdxRels[i]);
 			Oid			cldConstrOid = InvalidOid;
 
-			/* does this index have a parent?  if so, can't use it */
-			if (has_superclass(cldIdxId))
-				continue;
-
 			if (CompareIndexInfo(attachInfos[i], info,
 								 attachrelIdxRels[i]->rd_indcollation,
 								 idxRel->rd_indcollation,
@@ -20639,6 +20635,17 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 								 attmap,
 								 RelationGetDescr(rel)->natts))
 			{
+				/*
+				 * Does this index have a parent?  if so, this parent index is
+				 * redundant. All redundant indexes have already been removed
+				 * from partition.
+				 */
+				if (has_superclass(cldIdxId))
+				{
+					found = true;
+					continue;
+				}
+
 				/*
 				 * If this index is being created in the parent because of a
 				 * constraint, then the child needs to have a constraint also,

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2896,3 +2896,23 @@ SELECT user_name FROM users_test_1_prt_extra;
  C
 (1 row)
 
+--
+-- Test handling of redundant indexes in SPLIT PARTITION.
+--
+DROP TABLE IF EXISTS partition_test;
+CREATE TABLE partition_test
+(
+  id INT,
+  tm TIMESTAMP
+)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE(tm)
+(
+  PARTITION p2022 START ('2022-01-01'::TIMESTAMP) END ('2023-01-01'::TIMESTAMP),
+  DEFAULT PARTITION extra
+);
+CREATE INDEX partition_test_idx1 ON partition_test(id);
+CREATE INDEX partition_test_idx2 ON partition_test(id);
+ALTER TABLE partition_test SPLIT DEFAULT PARTITION START ('2023-01-01'::TIMESTAMP) END ('2024-01-01'::TIMESTAMP)
+ INTO (PARTITION p2023, DEFAULT PARTITION);
+NOTICE:  dropped partition "extra" for relation "partition_test"

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -1487,3 +1487,26 @@ SELECT user_name FROM users_test_1_prt_p2019;
 SELECT user_name FROM users_test_1_prt_p2020;
 -- Expect C
 SELECT user_name FROM users_test_1_prt_extra;
+
+--
+-- Test handling of redundant indexes in SPLIT PARTITION.
+--
+DROP TABLE IF EXISTS partition_test;
+
+CREATE TABLE partition_test
+(
+  id INT,
+  tm TIMESTAMP
+)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE(tm)
+(
+  PARTITION p2022 START ('2022-01-01'::TIMESTAMP) END ('2023-01-01'::TIMESTAMP),
+  DEFAULT PARTITION extra
+);
+
+CREATE INDEX partition_test_idx1 ON partition_test(id);
+CREATE INDEX partition_test_idx2 ON partition_test(id);
+
+ALTER TABLE partition_test SPLIT DEFAULT PARTITION START ('2023-01-01'::TIMESTAMP) END ('2024-01-01'::TIMESTAMP)
+ INTO (PARTITION p2023, DEFAULT PARTITION);


### PR DESCRIPTION
If partitioned table has two or more indexes on the same column, ALTER
TABLE SPLIT PARTITION will error out:

```sql
DROP TABLE IF EXISTS partition_test;

CREATE TABLE partition_test
(
  id INT,
  tm TIMESTAMP
)
DISTRIBUTED BY (id)
PARTITION BY RANGE(tm)
(
  PARTITION p2022 START ('2022-01-01'::TIMESTAMP) END ('2023-01-01'::TIMESTAMP),
  DEFAULT PARTITION extra
);

CREATE INDEX partition_test_idx1 ON partition_test(id);
CREATE INDEX partition_test_idx2 ON partition_test(id);

-- Report: ERROR:  index like "partition_test_idx2" does not exist on "pg_temp_xxxxxx"
ALTER TABLE partition_test SPLIT DEFAULT PARTITION START ('2023-01-01'::TIMESTAMP) END ('2024-01-01'::TIMESTAMP)
 INTO (PARTITION p2023, DEFAULT PARTITION);
```

The reason is transformIndexConstraints() will remove redundant indexes
so that AttachPartitionEnsureIndexes() reports error because of unmatched
index between the parent table and the new attached partition.

The main branch has no problem because it has a different mechanism for
implementing ADD/SPLIT partition.

ADD/SPLIT partition on 6X uses CREATE TABLE LIKE ... INCLUDING INDEXES
which would remove redundant indexes even in main branch. So this patch
thinks redundant index lost on new partitions is fine instead of keeping
the same behavior with the main branch.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
