### PR TITLE
Refactor pg_dump queries to gather partition definitions

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -161,6 +161,8 @@ getSchemaData(Archive *fout, int *numTablesPtr)
 	pg_log_info("reading user-defined tables");
 	tblinfo = getTables(fout, &numTables);
 
+	getPartitionDefs(fout, tblinfo, numTables);
+
 	getOwnedSeqs(fout, tblinfo, numTables);
 
 	pg_log_info("reading user-defined functions");

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -341,7 +341,7 @@ typedef struct _tableInfo
 	uint32		toast_minmxid;	/* toast table's relminmxid */
 	int			ncheck;			/* # of CHECK expressions */
 	Oid			reltype;		/* OID of table's composite type, if any */
-	char	   *reloftype;		/* underlying type for typed table */
+	Oid			reloftype;		/* underlying type for typed table */
 	/* these two are set only if table is a sequence owned by a column: */
 	Oid			owning_tab;		/* OID of table owning sequence */
 	int			owning_col;		/* attr # of column owning sequence */
@@ -379,8 +379,6 @@ typedef struct _tableInfo
 	char	  **attencoding;	/* the attribute encoding values */
 	struct _attrDefInfo **attrdefs; /* DEFAULT expressions */
 	struct _constraintInfo *checkexprs; /* CHECK constraints */
-	char	   *partkeydef;		/* partition key definition */
-	char	   *partbound;		/* partition bound definition */
 	bool		needs_override; /* has GENERATED ALWAYS AS IDENTITY */
 	char	   *amname;			/* relation access method */
 

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -800,6 +800,7 @@ extern ExtProtInfo *getExtProtocols(Archive *fout, int *numExtProtocols);
 extern BinaryUpgradeInfo *getBinaryUpgradeObjects(void);
 extern void getAOTableInfo(Archive *fout);
 extern void getBMIndxInfo(Archive *fout);
+extern void getPartitionDefs(Archive *fout, TableInfo tblinfo[], int numTables);
 /* END MPP ADDITION */
 
 #endif							/* PG_DUMP_H */


### PR DESCRIPTION
Commit 1:
Currently, when backing up a GP5 or GP6 database, getTables will
hold a lock on all partition tables in the database by calling
`pg_get_partition_def` and `pg_get_partition_template_def` on each table,
resulting in tables being locked that are not part of the backup set.
    
This commit extracts the `pg_get_partition_def` and
`pg_get_partition_template_def` function calls out of getTables and
into getPartitionDefs. Now, only partition tables in the backup set  will be
included in calls to these functions.

Commit 2:
Postpone calls of unsafe server-side functions in pg_dump.

Backported from PG15 e3fcbbd

Conflicts resolved:
* OidOptions enum value zeroIsError does not exist, instead used the
  existing zeroAsOpaque.
* Minor conflicts in dumpTableSchema resulting from foreign server
  related code introduced in PG13 commit 4e62091

Original commit message follows:

Avoid calling pg_get_partkeydef(), pg_get_expr(relpartbound),
and regtypeout until we have lock on the relevant tables.
The existing coding is at serious risk of failure if there
are any concurrent DROP TABLE commands going on --- including
drops of other sessions' temp tables.

Arguably this is a bug fix that should be back-patched, but it's
moderately invasive and we've not had all that many complaints
about such failures.  Let's just put it in HEAD for now.

Discussion: https://postgr.es/m/2273648.1634764485@sss.pgh.pa.us
Discussion: https://postgr.es/m/7d7eb6128f40401d81b3b7a898b6b4de@W2012-02.nidsa.loc

For main branch the issue could only occur when backing up from a GP5/GP6 server outside the gpupgrade workflow.
Since src/test/regress is testing main pg_dump against main server, a regress test is not useful (no calls to pg_get_partition_def). We don't have a test framework for backing up older server versions using most recent pg_dump, and that use-case is not supported. [See the 6X PR for the relevant test case](https://github.com/greenplum-db/gpdb/pull/15964/commits/ef9ba02e2df0cb4e9ec75d130e11cc818f889a4b).