### PR TITLE
[Backport] Reorder scalar comparison expression in case of cast (#15880)

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
@@ -369,10 +369,10 @@
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                   <dxl:If TypeMdid="0.1043.1.0">
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB2FiYw==" LintValue="578839396"/>
                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                         <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="14"/>
                       </dxl:Cast>
+                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB2FiYw==" LintValue="578839396"/>
                     </dxl:Comparison>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="14"/>
                     <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABmNk" LintValue="538477356"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vc-vc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vc-vc.mdp
@@ -273,7 +273,7 @@
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.057401" Rows="1.000000" Width="6"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.034418" Rows="1.000000" Width="6"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -287,7 +287,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.057379" Rows="1.000000" Width="6"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.034395" Rows="1.000000" Width="6"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -341,7 +341,7 @@
           </dxl:TableScan>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.017761" Rows="400.000000" Width="3"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.017022" Rows="1.000000" Width="3"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="a">
@@ -350,10 +350,10 @@
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUs=" LintValue="160784940"/>
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                   <dxl:Ident ColId="8" ColName="a" TypeMdid="0.1043.1.0"/>
                 </dxl:Cast>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUs=" LintValue="160784940"/>
               </dxl:Comparison>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="6.40981.1.0" TableName="infer_vc">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFWithCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFWithCast.mdp
@@ -276,10 +276,10 @@ explain select * from L where 2::numeric is distinct from b::numeric;
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:IsDistinctFrom OperatorMdid="0.1752.1.0">
-                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAACAA==" DoubleValue="2.000000"/>
                 <dxl:Cast TypeMdid="0.1700.1.0" FuncId="0.1740.1.0">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:Cast>
+                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAACAA==" DoubleValue="2.000000"/>
               </dxl:IsDistinctFrom>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="6.311296.1.0" TableName="l">

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCastUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCastUtils.h
@@ -50,6 +50,9 @@ public:
 	// check whether the given expression is a cast of something
 	static BOOL FScalarCast(CExpression *pexpr);
 
+	// check whether the given expression is a cast of ident
+	static BOOL FScalarCastIdent(CExpression *pexpr);
+
 	// return the given expression without any binary coercible casts
 	// that exist on the top
 	static CExpression *PexprWithoutBinaryCoercibleCasts(CExpression *pexpr);

--- a/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
@@ -170,6 +170,14 @@ CCastUtils::FScalarCast(CExpression *pexpr)
 	return COperator::EopScalarCast == pop->Eopid();
 }
 
+BOOL
+CCastUtils::FScalarCastIdent(CExpression *pexpr)
+{
+	GPOS_ASSERT(NULL != pexpr);
+
+	return FScalarCast(pexpr) && CUtils::FScalarIdent((*pexpr)[0]);
+}
+
 // return the given expression without any binary coercible casts
 // that exist on the top
 CExpression *

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -16,6 +16,7 @@
 #include "gpos/common/CAutoRef.h"
 #include "gpos/common/CAutoTimer.h"
 
+#include "gpopt/base/CCastUtils.h"
 #include "gpopt/base/CColRefSetIter.h"
 #include "gpopt/base/CColRefTable.h"
 #include "gpopt/base/CConstraintInterval.h"
@@ -2609,7 +2610,8 @@ CExpressionPreprocessor::PexprPruneProjListProjectOrGbAgg(
 	return pexprResult;
 }
 
-// reorder the child for scalar comparision to ensure that left child is a scalar ident and right child is a scalar const if not
+// reorder the child for scalar comparision to ensure that left child is a scalar ident
+// or cast(ident) and right child is a scalar const
 CExpression *
 CExpressionPreprocessor::PexprReorderScalarCmpChildren(CMemoryPool *mp,
 													   CExpression *pexpr)
