### PR TITLE
gpcheckcat shouldn't throw dependency error for pg_subscription and pg_transform

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -59,7 +59,9 @@ DEPENDENCY_EXCLUSION = [
     'pg_resourcetype',
     'pg_resqueue',
     'pg_resqueuecapability',
-    'pg_tablespace'
+    'pg_subscription',
+    'pg_tablespace',
+    'pg_transform'
     ]
 
 # ============================================================================

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -674,17 +674,23 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 3
         And the user runs "dropdb mis_attr_db"
 
-    Scenario: gpcheckcat should not report dependency error from pg_default_acl
+    Scenario: gpcheckcat should not report dependency error from pg_default_acl, pg_subscription and pg_transform
         Given database "check_dependency_error" is dropped and recreated
         And the user runs "psql -d check_dependency_error -c "CREATE ROLE foo; ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;""
         Then psql should return a return code of 0
-        When the user runs "gpcheckcat check_dependency_error"
+        And the user runs "psql -d check_dependency_error -c "CREATE SUBSCRIPTION foo CONNECTION '' PUBLICATION bar WITH (connect = false, slot_name = NONE);""
+        Then psql should return a return code of 0
+        And the user runs "psql -d check_dependency_error -c "CREATE TRANSFORM FOR int LANGUAGE SQL (FROM SQL WITH FUNCTION prsd_lextype(internal), TO SQL WITH FUNCTION int4recv(internal));""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R dependency check_dependency_error"
         Then gpcheckcat should return a return code of 0
         And gpcheckcat should not print "SUMMARY REPORT: FAILED" to stdout
         And gpcheckcat should not print "has a dependency issue on oid" to stdout
         And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "psql -d check_dependency_error -c "DROP SUBSCRIPTION foo""
+        And the user runs "psql -d check_dependency_error -c "DROP TRANSFORM FOR int LANGUAGE SQL""
         And the user runs "dropdb check_dependency_error"
-        And the user runs "psql -c "DROP ROLE foo""
+        And the user runs "psql -d postgres -c "DROP ROLE foo""
 
 
 ########################### @concourse_cluster tests ###########################


### PR DESCRIPTION
Objects in these two catalogs do not have pg_depend nor pg_shdepend entries. We should ignore the dependency check for them like a few others.

Fix https://github.com/greenplum-db/gpdb/issues/12016

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
