### PR TITLE
Separate out option 'num_segments' for foreign server validators

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -81,6 +81,9 @@ CREATE FOREIGN TABLE gp_ft1 (
 	f2 text,
 	f3 text
 ) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 'GP 1', mpp_execute 'all segments');
+CREATE FOREIGN TABLE gp_ft2 ( f1 int ) SERVER loopback OPTIONS (num_segments '3');
+ERROR:  invalid option "num_segments"
+HINT:  Valid options in this context are: schema_name, table_name, use_remote_estimate, updatable, fetch_size
 -- ===================================================================
 -- validate parallel writes (mpp_execute set to all segments)
 -- ===================================================================

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -81,6 +81,9 @@ CREATE FOREIGN TABLE gp_ft1 (
 	f2 text,
 	f3 text
 ) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 'GP 1', mpp_execute 'all segments');
+CREATE FOREIGN TABLE gp_ft2 ( f1 int ) SERVER loopback OPTIONS (num_segments '3');
+ERROR:  invalid option "num_segments"
+HINT:  Valid options in this context are: schema_name, table_name, use_remote_estimate, updatable, fetch_size
 -- ===================================================================
 -- validate parallel writes (mpp_execute set to all segments)
 -- ===================================================================

--- a/contrib/postgres_fdw/option.c
+++ b/contrib/postgres_fdw/option.c
@@ -180,8 +180,6 @@ InitPgFdwOptions(void)
 		/* fetch_size is available on both server and table */
 		{"fetch_size", ForeignServerRelationId, false},
 		{"fetch_size", ForeignTableRelationId, false},
-		/* num_segments is available on server only */
-		{"num_segments", ForeignServerRelationId, false},
 		{NULL, InvalidOid, false}
 	};
 

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -94,6 +94,8 @@ CREATE FOREIGN TABLE gp_ft1 (
 	f3 text
 ) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 'GP 1', mpp_execute 'all segments');
 
+CREATE FOREIGN TABLE gp_ft2 ( f1 int ) SERVER loopback OPTIONS (num_segments '3');
+
 -- ===================================================================
 -- validate parallel writes (mpp_execute set to all segments)
 -- ===================================================================

--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -196,6 +196,11 @@ transformGenericOptions(Oid catalogId,
 		SeparateOutMppExecute(&resultOptions);
 	}
 
+	if (catalogId == ForeignServerRelationId)
+	{
+		SeparateOutNumSegments(&resultOptions);
+	}
+	
 	if (OidIsValid(fdwvalidator))
 	{
 		Datum valarg = optionListToArray(resultOptions);


### PR DESCRIPTION
The legacy code of foreign data wrapper forget to separate the option 'num_segments', so when creating foreign server with option 'num_segments', each FDW extensions have to add an option 'num_segments' which is supposed to be a public option for FDW.

The testing cases has been add in this commit:
https://github.com/greenplum-db/gpdb/commit/4eda660b305cc10743eee16227983ec0d79311cc with 'num_segments' option added.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
