### PR TITLE
Fix warning: 'gp_test_options' defined but not used

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -52,8 +52,6 @@
 #define GP_SEGMENTID_TYPCOLL 0
 #define GP_SEGMENTID_OPFAMILY 1977	/* integer_ops */
 
-static char *gp_test_options = "";
-
 /* PRINT_DISPATCH_DECISIONS_STRING; */
 
 /**


### PR DESCRIPTION
#15925 removes dead function `FinalizeDirectDispatchDataForSlice()`.
Var `gp_test_options` becomes useless and causes this warning.
Delete the unused var.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>