### PR TITLE
Fix warning of gpfdist: passing argument 2 of 'pg_snprintf' makes integer from pointer without a cast

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3414,7 +3414,7 @@ int check_output_to_file(request_t *r, int wrote)
 	else
 	{
 		gwarning(r, "handle_post_request, left incomplete line: %d bytes", *buftop - wrote);
-		snprintf(error_msg, "Incomplete data written into file, left bytes: %d bytes", *buftop - wrote);
+		snprintf(error_msg, sizeof(error_msg), "Incomplete data written into file, left bytes: %d bytes", *buftop - wrote);
 		request_end(r, ERROR_CODE_GENERIC, error_msg);
 		return -1;
 	}


### PR DESCRIPTION

This warning is introduced by this [commit](https://github.com/greenplum-db/gpdb/commit/f0bf2c81913ec22addedcbd6b5b97032e4168577)

`snprintf()` or `pg_snprintf() `misses the input var `size_t count`.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>