### PR TITLE
Enable GUC `log_directory` to be modifiable

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -478,7 +478,7 @@ def canonicalize(addr):
 class Rsync(Command):
     def __init__(self, name, srcFile, dstFile, srcHost=None, dstHost=None, recursive=False,
                  verbose=True, archive_mode=True, checksum=False, delete=False, progress=False,
-                 stats=False, dry_run=False, bwlimit=None, exclude_list=[], ctxt=LOCAL,
+                 stats=False, dry_run=False, bwlimit=None, exclude_list={}, ctxt=LOCAL,
                  remoteHost=None, compress=False, progress_file=None, ignore_times=False, whole_file=False):
 
         """

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.0.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.0.sql
@@ -204,7 +204,7 @@ CREATE EXTERNAL WEB TABLE gp_toolkit.__gp_log_segment_ext
     logline int,
     logstack text
 )
-EXECUTE E'cat $GP_SEG_DATADIR/log/*.csv'
+EXECUTE E'cat $GP_SEG_LOGDIR/*.csv'
 FORMAT 'CSV' (DELIMITER AS ',' NULL AS '' QUOTE AS '"');
 
 REVOKE ALL ON TABLE gp_toolkit.__gp_log_segment_ext FROM public;
@@ -251,7 +251,7 @@ CREATE EXTERNAL WEB TABLE gp_toolkit.__gp_log_coordinator_ext
     logline int,
     logstack text
 )
-EXECUTE E'cat $GP_SEG_DATADIR/log/*.csv' ON COORDINATOR
+EXECUTE E'cat $GP_SEG_LOGDIR/*.csv' ON COORDINATOR
 FORMAT 'CSV' (DELIMITER AS ',' NULL AS '' QUOTE AS '"');
 
 REVOKE ALL ON TABLE gp_toolkit.__gp_log_coordinator_ext FROM public;

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -98,6 +98,7 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 												 * pg_conf file  */
 	extvar->GP_SEG_DATADIR = DataDir;	/* location of the segments
 												 * datadirectory */
+	extvar->GP_SEG_LOGDIR = Log_directory;	/* location of the segments */
 	sprintf(extvar->GP_DATE, "%04d%02d%02d",
 			1900 + tm->tm_year, 1 + tm->tm_mon, tm->tm_mday);
 	sprintf(extvar->GP_TIME, "%02d%02d%02d",

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1331,6 +1331,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-CSVOPT", ev->GP_CSVOPT);
 		set_httpheader(file, "X-GP_SEG_PG_CONF", ev->GP_SEG_PG_CONF);
 		set_httpheader(file, "X-GP_SEG_DATADIR", ev->GP_SEG_DATADIR);
+		set_httpheader(file, "X-GP_SEG_LOGDIR", ev->GP_SEG_LOGDIR);
 		set_httpheader(file, "X-GP-DATABASE", ev->GP_DATABASE);
 		set_httpheader(file, "X-GP-USER", ev->GP_USER);
 		set_httpheader(file, "X-GP-SEG-PORT", ev->GP_SEG_PORT);

--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -217,6 +217,7 @@ make_command(const char *cmd, extvar_t *ev)
 	make_export("GP_MASTER_PORT", ev->GP_MASTER_PORT, &buf);
 	make_export("GP_SEG_PG_CONF", ev->GP_SEG_PG_CONF, &buf);
 	make_export("GP_SEG_DATADIR", ev->GP_SEG_DATADIR, &buf);
+	make_export("GP_SEG_LOGDIR", ev->GP_SEG_LOGDIR, &buf);
 	make_export("GP_DATABASE", ev->GP_DATABASE, &buf);
 	make_export("GP_USER", ev->GP_USER, &buf);
 	make_export("GP_DATE", ev->GP_DATE, &buf);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -538,6 +538,9 @@ static void InitPostmasterDeathWatchHandle(void);
 
 static void setProcAffinity(int id);
 
+/* helper function */
+static void getLogDirectoryAbsolutePath(char *out_buf, size_t len);
+
 /*
  * Archiver is allowed to start up at the current postmaster state?
  *
@@ -1763,6 +1766,17 @@ checkControlFile(void)
 	FreeFile(fp);
 }
 
+static void
+getLogDirectoryAbsolutePath(char *out_buf, size_t len)
+{
+	if (is_absolute_path(Log_directory))
+	{
+		snprintf(out_buf, len, "%s",  Log_directory);
+		return;
+	}
+
+	snprintf(out_buf, len, "%s/%s", DataDir, Log_directory);
+}
 
 /*
  * check if file or directory under "DataDir" exists and is accessible
@@ -1782,7 +1796,7 @@ checkPgDir(const char *dir)
 	if (stat(buf, &st) != 0)
 	{
 		/* check if log is there */
-		snprintf(buf, sizeof(buf), "%s%s", DataDir, "/log");
+		getLogDirectoryAbsolutePath(buf, sizeof(buf));
 		if (stat(buf, &st) == 0)
 			elog(LOG, "System file or directory missing (%s), shutting down segment", dir);
 

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -454,10 +454,7 @@ SysLoggerMain(int argc, char *argv[])
 				currentLogDir = pstrdup(Log_directory);
 				rotation_requested = true;
 
-				/*
-				 * Also, create new directory if not present; ignore errors
-				 */
-				(void) MakePGDirectory(Log_directory);
+				pg_mkdir_p(Log_directory, pg_dir_create_mode);
 			}
 			if (strcmp(Log_filename, currentLogFilename) != 0)
 			{
@@ -841,10 +838,7 @@ SysLogger_Start(void)
 	}
 #endif
 
-	/*
-	 * Create log directory if not present; ignore errors
-	 */
-	(void) MakePGDirectory(Log_directory);
+	pg_mkdir_p(Log_directory, pg_dir_create_mode);
 
 	/*
 	 * The initial logfile is created right in the postmaster, to verify that
@@ -2385,7 +2379,6 @@ logfile_rotate(bool time_based_rotation, bool size_based_rotation,
 
 	return true;
 }
-
 
 /*
  * construct logfile name using timestamp information

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -1456,6 +1456,13 @@ sendDir(const char *path, int basepathlen, bool sizeonly, List *tablespaces,
 		if (excludeFound)
 			continue;
 
+		if (strcmp(de->d_name, Log_directory) == 0)
+		{
+			elog(DEBUG1, "contents of directory \"%s\" excluded from backup", de->d_name);
+			size += _tarWriteDir(pathbuf, basepathlen, &statbuf, sizeonly);
+			continue;
+		}
+
 		/*
 		 * Exclude contents of directory specified by statrelpath if not set
 		 * to the default (pg_stat_tmp) which is caught in the loop above.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -165,6 +165,7 @@ static bool call_string_check_hook(struct config_string *conf, char **newval,
 static bool call_enum_check_hook(struct config_enum *conf, int *newval,
 								 void **extra, GucSource source, int elevel);
 
+static bool check_log_directory(char **newval, void **extra, GucSource source);
 static bool check_log_destination(char **newval, void **extra, GucSource source);
 static void assign_log_destination(const char *newval, void *extra);
 
@@ -190,6 +191,7 @@ static bool check_canonical_path(char **newval, void **extra, GucSource source);
 static bool check_timezone_abbreviations(char **newval, void **extra, GucSource source);
 static void assign_timezone_abbreviations(const char *newval, void *extra);
 static const char *show_archive_command(void);
+static const char *show_log_directory_command(void);
 static void assign_tcp_keepalives_idle(int newval, void *extra);
 static void assign_tcp_keepalives_interval(int newval, void *extra);
 static void assign_tcp_keepalives_count(int newval, void *extra);
@@ -3980,15 +3982,15 @@ static struct config_string ConfigureNamesString[] =
 		check_log_destination, assign_log_destination, NULL
 	},
 	{
-		{"log_directory", PGC_SIGHUP, DEFUNCT_OPTIONS,
+		{"log_directory", PGC_SIGHUP, LOGGING_WHERE,
 			gettext_noop("Defunct: Sets the destination directory for log files."),
 			gettext_noop("Can be specified as relative to the data directory "
 						 "or as absolute path."),
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL
+			GUC_SUPERUSER_ONLY
 		},
 		&Log_directory,
 		"log",
-		check_canonical_path, NULL, NULL
+		check_log_directory, NULL, show_log_directory_command
 	},
 	{
 		{"log_filename", PGC_SIGHUP, LOGGING_WHERE,
@@ -11489,6 +11491,29 @@ assign_wal_consistency_checking(const char *newval, void *extra)
 }
 
 static bool
+check_log_directory(char **newval, void **extra, GucSource source)
+{
+	char *original_val = NULL;
+	char temp_buf[MAXPGPATH];
+
+	check_canonical_path(newval, extra, source);
+
+	/*
+	 * Having multiple segments using the same directory will create logfile
+	 * conflicts. Use dbid to make each segment log directory unique.
+	 */
+	if (!path_is_relative_and_below_cwd(*newval))
+	{
+		original_val = *newval;
+		snprintf(temp_buf, MAXPGPATH, "%s/%d",original_val, GpIdentity.dbid);
+		*newval = guc_strdup(ERROR, temp_buf);
+		free(original_val);
+	}
+
+	return true;
+}
+
+static bool
 check_log_destination(char **newval, void **extra, GucSource source)
 {
 	char	   *rawstring;
@@ -11726,6 +11751,22 @@ show_archive_command(void)
 		return XLogArchiveCommand;
 	else
 		return "(disabled)";
+}
+
+static const char *
+show_log_directory_command(void)
+{
+	static char show_path[MAXPGPATH];
+
+	/* trim out the dbid when reporting to the user */
+	if (!path_is_relative_and_below_cwd(Log_directory))
+	{
+		snprintf(show_path, sizeof(show_path), "%s", Log_directory);
+		get_parent_directory(show_path);
+		return show_path;
+	}
+
+	return Log_directory;
 }
 
 static void

--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -94,6 +94,9 @@ libpqConnect(const char *connstr)
 		pg_fatal("full_page_writes must be enabled in the source server");
 	pg_free(str);
 
+	log_directory = run_simple_query("SHOW log_directory");
+	pg_log_debug("log directory: %s", log_directory);
+
 	/*
 	 * Although we don't do any "real" updates, we do work with a temporary
 	 * table. We don't care about synchronous commit for that. It doesn't

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -57,6 +57,7 @@ int			WalSegSz;
 char	   *datadir_target = NULL;
 char	   *datadir_source = NULL;
 char	   *connstr_source = NULL;
+char	   *log_directory = NULL;
 
 static bool debug = false;
 bool		showprogress = false;
@@ -495,6 +496,7 @@ main(int argc, char **argv)
 		pg_log_info("syncing target data directory");
 	syncTargetDirectory();
 
+	pg_free(log_directory);
 	pg_log_info("Done!");
 
 	return 0;

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -39,6 +39,9 @@ extern int	targetNentries;
 /* general state */
 extern PGconn *conn;
 
+/* guc collection */
+extern char	   *log_directory;
+
 /* Progress counters */
 extern uint64 fetch_size;
 extern uint64 fetch_done;

--- a/src/bin/pg_rewind/t/RewindTest.pm
+++ b/src/bin/pg_rewind/t/RewindTest.pm
@@ -152,6 +152,7 @@ sub start_master
 	$node_master->psql(
 		'postgres', "
 		CREATE ROLE rewind_user LOGIN;
+		GRANT pg_read_all_settings TO rewind_user;
 		GRANT EXECUTE ON function pg_catalog.pg_ls_dir(text, boolean, boolean)
 		  TO rewind_user;
 		GRANT EXECUTE ON function pg_catalog.pg_stat_file(text, boolean)

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -54,6 +54,7 @@ typedef struct extvar_t
 	char* GP_USER;
 	char* GP_SEG_PG_CONF;   /*location of the segments pg_conf file*/
 	char* GP_SEG_DATADIR;   /*location of the segments datadirectory*/
+	char* GP_SEG_LOGDIR;    /*location of the segment's log directory*/
 	char GP_DATE[9];		/* YYYYMMDD */
 	char GP_TIME[7];		/* HHMMSS */
 	char GP_XID[TMGIDSIZE];		/* global transaction id */

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -238,6 +238,7 @@ extern bool ConvertCoordinatorDataDirToSegment;
 extern PGDLLIMPORT bool ExitOnAnyError;
 
 extern PGDLLIMPORT char *DataDir;
+extern PGDLLIMPORT char *Log_directory;
 extern PGDLLIMPORT int data_directory_mode;
 
 extern PGDLLIMPORT int NBuffers;

--- a/src/test/isolation2/expected/log_directory.out
+++ b/src/test/isolation2/expected/log_directory.out
@@ -1,0 +1,117 @@
+-- This is to test GUC log_directory
+-- Expected behavior:
+-- If the log_directory is outside the datadir, create the path and a child
+-- directory with dbid as the name.
+-- If the log_directory is within the datadir, just create it and use
+
+-- SETUP
+-- start_ignore
+! gpconfig -c log_directory -v relative_log;
+
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: relative_log
+Segment     value: relative_log
+
+
+-- SCENARIO: pg_basebackup with force-overwrite should not overwrite the
+-- `log_directory` inside the data directory
+! mkdir -p /tmp/datafoo/relative_log;
+
+! echo "fakeinfo" > /tmp/datafoo/relative_log/fakefile;
+
+SELECT pg_basebackup(address, 100, port, false, NULL, '/tmp/datafoo', true, 'stream') FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ pg_basebackup 
+---------------
+               
+(1 row)
+-- verify: fakefile should still exist
+! diff -r $COORDINATOR_DATA_DIRECTORY /tmp/datafoo | grep fakefile;
+Only in /tmp/datafoo/relative_log: fakefile
+
+! rm -rf /tmp/datafoo;
+
+
+-- SCENARIO: Verify absolute path works
+! rm -rf /tmp/foobar;
+
+-- start_ignore
+! gpconfig -c log_directory -v /tmp/foobar;
+
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: /tmp/foobar
+Segment     value: /tmp/foobar
+
+! ls /tmp/foobar;
+1
+2
+3
+4
+5
+6
+7
+8
+
+
+-- verify reading the logs works for absolute paths
+CREATE TABLE logdir_test_absolute(a int);
+CREATE TABLE
+-- this should return 1
+SELECT COUNT(*) FROM gp_toolkit.__gp_log_coordinator_ext WHERE logmessage LIKE 'statement: CREATE TABLE logdir_test_absolute%';
+ count 
+-------
+ 1     
+(1 row)
+
+-- SCENARIO: Verify relative path works
+-- start_ignore
+! gpconfig -c log_directory -v still_relative;
+
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: still_relative
+Segment     value: still_relative
+
+
+-- verify reading the logs works for non-default relative path
+CREATE TABLE logdir_test_relative_path(a int);
+CREATE TABLE
+-- this should return 1
+SELECT COUNT(*) FROM gp_toolkit.__gp_log_coordinator_ext WHERE logmessage LIKE 'statement: CREATE TABLE logdir_test_relative_path%';
+ count 
+-------
+ 1     
+(1 row)
+
+-- return to default
+-- start_ignore
+! gpconfig -r log_directory;
+
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: log
+Segment     value: log
+
+
+-- cleanup
+! rm -rf /tmp/foobar;
+
+! rm -rf $COORDINATOR_DATA_DIRECTORY/still_relative;
+
+DROP TABLE logdir_test_absolute;
+DROP TABLE
+DROP TABLE logdir_test_relative_path;
+DROP TABLE

--- a/src/test/isolation2/expected/prepared_xact_deadlock_pg_rewind.out
+++ b/src/test/isolation2/expected/prepared_xact_deadlock_pg_rewind.out
@@ -13,6 +13,58 @@ ALTER SYSTEM
  t              
 (1 row)
 
+!\retcode gpconfig -c log_directory -v relative_log;
+-- start_ignore
+20230807:17:11:46:067216 gpconfig:tmarbin7MD6R:tmarbin-[INFO]:-completed successfully with parameters '-c log_directory -v relative_log'
+
+-- end_ignore
+(exited with code 0)
+-- start_ignore
+!\retcode gpstop -u;
+-- start_ignore
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Starting gpstop with args: -u
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Gathering information and validating the environment...
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Segment details from coordinator...
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev'
+20230807:17:11:47:067341 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+!\retcode sleep 1;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+!\retcode gpconfig -s log_directory;
+-- start_ignore
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: relative_log
+Segment     value: relative_log
+
+-- end_ignore
+(exited with code 0)
+
+select remove_bogus_file(datadir, setting) from pg_settings, gp_segment_configuration c where c.content=0 AND name='log_directory';
+ remove_bogus_file 
+-------------------
+                   
+                   
+(2 rows)
+-- write a bogus file to show that we are not syncing the bogus file during recoverseg with pg_rewind
+select write_bogus_file(datadir, setting) from pg_settings, gp_segment_configuration c where c.role='p' and c.content=0 AND name='log_directory';
+ write_bogus_file 
+------------------
+ OK               
+(1 row)
+select assert_bogus_file_does_not_exist(datadir, setting) from pg_settings, gp_segment_configuration c where c.role='m' and c.content=0 AND name='log_directory';
+ assert_bogus_file_does_not_exist 
+----------------------------------
+ OK                               
+(1 row)
+
 1: select gp_inject_fault('after_xlog_xact_prepare_flushed', 'suspend', dbid) from gp_segment_configuration where role='p' and content = 0;
  gp_inject_fault 
 -----------------
@@ -70,12 +122,246 @@ select wait_until_all_segments_synchronized();
  OK                                   
 (1 row)
 !\retcode gprecoverseg -ar;
+-- start_ignore
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Starting gprecoverseg with args: -ar
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev'
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 12.12 (Greenplum Database 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev) on x86_64-apple-darwin22.6.0, compiled by Homebrew clang version 16.0.5, 64-bit compiled on Aug  7 2023 09:58:41 (with assert checking) Bhuvnesh C.'
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Segment details from coordinator...
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Greenplum instance recovery parameters
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Recovery type              = Rebalance
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Unbalanced segment 1 of 2
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance host        = tmarbin7MD6R.vmware.com
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance address     = tmarbin7MD6R.vmware.com
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance directory   = /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance port        = 7005
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Balanced role                   = Mirror
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Current role                    = Primary
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Unbalanced segment 2 of 2
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance host        = tmarbin7MD6R.vmware.com
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance address     = tmarbin7MD6R.vmware.com
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance directory   = /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Unbalanced instance port        = 7002
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Balanced role                   = Primary
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Current role                    = Mirror
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Determining primary and mirror segment pairs to rebalance
+20230807:17:12:03:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Stopping unbalanced primary segments...
+...
+20230807:17:12:06:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Triggering segment reconfiguration
+20230807:17:12:10:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Starting segment synchronization
+20230807:17:12:10:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-=============================START ANOTHER RECOVER=========================================
+20230807:17:12:10:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev'
+20230807:17:12:10:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 12.12 (Greenplum Database 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev) on x86_64-apple-darwin22.6.0, compiled by Homebrew clang version 16.0.5, 64-bit compiled on Aug  7 2023 09:58:41 (with assert checking) Bhuvnesh C.'
+20230807:17:12:10:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Segment details from coordinator...
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Successfully finished pg_controldata /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0 for dbid 2:
+stdout: pg_control version number:            12010700
+Catalog version number:               302307241
+Database system identifier:           7264634836426760954
+Database cluster state:               in production
+pg_control last modified:             Mon Aug  7 17:12:10 2023
+Latest checkpoint location:           0/45487F90
+Latest checkpoint's REDO location:    0/45472768
+Latest checkpoint's REDO WAL file:    0000001B0000000000000011
+Latest checkpoint's TimeLineID:       27
+Latest checkpoint's PrevTimeLineID:   27
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0:1555
+Latest checkpoint's NextGxid:         8658
+Latest checkpoint's NextOID:          123598
+Latest checkpoint's NextRelfilenode:  122916
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        529
+Latest checkpoint's oldestXID's DB:   13719
+Latest checkpoint's oldestActiveXID:  1555
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 13720
+Latest checkpoint's oldestCommitTsXid:0
+Latest checkpoint's newestCommitTsXid:0
+Time of latest checkpoint:            Mon Aug  7 17:12:08 2023
+Fake LSN counter for unlogged rels:   0/3E8
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+wal_level setting:                    replica
+wal_log_hints setting:                off
+max_connections setting:              750
+max_worker_processes setting:         12
+max_wal_senders setting:              10
+max_prepared_xacts setting:           250
+max_locks_per_xact setting:           128
+track_commit_timestamp setting:       off
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+Mock authentication nonce:            e9e26648a2e4ba839e9edbcf76868f6cffb98773b915116863a12c21e7b8f01e
+
+stderr: 
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Successfully finished pg_controldata /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0 for dbid 5:
+stdout: pg_control version number:            12010700
+Catalog version number:               302307241
+Database system identifier:           7264634836426760954
+Database cluster state:               shut down
+pg_control last modified:             Mon Aug  7 17:12:04 2023
+Latest checkpoint location:           0/454726B0
+Latest checkpoint's REDO location:    0/454726B0
+Latest checkpoint's REDO WAL file:    0000001A0000000000000011
+Latest checkpoint's TimeLineID:       26
+Latest checkpoint's PrevTimeLineID:   26
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0:1555
+Latest checkpoint's NextGxid:         8658
+Latest checkpoint's NextOID:          123598
+Latest checkpoint's NextRelfilenode:  122916
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        529
+Latest checkpoint's oldestXID's DB:   13719
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 13720
+Latest checkpoint's oldestCommitTsXid:0
+Latest checkpoint's newestCommitTsXid:0
+Time of latest checkpoint:            Mon Aug  7 17:12:04 2023
+Fake LSN counter for unlogged rels:   0/3E8
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+wal_level setting:                    replica
+wal_log_hints setting:                off
+max_connections setting:              750
+max_worker_processes setting:         12
+max_wal_senders setting:              10
+max_prepared_xacts setting:           250
+max_locks_per_xact setting:           128
+track_commit_timestamp setting:       off
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+Mock authentication nonce:            e9e26648a2e4ba839e9edbcf76868f6cffb98773b915116863a12c21e7b8f01e
+
+stderr: 
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Greenplum instance recovery parameters
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Recovery type              = Standard
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Recovery 1 of 1
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Synchronization mode                 = Incremental
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Failed instance host                 = tmarbin7MD6R.vmware.com
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Failed instance address              = tmarbin7MD6R.vmware.com
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Failed instance directory            = /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Failed instance port                 = 7005
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Recovery Source instance host        = tmarbin7MD6R.vmware.com
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Recovery Source instance address     = tmarbin7MD6R.vmware.com
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Recovery Source instance directory   = /Users/tmarbin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Recovery Source instance port        = 7002
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-   Recovery Target                      = in-place
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:----------------------------------------------------------
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Starting to create new pg_hba.conf on primary segments
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-killing existing walsender process on primary tmarbin7MD6R.vmware.com:7002 to refresh replication connection
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Successfully modified pg_hba.conf on primary segments to allow replication connections
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-1 segment(s) to recover
+20230807:17:12:11:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Ensuring 1 failed segment(s) are stopped
+20230807:17:12:12:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Setting up the required segments for recovery
+20230807:17:12:12:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Updating configuration for mirrors
+20230807:17:12:12:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Initiating segment recovery. Upon completion, will start the successfully recovered segments
+20230807:17:12:12:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-era is c02d89bbf5444e0b_230807162043
+tmarbin7MD6R.vmware.com (dbid 5): pg_rewind: no rewind required
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Triggering FTS probe
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-********************************
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Segments successfully recovered.
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-********************************
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Recovered mirror segments need to sync WAL with primary segments.
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-Use 'gpstate -e' to check progress of WAL sync remaining bytes
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-==============================END ANOTHER RECOVER==========================================
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-******************************************************************
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-The rebalance operation has completed successfully.
+20230807:17:12:14:067700 gprecoverseg:tmarbin7MD6R:tmarbin-[INFO]:-******************************************************************
+
+-- end_ignore
 (exited with code 0)
 select wait_until_all_segments_synchronized();
  wait_until_all_segments_synchronized 
 --------------------------------------
  OK                                   
 (1 row)
+select assert_bogus_file_does_not_exist(datadir, setting) from pg_settings, gp_segment_configuration c where c.role='m' and c.content=0 AND name='log_directory';
+ assert_bogus_file_does_not_exist 
+----------------------------------
+ OK                               
+(1 row)
+
+-- cleanup
+select remove_bogus_file(datadir, setting) from pg_settings, gp_segment_configuration c where c.content=0 AND name='log_directory';
+ remove_bogus_file 
+-------------------
+                   
+                   
+(2 rows)
+!\retcode gpconfig -c log_directory -v log;
+-- start_ignore
+20230807:17:12:15:068098 gpconfig:tmarbin7MD6R:tmarbin-[INFO]:-completed successfully with parameters '-c log_directory -v log'
+
+-- end_ignore
+(exited with code 0)
+-- start_ignore
+!\retcode gpstop -u;
+-- start_ignore
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Starting gpstop with args: -u
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Gathering information and validating the environment...
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Segment details from coordinator...
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev'
+20230807:17:12:15:068219 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+!\retcode sleep 1;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+!\retcode gpconfig -s log_directory;
+-- start_ignore
+Values on all segments are consistent
+GUC              : log_directory
+Coordinator value: log
+Segment     value: log
+
+-- end_ignore
+(exited with code 0)
 
 -- reset fts GUCs.
 3: alter system reset gp_fts_probe_retries;

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -1,3 +1,18 @@
+-- start_ignore
+! gpconfig -c plpython3.python_path -v "'$GPHOME/lib/python'" --skipvalidation;
+20230807:17:11:44:067053 gpconfig:tmarbin7MD6R:tmarbin-[INFO]:-completed successfully with parameters '-c plpython3.python_path -v ''"'"'/usr/local/gpdb/lib/python'"'"'' --skipvalidation'
+
+! gpstop -u;
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Starting gpstop with args: -u
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Gathering information and validating the environment...
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Obtaining Segment details from coordinator...
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.40.gba435b5c3b9 build dev'
+20230807:17:11:44:067174 gpstop:tmarbin7MD6R:tmarbin-[INFO]:-Signalling all postmaster processes to reload
+
+create or replace language plpython3u;
+CREATE LANGUAGE
+-- end_ignore
 
 -- Helper function, to call either __gp_aoseg, or gp_aocsseg, depending
 -- on whether the table is row- or column-oriented. This allows us to
@@ -168,4 +183,15 @@ CREATE FUNCTION
 
 -- Check if autovacuum is enabled/disabled by inspecting the av launcher.
 CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS $$ declare retries int; /* in func */ expected_count int; /* in func */ begin retries := 1200; /* in func */ if enabled then /* (1 for each primary and 1 for the coordinator) */ expected_count := 4; /* in func */ else expected_count := 0; /* in func */ end if; /* in func */ loop if (select count(*) = expected_count from gp_stat_activity where backend_type = 'autovacuum launcher') then return true; /* in func */ end if; /* in func */ if retries <= 0 then return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE FUNCTION
+
+CREATE OR REPLACE FUNCTION write_bogus_file(datadir text, log_dir text) RETURNS TEXT AS $$ import subprocess import os bogus_file = os.path.join(datadir, log_dir, 'bogusfile') cmd = "echo 'something' >> %s" % bogus_file 
+proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True) stdout, stderr = proc.communicate() 
+if proc.returncode == 0: return 'OK' else: raise Exception(stdout.decode()+'|'+stderr.decode()) $$ LANGUAGE plpython3u;
+CREATE FUNCTION
+
+CREATE OR REPLACE FUNCTION remove_bogus_file(datadir text, log_dir text) RETURNS TEXT AS $$ import subprocess import os bogus_file = os.path.join(datadir, log_dir, 'bogusfile') try: os.remove(bogus_file) except FileNotFoundError as e: pass $$ LANGUAGE plpython3u;
+CREATE FUNCTION
+
+CREATE OR REPLACE FUNCTION assert_bogus_file_does_not_exist(datadir text, log_dir text) RETURNS TEXT AS $$ import subprocess import os bogus_file = os.path.join(datadir, log_dir, 'bogusfile') if os.path.exists(bogus_file): raise Exception("bogus file: %s should not exist" % bogus_file) return 'OK' $$ LANGUAGE plpython3u;
 CREATE FUNCTION

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -8,6 +8,7 @@ test: checkpoint_dtx_info
 test: autovacuum-analyze
 test: vacuum_skip_locked_onseg
 test: lockmodes
+test: log_directory
 test: pg_rewind_fail_missing_xlog
 test: prepared_xact_deadlock_pg_rewind
 test: ao_partition_lock

--- a/src/test/isolation2/sql/log_directory.sql
+++ b/src/test/isolation2/sql/log_directory.sql
@@ -1,0 +1,60 @@
+-- This is to test GUC log_directory
+-- Expected behavior:
+-- If the log_directory is outside the datadir, create the path and a child
+-- directory with dbid as the name.
+-- If the log_directory is within the datadir, just create it and use
+
+-- SETUP
+-- start_ignore
+! gpconfig -c log_directory -v relative_log;
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+
+-- SCENARIO: pg_basebackup with force-overwrite should not overwrite the
+-- `log_directory` inside the data directory
+! mkdir -p /tmp/datafoo/relative_log;
+! echo "fakeinfo" > /tmp/datafoo/relative_log/fakefile;
+SELECT pg_basebackup(address, 100, port, false, NULL, '/tmp/datafoo', true, 'stream') FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+-- verify: fakefile should still exist
+! diff -r $COORDINATOR_DATA_DIRECTORY /tmp/datafoo | grep fakefile;
+! rm -rf /tmp/datafoo;
+
+-- SCENARIO: Verify absolute path works
+! rm -rf /tmp/foobar;
+-- start_ignore
+! gpconfig -c log_directory -v /tmp/foobar;
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+! ls /tmp/foobar;
+
+-- verify reading the logs works for absolute paths
+CREATE TABLE logdir_test_absolute(a int);
+-- this should return 1
+SELECT COUNT(*) FROM gp_toolkit.__gp_log_coordinator_ext WHERE logmessage LIKE 'statement: CREATE TABLE logdir_test_absolute%';
+
+-- SCENARIO: Verify relative path works
+-- start_ignore
+! gpconfig -c log_directory -v still_relative;
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+
+-- verify reading the logs works for non-default relative path
+CREATE TABLE logdir_test_relative_path(a int);
+-- this should return 1
+SELECT COUNT(*) FROM gp_toolkit.__gp_log_coordinator_ext WHERE logmessage LIKE 'statement: CREATE TABLE logdir_test_relative_path%';
+
+-- return to default
+-- start_ignore
+! gpconfig -r log_directory;
+! gpstop -u;
+-- end_ignore
+! gpconfig -s log_directory;
+
+-- cleanup
+! rm -rf /tmp/foobar;
+! rm -rf $COORDINATOR_DATA_DIRECTORY/still_relative;
+DROP TABLE logdir_test_absolute;
+DROP TABLE logdir_test_relative_path;


### PR DESCRIPTION
  Enable GUC `log_directory` to be modifiable

  This commit enables the flexibility of `log_directory`.
  There are three scenarios to consider.
  - Absolute path
  - Relative path to the data directory
  - Relative path but goes outside the data directory

When the GUC change is an absolute path (or outside the data directory),
we will append a unique identifier (DBID) to the `log_directory` GUC. If
we do not do this, the segment logs will overwrite one another and cause issues.
    For example:
        `log_directory: /tmp/foosball` will internally change to
        coordinator: /tmp/foosball/1, seg0: /tmp/foosball/2, seg1:
        /tmp/foosball/3, and so on.

   The points above are all internal, so when a user queries the
    `log_directory` GUC, it will not have the DBID.

   For example:

          $ gpconfig -s log_directory
          Values on all segments are consistent
          GUC              : log_directory
          Coordinator value: /tmp/foosball
          Segment     value: /tmp/foosball

The change will work with reload `gpstop -u` and immediately take effect
once the reload is done. NOTE: there maybe some time required per reload.

COMMIT NOTES

  - Add `GP_SEG_LOGDIR` environment variable for gp_toolkit
    In order to know the segment log directory per segment, introduce
    `GP_SEG_LOGDIR`.
  - Update `get_debug_event_counters.py` for `log_directory` GUC
  - Make the default search be more flexible to accomadate the `log_directory`
    GUC.
  - Add log_directory GUC test

  postmaster logging:
    Also check the `Log_directory` to see if we can elog to the absolute
    path directory instead of the default `log` directory in datadir.

  gprecoverseg:
    - Add log_directory GUC for `gprecoverseg --differential`
      Exclude relative path `log_directory` GUC when doing an rsync with
      `--differential`.
    - Update to use `set` instead of `list` for `exclude_list` to easily add
      directories and to easily determine if there is a test failure

  basebackup:
      - Exclude `log_directory` from basebackup.c

  pg_basebackup:
      - Exclude `log_directory` for pg_basebackup
        During `--force-overwrite`, we need to ensure that we don't clear out the
        `log_directory`.

  pg_rewind:
      - Exclude `log_directory` GUC when using pg_rewind with --source-server
      - When using `--source-server`, we require to read `log_directory`
        GUC from the database; hence, we now require access privileges for
        pg_read_all_settings.
      - Modify pg_rewind TAP test to accomadate `log_directory` change
      NOTE: this feature is only for `--source-server` and
      `--source-pgdata` will not exclude the `log_directory`. This is due
      to the limitation of not knowing the log directory location for
      `--source-pgdata` since the database is not up.