### PR TITLE
Fix: BaseException.message deprecated since Python 2.6

### DIFF
--- a/gpMgmt/sbin/gpconfig_helper.py
+++ b/gpMgmt/sbin/gpconfig_helper.py
@@ -126,7 +126,7 @@ def main():
             return
         except Exception as err:
             sys.stderr.write("Failed to get value for parameter '%s' in file %s due to: %s" % (
-                options.get_parameter, options.file, err.message))
+                options.get_parameter, options.file, str(err)))
             sys.exit(1)
 
     if options.remove_parameter:
@@ -135,7 +135,7 @@ def main():
             return
         except Exception as err:
             sys.stderr.write("Failed to remove parameter '%s' in file %s due to: %s" %
-                             (options.remove_parameter, options.file, err.message))
+                             (options.remove_parameter, options.file, str(err)))
             sys.exit(1)
 
     if options.add_parameter:
@@ -145,7 +145,7 @@ def main():
             return
         except Exception as err:
             sys.stderr.write("Failed to add parameter '%s' in file %s due to: %s" %
-                             (options.add_parameter, options.file, err.message))
+                             (options.add_parameter, options.file, str(err)))
             sys.exit(1)
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2027,7 +2027,7 @@ def impl(context, type):
         result = curs.fetchall()
         segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:
-        raise Exception("Could not retrieve segment information: %s" % e.message)
+        raise Exception("Could not retrieve segment information: %s" % str(e))
     finally:
         conn.close()
 
@@ -2070,7 +2070,7 @@ def impl(context, filename, some, output):
         result = curs.fetchall()
         segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:
-        raise Exception("Could not retrieve segment information: %s" % e.message)
+        raise Exception("Could not retrieve segment information: %s" % str(e))
     finally:
         conn.close()
 
@@ -2116,7 +2116,7 @@ def impl(context, filename, contain, output):
         result = curs.fetchall()
         segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:
-        raise Exception("Could not retrieve segment information: %s" % e.message)
+        raise Exception("Could not retrieve segment information: %s" % str(e))
     finally:
         conn.close()
 
@@ -2142,7 +2142,7 @@ def impl(context, filename):
             result = curs.fetchall()
             segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:
-        raise Exception("Could not retrieve segment information: %s" % e.message)
+        raise Exception("Could not retrieve segment information: %s" % str(e))
 
     for info in segment_info:
         host, datadir = info


### PR DESCRIPTION
Long log:

`BaseException.message` was deprecated since Python 2.6 and removed in Python 3.
Please refer to [stackoverflow link](https://stackoverflow.com/questions/13063212/deprecationwarning-baseexception-message-has-been-deprecated-as-of-python-2-6-e
)
This is a tiny example:
```
def test_func():
    if 1 == 2:
        allen_dic = {}  # trigger an exception
    allen_dic['allen'] = 'handsome'

try:
    test_func()
except Exception as e:
    raise Exception("Error msg: %s" % e.message)
```

Run the example in _Python3_, error result is shown as below:
```
Traceback (most recent call last):
  File "hello.py", line 9, in <module>
    raise Exception("Error msg: %s" % e.message)
AttributeError: 'UnboundLocalError' object has no attribute 'message'
```

**Solution**: substitute `str(e)` for `e.message`


Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>