### PR TITLE
Don't apply str(obj, errors='ignore') on a str object.

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2649,9 +2649,7 @@ class gpload:
                 self.db.set_notice_receiver(notice_processor_Notice)
                 self.rowsInserted = self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = str(e)
-                self.log(self.ERROR, strE + ' encountered while running ' + sql)
+                self.log(self.ERROR, '{} encountered while running {}'.format(e, sql))
         self.report_errors()
 
     def do_method_insert(self):
@@ -2742,9 +2740,7 @@ class gpload:
             try:
                 self.rowsUpdated = self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = str(e)
-                self.log(self.ERROR, strE + ' encountered while running ' + sql)
+                self.log(self.ERROR, '{} encountered while running {}'.format(e, sql))
 				
     def get_qualified_tablename(self):
         '''
@@ -2839,8 +2835,7 @@ class gpload:
             try:
                 self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                strE = str(e)
-                self.log(self.ERROR, strE + ' encountered while running ' + sql)
+                self.log(self.ERROR, '{} encountered while running {}'.format(e, sql))
 
         # insert new rows to the target table
 
@@ -2859,9 +2854,7 @@ class gpload:
             try:
                 self.rowsInserted = self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = str(e)
-                self.log(self.ERROR, strE + ' encountered while running ' + sql)
+                self.log(self.ERROR, '{} encountered while running {}'.format(e, sql))
 
     def do_truncate(self, tblname):
         self.log(self.LOG, "Truncate table %s" %(tblname))

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2651,8 +2651,7 @@ class gpload:
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
                 strE = str(e)
-                strF = str(sql)
-                self.log(self.ERROR, strE + ' encountered while running ' + strF)
+                self.log(self.ERROR, strE + ' encountered while running ' + sql)
         self.report_errors()
 
     def do_method_insert(self):
@@ -2745,8 +2744,7 @@ class gpload:
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
                 strE = str(e)
-                strF = str(sql)
-                self.log(self.ERROR, strE + ' encountered while running ' + strF)
+                self.log(self.ERROR, strE + ' encountered while running ' + sql)
 				
     def get_qualified_tablename(self):
         '''
@@ -2842,8 +2840,7 @@ class gpload:
                 self.db.query(sql.encode('utf-8'))
             except Exception as e:
                 strE = str(e)
-                strF = str(sql)
-                self.log(self.ERROR, strE + ' encountered while running ' + strF)
+                self.log(self.ERROR, strE + ' encountered while running ' + sql)
 
         # insert new rows to the target table
 
@@ -2864,8 +2861,7 @@ class gpload:
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
                 strE = str(e)
-                strF = str(sql)
-                self.log(self.ERROR, strE + ' encountered while running ' + strF)
+                self.log(self.ERROR, strE + ' encountered while running ' + sql)
 
     def do_truncate(self, tblname):
         self.log(self.LOG, "Truncate table %s" %(tblname))

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2744,8 +2744,8 @@ class gpload:
                 self.rowsUpdated = self.db.query(sql.encode('utf-8'))
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = str(str(e), errors = 'ignore')
-                strF = str(str(sql), errors = 'ignore')
+                strE = str(e)
+                strF = str(sql)
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
 				
     def get_qualified_tablename(self):
@@ -2841,8 +2841,8 @@ class gpload:
             try:
                 self.db.query(sql.encode('utf-8'))
             except Exception as e:
-                strE = str(str(e), errors = 'ignore')
-                strF = str(str(sql), errors = 'ignore')
+                strE = str(e)
+                strF = str(sql)
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
 
         # insert new rows to the target table
@@ -2863,8 +2863,8 @@ class gpload:
                 self.rowsInserted = self.db.query(sql.encode('utf-8'))
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = str(str(e), errors = 'ignore')
-                strF = str(str(sql), errors = 'ignore')
+                strE = str(e)
+                strF = str(sql)
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
 
     def do_truncate(self, tblname):

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2650,8 +2650,8 @@ class gpload:
                 self.rowsInserted = self.db.query(sql.encode('utf-8'))
             except Exception as e:
                 # We need to be a bit careful about the error since it may contain non-unicode characters
