### PR TITLE
 Clean up the use of the deprecated unittest.TestCase.assertEquals()

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
@@ -17,35 +17,35 @@ class GpCheckPerf(GpTestCase):
     def test_get_memory_on_darwin(self, mock_run, mock_get_platform):
         mock_run.return_value = [1, 'hw.physmem: 1234']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, None)
+        self.assertEqual(actual_result, None)
 
         mock_run.return_value = [0, 'hw.physmem: 0']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, None)
+        self.assertEqual(actual_result, None)
 
         mock_run.return_value = [0, 'hw.physmem: 1234']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, 1234)
+        self.assertEqual(actual_result, 1234)
 
     @patch('gpcheckperf.getPlatform', return_value='linux')
     @patch('gpcheckperf.run')
     def test_get_memory_on_linux(self, mock_run, mock_get_platform):
         mock_run.return_value = [1, 'MemTotal:        10 kB']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, None)
+        self.assertEqual(actual_result, None)
 
         mock_run.return_value = [0, 'MemTotal:        0 kB']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, None)
+        self.assertEqual(actual_result, None)
 
         mock_run.return_value = [0, 'MemTotal:        10 kB']
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, 10240)
+        self.assertEqual(actual_result, 10240)
 
     @patch('gpcheckperf.getPlatform', return_value='abc')
     def test_get_memory_on_invalid_platform(self, mock_get_platform):
         actual_result = self.subject.getMemory()
-        self.assertEquals(actual_result, None)
+        self.assertEqual(actual_result, None)
 
     @patch('gpcheckperf.getMemory', return_value=None)
     def test_parseCommandLine_when_get_memory_fails(self, mock_get_memory):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_mainUtils.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_mainUtils.py
@@ -15,18 +15,18 @@ class MainUtilsTestCase(GpTestCase):
 
     def test_release_removes_lock(self):
         self.lock.acquire()
-        self.assertEquals(True,os.path.exists(self.lockfile))
+        self.assertEqual(True,os.path.exists(self.lockfile))
         self.lock.release()
-        self.assertEquals(False, os.path.exists(self.lockfile))
+        self.assertEqual(False, os.path.exists(self.lockfile))
 
     def test_with_block_removes_lock(self):
         with self.lock:
-            self.assertEquals(True,os.path.exists(self.lockfile))
-        self.assertEquals(False, os.path.exists(self.lockfile))
+            self.assertEqual(True,os.path.exists(self.lockfile))
+        self.assertEqual(False, os.path.exists(self.lockfile))
 
     def test_lock_owned_by_parent(self):
         with self.lock as l:
-            self.assertEquals(l.read_pid(), self.ppid)
+            self.assertEqual(l.read_pid(), self.ppid)
 
 
     def test_exceptionPIDLockHeld_if_same_pid(self):
@@ -38,7 +38,7 @@ class MainUtilsTestCase(GpTestCase):
         with self.lock as l:
             pid = os.fork()
             if pid == 0:
-                self.assertEquals(l.read_pid(), self.ppid)
+                self.assertEqual(l.read_pid(), self.ppid)
                 os._exit(0)
             else:
                 os.wait()
@@ -90,7 +90,7 @@ class MainUtilsTestCase(GpTestCase):
                 # we expect the the acquire to fail
                 except:
                     pass
-                self.assertEquals(True, os.path.exists(self.lockfile))
+                self.assertEqual(True, os.path.exists(self.lockfile))
                 os._exit(0)
             else:
                 os.wait()


### PR DESCRIPTION
Long log:
Since `assertEquals()` has become a deprecated method in unittest,
`assertEquals()`  should be substituted by `assertEqual()`.

Take an example as below:
```
import unittest
  
class TestStringMethods(unittest.TestCase):
    def test_negative(self):
        firstValue = "abc"
        secondValue = "abc"
        self.assertEquals(firstValue, secondValue)
  
if __name__ == '__main__':
    unittest.main()
```
run main.py, `DeprecationWarning `will happen.
```
python3 main.py 
main.py:7: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(firstValue, secondValue)
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>