### PR TITLE
6X: Add getPartitionDefs function to pg_dump

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -156,6 +156,8 @@ getSchemaData(Archive *fout, int *numTablesPtr, int binary_upgrade)
 		write_msg(NULL, "reading user-defined tables\n");
 	tblinfo = getTables(fout, &numTables);
 
+	getPartitionDefs(fout, tblinfo, numTables);
+
 	getOwnedSeqs(fout, tblinfo, numTables);
 
 	if (g_verbose)

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -666,6 +666,7 @@ extern void getBinaryUpgradeTypeArrInfo(Archive *fout, BinaryUpgradeInfo *binfo,
 extern bool	testExtProtocolSupport(Archive *fout);
 extern void getAOTableInfo(Archive *fout);
 extern void getBMIndxInfo(Archive *fout);
+extern void getPartitionDefs(Archive *fout, TableInfo tblinfo[], int numTables);
 /* END MPP ADDITION */
 
 

--- a/src/test/regress/expected/pg_dump_locking.out
+++ b/src/test/regress/expected/pg_dump_locking.out
@@ -1,0 +1,39 @@
+-- Ensure that pg_dump only locks partition tables that are included in the backup set.
+-- An existing ACCESS EXCLUSIVE lock on a partition table outside the backup set should
+-- not block pg_dump execution.
+CREATE SCHEMA dump_this_schema;
+CREATE SCHEMA locked_table_schema;
+CREATE TABLE dump_this_schema.dump_this_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+NOTICE:  CREATE TABLE will create partition "dump_this_table_1_prt_p1" for table "dump_this_table"
+NOTICE:  CREATE TABLE will create partition "dump_this_table_1_prt_p2" for table "dump_this_table"
+CREATE TABLE locked_table_schema.locked_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+NOTICE:  CREATE TABLE will create partition "locked_table_1_prt_p1" for table "locked_table"
+NOTICE:  CREATE TABLE will create partition "locked_table_1_prt_p2" for table "locked_table"
+BEGIN; LOCK TABLE locked_table_schema.locked_table IN ACCESS EXCLUSIVE MODE;
+-- Run pg_dump with the Access Exclusive lock held. We expect pg_dump to complete
+-- and output a CREATE TABLE statement for dump_this_schema.dump_this_table.
+\! pg_dump -s -t dump_this_schema.dump_this_table regression | grep 'CREATE TABLE'
+CREATE TABLE dump_this_schema.dump_this_table (
+END;
+DROP SCHEMA dump_this_schema CASCADE;
+NOTICE:  drop cascades to table dump_this_schema.dump_this_table
+DROP SCHEMA locked_table_schema CASCADE;
+NOTICE:  drop cascades to table locked_table_schema.locked_table

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -17,6 +17,8 @@
 
 test: pg_dump_binary_upgrade
 
+test: pg_dump_locking
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/sql/pg_dump_locking.sql
+++ b/src/test/regress/sql/pg_dump_locking.sql
@@ -1,0 +1,38 @@
+-- Ensure that pg_dump only locks partition tables that are included in the backup set.
+-- An existing ACCESS EXCLUSIVE lock on a partition table outside the backup set should
+-- not block pg_dump execution.
+
+CREATE SCHEMA dump_this_schema;
+CREATE SCHEMA locked_table_schema;
+
+CREATE TABLE dump_this_schema.dump_this_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+
+CREATE TABLE locked_table_schema.locked_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+
+BEGIN; LOCK TABLE locked_table_schema.locked_table IN ACCESS EXCLUSIVE MODE;
+-- Run pg_dump with the Access Exclusive lock held. We expect pg_dump to complete
+-- and output a CREATE TABLE statement for dump_this_schema.dump_this_table.
+\! pg_dump -s -t dump_this_schema.dump_this_table regression | grep 'CREATE TABLE'
+
+END;
+
+DROP SCHEMA dump_this_schema CASCADE;
+DROP SCHEMA locked_table_schema CASCADE;


### PR DESCRIPTION
Currently, getTables will hold a lock on all partition tables in the database by calling `pg_get_partition_def` and
`pg_get_partition_template_def` on each table, resulting in tables being locked that are not part of the backup set.

This commit extracts the `pg_get_partition_def` and `pg_get_partition_template_def` function calls out of getTables and into `getPartitionDefs`. Now, only partition tables in the backup set  will be included in calls to these functions.

Add a regression test to ensure pg_dump doesn't attempt to lock
partition tables outside the backup set.
