### PR TITLE
Make slabs and generations use gp_malloc|free

### DIFF
--- a/src/backend/utils/mmgr/generation.c
+++ b/src/backend/utils/mmgr/generation.c
@@ -39,9 +39,9 @@
 #include "postgres.h"
 
 #include "lib/ilist.h"
+#include "utils/gp_alloc.h"
 #include "utils/memdebug.h"
 #include "utils/memutils.h"
-
 
 #define Generation_BLOCKHDRSZ	MAXALIGN(sizeof(GenerationBlock))
 #define Generation_CHUNKHDRSZ	sizeof(GenerationChunk)
@@ -241,7 +241,7 @@ GenerationContextCreate(MemoryContext parent,
 	 * freeing the first generation of allocations.
 	 */
 
-	set = (GenerationContext *) malloc(MAXALIGN(sizeof(GenerationContext)));
+	set = (GenerationContext *) gp_malloc(MAXALIGN(sizeof(GenerationContext)));
 	if (set == NULL)
 	{
 		MemoryContextStats(TopMemoryContext);
@@ -304,7 +304,7 @@ GenerationReset(MemoryContext context)
 		wipe_mem(block, block->blksize);
 #endif
 
-		free(block);
+		gp_free(block);
 	}
 
 	set->block = NULL;
@@ -322,7 +322,7 @@ GenerationDelete(MemoryContext context, MemoryContext parent)
 	/* Reset to release all the GenerationBlocks */
 	GenerationReset(context);
 	/* And free the context header */
-	free(context);
+	gp_free(context);
 }
 
 /*
@@ -351,7 +351,7 @@ GenerationAlloc(MemoryContext context, Size size)
 	{
 		Size		blksize = chunk_size + Generation_BLOCKHDRSZ + Generation_CHUNKHDRSZ;
 
-		block = (GenerationBlock *) malloc(blksize);
+		block = (GenerationBlock *) gp_malloc(blksize);
 		if (block == NULL)
 			return NULL;
 
@@ -407,7 +407,7 @@ GenerationAlloc(MemoryContext context, Size size)
 	{
 		Size		blksize = set->blockSize;
 
-		block = (GenerationBlock *) malloc(blksize);
+		block = (GenerationBlock *) gp_malloc(blksize);
 
 		if (block == NULL)
 			return NULL;
@@ -530,7 +530,7 @@ GenerationFree(MemoryContext context, void *pointer)
 		set->block = NULL;
 
 	context->mem_allocated -= block->blksize;
-	free(block);
+	gp_free(block);
 }
 
 /*

--- a/src/backend/utils/mmgr/slab.c
+++ b/src/backend/utils/mmgr/slab.c
@@ -54,8 +54,8 @@
 
 #include "utils/memdebug.h"
 #include "utils/memutils.h"
+#include "utils/gp_alloc.h"
 #include "lib/ilist.h"
-
 
 /*
  * SlabContext is a specialized implementation of MemoryContext.
@@ -243,7 +243,7 @@ SlabContextCreate(MemoryContext parent,
 	headerSize += chunksPerBlock * sizeof(bool);
 #endif
 
-	slab = (SlabContext *) malloc(headerSize);
+	slab = (SlabContext *) gp_malloc(headerSize);
 	if (slab == NULL)
 	{
 		MemoryContextStats(TopMemoryContext);
@@ -322,7 +322,7 @@ SlabReset(MemoryContext context)
 #ifdef CLOBBER_FREED_MEMORY
 			wipe_mem(block, slab->blockSize);
 #endif
-			free(block);
+			gp_free(block);
 			slab->nblocks--;
 			context->mem_allocated -= slab->blockSize;
 		}
@@ -344,7 +344,7 @@ SlabDelete(MemoryContext context, MemoryContext parent)
 	/* Reset to release all the SlabBlocks */
 	SlabReset(context);
 	/* And free the context header */
-	free(context);
+	gp_free(context);
 }
 
 /*
@@ -379,7 +379,7 @@ SlabAlloc(MemoryContext context, Size size)
 	 */
 	if (slab->minFreeChunks == 0)
 	{
-		block = (SlabBlock *) malloc(slab->blockSize);
+		block = (SlabBlock *) gp_malloc(slab->blockSize);
 
 		if (block == NULL)
 			return NULL;
@@ -578,7 +578,7 @@ SlabFree(MemoryContext context, void *pointer)
 	/* If the block is now completely empty, free it. */
 	if (block->nfree == slab->chunksPerBlock)
 	{
-		free(block);
+		gp_free(block);
 		slab->nblocks--;
 		context->mem_allocated -= slab->blockSize;
 	}


### PR DESCRIPTION
We need to call gp_malloc|free() for the newly added MemoryContext types
instead of malloc|free(), so that we can get the VMEM reservation etc.

This was missed during the 12 merge.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/use_gp_malloc
