### PR TITLE
Fix error of relabelType in group by clause

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2649,17 +2649,6 @@ build_tlist_index(List *tlist)
 
 		Assert(expr);
 
-		/*
-		 * Allow a Var in parent node's expr to find matching Var in tlist
-		 * ignoring any RelabelType nodes atop the tlist Var.  Also set
-		 * has_non_vars so tlist expr can be matched as a whole.
-		 */
-		while (IsA(expr, RelabelType))
-		{
-			expr = ((RelabelType *)expr)->arg;
-			itlist->has_non_vars = true;
-		}
-
 		if (expr && IsA(expr, Var))
 		{
 			Var		   *var = (Var *) expr;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1813,6 +1813,33 @@ select 1, median(col1) from group_by_const group by 1;
         1 |  500.5
 (1 row)
 
+-- Test GROUP BY with a RelabelType
+create table tx (c1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tx values('hello');
+EXPLAIN (COSTS OFF, VERBOSE ON)
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (min(c1)), ((c1)::character varying)
+   ->  HashAggregate
+         Output: min(c1), ((c1)::character varying)
+         Group Key: (tx.c1)::character varying
+         ->  Seq Scan on bfv_aggregate.tx
+               Output: (c1)::character varying, c1
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(9 rows)
+
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+  min  
+-------
+ hello
+(1 row)
+
+drop table tx;
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 set optimizer_force_multistage_agg to on;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1827,6 +1827,48 @@ select 1, median(col1) from group_by_const group by 1;
         1 |  500.5
 (1 row)
 
+-- Test GROUP BY with a RelabelType
+create table tx (c1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tx values('hello');
+EXPLAIN (COSTS OFF, VERBOSE ON)
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (min(c1))
+   ->  Finalize GroupAggregate
+         Output: min(c1)
+         Group Key: ((tx.c1)::character varying)
+         ->  Sort
+               Output: ((c1)::character varying), (PARTIAL min(c1))
+               Sort Key: ((tx.c1)::character varying)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: ((c1)::character varying), (PARTIAL min(c1))
+                     Hash Key: ((c1)::character varying)
+                     ->  Partial GroupAggregate
+                           Output: ((c1)::character varying), PARTIAL min(c1)
+                           Group Key: ((tx.c1)::character varying)
+                           ->  Sort
+                                 Output: ((c1)::character varying), c1
+                                 Sort Key: ((tx.c1)::character varying)
+                                 ->  Result
+                                       Output: c1, c1
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: c1
+                                             ->  Seq Scan on bfv_aggregate.tx
+                                                   Output: c1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
+
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+  min  
+-------
+ hello
+(1 row)
+
+drop table tx;
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 set optimizer_force_multistage_agg to on;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1471,6 +1471,14 @@ explain (costs off)
 select 1, median(col1) from group_by_const group by 1;
 select 1, median(col1) from group_by_const group by 1;
 
+-- Test GROUP BY with a RelabelType
+create table tx (c1 text);
+insert into tx values('hello');
+EXPLAIN (COSTS OFF, VERBOSE ON)
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
+drop table tx;
+
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 


### PR DESCRIPTION
### **RCA**
The root cause was that Aggref in targetlist of AggNode refer incorrect VAR in subplan targetlist.
```
postgres=# explain verbose SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=298.00..314.67 rows=1000 width=64)
   Output: (min(c1)), ((c1)::character varying)
   ->  HashAggregate  (cost=298.00..301.33 rows=333 width=64)
         Output: min(c1), ((c1)::character varying)
         Group Key: (tx.c1)::character varying
         ->  Seq Scan on public.tx  (cost=0.00..210.00 rows=17600 width=64)
               Output: (c1)::character varying, c1
 Optimizer: Postgres query optimizer
 Settings: optimizer = 'off'
(9 rows)
```
as above plan, c1 in min(c1) should refer to c1 column in Seq Scan Node, but now c1 refer to `(c1)::character varying`,
which is wrong and will result in an ERROR as we check arguments of min() function.

### main change:
The removed code comes from long long ago and hard to track it now, and upstream also remove those code.
In theory, we don't need to extract vars from RelabelType, we should just let upper RelabelType refer to lower
RelabelType directly.




## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
