### PR TITLE
Docs: reorder of platform requirements 6 x

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.md.hbs
@@ -2,13 +2,7 @@
 
 This topic describes the Greenplum Database 6 platform and operating system software requirements for deploying the software to VMware vSphere, to on-premise hardware, or to public cloud services such as AWS, GCP, or Azure.
 
-{{> 'gpvirtual/vpshere/supported-platforms' }}
-
-## <a id="on-prem"></a> On-Premise Hardware Requirements
-
-This topic describes the Greenplum Database 6 platform and operating system software requirements for deploying to on-premise hardware. It also provides important compatibility information for Greenplum tools and extensions.
-
-### <a id="topic13"></a>Operating Systems 
+## <a id="topic13"></a>Operating System Requirements
 
 Greenplum Database 6 runs on the following operating system platforms:
 
@@ -34,7 +28,7 @@ RHEL 7.3 and CentOS 7.3 resolves the issue.
 
 Greenplum Database server supports TLS version 1.2 on RHEL/CentOS systems, and TLS version 1.3 on Ubuntu systems.
 
-#### <a id="topic_i4k_nlx_zgb"></a>Software Dependencies 
+### <a id="topic_i4k_nlx_zgb"></a>Software Dependencies 
 
 Greenplum Database 6 requires the following software packages on RHEL/CentOS 6/7 systems which are installed automatically as dependencies when you install the Greenplum RPM package\):
 
@@ -100,83 +94,16 @@ Greenplum Database 6 uses Python 2.7.18, which is included with the product inst
 
 > **Important** For all Greenplum Database host systems, if SELinux is enabled in `Enforcing` mode then the Greenplum process and users can operate successfully in the default `Unconfined` context. If increased confinement is required, then you must configure SELinux contexts, policies, and domains based on your security requirements, and test your configuration to ensure there is no functionality or performance impact to Greenplum Database. Similarly, you should either deactivate or configure firewall software as needed to allow communication between Greenplum hosts. See [Deactivate or Configure SELinux](prep_os.html).
 
