### PR TITLE
Allow ORCA plans with empty target list

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5402,7 +5402,16 @@ List *
 CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols(
 	List *target_list, const IMDRelation *md_rel)
 {
-	GPOS_ASSERT(nullptr != target_list);
+	// There are cases where target list can be null
+	// Eg. insert rows with no columns into a table with no columns
+	//
+	// create table foo();
+	// insert into foo default values;
+	if (nullptr == target_list)
+	{
+		return nullptr;
+	}
+
 	GPOS_ASSERT(gpdb::ListLength(target_list) <= md_rel->ColumnCount());
 
 	List *result_list = NIL;

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -645,3 +645,17 @@ select * from foo;
 
 drop table foo;
 drop table bar;
+-- This test is to verify ORCA can generate plans with empty
+-- target lists. This can happen when inserting rows with no
+-- columns into a table with no columns
+create table test();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+explain (analyze, costs off, timing off, summary off) insert into test default values;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Insert on test (actual rows=0 loops=1)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1) (actual rows=1 loops=1)
+         ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -639,3 +639,20 @@ select * from foo;
 
 drop table foo;
 drop table bar;
+-- This test is to verify ORCA can generate plans with empty
+-- target lists. This can happen when inserting rows with no
+-- columns into a table with no columns
+create table test();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+explain (analyze, costs off, timing off, summary off) insert into test default values;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Insert on test (actual rows=0 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
+               ->  Result (actual rows=1 loops=1)
+                     One-Time Filter: (gp_execution_segment() = 2)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+

--- a/src/test/regress/sql/bfv_dml.sql
+++ b/src/test/regress/sql/bfv_dml.sql
@@ -355,3 +355,9 @@ delete from foo using (select a from foo union all select b from bar) v;
 select * from foo;
 drop table foo;
 drop table bar;
+
+-- This test is to verify ORCA can generate plans with empty
+-- target lists. This can happen when inserting rows with no
+-- columns into a table with no columns
+create table test();
+explain (analyze, costs off, timing off, summary off) insert into test default values;


### PR DESCRIPTION
Currently, in constructing the target list for a DML statement, we require the target list to be not NULL. If the target list is NULL, we fall back in the debug build. This PR changes this behavior by removing the assertion that the target list has to be non-NULL. One example of an empty target list is inserting rows without columns into tables without columns.