### PR TITLE
Don't inherit parent's reloptions if child partition's AM differs

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1814,10 +1814,12 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 		/* if WITH has "tablename" then it will be used as name for partition */
 		partcomp.tablename = extract_tablename_from_options(&elem->options);
 
-		if (elem->options == NIL)
-			elem->options = parentoptions ? copyObject(parentoptions) : NIL;
 		if (elem->accessMethod == NULL)
 			elem->accessMethod = parentaccessmethod ? pstrdup(parentaccessmethod) : NULL;
+
+		/* if no options are specified AND child has same access method as parent, use parent options */
+		if (elem->options == NIL && (!parentaccessmethod || strcmp(elem->accessMethod, parentaccessmethod) == 0))
+			elem->options = parentoptions ? copyObject(parentoptions) : NIL;
 
 		if (elem->accessMethod && strcmp(elem->accessMethod, "ao_column") == 0)
 			elem->colencs = merge_partition_encoding(pstate, elem->colencs, penc_cls);

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -14,6 +14,7 @@
 #include "postgres.h"
 
 #include "access/table.h"
+#include "access/tableam.h"
 #include "catalog/partition.h"
 #include "catalog/pg_collation.h"
 #include "catalog/gp_partition_template.h"
@@ -1818,7 +1819,10 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 			elem->accessMethod = parentaccessmethod ? pstrdup(parentaccessmethod) : NULL;
 
 		/* if no options are specified AND child has same access method as parent, use parent options */
-		if (elem->options == NIL && (!parentaccessmethod || strcmp(elem->accessMethod, parentaccessmethod) == 0))
+		if (elem->options == NIL &&
+			(!elem->accessMethod ||
+			(parentaccessmethod && strcmp(elem->accessMethod, parentaccessmethod) == 0) ||
+			(!parentaccessmethod && strcmp(elem->accessMethod, default_table_access_method) == 0)))
 			elem->options = parentoptions ? copyObject(parentoptions) : NIL;
 
 		if (elem->accessMethod && strcmp(elem->accessMethod, "ao_column") == 0)

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -977,13 +977,15 @@ create unique index on root_part_1_prt_interior_1_2_prt_leaf(a, b);
 alter table root_part_1_prt_interior_1_2_prt_leaf add primary key using index root_part_1_prt_interior_1_2_prt_leaf_a_b_idx2;
 drop table root_part;
 
--- Allow both parent partitioned table and child partitioned table to specify reloptions in WITH clause.
+-- The following tests verifies reloptions inheritance for partitioned tables.
 -- When parent's reloptions are specified, a child partition's reloptions should be set as below:
 -- 1) If child's reloptions are specified, then the child's reloptions override the parent's reloptions.
 -- 2) If child's reloptions are not specified, and if parent's and child's table access methods are same, then the parent's reloptions are inherited.
 -- 3) If child's reloptions are not specified, and if parent's and child's table access methods are different, then the child's reloptions are set to default.
 -- 4) Note that "appendonly" and "orientation" reloptions are not "real" reloptions and are instead treated as table access method specifications.
 -- So, if child's WITH clause has only "appendonly" and/or "orientation" specified, they are handled as in (2) and (3) above.
+
+-- Test 1: Parent's reloptions are explicitly specified, and parent's AM is explicitly specified as ao_row
 create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compresslevel=5,blocksize=65536)
 	partition by range(b)
 		(partition p1_heap start (0) end (10) with (appendonly=false),
@@ -991,3 +993,28 @@ create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compr
 		 partition p3_new_relopt start (20) end (30) with (compresstype=zstd, compresslevel=3),
 		 default partition def);
 select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+
+-- Test 2: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+create table part_heap1(a int, b int) using heap with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap1') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+
+-- Test 3: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+create table part_heap2(a int, b int) with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap2') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+
+-- Test 4: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as ao_column
+set default_table_access_method = 'ao_column';
+create table part_aoco(a int, b int) with (compresstype=zlib,compresslevel=5,blocksize=65536)
+	partition by range(b)
+		(partition p1_heap start (0) end (10) with (appendonly=false),
+		 partition p2_ao start (10) end (20) with (appendonly=true, orientation=row),
+		 partition p3_new_relopt start (20) end (30) with (compresstype=zstd, compresslevel=3),
+		 default partition def);
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_aoco') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+reset default_table_access_method;
+
+-- cleanup
+drop table part_ao;
+drop table part_heap1;
+drop table part_heap2;
+drop table part_aoco;

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -976,3 +976,18 @@ alter table root_part_1_prt_interior_1 add primary key using index root_part_1_p
 create unique index on root_part_1_prt_interior_1_2_prt_leaf(a, b);
 alter table root_part_1_prt_interior_1_2_prt_leaf add primary key using index root_part_1_prt_interior_1_2_prt_leaf_a_b_idx2;
 drop table root_part;
