### PR TITLE
Check `gpdb_get_master_data_dir` result in getconfig

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1815,7 +1815,8 @@ static void getconfig(void)
 	gpdb_get_master_data_dir(&hostname, &master_data_directory, pool);
 	if (ax.master_data_directory == NULL)
 	{
-		if (master_data_directory == NULL) {
+		if (master_data_directory == NULL) 
+		{
 			gpmon_fatalx(FLINE, rc, "Failed to create APR pool: failed to resolve master data directory\n");
 		}
 		ax.master_data_directory = strdup(master_data_directory);

--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1815,6 +1815,9 @@ static void getconfig(void)
 	gpdb_get_master_data_dir(&hostname, &master_data_directory, pool);
 	if (ax.master_data_directory == NULL)
 	{
+		if (master_data_directory == NULL) {
+			gpmon_fatalx(FLINE, rc, "Failed to create APR pool: failed to resolve master data directory\n");
+		}
 		ax.master_data_directory = strdup(master_data_directory);
 		CHECKMEM(ax.master_data_directory);
 	}


### PR DESCRIPTION
gpdb_get_master_data_dir should set master_data_dir variable with non-NULL pointer. However, there is codepath in this function that leads to NULL result. We need to check this case and finish gpmon process with error if any trouble.

This case is really reproduced in our production
```
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
#1  0x00007f18fc1de9ce in __GI___strdup (s=0x0) at strdup.c:41
#2  0x000055ff3885813d in getconfig () at gpmmon.c:1679
#3  main (argc=<optimized out>, argv=<optimized out>) at gpmmon.c:1358
(gdb) Quit
```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
