### PR TITLE
pg_dump: collect using sequence

### DIFF
--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -45,7 +45,8 @@ Indexes:
 --------------------------------------------------------------------------------
 -- Scenario: User table without hll flag
 --------------------------------------------------------------------------------
-create table minirepro_foo(a int) partition by range(a);
+create sequence minirepro_foo_b_seq cache 1;
+create table minirepro_foo(a int, b int default nextval('minirepro_foo_b_seq'::regclass)) partition by range(a);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table minirepro_foo_1 partition of minirepro_foo for values from (1) to (5);
@@ -57,6 +58,7 @@ analyze minirepro_foo;
 -- end_ignore
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
+drop sequence minirepro_foo_b_seq;
 -- start_ignore
 \! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
@@ -76,6 +78,7 @@ SET
 SET
 SET
 SET
+CREATE SEQUENCE
 SET
 SET
 CREATE TABLE
@@ -84,6 +87,8 @@ ALTER TABLE
 SET
 UPDATE 1
 UPDATE 1
+INSERT 0 1
+INSERT 0 1
 INSERT 0 1
 INSERT 0 1
 -- end_ignore
@@ -121,12 +126,15 @@ select
 from pg_statistic where starelid IN ('minirepro_foo'::regclass, 'minirepro_foo_1'::regclass);
  staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 | stavalues1 | stavalues2 | stavalues3 | stavalues4 | stavalues5 
 -----------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+------------+------------+------------+------------+------------
+         2 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
+         2 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
          1 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
          1 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
-(2 rows)
+(4 rows)
 
 -- Cleanup
 drop table minirepro_foo;
+drop sequence minirepro_foo_b_seq;
 --------------------------------------------------------------------------------
 -- Scenario: User table with hll flag
 --------------------------------------------------------------------------------

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -11,7 +11,8 @@
 -- Scenario: User table without hll flag
 --------------------------------------------------------------------------------
 
-create table minirepro_foo(a int) partition by range(a);
+create sequence minirepro_foo_b_seq cache 1;
+create table minirepro_foo(a int, b int default nextval('minirepro_foo_b_seq'::regclass)) partition by range(a);
 create table minirepro_foo_1 partition of minirepro_foo for values from (1) to (5);
 insert into minirepro_foo values(1);
 analyze minirepro_foo;
@@ -25,6 +26,7 @@ analyze minirepro_foo;
 
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
+drop sequence minirepro_foo_b_seq;
 
 -- start_ignore
 \! psql -Xf data/minirepro.sql regression
@@ -65,6 +67,7 @@ from pg_statistic where starelid IN ('minirepro_foo'::regclass, 'minirepro_foo_1
 
 -- Cleanup
 drop table minirepro_foo;
+drop sequence minirepro_foo_b_seq;
 
 --------------------------------------------------------------------------------
 -- Scenario: User table with hll flag


### PR DESCRIPTION
When a table has an explicitly created sequence, the sequence is ignored by pg_dump if it's not owned by the table.

Collect all sequences which maybe referenced by table columns. For implicitly created sequence like SERIAL and GENERATED AS IDENTITY, the sequence and the referenced table have dependency in pg_depend with dependency type 'a' and 'i'. For explicitly created sequence and SERIAL, they both have dependency with referenced attribute definition. Consider both scenarios when identify used sequences.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