-#### <a id="topic_xbl_mkx_zgb"></a>Java 
+### <a id="topic_xbl_mkx_zgb"></a>Java 
 
 Greenplum Databased 6 supports these Java versions for PL/Java and PXF:
 
 -   Open JDK 8 or Open JDK 11, available from [AdoptOpenJDK](https://adoptopenjdk.net)
 -   Oracle JDK 8 or Oracle JDK 11
 
-### <a id="topic_tnl_3mx_zgb"></a>Hardware and Network 
+## <a id="topic31"></a>VMware Greenplum Tools and Extensions Compatibility
 
-The following table lists minimum recommended specifications for hardware servers intended to support Greenplum Database on Linux systems in a production environment. All host servers in your Greenplum Database system must have the same hardware and software configuration. Greenplum also provides hardware build guides for its certified hardware platforms. It is recommended that you work with a Greenplum Systems Engineer to review your anticipated environment to ensure an appropriate hardware configuration for Greenplum Database.
-
-<div class="tablenoborder"><table cellpadding="4" cellspacing="0" summary="" id="topic_tnl_3mx_zgb__ji162790" class="table" frame="border" border="1" rules="all"><caption><span class="tablecap">Minimum Hardware Requirements</span></caption><colgroup><col style="width:120pt" /><col style="width:255pt" /></colgroup><tbody class="tbody">
-<tr class="row">
-<td class="entry nocellnorowborder" style="vertical-align:top;">Minimum CPU</td>
-<td class="entry cell-norowborder" style="vertical-align:top;">Any x86_64 compatible CPU</td>
-</tr>
-<tr class="row">
-<td class="entry nocellnorowborder" style="vertical-align:top;">Minimum Memory</td>
-<td class="entry cell-norowborder" style="vertical-align:top;">16 GB RAM per server</td>
-</tr>
-<tr class="row">
-<td class="entry nocellnorowborder" style="vertical-align:top;">Disk Space Requirements</td>
-<td class="entry cell-norowborder" style="vertical-align:top;">
-<ul class="ul" id="topic_tnl_3mx_zgb__ul_us1_b4n_r4">
-<li class="li">150MB per host for Greenplum installation</li>
-<li class="li">Approximately 300MB per segment instance for metadata</li>
-<li class="li">Cap disk capacity at 70% full to accommodate temporary files and prevent performance degradation</li>
-</ul>
-</td>
-</tr>
-<tr class="row">
-<td class="entry row-nocellborder" style="vertical-align:top;">Network Requirements</td>
-<td class="entry cellrowborder" style="vertical-align:top;">10 Gigabit Ethernet within the array<p class="p">NIC bonding is
-                  recommended when multiple interfaces are present</p>
-<p class="p">Greenplum Database can use
-                  either IPV4 or IPV6 protocols.</p>
-</td>
-</tr>
-</tbody>
-</table>
-</div>
-
-#### <a id="topic_elb_4ss_n4b"></a>VMware Greenplum on DCA Systems 
-
-You must run VMware Greenplum version 6.9 or later on Dell EMC DCA systems, with software version 4.2.0.0 and later.
-
-### <a id="topic_pnz_5zd_xs"></a>Storage 
-
-The only file system supported for running Greenplum Database is the XFS file system. All other file systems are explicitly *not* supported by VMware.
-
-Greenplum Database is supported on network or shared storage if the shared storage is presented as a block device to the servers running Greenplum Database and the XFS file system is mounted on the block device. Network file systems are *not* supported. When using network or shared storage, Greenplum Database mirroring must be used in the same way as with local storage, and no modifications may be made to the mirroring scheme or the recovery scheme of the segments.
-
-Other features of the shared storage such as de-duplication and/or replication are not directly supported by Greenplum Database, but may be used with support of the storage vendor as long as they do not interfere with the expected operation of Greenplum Database at the discretion of VMware.
-
-Greenplum Database can be deployed to virtualized systems only if the storage is presented as block devices and the XFS file system is mounted for the storage of the segment directories.
-
-Greenplum Database is supported on Amazon Web Services \(AWS\) servers using either Amazon instance store \(Amazon uses the volume names `ephemeral[0-23]`\) or Amazon Elastic Block Store \(Amazon EBS\) storage. If using Amazon EBS storage the storage should be RAID of Amazon EBS volumes and mounted with the XFS file system for it to be a supported configuration.
-
-#### <a id="fixme"></a>Data Domain Boost \(VMware Greenplum\) 
-
-VMware Greenplum 6 supports Data Domain Boost for backup on Red Hat Enterprise Linux. This table lists the versions of Data Domain Boost SDK and DDOS supported by VMware Greenplum 6.
-
-|VMware Greenplum|Data Domain Boost|DDOS|
-|---------------|-----------------|----|
-|6.x|3.3|6.1 \(all versions\), 6.0 \(all versions\)|
-
-> **Note** In addition to the DDOS versions listed in the previous table, VMware Greenplum supports all minor patch releases \(fourth digit releases\) later than the certified version.
-
-### <a id="topic31"></a>VMware Greenplum Tools and Extensions Compatibility 
-
--   [Client Tools](#topic32) \(VMware Greenplum\)
--   [Extensions](#topic_eyc_l2h_zz)
--   [Data Connectors](#topic_xpf_25b_hbb)
--   [VMware Greenplum Text](#topic_ncl_w1d_r1b)
--   [Greenplum Command Center](#topic_zkq_j5b_hbb)
-
-#### <a id="topic32"></a>Client Tools 
+### <a id="topic32"></a>Client Tools 
 
 VMware releases a Clients tool package on various platforms that can be used to access Greenplum Database from a client system. The Greenplum 6 Clients tool package is supported on the following platforms:
 
@@ -193,7 +120,7 @@ VMware releases a Clients tool package on various platforms that can be used to 
 
 The Greenplum 6 Clients package includes the client and loader programs provided in the Greenplum 5 packages plus the addition of database/role/language commands and the Greenplum Streaming Server command utilities. Refer to [Greenplum Client and Loader Tools Package](/vmware/client_tool_guides/intro.html) for installation and usage details of the Greenplum 6 Client tools.
 
-#### <a id="topic_eyc_l2h_zz"></a>Extensions 
+### <a id="topic_eyc_l2h_zz"></a>Extensions  
 
 This table lists the versions of the Greenplum Extensions that are compatible with this release of Greenplum Database 6.
 
@@ -209,7 +136,7 @@ This table lists the versions of the Greenplum Extensions that are compatible wi
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d78288e683 "><a class="xref" href="../analytics/pl_java.html">PL/Java</a></td>
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d78288e686 ">2.0.4</td>
 <td class="entry cell-norowborder" style="vertical-align:top;" headers="d78288e689 ">Supports Java 8 and 11.</td>
-</tr>
+</tr>           
 <tr class="row">
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d78288e683 "><a class="xref" href="../install_guide/install_python_dsmod.html">Python Data Science Module Package</a></td>
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d78288e686 ">2.0.6</td>
@@ -279,7 +206,7 @@ These Greenplum Database extensions are installed with Greenplum Database
 -   PL/Python Extension
 -   pgcrypto Extension
 
-#### <a id="topic_xpf_25b_hbb"></a>Data Connectors 
+### <a id="topic_xpf_25b_hbb"></a>Data Connectors
 
 -   Greenplum Platform Extension Framework \(PXF\) - PXF provides access to Hadoop, object store, and SQL external data stores. Refer to [Accessing External Data with PXF](../admin_guide/external/pxf-overview.html) in the *Greenplum Database Administrator Guide* for PXF configuration and usage information.
 
@@ -299,15 +226,76 @@ These Greenplum Database extensions are installed with Greenplum Database
 
 Connecting to IBM Cognos software with an ODBC driver is not supported. Greenplum Database supports connecting to IBM Cognos software with the DataDirect JDBC driver for VMware Greenplum. This driver is available as a download from [VMware Tanzu Network](https://network.pivotal.io/products/pivotal-gpdb).
 
-#### <a id="topic_ncl_w1d_r1b"></a>VMware Greenplum Text 
+### <a id="topic_ncl_w1d_r1b"></a>VMware Greenplum Text
 
 VMware Greenplum 6.0 through 6.4 are compatible with VMware Greenplum Text 3.3.1 through 3.4.1. VMware Greenplum 6.5 and later are compatible with VMware Greenplum Text 3.4.2 and later. See the [Greenplum Text documentation](http://docs.vmware.com/en/VMware-Greenplum-Text/index.html) for additional compatibility information.
 
-#### <a id="topic_zkq_j5b_hbb"></a>Greenplum Command Center 
+### <a id="topic_zkq_j5b_hbb"></a>Greenplum Command Center
 
 VMware Greenplum 6.15 is compatible only with VMware Greenplum Command Center 6.4.0 and later. See the [Greenplum Command Center documentation](http://docs.vmware.com/en/VMware-Greenplum-Command-Center/index.html) for additional compatibility information.
 
-### <a id="topic36"></a>Hadoop Distributions 
+## <a id="topic_tnl_3mx_zgb"></a>Hardware Requirements
+
+The following table lists minimum recommended specifications for hardware servers intended to support Greenplum Database on Linux systems in a production environment. All host servers in your Greenplum Database system must have the same hardware and software configuration. Greenplum also provides hardware build guides for its certified hardware platforms. It is recommended that you work with a Greenplum Systems Engineer to review your anticipated environment to ensure an appropriate hardware configuration for Greenplum Database.
+
+<div class="tablenoborder"><table cellpadding="4" cellspacing="0" summary="" id="topic_tnl_3mx_zgb__ji162790" class="table" frame="border" border="1" rules="all"><caption><span class="tablecap">Minimum Hardware Requirements</span></caption><colgroup><col style="width:120pt" /><col style="width:255pt" /></colgroup><tbody class="tbody">
+<tr class="row">
+<td class="entry nocellnorowborder" style="vertical-align:top;">Minimum CPU</td>
+<td class="entry cell-norowborder" style="vertical-align:top;">Any x86_64 compatible CPU</td>
+</tr>
+<tr class="row">
+<td class="entry nocellnorowborder" style="vertical-align:top;">Minimum Memory</td>
+<td class="entry cell-norowborder" style="vertical-align:top;">16 GB RAM per server</td>
+</tr>
+<tr class="row">
+<td class="entry nocellnorowborder" style="vertical-align:top;">Disk Space Requirements</td>
+<td class="entry cell-norowborder" style="vertical-align:top;">
+<ul class="ul" id="topic_tnl_3mx_zgb__ul_us1_b4n_r4">
+<li class="li">150MB per host for Greenplum installation</li>
+<li class="li">Approximately 300MB per segment instance for metadata</li>
+<li class="li">Cap disk capacity at 70% full to accommodate temporary files and prevent performance degradation</li>
+</ul>
+</td>
+</tr>
+<tr class="row">
+<td class="entry row-nocellborder" style="vertical-align:top;">Network Requirements</td>
+<td class="entry cellrowborder" style="vertical-align:top;">10 Gigabit Ethernet within the array<p class="p">NIC bonding is
+                  recommended when multiple interfaces are present</p>
+<p class="p">Greenplum Database can use
+                  either IPV4 or IPV6 protocols.</p>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+
+### <a id="topic_elb_4ss_n4b"></a>VMware Greenplum on DCA Systems 
+
+You must run VMware Greenplum version 6.9 or later on Dell EMC DCA systems, with software version 4.2.0.0 and later.
+
+## <a id="topic_pnz_5zd_xs"></a>Storage 
+
+The only file system supported for running Greenplum Database is the XFS file system. All other file systems are explicitly *not* supported by VMware.
+
+Greenplum Database is supported on network or shared storage if the shared storage is presented as a block device to the servers running Greenplum Database and the XFS file system is mounted on the block device. Network file systems are *not* supported. When using network or shared storage, Greenplum Database mirroring must be used in the same way as with local storage, and no modifications may be made to the mirroring scheme or the recovery scheme of the segments.
+
+Other features of the shared storage such as de-duplication and/or replication are not directly supported by Greenplum Database, but may be used with support of the storage vendor as long as they do not interfere with the expected operation of Greenplum Database at the discretion of VMware.
+
+Greenplum Database can be deployed to virtualized systems only if the storage is presented as block devices and the XFS file system is mounted for the storage of the segment directories.
+
+Greenplum Database is supported on Amazon Web Services \(AWS\) servers using either Amazon instance store \(Amazon uses the volume names `ephemeral[0-23]`\) or Amazon Elastic Block Store \(Amazon EBS\) storage. If using Amazon EBS storage the storage should be RAID of Amazon EBS volumes and mounted with the XFS file system for it to be a supported configuration.
+
+### <a id="fixme"></a>Data Domain Boost \(VMware Greenplum\) 
+
+VMware Greenplum 6 supports Data Domain Boost for backup on Red Hat Enterprise Linux. This table lists the versions of Data Domain Boost SDK and DDOS supported by VMware Greenplum 6.
+
+|VMware Greenplum|Data Domain Boost|DDOS|
+|---------------|-----------------|----|
+|6.x|3.3|6.1 \(all versions\), 6.0 \(all versions\)|
+
+> **Note** In addition to the DDOS versions listed in the previous table, VMware Greenplum supports all minor patch releases \(fourth digit releases\) later than the certified version.
+
+## <a id="topic36"></a>Hadoop Distributions 
 
 Greenplum Database provides access to HDFS with the [Greenplum Platform Extension Framework \(PXF\)](https://docs.vmware.com/en/VMware-Greenplum-Platform-Extension-Framework/index.html).
 
@@ -320,6 +308,8 @@ PXF can use Cloudera, Hortonworks Data Platform, MapR, and generic Apache Hadoop
 |5.8.1|2.x|1.x|1.3.2|
 
 > **Note** If you plan to access JSON format data stored in a Cloudera Hadoop cluster, PXF requires a Cloudera version 5.8 or later Hadoop distribution.
+
+{{> 'gpvirtual/vpshere/supported-platforms' }}
 
 ## <a id="public-cloud"></a>Public Cloud Requirements
 
@@ -347,10 +337,6 @@ The disk settings for cloud deployments are the same as on-premise with a few mo
 -  Use mq-deadline instead of the deadline scheduler for the R5 series instance type in AWS
 -  Use a swap disk per VM (32GB size works well)
 
-### <a id="cd-security"></a>Security
-
-It is highly encouraged to deactivate SSH password authentication to the virtual machines in the cloud and use SSH keys instead.  Using MD5-encrypted passwords for Greenplum Database is also a good practice.
-
 ### <a id="aws"></a>Amazon Web Services (AWS)
 
 #### <a id="aws-vm-type"></a>Virtual Machine Type
@@ -368,7 +354,6 @@ This variable is pretty simple.  Greenplum needs at least 8GB of RAM per segment
 AWS provides 25Gbit network performance on the largest instance types, but the network is typically not the bottleneck in AWS. The "up to 10Gbit" network is sufficient in AWS.
 
 Installing network drivers in the VM is also required in AWS, and depends on the instance type.  Some instance types use an Intel driver while others use an Amazon ENA driver.  Loading the driver requires modifying the machine image (AMI) to take advantage of the driver.
-
 
 #### <a id="storage"></a>Storage
 
@@ -426,7 +411,6 @@ Standard (HDD) and SSD disks are available in GCP.  SSD is slightly faster in te
 The biggest obstacle to maximizing storage performance is the throughput limit placed on every virtual machine.  Unlike AWS and Azure, the storage throughput limit is relatively low, consistent across all instance types, and only a single disk is needed to reach the VM limit.  
 
 ![GCP disk read/write rates](./graphics/gcp-disk-rates.png)
-
 
 #### <a id="gcp-recommend"></a>GCP Recommendations
 


### PR DESCRIPTION
This PR changes the order of the different subtopics in the Platform Requirements page, in order to make it easier for the user to identify them.
It removes the "On premise hardware requirements" as OS, tools/extensions, hardware, storage and hadoop requirements are common for any kind of installation.
Bringing Cloud and vSphere to the bottom of the page.

Test site: https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-platformreq-6X/greenplum-database/install_guide-platform-requirements-overview.html