-                strE = e.__str__().encode().decode('unicode-escape')
-                strF = sql.encode().decode('unicode-escape')
+                strE = str(e)
+                strF = str(sql)
                 self.log(self.ERROR, strE + ' encountered while running ' + strF)
         self.report_errors()
 

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -23,7 +23,7 @@ m/^HINT:  Use the escape string syntax for backslashes.*/
 -- m/started gpfdist/
 -- s/started gpfdist -p \d* -P \d* -f .*/ports/
 -- m/gpfdist:/
--- s#gpfdist://\d*.\d*.\d*.\d*:\d*//\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*\w*\W*data_file.txt#LOCATION#
+-- s#gpfdist:.*data_file.txt#LOCATION#
 -- m/data_file.tbl/
 -- s/(").*data_file.tbl(")/data/
 -- m/cmdtime/

--- a/gpMgmt/bin/gpload_test/gpload2/query497.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query497.ans
@@ -5,7 +5,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 16:55:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
 2021-01-04 16:55:52|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 16:55:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a651e6f8_4e6a_11eb_b8a4_7085c2381836
-2021-01-04 16:55:53|ERROR|unexpected error -- backtrace written to log file
+2021-01-04 16:55:52|ERROR|ERROR:  column "non_col" does not exist
+LINE 1: ...ble."s1" and into_table."s2"=from_table."s2" and  non_col = ...
+                                                             ^
+ encountered while running update public."texttable" into_table set "n2"=from_table."n2" from staging_gpload_reusable_4b4814f7db18b678f1605a0caec3c1fe from_table where into_table."n1"=from_table."n1" and into_table."s1"=from_table."s1" and into_table."s2"=from_table."s2" and  non_col = 5
 2021-01-04 16:55:53|INFO|rows Inserted          = 0
 2021-01-04 16:55:53|INFO|rows Updated           = 0
 2021-01-04 16:55:53|INFO|data formatting errors = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query75.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query75.ans
@@ -14,7 +14,11 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-08-10 14:56:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-08-10 14:56:46|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
 2021-08-10 14:56:46|INFO|reusing external table ext_gpload_reusable_2092c476_f9a8_11eb_b503_0050569e2380
-2021-08-10 14:56:46|ERROR|unexpected error -- backtrace written to log file
+2021-08-10 14:56:46|ERROR|ERROR:  column "列" does not exist
+LINE 1: ..." FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS g...
+                                                             ^
+HINT:  Perhaps you meant to reference the column "staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7.列1" or the column "chinese表.列1".
+ encountered while running INSERT INTO public."chinese表" ("列1","列#2","lie3") (SELECT from_table."列1",from_table."列#2",from_table."lie3" FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS gpload_row_number FROM staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7) AS from_table WHERE gpload_row_number=1)
 2021-08-10 14:56:46|INFO|rows Inserted          = 0
 2021-08-10 14:56:46|INFO|rows Updated           = 8
 2021-08-10 14:56:46|INFO|data formatting errors = 0
@@ -33,7 +37,11 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-08-10 14:56:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-08-10 14:56:46|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
 2021-08-10 14:56:46|INFO|reusing external table ext_gpload_reusable_2092c476_f9a8_11eb_b503_0050569e2380
-2021-08-10 14:56:46|ERROR|unexpected error -- backtrace written to log file
+2021-08-10 14:56:46|ERROR|ERROR:  column "列" does not exist
+LINE 1: ..." FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS g...
+                                                             ^
+HINT:  Perhaps you meant to reference the column "staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7.列1" or the column "chinese表.列1".
+ encountered while running INSERT INTO public."chinese表" ("列1","列#2","lie3") (SELECT from_table."列1",from_table."列#2",from_table."lie3" FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS gpload_row_number FROM staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7) AS from_table WHERE gpload_row_number=1)
 2021-08-10 14:56:46|INFO|rows Inserted          = 0
 2021-08-10 14:56:46|INFO|rows Updated           = 8
 2021-08-10 14:56:46|INFO|data formatting errors = 0


### PR DESCRIPTION
Don't apply str(obj, errors='ignore') on a str object, otherwise an exception will be raised.

```
➜ python
Python 3.11.3 (main, Apr  5 2023, 15:52:25) [GCC 12.2.1 20230201] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> str(str('a'))
'a'
>>> str(str('a'), errors='ignore')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: decoding str is not supported
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
