### PR TITLE
Docs: few modifications to existing resource group documentation

### DIFF
--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -293,7 +293,7 @@ When you install Greenplum Database, no resource management policy is enabled by
 
 Once enabled, any transaction submitted by a role is directed to the resource group assigned to the role, and is governed by that resource group's concurrency, memory, and CPU limits. 
 
-Greenplum Database creates three default resource groups for roles named `admin_group`, `default_group`, and `system_group`. When you enable resources groups, any role that was not explicitly assigned a resource group is assigned the default group for the role's capability. `SUPERUSER` roles are assigned the `admin_group`, non-admin roles are assigned the group named `default_group`. The resources of the Greenplum Database system processes are assigned to the `system_group`.
+Greenplum Database creates three default resource groups for roles named `admin_group`, `default_group`, and `system_group`. When you enable resources groups, any role that was not explicitly assigned a resource group is assigned the default group for the role's capability. `SUPERUSER` roles are assigned the `admin_group`, non-admin roles are assigned the group named `default_group`. The resources of the Greenplum Database system processes are assigned to the `system_group`. You cannot manually assign any roles to the `system_group`.
 
 The default resource groups `admin_group`, `default_group`, and `system_group`  are created with the following resource limits:
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1314,6 +1314,8 @@ Specifies a fixed amount of memory, in MB, reserved for all queries in a resourc
 
 While `MEMORY LIMIT` applies to queries across sessions, `gp_resgroup_memory_query_fixed_mem` overrides that limit at a session level. Thus, you can use this configuration parameter to adjust query memory budget for a particular session, on an ad hoc basis. 
 
+The value of `gp_resgroup_memory_query_fixed_mem` must be lower than `max_statement_mem`.
+
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
 |0 < integer < INT_MAX| 0 |coordinator, session, user|


### PR DESCRIPTION
This PR adds the following sentences to the existing resource group documentation for Greenplum 7:

- You cannot manually assign roles to the system_group resource group.
- The value of `gp_resgroup_memory_query_fixed_mem` must be lower than `max_statement_mem`.
