### PR TITLE
Don't push upper predicates down to modifying CTEs

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2972,7 +2972,12 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 		config->honor_order_by = false;
 
-		if (!cte->cterecursive)
+		/*
+		 * Additionally to recursive CTE queries, don't try to push down quals
+		 * to non-SELECT queries. There can be DML operation with RETURNING
+		 * clause, and it's incorrect to push down upper quals to it.
+		 */
+		if (!cte->cterecursive && subquery->commandType == CMD_SELECT)
 		{
 			/*
 			 * Adjust the subquery so that 'root', i.e. this subquery, is the

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2359,3 +2359,118 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Test planner not pushing down quals to non-SELECT queries inside CTE. There
+-- can be a DML operation, and it's incorrect to push down upper quals to it.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning *
+) select count(*) from cte where i > 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Insert on with_dml
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                           Hash Key: i.i
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning *
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from with_dml;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select * from cte where i > 2 order by i;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: cte.i
+   ->  Sort
+         Sort Key: cte.i
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Update on with_dml
+                     ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select * from cte where i > 2 order by i;
+ i 
+---
+ 3
+ 4
+ 5
+(3 rows)
+
+select * from with_dml order by i;
+ i |  j  
+---+-----
+ 1 | 101
+ 2 | 201
+ 3 | 301
+ 4 | 401
+ 5 | 501
+(5 rows)
+
+explain (costs off)
+with cte as (
+    delete from with_dml
+    returning i
+) select * from cte where i > 2 order by i;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: cte.i
+   ->  Sort
+         Sort Key: cte.i
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Delete on with_dml
+                     ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    delete from with_dml
+    returning i
+) select * from cte where i > 2 order by i;
+ i 
+---
+ 3
+ 4
+ 5
+(3 rows)
+
+select count(*) from with_dml;
+ count 
+-------
+     0
+(1 row)
+
+drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2373,3 +2373,118 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Test planner not pushing down quals to non-SELECT queries inside CTE. There
+-- can be a DML operation, and it's incorrect to push down upper quals to it.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning *
+) select count(*) from cte where i > 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Insert on with_dml
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                           Hash Key: i.i
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning *
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from with_dml;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select * from cte where i > 2 order by i;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: cte.i
+   ->  Sort
+         Sort Key: cte.i
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Update on with_dml
+                     ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select * from cte where i > 2 order by i;
+ i 
+---
+ 3
+ 4
+ 5
+(3 rows)
+
+select * from with_dml order by i;
+ i |  j  
+---+-----
+ 1 | 101
+ 2 | 201
+ 3 | 301
+ 4 | 401
+ 5 | 501
+(5 rows)
+
+explain (costs off)
+with cte as (
+    delete from with_dml
+    returning i
+) select * from cte where i > 2 order by i;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: cte.i
+   ->  Sort
+         Sort Key: cte.i
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Delete on with_dml
+                     ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    delete from with_dml
+    returning i
+) select * from cte where i > 2 order by i;
+ i 
+---
+ 3
+ 4
+ 5
+(3 rows)
+
+select count(*) from with_dml;
+ count 
+-------
+     0
+(1 row)
+
+drop table with_dml;


### PR DESCRIPTION
For queries, which contain DML operations inside the WITH clause, pushing down restrictions from upper query levels can lead to conditional table modification or cause planner errors. That behaviour is undesirable, because in context of modifying CTEs it is expected, that the DML operation will affect the whole table, and the restriction at upper level is applied to the result of RETURNING clause.

Therefore, this patch proposes limitations that don't allow planner to push the predicates down from upper level to CTEs, whose commandType is non-SELECT. The if-clause inside the `set_cte_pathlist` function was extended with additional condition, which checks the commandType of CTE's subquery.

Simpliest example of the incorrect plan:
```
create table with_dml (i int, j int) distributed by (i);
explain (costs off)
with cte as (
insert into with_dml select i, i * 100 from generate_series(1, 5) i
returning i
) select count (*) from cte where i > 2;
                               QUERY PLAN                               
------------------------------------------------------------------------
 Aggregate
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Subquery Scan on cte
               ->  Insert on with_dml
                     ->  Redistribute Motion 1:3  (slice2; segments: 1)
                           Hash Key: i.i
                           ->  Function Scan on generate_series i
                                 Filter: (i > 2)
 Optimizer: Postgres query optimizer
(9 rows)
```
As for UPDATE/DELETE statments inside the CTE, the planner may throw an error
```
explain (costs off)
with cte as (
update with_dml set j = j + 1
returning i
) select count (*) from cte where i > 2;
ERROR:  could not find replacement targetlist entry for attno 1 (rewriteManip.c:1529)
```
The error is thrown when the planner tries to replace Vars in qual inside the `ReplaceVarsFromTargetList` function during pushing the quals down to the CTE.