+
+-- Allow both parent partitioned table and child partitioned table to specify reloptions in WITH clause.
+-- When parent's reloptions are specified, a child partition's reloptions should be set as below:
+-- 1) If child's reloptions are specified, then the child's reloptions override the parent's reloptions.
+-- 2) If child's reloptions are not specified, and if parent's and child's table access methods are same, then the parent's reloptions are inherited.
+-- 3) If child's reloptions are not specified, and if parent's and child's table access methods are different, then the child's reloptions are set to default.
+-- 4) Note that "appendonly" and "orientation" reloptions are not "real" reloptions and are instead treated as table access method specifications.
+-- So, if child's WITH clause has only "appendonly" and/or "orientation" specified, they are handled as in (2) and (3) above.
+create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compresslevel=5,blocksize=65536)
+	partition by range(b)
+		(partition p1_heap start (0) end (10) with (appendonly=false),
+		 partition p2_aoco start (10) end (20) with (appendonly=true, orientation=column),
+		 partition p3_new_relopt start (20) end (30) with (compresstype=zstd, compresslevel=3),
+		 default partition def);
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -994,7 +994,7 @@ create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compr
 		 default partition def);
 select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
 
--- Test 2: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+-- Test 2: Parent's reloptions are explicitly specified, and parent's AM is explicitly specified as heap
 create table part_heap1(a int, b int) using heap with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
 select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap1') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
 

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2870,13 +2870,14 @@ ERROR:  ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned
 create unique index on root_part_1_prt_interior_1_2_prt_leaf(a, b);
 alter table root_part_1_prt_interior_1_2_prt_leaf add primary key using index root_part_1_prt_interior_1_2_prt_leaf_a_b_idx2;
 drop table root_part;
--- Allow both parent partitioned table and child partitioned table to specify reloptions in WITH clause.
+-- The following tests verifies reloptions inheritance for partitioned tables.
 -- When parent's reloptions are specified, a child partition's reloptions should be set as below:
 -- 1) If child's reloptions are specified, then the child's reloptions override the parent's reloptions.
 -- 2) If child's reloptions are not specified, and if parent's and child's table access methods are same, then the parent's reloptions are inherited.
 -- 3) If child's reloptions are not specified, and if parent's and child's table access methods are different, then the child's reloptions are set to default.
 -- 4) Note that "appendonly" and "orientation" reloptions are not "real" reloptions and are instead treated as table access method specifications.
 -- So, if child's WITH clause has only "appendonly" and/or "orientation" specified, they are handled as in (2) and (3) above.
