### PR TITLE
Fix the version argument to ArgumentParser is deprecated

### DIFF
--- a/src/backend/gporca/scripts/convert_minirepro_5_to_6.py
+++ b/src/backend/gporca/scripts/convert_minirepro_5_to_6.py
@@ -85,8 +85,9 @@ def convert_insert_statement(infile, outfile):
 
 
 def parseargs():
-	parser = argparse.ArgumentParser(description=_help, version='1.0')
+	parser = argparse.ArgumentParser(description=_help)
 
+	parser.add_argument('--version', action='version', version='1.0')
 	parser.add_argument("filepath", help="Path to minirepro file")
 
 	args = parser.parse_args()

--- a/src/backend/gporca/scripts/get_debug_event_counters.py
+++ b/src/backend/gporca/scripts/get_debug_event_counters.py
@@ -172,8 +172,9 @@ def processLogFile(logFileLines, allruns):
 
 
 def parseargs():
-	parser = argparse.ArgumentParser(description=_help, version='1.0')
+	parser = argparse.ArgumentParser(description=_help)
 
+	parser.add_argument('--version', action='version', version='1.0')
 	parser.add_argument("--logFile", default="",
 						help="GPDB log file saved from a run with debug event counters enabled (default is to search "
 							 "GPDB coordinator log directory)")


### PR DESCRIPTION
The "version" argument to ArgumentParser is deprecated. 
Please refer to https://bugs.launchpad.net/yade/+bug/1134422

Take a short example:
```
import argparse
parser = argparse.ArgumentParser(version='1.0')
```
the error result is shown as below:
```
$ python3 main.py 
Traceback (most recent call last):
  File "main.py", line 2, in <module>
    parser = argparse.ArgumentParser(version='1.0')
TypeError: __init__() got an unexpected keyword argument 'version'
```

**Solution**: use `parser.add_argument()` to fix it.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>