### PR TITLE
remove FIXME in function `create_motion_path_for_updel()`

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2413,12 +2413,6 @@ create_motion_path_for_upddel(PlannerInfo *root, Index rti, GpPolicy *policy,
 			return subpath;
 		else
 		{
-			/* GPDB_96_MERGE_FIXME: avoid creating the Explicit Motion in
-			 * simple cases, where all the input data is already on the
-			 * same segment.
-			 *
-			 * Is "strewn" correct here? Can we do better?
-			 */
 			CdbPathLocus_MakeStrewn(&targetLocus, policy->numsegments);
 			subpath = cdbpath_create_explicit_motion_path(root,
 														  subpath,


### PR DESCRIPTION
Since there already have PR #9183 to elide explicit motion, we can delete this
FIXME directly.