+-- Test 1: Parent's reloptions are explicitly specified, and parent's AM is explicitly specified as ao_row
 create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compresslevel=5,blocksize=65536)
 	partition by range(b)
 		(partition p1_heap start (0) end (10) with (appendonly=false),
@@ -2893,3 +2894,45 @@ select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t
  part_ao_1_prt_p3_new_relopt | ao_row    | {blocksize=65536,compresstype=zstd,compresslevel=3,checksum=true}
 (5 rows)
 
+-- Test 2: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+create table part_heap1(a int, b int) using heap with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap1') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+       relname       | amname |                            reloptions                             
+---------------------+--------+-------------------------------------------------------------------
+ part_heap1          | heap   | {fillfactor=70}
+ part_heap1_1_prt_p1 | ao_row | {blocksize=32768,compresslevel=0,compresstype=none,checksum=true}
+(2 rows)
+
+-- Test 3: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+create table part_heap2(a int, b int) with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap2') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+       relname       | amname |                            reloptions                             
+---------------------+--------+-------------------------------------------------------------------
+ part_heap2          | heap   | {fillfactor=70}
+ part_heap2_1_prt_p1 | ao_row | {blocksize=32768,compresslevel=0,compresstype=none,checksum=true}
+(2 rows)
+
+-- Test 4: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as ao_column
+set default_table_access_method = 'ao_column';
+create table part_aoco(a int, b int) with (compresstype=zlib,compresslevel=5,blocksize=65536)
+	partition by range(b)
+		(partition p1_heap start (0) end (10) with (appendonly=false),
+		 partition p2_ao start (10) end (20) with (appendonly=true, orientation=row),
+		 partition p3_new_relopt start (20) end (30) with (compresstype=zstd, compresslevel=3),
+		 default partition def);
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_aoco') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+            relname            |  amname   |                            reloptions                             
+-------------------------------+-----------+-------------------------------------------------------------------
+ part_aoco                     | ao_column | {compresstype=zlib,compresslevel=5,blocksize=65536}
+ part_aoco_1_prt_def           | ao_column | {compresstype=zlib,compresslevel=5,blocksize=65536,checksum=true}
+ part_aoco_1_prt_p1_heap       | heap      | 
+ part_aoco_1_prt_p2_ao         | ao_row    | {blocksize=32768,compresslevel=0,compresstype=none,checksum=true}
+ part_aoco_1_prt_p3_new_relopt | ao_column | {blocksize=65536,compresstype=zstd,compresslevel=3,checksum=true}
+(5 rows)
+
+reset default_table_access_method;
+-- cleanup
+drop table part_ao;
+drop table part_heap1;
+drop table part_heap2;
+drop table part_aoco;

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2894,7 +2894,7 @@ select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t
  part_ao_1_prt_p3_new_relopt | ao_row    | {blocksize=65536,compresstype=zstd,compresslevel=3,checksum=true}
 (5 rows)
 
--- Test 2: Parent's reloptions are explicitly specified, and parent's AM is implicitly specified as heap
+-- Test 2: Parent's reloptions are explicitly specified, and parent's AM is explicitly specified as heap
 create table part_heap1(a int, b int) using heap with (fillfactor=70) partition by range(b) (partition p1 start(0) end(10) with(appendonly=true));
 select c.relname, am.amname, c.reloptions from pg_partition_tree('part_heap1') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
        relname       | amname |                            reloptions                             

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2870,3 +2870,26 @@ ERROR:  ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned
 create unique index on root_part_1_prt_interior_1_2_prt_leaf(a, b);
 alter table root_part_1_prt_interior_1_2_prt_leaf add primary key using index root_part_1_prt_interior_1_2_prt_leaf_a_b_idx2;
 drop table root_part;
+-- Allow both parent partitioned table and child partitioned table to specify reloptions in WITH clause.
+-- When parent's reloptions are specified, a child partition's reloptions should be set as below:
+-- 1) If child's reloptions are specified, then the child's reloptions override the parent's reloptions.
+-- 2) If child's reloptions are not specified, and if parent's and child's table access methods are same, then the parent's reloptions are inherited.
+-- 3) If child's reloptions are not specified, and if parent's and child's table access methods are different, then the child's reloptions are set to default.
+-- 4) Note that "appendonly" and "orientation" reloptions are not "real" reloptions and are instead treated as table access method specifications.
+-- So, if child's WITH clause has only "appendonly" and/or "orientation" specified, they are handled as in (2) and (3) above.
+create table part_ao(a int, b int) with (appendonly=true,compresstype=zlib,compresslevel=5,blocksize=65536)
+	partition by range(b)
+		(partition p1_heap start (0) end (10) with (appendonly=false),
+		 partition p2_aoco start (10) end (20) with (appendonly=true, orientation=column),
+		 partition p3_new_relopt start (20) end (30) with (compresstype=zstd, compresslevel=3),
+		 default partition def);
+select c.relname, am.amname, c.reloptions from pg_partition_tree('part_ao') as t join pg_class c on (t.relid::oid = c.oid) left join pg_am am on (c.relam = am.oid);
+           relname           |  amname   |                            reloptions                             
+-----------------------------+-----------+-------------------------------------------------------------------
+ part_ao                     | ao_row    | {compresstype=zlib,compresslevel=5,blocksize=65536}
+ part_ao_1_prt_def           | ao_row    | {compresstype=zlib,compresslevel=5,blocksize=65536,checksum=true}
+ part_ao_1_prt_p1_heap       | heap      | 
+ part_ao_1_prt_p2_aoco       | ao_column | {blocksize=32768,compresslevel=0,compresstype=none,checksum=true}
+ part_ao_1_prt_p3_new_relopt | ao_row    | {blocksize=65536,compresstype=zstd,compresslevel=3,checksum=true}
+(5 rows)
+


### PR DESCRIPTION
This commit addresses an issue arising when creating a partitioned table with its child partitions using the classic partitioning syntax in one command. Semantically, if both the parent and the child table had specified reloptions (using the WITH clause), the child's reloptions would override the parent's.

However, in Greenplum 7, with the integration of the table AM API, the internal parsing of "appendonly" and "orientation" as reloptions has been phased out. Instead, the syntax "USING ao_{row,column}" has been standardized, effectively making "WITH (appendonly=true, orientation=xxx)" an alias.

Thus, if a child partition is created using the classic partitioning syntax, and it uses a different table access method than its parent but doesn't specify its own reloptions, it's better for the child not to inherit the parent's reloptions. This is because these reloptions may not be compatible with the child's access method.

This commit ensures that a child partition doesn't inherit the parent's reloptions when their table access methods are different.

Fixes #14913

Reported-by: Andrew Repp <reppa@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