@@ -2624,7 +2626,11 @@ CExpressionPreprocessor::PexprReorderScalarCmpChildren(CMemoryPool *mp,
 		CExpression *pexprLeft = (*pexpr)[0];
 		CExpression *pexprRight = (*pexpr)[1];
 
-		if (CUtils::FScalarConst(pexprLeft) && CUtils::FScalarIdent(pexprRight))
+		// left side is const
+		// right side is either ident, or, cast of ident
+		if (CUtils::FScalarConst(pexprLeft) &&
+			(CUtils::FScalarIdent(pexprRight) ||
+			 CCastUtils::FScalarCastIdent(pexprRight)))
 		{
 			CScalarCmp *popScalarCmpCommuted =
 				(dynamic_cast<CScalarCmp *>(pop))->PopCommutedOp(mp, pop);

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -771,3 +771,130 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+-- The following tests are to verify a fix that allows ORCA to
+-- choose the bitmap index scan alternative when the predicate
+-- is in the form of `value operator cast(column)`. The fix
+-- converts the scalar comparison expression to the more common 
+-- form of `cast(column) operator value` in the preprocessor.
+-- Each test includes two queries. One query's predicate has 
+-- the column on the left side, and the other has the column
+-- on the right side. We expect the two queries to generate
+-- identical plans with bitmap index scan.
+-- Index only scan will probably be selected once index only
+-- scan in enabled for AO tables in ORCA. To prevent retain
+-- the bitmap scan alternative, turn off index only scan.
+set optimizer_enable_indexonlyscan=off;
+-- Test AO table
+-- Index scan is disabled in AO table, so bitmap scan is the
+-- most performant
+create table ao_tbl (
+    path_hash character varying(10)
+) with (appendonly='true');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'path_hash' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index ao_idx on ao_tbl using btree (path_hash);
+insert into ao_tbl select 'abc' from generate_series(1,20) i;
+analyze ao_tbl;
+-- identical plans
+explain select * from ao_tbl where path_hash = 'ABC'; 
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=100.15..200.16 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=100.15..200.16 rows=1 width=4)
+         Recheck Cond: ((path_hash)::text = 'ABC'::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..100.14 rows=1 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain select * from ao_tbl where 'ABC' = path_hash;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=100.15..200.16 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=100.15..200.16 rows=1 width=4)
+         Recheck Cond: ('ABC'::text = (path_hash)::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..100.14 rows=1 width=0)
+               Index Cond: ('ABC'::text = (path_hash)::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+-- Test AO partition table
+-- Dynamic index scan is disabled in AO table, so dynamic bitmap
+-- scan is the most performant
+create table part_tbl (
+    path_hash character varying(10)
+) partition by list(path_hash) 
+          (partition pics values('a') , 
+          default partition other with (appendonly='true'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'path_hash' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_pics" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_other" for table "part_tbl"
+create index part_idx on part_tbl using btree (path_hash);
+insert into part_tbl select 'abc' from generate_series(1,20) i;
+analyze part_tbl;
+-- identical plans
+explain select * from part_tbl where path_hash = 'ABC'; 
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=100.15..200.16 rows=1 width=4)
+   ->  Append  (cost=100.15..200.16 rows=1 width=4)
+         ->  Bitmap Heap Scan on part_tbl_1_prt_other  (cost=100.15..200.16 rows=1 width=4)
+               Recheck Cond: ((path_hash)::text = 'ABC'::text)
+               ->  Bitmap Index Scan on part_tbl_1_prt_other_path_hash_idx  (cost=0.00..100.14 rows=1 width=0)
+                     Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from part_tbl where 'ABC' = path_hash; 
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=100.15..200.16 rows=1 width=4)
+   ->  Append  (cost=100.15..200.16 rows=1 width=4)
+         ->  Bitmap Heap Scan on part_tbl_1_prt_other  (cost=100.15..200.16 rows=1 width=4)
+               Recheck Cond: ('ABC'::text = (path_hash)::text)
+               ->  Bitmap Index Scan on part_tbl_1_prt_other_path_hash_idx  (cost=0.00..100.14 rows=1 width=0)
+                     Index Cond: ('ABC'::text = (path_hash)::text)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- Test table indexed on two columns
+-- Two indices allow ORCA to generate the bitmap scan alternative
+create table two_idx_tbl (x varchar(10), y varchar(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index x_idx on two_idx_tbl using btree (x);
+create index y_idx on two_idx_tbl using btree (y);
+insert into two_idx_tbl select 'aa', 'bb' from generate_series(1,10000) i;
+analyze two_idx_tbl;
+-- encourage bitmap scan by discouraging index scan
+set optimizer_enable_indexscan=off;
+-- identical plans
+explain select * from two_idx_tbl where x = 'cc' or y = 'dd';
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.34..300.35 rows=1 width=6)
+   ->  Bitmap Heap Scan on two_idx_tbl  (cost=200.34..300.35 rows=1 width=6)
+         Recheck Cond: (((x)::text = 'cc'::text) OR ((y)::text = 'dd'::text))
+         ->  BitmapOr  (cost=200.34..200.34 rows=1 width=0)
+               ->  Bitmap Index Scan on x_idx  (cost=0.00..100.17 rows=1 width=0)
+                     Index Cond: ((x)::text = 'cc'::text)
+               ->  Bitmap Index Scan on y_idx  (cost=0.00..100.17 rows=1 width=0)
+                     Index Cond: ((y)::text = 'dd'::text)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.34..300.35 rows=1 width=6)
+   ->  Bitmap Heap Scan on two_idx_tbl  (cost=200.34..300.35 rows=1 width=6)
+         Recheck Cond: (('cc'::text = (x)::text) OR ('dd'::text = (y)::text))
+         ->  BitmapOr  (cost=200.34..200.34 rows=1 width=0)
+               ->  Bitmap Index Scan on x_idx  (cost=0.00..100.17 rows=1 width=0)
+                     Index Cond: ('cc'::text = (x)::text)
+               ->  Bitmap Index Scan on y_idx  (cost=0.00..100.17 rows=1 width=0)
+                     Index Cond: ('dd'::text = (y)::text)
+ Optimizer: Postgres query optimizer
+(9 rows)
+

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -758,3 +758,134 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+-- The following tests are to verify a fix that allows ORCA to
+-- choose the bitmap index scan alternative when the predicate
+-- is in the form of `value operator cast(column)`. The fix
+-- converts the scalar comparison expression to the more common 
+-- form of `cast(column) operator value` in the preprocessor.
+-- Each test includes two queries. One query's predicate has 
+-- the column on the left side, and the other has the column
+-- on the right side. We expect the two queries to generate
+-- identical plans with bitmap index scan.
+-- Index only scan will probably be selected once index only
+-- scan in enabled for AO tables in ORCA. To prevent retain
+-- the bitmap scan alternative, turn off index only scan.
+set optimizer_enable_indexonlyscan=off;
+-- Test AO table
+-- Index scan is disabled in AO table, so bitmap scan is the
+-- most performant
+create table ao_tbl (
+    path_hash character varying(10)
+) with (appendonly='true');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'path_hash' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index ao_idx on ao_tbl using btree (path_hash);
+insert into ao_tbl select 'abc' from generate_series(1,20) i;
+analyze ao_tbl;
+-- identical plans
+explain select * from ao_tbl where path_hash = 'ABC'; 
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.96 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=0.00..387.96 rows=1 width=4)
+         Recheck Cond: ((path_hash)::text = 'ABC'::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+explain select * from ao_tbl where 'ABC' = path_hash;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.96 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=0.00..387.96 rows=1 width=4)
+         Recheck Cond: ((path_hash)::text = 'ABC'::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+-- Test AO partition table
+-- Dynamic index scan is disabled in AO table, so dynamic bitmap
+-- scan is the most performant
+create table part_tbl (
+    path_hash character varying(10)
+) partition by list(path_hash) 
+          (partition pics values('a') , 
+          default partition other with (appendonly='true'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'path_hash' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_pics" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_other" for table "part_tbl"
+create index part_idx on part_tbl using btree (path_hash);
+insert into part_tbl select 'abc' from generate_series(1,20) i;
+analyze part_tbl;
+-- identical plans
+explain select * from part_tbl where path_hash = 'ABC'; 
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.97 rows=1 width=4)
+   ->  Sequence  (cost=0.00..387.97 rows=1 width=4)
+         ->  Partition Selector for part_tbl (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Bitmap Heap Scan on part_tbl (dynamic scan id: 1)  (cost=0.00..387.97 rows=1 width=4)
+               Recheck Cond: ((path_hash)::text = 'ABC'::text)
+               ->  Dynamic Bitmap Index Scan on part_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain select * from part_tbl where 'ABC' = path_hash; 
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.97 rows=1 width=4)
+   ->  Sequence  (cost=0.00..387.97 rows=1 width=4)
+         ->  Partition Selector for part_tbl (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Bitmap Heap Scan on part_tbl (dynamic scan id: 1)  (cost=0.00..387.97 rows=1 width=4)
+               Recheck Cond: ((path_hash)::text = 'ABC'::text)
+               ->  Dynamic Bitmap Index Scan on part_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+-- Test table indexed on two columns
+-- Two indices allow ORCA to generate the bitmap scan alternative
+create table two_idx_tbl (x varchar(10), y varchar(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index x_idx on two_idx_tbl using btree (x);
+create index y_idx on two_idx_tbl using btree (y);
+insert into two_idx_tbl select 'aa', 'bb' from generate_series(1,10000) i;
+analyze two_idx_tbl;
+-- encourage bitmap scan by discouraging index scan
+set optimizer_enable_indexscan=off;
+-- identical plans
+explain select * from two_idx_tbl where x = 'cc' or y = 'dd';
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=3 width=6)
+   ->  Bitmap Heap Scan on two_idx_tbl  (cost=0.00..431.06 rows=1 width=6)
+         Recheck Cond: (((x)::text = 'cc'::text) OR ((y)::text = 'dd'::text))
+         ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+               ->  Bitmap Index Scan on x_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((x)::text = 'cc'::text)
+               ->  Bitmap Index Scan on y_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((y)::text = 'dd'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.06 rows=3 width=6)
+   ->  Bitmap Heap Scan on two_idx_tbl  (cost=0.00..431.06 rows=1 width=6)
+         Recheck Cond: (((x)::text = 'cc'::text) OR ((y)::text = 'dd'::text))
+         ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+               ->  Bitmap Index Scan on x_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((x)::text = 'cc'::text)
+               ->  Bitmap Index Scan on y_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: ((y)::text = 'dd'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -353,3 +353,60 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+
+-- The following tests are to verify a fix that allows ORCA to
+-- choose the bitmap index scan alternative when the predicate
+-- is in the form of `value operator cast(column)`. The fix
+-- converts the scalar comparison expression to the more common 
+-- form of `cast(column) operator value` in the preprocessor.
+
+-- Each test includes two queries. One query's predicate has 
+-- the column on the left side, and the other has the column
+-- on the right side. We expect the two queries to generate
+-- identical plans with bitmap index scan.
+
+-- Index only scan will probably be selected once index only
+-- scan in enabled for AO tables in ORCA. To prevent retain
+-- the bitmap scan alternative, turn off index only scan.
+set optimizer_enable_indexonlyscan=off;
+-- Test AO table
+-- Index scan is disabled in AO table, so bitmap scan is the
+-- most performant
+create table ao_tbl (
+    path_hash character varying(10)
+) with (appendonly='true');
+create index ao_idx on ao_tbl using btree (path_hash);
+insert into ao_tbl select 'abc' from generate_series(1,20) i;
+analyze ao_tbl;
+-- identical plans
+explain select * from ao_tbl where path_hash = 'ABC'; 
+explain select * from ao_tbl where 'ABC' = path_hash;
+
+-- Test AO partition table
+-- Dynamic index scan is disabled in AO table, so dynamic bitmap
+-- scan is the most performant
+create table part_tbl (
+    path_hash character varying(10)
+) partition by list(path_hash) 
+          (partition pics values('a') , 
+          default partition other with (appendonly='true'));
+create index part_idx on part_tbl using btree (path_hash);
+insert into part_tbl select 'abc' from generate_series(1,20) i;
+analyze part_tbl;
+-- identical plans
+explain select * from part_tbl where path_hash = 'ABC'; 
+explain select * from part_tbl where 'ABC' = path_hash; 
+
+-- Test table indexed on two columns
+-- Two indices allow ORCA to generate the bitmap scan alternative
+create table two_idx_tbl (x varchar(10), y varchar(10));
+create index x_idx on two_idx_tbl using btree (x);
+create index y_idx on two_idx_tbl using btree (y);
+insert into two_idx_tbl select 'aa', 'bb' from generate_series(1,10000) i;
+analyze two_idx_tbl;
+-- encourage bitmap scan by discouraging index scan
+set optimizer_enable_indexscan=off;
+-- identical plans
+explain select * from two_idx_tbl where x = 'cc' or y = 'dd';
+explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
+


### PR DESCRIPTION
Motivation:
Customer reports plan difference when the predicate is written in the form of `col op val` vs. `val op col`. Specifically, if the column is the on left side, ORCA is able to leverage the bitmap scan alternative given the indexed column. When the value is placed on the left side, ORCA chooses much inferior a plan with sequential scan.

Root cause:
The transform from select into bitmap scan expects predicates with columns on the left side and values on the right side. That is, in order for the bitmap scan alternative to be generated, the predicate has to be in the form of `col op val`. If the predicate is written in the form `val op col`, preprocessor converts it to `col op val`. This way, entering the exploration phase, a scalar comparison expression is already reordered.

However, as of now, the expression reordering only works for `const op ident`, but not for `const op cast(ident)`, which is the case of this query. Because of this, the bitmap scan alternative isn't generated, and ORCA chooses the less performant sequential scan.

Solution:
Support scalar comparison expression reordering in case of cast.

Implementation:
We implement this logic in the preprocessor instead of xform for two reasons. 1. Preprocessor handles expression conversion recursively, so it works for nested expressions. 2. Preprocessor has a broader impact than xform, and could potentially benefit other xforms that expect predicates to be in the form of `col op val`.

Test:
The scalar comparison expression order affects bitmap scan, but not index scan. To demonstrate the fix allows the generation of the bitmap scan alternative, we use 1. appendonly tables where index scan isn't supported, and 2. more than one index when scanning a table.

Co-authored-by: Jingyu Wang <wjingyu@vmware.com>
(cherry picked from commit fe88dfc7657194fe8107f786f59f113ea6da5a80)

Fix https://github.com/greenplum-db/gpdb/issues/15624