### PR TITLE
Pass requiredPerms from parse tree to plstmt

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -37,6 +37,7 @@ extern "C" {
 }
 
 #include <algorithm>
+#include <limits>  // std::numeric_limits
 #include <numeric>
 #include <tuple>
 
@@ -595,8 +596,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTblScan(
 	GPOS_ASSERT(dxl_table_descr->LockMode() != -1);
 	gpdb::GPDBLockRelationOid(mdid->Oid(), dxl_table_descr->LockMode());
 
-	Index index =
-		ProcessDXLTblDescr(dxl_table_descr, &base_table_context, ACL_SELECT);
+	Index index = ProcessDXLTblDescr(dxl_table_descr, &base_table_context);
 
 	// a table scan node must have 2 children: projection list and filter
 	GPOS_ASSERT(2 == tbl_scan_dxlnode->Arity());
@@ -781,8 +781,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan(
 	GPOS_ASSERT(dxl_table_descr->LockMode() != -1);
 	gpdb::GPDBLockRelationOid(mdid->Oid(), dxl_table_descr->LockMode());
 
-	Index index =
-		ProcessDXLTblDescr(dxl_table_descr, &base_table_context, ACL_SELECT);
+	Index index = ProcessDXLTblDescr(dxl_table_descr, &base_table_context);
 
 	IndexScan *index_scan = nullptr;
 	index_scan = MakeNode(IndexScan);
@@ -953,8 +952,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan(
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(
 		physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
 
-	Index index =
-		ProcessDXLTblDescr(table_desc, &base_table_context, ACL_SELECT);
+	Index index = ProcessDXLTblDescr(table_desc, &base_table_context);
 
 	IndexOnlyScan *index_scan = MakeNode(IndexOnlyScan);
 	index_scan->scan.scanrelid = index;
@@ -3931,7 +3929,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAppend(
 		CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 		(void) ProcessDXLTblDescr(phy_append_dxlop->GetDXLTableDesc(),
-								  &base_table_context, ACL_SELECT);
+								  &base_table_context);
 
 		append->join_prune_paramids = NIL;
 		const ULongPtrArray *selector_ids = phy_append_dxlop->GetSelectorIds();
@@ -4297,7 +4295,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	Index index = ProcessDXLTblDescr(dyn_tbl_scan_dxlop->GetDXLTableDescr(),
-									 &base_table_context, ACL_SELECT);
+									 &base_table_context);
 
 	// create dynamic scan node
 	DynamicSeqScan *dyn_seq_scan = MakeNode(DynamicSeqScan);
@@ -4388,8 +4386,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 	const CDXLTableDescr *table_desc = dyn_index_scan_dxlop->GetDXLTableDescr();
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_desc->MDId());
 
-	Index index =
-		ProcessDXLTblDescr(table_desc, &base_table_context, ACL_SELECT);
+	Index index = ProcessDXLTblDescr(table_desc, &base_table_context);
 
 	DynamicIndexScan *dyn_idx_scan = MakeNode(DynamicIndexScan);
 
@@ -4537,7 +4534,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynForeignScan(
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
 	Index index = ProcessDXLTblDescr(dyn_foreign_scan_dxlop->GetDXLTableDescr(),
-									 &base_table_context, ACL_SELECT);
+									 &base_table_context);
 	// rte of root dynamic scan
 	RangeTblEntry *rte = m_dxl_to_plstmt_context->GetRTEByIndex(index);
 	Oid oid_root = rte->relid;
@@ -4680,7 +4677,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	// create ModifyTable node
 	ModifyTable *dml = MakeNode(ModifyTable);
 	Plan *plan = &(dml->plan);
-	AclMode acl_mode = ACL_NO_RIGHTS;
 	BOOL isSplit = phy_dml_dxlop->FSplit();
 
 	switch (phy_dml_dxlop->GetDmlOpType())
@@ -4688,19 +4684,16 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 		case gpdxl::Edxldmldelete:
 		{
 			m_cmd_type = CMD_DELETE;
-			acl_mode = ACL_DELETE;
 			break;
 		}
 		case gpdxl::Edxldmlupdate:
 		{
 			m_cmd_type = CMD_UPDATE;
-			acl_mode = ACL_UPDATE;
 			break;
 		}
 		case gpdxl::Edxldmlinsert:
 		{
 			m_cmd_type = CMD_INSERT;
-			acl_mode = ACL_INSERT;
 			break;
 		}
 		case gpdxl::EdxldmlSentinel:
@@ -4742,8 +4735,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 
 	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
 
-	Index index =
-		ProcessDXLTblDescr(table_descr, &base_table_context, acl_mode);
+	Index index = ProcessDXLTblDescr(table_descr, &base_table_context);
 
 	m_result_rel_list = gpdb::LAppendInt(m_result_rel_list, index);
 
@@ -5183,7 +5175,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAssert(
 Index
 CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 	const CDXLTableDescr *table_descr,
-	CDXLTranslateContextBaseTable *base_table_context, AclMode acl_mode)
+	CDXLTranslateContextBaseTable *base_table_context)
 {
 	GPOS_ASSERT(nullptr != table_descr);
 
@@ -5218,13 +5210,18 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
 	}
 
+	INT acl_mode = table_descr->GetAclMode();
+	GPOS_ASSERT(acl_mode >= 0 &&
+				acl_mode <= std::numeric_limits<AclMode>::max());
+	AclMode required_perms = static_cast<AclMode>(acl_mode);
+
 	// descriptor was already processed, and translated RTE is stored at
 	// context rtable list (only update required perms of this rte is needed)
 	if (rte_was_translated)
 	{
 		RangeTblEntry *rte = m_dxl_to_plstmt_context->GetRTEByIndex(index);
 		GPOS_ASSERT(nullptr != rte);
-		rte->requiredPerms |= acl_mode;
+		rte->requiredPerms |= required_perms;
 		return index;
 	}
 
@@ -5233,7 +5230,7 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 	rte->rtekind = RTE_RELATION;
 	rte->relid = oid;
 	rte->checkAsUser = table_descr->GetExecuteAsUserId();
-	rte->requiredPerms |= acl_mode;
+	rte->requiredPerms |= required_perms;
 	rte->rellockmode = table_descr->LockMode();
 
 	Alias *alias = MakeNode(Alias);
@@ -5282,10 +5279,16 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 
 	rte->eref = alias;
 
+	// A new RTE is added to the range table entries list if it's not found in the look
+	// up table. However, it is only added to the look up table if it's a result relation
+	// This is because the look up table is our way of merging duplicate result relations
 	m_dxl_to_plstmt_context->AddRTE(rte);
 	GPOS_ASSERT(gpdb::ListLength(
 					m_dxl_to_plstmt_context->GetRTableEntriesList()) == index);
-	m_dxl_to_plstmt_context->InsertUsedRTEIndexes(assigned_query_id, index);
+	if (UNASSIGNED_QUERYID != assigned_query_id)
+	{
+		m_dxl_to_plstmt_context->InsertUsedRTEIndexes(assigned_query_id, index);
+	}
 
 	return index;
 }
@@ -6245,8 +6248,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan(
 	GPOS_ASSERT(table_descr->LockMode() != -1);
 	gpdb::GPDBLockRelationOid(mdid->Oid(), table_descr->LockMode());
 
-	Index index =
-		ProcessDXLTblDescr(table_descr, &base_table_context, ACL_SELECT);
+	Index index = ProcessDXLTblDescr(table_descr, &base_table_context);
 
 	DynamicBitmapHeapScan *dscan;
 	BitmapHeapScan *bitmap_tbl_scan;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5188,8 +5188,10 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 	GPOS_ASSERT(nullptr != table_descr);
 
 	BOOL rte_was_translated = false;
-	Index index = m_dxl_to_plstmt_context->GetRTEIndexByTableDescr(
-		table_descr, &rte_was_translated);
+
+	ULONG assigned_query_id = table_descr->GetAssignedQueryIdForTargetRel();
+	Index index = m_dxl_to_plstmt_context->GetRTEIndexByAssignedQueryId(
+		assigned_query_id, &rte_was_translated);
 
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 	const ULONG num_of_non_sys_cols =
@@ -5281,6 +5283,9 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 	rte->eref = alias;
 
 	m_dxl_to_plstmt_context->AddRTE(rte);
+	GPOS_ASSERT(gpdb::ListLength(
+					m_dxl_to_plstmt_context->GetRTableEntriesList()) == index);
+	m_dxl_to_plstmt_context->InsertUsedRTEIndexes(assigned_query_id, index);
 
 	return index;
 }

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -129,9 +129,10 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	CDXLTableDescr *table_descr = GPOS_NEW(mp)
-		CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
-					   rte->rellockmode, assigned_query_id_for_target_rel);
+	INT required_perms = static_cast<INT>(rte->requiredPerms);
+	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(
+		mp, mdid, table_mdname, rte->checkAsUser, rte->rellockmode,
+		required_perms, assigned_query_id_for_target_rel);
 
 	const ULONG len = rel->ColumnCount();
 

--- a/src/backend/gporca/data/dxl/minidump/RTErequiredPerms.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RTErequiredPerms.mdp
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Verify the generation of AclMode, which should be
+    the bit OR of all required permissions. The query requests
+    SELECT privilege on t2, and SELECT + DELETE privileges on t1
+
+    create table t1 (i int);
+    create table t2 (j int);
+    insert into t1 values (1), (2), (3);
+    insert into t2 values (1), (2);
+    delete from t1 where i in (select j from t2);
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationExtendedStatistics Mdid="10.25685.1.0" Name="t1"/>
+      <dxl:RelationExtendedStatistics Mdid="10.25688.1.0" Name="t2"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.25685.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.25688.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.25685.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.25685.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.25688.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.25688.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="6.25685.1.0" TableName="t1" LockMode="7" AclMode="10" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="17" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalSelect>
+          <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="9">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="6.25688.1.0" TableName="t2" LockMode="1" AclMode="2">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:SubqueryAny>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.25685.1.0" TableName="t1" LockMode="7" AclMode="10" AssignedQueryIdForTargetRel="1">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="33">
+      <dxl:DMLDelete Columns="0" ActionCol="20" CtidCol="1" SegmentIdCol="7">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.023904" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.25685.1.0" TableName="t1" LockMode="7" AclMode="10" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="23" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000466" Rows="1.000000" Width="18"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="ctid">
+              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:HashJoin JoinType="In">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000460" Rows="1.000000" Width="14"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ctid">
+                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="14"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="ctid">
+                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.25685.1.0" TableName="t1" LockMode="7" AclMode="10" AssignedQueryIdForTargetRel="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="j">
+                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.25688.1.0" TableName="t2" LockMode="1" AclMode="2">
+                <dxl:Columns>
+                  <dxl:Column ColId="8" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:HashJoin>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -88,6 +88,9 @@ private:
 	// lockmode from the parser
 	INT m_lockmode;
 
+	// acl mode from the parser
+	INT m_acl_mode;
+
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
 	// target one within DML operation. If descriptor doesn't point
@@ -102,7 +105,7 @@ public:
 					 BOOL convert_hash_to_random,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
-					 ULONG ulExecuteAsUser, INT lockmode,
+					 ULONG ulExecuteAsUser, INT lockmode, INT acl_mode,
 					 ULONG assigned_query_id_for_target_rel);
 
 	// dtor
@@ -149,6 +152,12 @@ public:
 	LockMode() const
 	{
 		return m_lockmode;
+	}
+
+	INT
+	GetAclMode() const
+	{
+		return m_acl_mode;
 	}
 
 	// return the position of a particular attribute (identified by attno)

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -38,7 +38,7 @@ CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
 	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
-	INT lockmode, ULONG assigned_query_id_for_target_rel)
+	INT lockmode, INT acl_mode, ULONG assigned_query_id_for_target_rel)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),
@@ -52,6 +52,7 @@ CTableDescriptor::CTableDescriptor(
 	  m_pdrgpbsKeys(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
 	  m_lockmode(lockmode),
+	  m_acl_mode(acl_mode),
 	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(nullptr != mp);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2143,7 +2143,8 @@ CTranslatorDXLToExpr::Ptabdesc(CDXLTableDescr *table_descr)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId(),
-		table_descr->LockMode(), table_descr->GetAssignedQueryIdForTargetRel());
+		table_descr->LockMode(), table_descr->GetAclMode(),
+		table_descr->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = table_descr->Arity();
 	for (ULONG ul = 0; ul < ulColumns; ul++)
@@ -2342,7 +2343,8 @@ CTranslatorDXLToExpr::PtabdescFromCTAS(CDXLLogicalCTAS *pdxlopCTAS)
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type,
 		0,	// ulExecuteAsUser, use permissions of current user
-		3,	// CTEs always use a RowExclusiveLock on the table. See createas.c
+		3,	// CTAS always uses a RowExclusiveLock on the table. See createas.c
+		2,	// CTAS always requires SELECT and SELECT only privilege
 		UNASSIGNED_QUERYID);
 
 	// populate column information from the dxl table descriptor

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1254,7 +1254,7 @@ CTranslatorExprToDXL::MakeTableDescForPart(const IMDRelation *part,
 		m_mp, part_mdid, part->Mdname().GetMDName(),
 		part->ConvertHashToRandom(), part->GetRelDistribution(),
 		part->RetrieveRelStorageType(), root_table_desc->GetExecuteAsUserId(),
-		root_table_desc->LockMode(),
+		root_table_desc->LockMode(), root_table_desc->GetAclMode(),
 		root_table_desc->GetAssignedQueryIdForTargetRel());
 
 	for (ULONG ul = 0; ul < part->ColumnCount(); ++ul)
@@ -6707,9 +6707,10 @@ CTranslatorExprToDXL::MakeDXLTableDescr(
 	CMDIdGPDB *mdid = CMDIdGPDB::CastMdid(ptabdesc->MDId());
 	mdid->AddRef();
 
-	CDXLTableDescr *table_descr = GPOS_NEW(m_mp) CDXLTableDescr(
-		m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
-		ptabdesc->LockMode(), ptabdesc->GetAssignedQueryIdForTargetRel());
+	CDXLTableDescr *table_descr = GPOS_NEW(m_mp)
+		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
+					   ptabdesc->LockMode(), ptabdesc->GetAclMode(),
+					   ptabdesc->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = ptabdesc->ColumnCount();
 	// translate col descriptors

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -53,6 +53,9 @@ private:
 	// lock mode from the parser
 	INT m_lockmode;
 
+	// acl mode from the parser
+	INT m_acl_mode;
+
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
 	// target one within DML operation. If descriptor doesn't point
@@ -66,7 +69,7 @@ public:
 
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-				   ULONG ulExecuteAsUser, int lockmode,
+				   ULONG ulExecuteAsUser, int lockmode, INT acl_mode,
 				   ULONG assigned_query_id_for_target_rel = UNASSIGNED_QUERYID);
 
 	~CDXLTableDescr() override;
@@ -90,6 +93,9 @@ public:
 
 	// lock mode
 	INT LockMode() const;
+
+	// acl mode
+	INT GetAclMode() const;
 
 	// get the column descriptor at the given position
 	const CDXLColDescr *GetColumnDescrAt(ULONG idx) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -449,6 +449,7 @@ enum Edxltoken
 	EdxltokenVersion,
 	EdxltokenMdid,
 	EdxltokenLockMode,
+	EdxltokenAclMode,
 	EdxltokenMDTypeRequest,
 	EdxltokenTypeInfo,
 	EdxltokenFuncInfo,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1527,6 +1527,10 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 		dxl_memory_manager, attrs, EdxltokenLockMode, EdxltokenTableDescr,
 		true /* is_optional */, -1);
 
+	INT acl_mode = ExtractConvertAttrValueToInt(
+		dxl_memory_manager, attrs, EdxltokenAclMode, EdxltokenTableDescr,
+		true /* is_optional */, -1);
+
 	if (nullptr != execute_as_user_xml)
 	{
 		user_id = ConvertAttrValueToUlong(
@@ -1538,8 +1542,9 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 		dxl_memory_manager, attrs, EdxltokenAssignedQueryIdForTargetRel,
 		EdxltokenTableDescr, true /* is_optional */, UNASSIGNED_QUERYID);
 
-	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id, lockmode,
-									   assigned_query_id_for_target_rel);
+	return GPOS_NEW(mp)
+		CDXLTableDescr(mp, mdid, mdname, user_id, lockmode, acl_mode,
+					   assigned_query_id_for_target_rel);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -21,6 +21,7 @@ using namespace gpdxl;
 
 #define GPDXL_DEFAULT_USERID 0
 #define GPDXL_INVALID_LOCKMODE -1
+#define GPDXL_ACL_NO_RIGHTS 0
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -32,12 +33,14 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 							   ULONG ulExecuteAsUser, int lockmode,
+							   INT acl_mode,
 							   ULONG assigned_query_id_for_target_rel)
 	: m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
 	  m_lockmode(lockmode),
+	  m_acl_mode(acl_mode),
 	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(nullptr != m_mdname);
@@ -123,6 +126,12 @@ INT
 CDXLTableDescr::LockMode() const
 {
 	return m_lockmode;
+}
+
+INT
+CDXLTableDescr::GetAclMode() const
+{
+	return m_acl_mode;
 }
 
 //---------------------------------------------------------------------------
@@ -218,6 +227,12 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 	{
 		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenLockMode), LockMode());
+	}
+
+	if (GPDXL_ACL_NO_RIGHTS <= GetAclMode())
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenAclMode), GetAclMode());
 	}
 
 	if (UNASSIGNED_QUERYID != m_assigned_query_id_for_target_rel)

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -496,6 +496,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenVersion, GPOS_WSZ_LIT("Version")},
 		{EdxltokenMdid, GPOS_WSZ_LIT("Mdid")},
 		{EdxltokenLockMode, GPOS_WSZ_LIT("LockMode")},
+		{EdxltokenAclMode, GPOS_WSZ_LIT("AclMode")},
 		{EdxltokenMDTypeRequest, GPOS_WSZ_LIT("TypeRequest")},
 		{EdxltokenTypeInfo, GPOS_WSZ_LIT("TypeInfo")},
 		{EdxltokenFuncInfo, GPOS_WSZ_LIT("FuncInfo")},

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -223,6 +223,7 @@ CTestUtils::PtabdescPlainWithColNameFormat(
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
 		0,	 // ulExecuteAsUser
 		-1,	 // lockmode
+		2,	 // aclmode SELECT
 		0	 // UNASSIGNED_QUERYID
 	);
 

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -319,6 +319,7 @@ CStatisticsTest::PtabdescTwoColumnSource(CMemoryPool *mp,
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
 		0,	 // ulExecuteAsUser
 		-1,	 // lockmode
+		2,	 // aclmode SELECT
 		0	 // UNASSIGNED_QUERYID
 	);
 

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -91,6 +91,7 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/DML-Volatile-Function.mdp",
 	"../data/dxl/minidump/UpdateWindowGatherMerge.mdp",
 	"../data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp",
+	"../data/dxl/minidump/RTErequiredPerms.mdp",
 };
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
@@ -254,6 +254,7 @@ public:
 			CMDRelationGPDB::EreldistrCoordinatorOnly,
 			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser,
 			-1, /* lockmode */
+			2,	/* aclmode SELECT */
 			0 /* UNASSIGNED_QUERYID */);
 	}
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -194,6 +194,9 @@ public:
 	// add a range table entry
 	void AddRTE(RangeTblEntry *rte, BOOL is_result_relation = false);
 
+	void InsertUsedRTEIndexes(ULONG assigned_query_id_for_target_rel,
+							  Index index);
+
 	void AddSubplan(Plan *);
 
 	// add a slice table entry
@@ -243,8 +246,8 @@ public:
 	// get rte from m_rtable_entries_list by given index
 	RangeTblEntry *GetRTEByIndex(Index index);
 
-	Index GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
-								  BOOL *is_rte_exists);
+	Index GetRTEIndexByAssignedQueryId(ULONG assigned_query_id_for_target_rel,
+									   BOOL *is_rte_exists);
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -441,8 +441,7 @@ private:
 
 	// create range table entry from a table descriptor
 	Index ProcessDXLTblDescr(const CDXLTableDescr *table_descr,
-							 CDXLTranslateContextBaseTable *base_table_context,
-							 AclMode acl_mode);
+							 CDXLTranslateContextBaseTable *base_table_context);
 
 	// translate DXL projection list into a target list
 	List *TranslateDXLProjList(

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -5,8 +5,9 @@
 -- m/DETAIL:  Failing row contains \(.*\) = \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\) = \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
-set optimizer=off;
+set optimizer_trace_fallback = on;
 set enable_nestloop=on;
+set optimizer_enable_nljoin = on;
 -- Clean up in case a prior regression run failed
 -- Suppress NOTICE messages when users/groups don't exist
 SET client_min_messages TO 'warning';
@@ -138,6 +139,9 @@ SELECT * FROM atest2 WHERE ( col1 IN ( SELECT b FROM atest1 ) );
 ------+------
 (0 rows)
 
+-- test ctas
+create table atest2_ctas_ok as select col1 from atest2
+where col1 in (select distinct b from atest1); -- ok 
 SET SESSION AUTHORIZATION regress_priv_user3;
 SELECT session_user, current_user;
     session_user    |    current_user    
@@ -145,6 +149,9 @@ SELECT session_user, current_user;
  regress_priv_user3 | regress_priv_user3
 (1 row)
 
+create table atest2_ctas_fail as select col1 from atest2
+where col1 in (select distinct b from atest1); -- fail 
+ERROR:  permission denied for table atest2
 SELECT * FROM atest1; -- ok
  a |  b  
 ---+-----
@@ -197,7 +204,7 @@ SELECT * FROM atest1; -- ok
 -- regress_priv_user1 will own a table and provide views for it.
 SET SESSION AUTHORIZATION regress_priv_user1;
 CREATE TABLE atest12 as
-  SELECT x AS a, 10001 - x AS b FROM generate_series(1,10000) x;
+  SELECT x AS a, 10001 - x AS b FROM generate_series(1,10000) x distributed by (a);
 CREATE INDEX ON atest12 (a);
 CREATE INDEX ON atest12 (abs(a));
 VACUUM ANALYZE atest12;
@@ -290,6 +297,8 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- reset the plan cache, sometimes it would re-plan these prepared statements and log ORCA fallbacks
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
                          QUERY PLAN                         
 ------------------------------------------------------------
@@ -2436,6 +2445,7 @@ DROP TABLE atest6;
 DROP TABLE atestc;
 DROP TABLE atestp1;
 DROP TABLE atestp2;
+DROP TABLE atest2_ctas_ok;
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
  lo_unlink 

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -5,57 +5,61 @@
 -- m/DETAIL:  Failing row contains \(.*\) = \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\) = \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
-
 set optimizer_trace_fallback = on;
 set enable_nestloop=on;
 set optimizer_enable_nljoin = on;
-
 -- Clean up in case a prior regression run failed
-
 -- Suppress NOTICE messages when users/groups don't exist
 SET client_min_messages TO 'warning';
-
 DROP ROLE IF EXISTS regress_priv_group1;
 DROP ROLE IF EXISTS regress_priv_group2;
-
 DROP ROLE IF EXISTS regress_priv_user1;
 DROP ROLE IF EXISTS regress_priv_user2;
 DROP ROLE IF EXISTS regress_priv_user3;
 DROP ROLE IF EXISTS regress_priv_user4;
 DROP ROLE IF EXISTS regress_priv_user5;
 DROP ROLE IF EXISTS regress_priv_user6;
-
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on coordinator-only tables
+ lo_unlink 
+-----------
+(0 rows)
+
 -- end_ignore
-
 RESET client_min_messages;
-
 -- test proper begins here
-
 CREATE USER regress_priv_user1;
 CREATE USER regress_priv_user2;
 CREATE USER regress_priv_user3;
 CREATE USER regress_priv_user4;
 CREATE USER regress_priv_user5;
 CREATE USER regress_priv_user5;	-- duplicate
-
+ERROR:  role "regress_priv_user5" already exists
 CREATE GROUP regress_priv_group1;
 CREATE GROUP regress_priv_group2 WITH USER regress_priv_user1, regress_priv_user2;
-
 ALTER GROUP regress_priv_group1 ADD USER regress_priv_user4;
-
 ALTER GROUP regress_priv_group2 ADD USER regress_priv_user2;	-- duplicate
+NOTICE:  role "regress_priv_user2" is already a member of role "regress_priv_group2"
 ALTER GROUP regress_priv_group2 DROP USER regress_priv_user2;
 GRANT regress_priv_group2 TO regress_priv_user4 WITH ADMIN OPTION;
-
 -- test owner privileges
-
 SET SESSION AUTHORIZATION regress_priv_user1;
 SELECT session_user, current_user;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7} not supported in DXL
+    session_user    |    current_user    
+--------------------+--------------------
+ regress_priv_user1 | regress_priv_user1
+(1 row)
 
 CREATE TABLE atest1 ( a int, b text ) distributed randomly;
 SELECT * FROM atest1;
+ a | b 
+---+---
+(0 rows)
+
 INSERT INTO atest1 VALUES (1, 'one');
 DELETE FROM atest1;
 UPDATE atest1 SET a = 1 WHERE b = 'blech';
@@ -63,103 +67,160 @@ TRUNCATE atest1;
 BEGIN;
 LOCK atest1 IN ACCESS EXCLUSIVE MODE;
 COMMIT;
-
 REVOKE ALL ON atest1 FROM PUBLIC;
+NOTICE:  no privileges could be revoked
 SELECT * FROM atest1;
+ a | b 
+---+---
+(0 rows)
 
 GRANT ALL ON atest1 TO regress_priv_user2;
 GRANT SELECT ON atest1 TO regress_priv_user3, regress_priv_user4;
 SELECT * FROM atest1;
+ a | b 
+---+---
+(0 rows)
 
 CREATE TABLE atest2 (col1 varchar(10), col2 boolean);
 GRANT SELECT ON atest2 TO regress_priv_user2;
 GRANT UPDATE ON atest2 TO regress_priv_user3;
 GRANT INSERT ON atest2 TO regress_priv_user4;
 GRANT TRUNCATE ON atest2 TO regress_priv_user5;
-
-
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT session_user, current_user;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7} not supported in DXL
+    session_user    |    current_user    
+--------------------+--------------------
+ regress_priv_user2 | regress_priv_user2
+(1 row)
 
 -- try various combinations of queries on atest1 and atest2
-
 SELECT * FROM atest1; -- ok
+ a | b 
+---+---
+(0 rows)
+
 SELECT * FROM atest2; -- ok
+ col1 | col2 
+------+------
+(0 rows)
+
 INSERT INTO atest1 VALUES (2, 'two'); -- ok
 INSERT INTO atest2 VALUES ('foo', true); -- fail
+ERROR:  permission denied for table atest2
 INSERT INTO atest1 SELECT 1, b FROM atest1; -- ok
 UPDATE atest1 SET a = 1 WHERE a = 2; -- ok
 UPDATE atest2 SET col2 = NOT col2; -- fail
+ERROR:  permission denied for table atest2
 SELECT * FROM atest1 FOR UPDATE; -- ok
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
+
 SELECT * FROM atest2 FOR UPDATE; -- fail
+ERROR:  permission denied for table atest2
 DELETE FROM atest2; -- fail
+ERROR:  permission denied for table atest2
 TRUNCATE atest2; -- fail
+ERROR:  permission denied for table atest2
 BEGIN;
 LOCK atest2 IN ACCESS EXCLUSIVE MODE; -- fail
+ERROR:  permission denied for table atest2
 COMMIT;
 COPY atest2 FROM stdin; -- fail
+ERROR:  permission denied for table atest2
 GRANT ALL ON atest1 TO PUBLIC; -- fail
-
+WARNING:  no privileges were granted for "atest1"
 -- checks in subquery, both ok
 SELECT * FROM atest1 WHERE ( b IN ( SELECT col1 FROM atest2 ) );
+ a | b 
+---+---
+(0 rows)
+
 SELECT * FROM atest2 WHERE ( col1 IN ( SELECT b FROM atest1 ) );
+ col1 | col2 
+------+------
+(0 rows)
 
 -- test ctas
 create table atest2_ctas_ok as select col1 from atest2
 where col1 in (select distinct b from atest1); -- ok 
-
 SET SESSION AUTHORIZATION regress_priv_user3;
 SELECT session_user, current_user;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7} not supported in DXL
+    session_user    |    current_user    
+--------------------+--------------------
+ regress_priv_user3 | regress_priv_user3
+(1 row)
 
 create table atest2_ctas_fail as select col1 from atest2
 where col1 in (select distinct b from atest1); -- fail 
-
+ERROR:  permission denied for table atest2
 SELECT * FROM atest1; -- ok
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
+
 SELECT * FROM atest2; -- fail
+ERROR:  permission denied for table atest2
 INSERT INTO atest1 VALUES (2, 'two'); -- fail
+ERROR:  permission denied for table atest1
 INSERT INTO atest2 VALUES ('foo', true); -- fail
+ERROR:  permission denied for table atest2
 INSERT INTO atest1 SELECT 1, b FROM atest1; -- fail
+ERROR:  permission denied for table atest1
 UPDATE atest1 SET a = 1 WHERE a = 2; -- fail
+ERROR:  permission denied for table atest1
 UPDATE atest2 SET col2 = NULL; -- ok
 UPDATE atest2 SET col2 = NOT col2; -- fails; requires SELECT on atest2
+ERROR:  permission denied for table atest2
 UPDATE atest2 SET col2 = true FROM atest1 WHERE atest1.a = 5; -- ok
 SELECT * FROM atest1 FOR UPDATE; -- fail
+ERROR:  permission denied for table atest1
 SELECT * FROM atest2 FOR UPDATE; -- fail
+ERROR:  permission denied for table atest2
 DELETE FROM atest2; -- fail
+ERROR:  permission denied for table atest2
 TRUNCATE atest2; -- fail
+ERROR:  permission denied for table atest2
 BEGIN;
 LOCK atest2 IN ACCESS EXCLUSIVE MODE; -- ok
 COMMIT;
 COPY atest2 FROM stdin; -- fail
-
+ERROR:  permission denied for table atest2
 -- checks in subquery, both fail
 SELECT * FROM atest1 WHERE ( b IN ( SELECT col1 FROM atest2 ) );
+ERROR:  permission denied for table atest2
 SELECT * FROM atest2 WHERE ( col1 IN ( SELECT b FROM atest1 ) );
-
+ERROR:  permission denied for table atest2
 SET SESSION AUTHORIZATION regress_priv_user4;
 COPY atest2 FROM stdin; -- ok
-bar	true
-\.
 SELECT * FROM atest1; -- ok
-
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
 
 -- test leaky-function protections in selfuncs
-
 -- regress_priv_user1 will own a table and provide views for it.
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 CREATE TABLE atest12 as
   SELECT x AS a, 10001 - x AS b FROM generate_series(1,10000) x distributed by (a);
 CREATE INDEX ON atest12 (a);
 CREATE INDEX ON atest12 (abs(a));
 VACUUM ANALYZE atest12;
-
 CREATE FUNCTION leak(integer,integer) RETURNS boolean
   AS $$begin return $1 < $2; end$$
   LANGUAGE plpgsql immutable;
 CREATE OPERATOR <<< (procedure = leak, leftarg = integer, rightarg = integer,
                      restrict = scalarltsel);
-
 -- views with leaky operator
 CREATE VIEW atest12v AS
   SELECT * FROM atest12 WHERE b <<< 5;
@@ -167,292 +228,521 @@ CREATE VIEW atest12sbv WITH (security_barrier=true) AS
   SELECT * FROM atest12 WHERE b <<< 5;
 GRANT SELECT ON atest12v TO PUBLIC;
 GRANT SELECT ON atest12sbv TO PUBLIC;
-
 -- This plan should use nestloop, knowing that few rows will be selected.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+               Filter: (b <<< 5)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: (b <<< 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
 
 -- And this one.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
   WHERE x.a = y.b and abs(y.a) <<< 5;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: (abs(a) <<< 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 -- This should also be a nestloop, but the security barrier forces the inner
 -- scan to be materialized
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: views with security_barrier ON
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: (atest12_1.a = atest12.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: atest12.b
+               ->  Seq Scan on atest12
+                     Filter: (b <<< 5)
+         ->  Materialize
+               ->  Seq Scan on atest12 atest12_1
+                     Filter: (b <<< 5)
+ Optimizer: Postgres query optimizer
+(11 rows)
 
 -- Check if regress_priv_user2 can break security.
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 CREATE FUNCTION leak2(integer,integer) RETURNS boolean
   AS $$begin raise notice 'leak % %', $1, $2; return $1 > $2; end$$
   LANGUAGE plpgsql immutable;
 CREATE OPERATOR >>> (procedure = leak2, leftarg = integer, rightarg = integer,
                      restrict = scalargtsel);
-
 -- This should not show any "leak" notices before failing.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12 WHERE a >>> 0;
-
+ERROR:  permission denied for table atest12
 -- These plans should continue to use a nestloop, since they execute with the
 -- privileges of the view owner.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+               Filter: (b <<< 5)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: (b <<< 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 -- reset the plan cache, sometimes it would re-plan these prepared statements and log ORCA fallbacks
 discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: views with security_barrier ON
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: (atest12_1.a = atest12.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: atest12.b
+               ->  Seq Scan on atest12
+                     Filter: (b <<< 5)
+         ->  Materialize
+               ->  Seq Scan on atest12 atest12_1
+                     Filter: (b <<< 5)
+ Optimizer: Postgres query optimizer
+(11 rows)
 
 -- A non-security barrier view does not guard against information leakage.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y
   WHERE x.a = y.b and abs(y.a) <<< 5;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+               Filter: (b <<< 5)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: ((b <<< 5) AND (abs(a) <<< 5))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
 
 -- But a security barrier view isolates the leaky operator.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y
   WHERE x.a = y.b and abs(y.a) <<< 5;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: views with security_barrier ON
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: (atest12_1.a = y.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: y.b
+               ->  Subquery Scan on y
+                     Filter: (abs(y.a) <<< 5)
+                     ->  Seq Scan on atest12
+                           Filter: (b <<< 5)
+         ->  Materialize
+               ->  Seq Scan on atest12 atest12_1
+                     Filter: (b <<< 5)
+ Optimizer: Postgres query optimizer
+(13 rows)
 
 -- Now regress_priv_user1 grants sufficient access to regress_priv_user2.
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT (a, b) ON atest12 TO PUBLIC;
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 -- regress_priv_user2 should continue to get a good row estimate.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+               Filter: (b <<< 5)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: (b <<< 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
 
 -- But not for this, due to lack of table-wide permissions needed
 -- to make use of the expression index's statistics.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
   WHERE x.a = y.b and abs(y.a) <<< 5;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (atest12.a = atest12_1.b)
+         ->  Seq Scan on atest12
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: atest12_1.b
+                     ->  Seq Scan on atest12 atest12_1
+                           Filter: (abs(a) <<< 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 -- clean up (regress_priv_user1's objects are all dropped later)
 DROP FUNCTION leak2(integer, integer) CASCADE;
-
-
+NOTICE:  drop cascades to operator >>>(integer,integer)
 -- groups
-
 SET SESSION AUTHORIZATION regress_priv_user3;
 CREATE TABLE atest3 (one int, two int, three int);
 GRANT DELETE ON atest3 TO GROUP regress_priv_group2;
-
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 SELECT * FROM atest3; -- fail
+ERROR:  permission denied for table atest3
 DELETE FROM atest3; -- ok
-
 BEGIN;
 RESET SESSION AUTHORIZATION;
 ALTER ROLE regress_priv_user1 NOINHERIT;
 SET SESSION AUTHORIZATION regress_priv_user1;
 DELETE FROM atest3;
+ERROR:  permission denied for table atest3
 ROLLBACK;
-
 -- views
-
 SET SESSION AUTHORIZATION regress_priv_user3;
-
 CREATE VIEW atestv1 AS SELECT * FROM atest1; -- ok
 /* The next *should* fail, but it's not implemented that way yet. */
 CREATE VIEW atestv2 AS SELECT * FROM atest2;
 CREATE VIEW atestv3 AS SELECT * FROM atest3; -- ok
 /* Empty view is a corner case that failed in 9.2. */
 CREATE VIEW atestv0 AS SELECT 0 as x WHERE false; -- ok
-
 SELECT * FROM atestv1; -- ok
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
+
 SELECT * FROM atestv2; -- fail
+ERROR:  permission denied for table atest2
 GRANT SELECT ON atestv1, atestv3 TO regress_priv_user4;
 GRANT SELECT ON atestv2 TO regress_priv_user2;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
-
 SELECT * FROM atestv1; -- ok
-SELECT * FROM atestv2; -- fail
-SELECT * FROM atestv3; -- ok
-SELECT * FROM atestv0; -- fail
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
 
+SELECT * FROM atestv2; -- fail
+ERROR:  permission denied for view atestv2
+SELECT * FROM atestv3; -- ok
+ one | two | three 
+-----+-----+-------
+(0 rows)
+
+SELECT * FROM atestv0; -- fail
+ERROR:  permission denied for view atestv0
 -- Appendrels excluded by constraints failed to check permissions in 8.4-9.2.
 select * from
   ((select a.q1 as x from int8_tbl a offset 0)
    union all
    (select b.q2 as x from int8_tbl b offset 0)) ss
 where false;
-
+ERROR:  permission denied for table int8_tbl
 set constraint_exclusion = on;
 select * from
   ((select a.q1 as x, random() from int8_tbl a where q1 > 0)
    union all
    (select b.q2 as x, random() from int8_tbl b where q2 > 0)) ss
 where x < 0;
+ERROR:  permission denied for table int8_tbl
 reset constraint_exclusion;
-
 CREATE VIEW atestv4 AS SELECT * FROM atestv3; -- nested view
 SELECT * FROM atestv4; -- ok
+ one | two | three 
+-----+-----+-------
+(0 rows)
+
 GRANT SELECT ON atestv4 TO regress_priv_user2;
-
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 -- Two complex cases:
-
 SELECT * FROM atestv3; -- fail
+ERROR:  permission denied for view atestv3
 SELECT * FROM atestv4; -- ok (even though regress_priv_user2 cannot access underlying atestv3)
+ one | two | three 
+-----+-----+-------
+(0 rows)
 
 SELECT * FROM atest2; -- ok
+ col1 | col2 
+------+------
+ bar  | t
+(1 row)
+
 SELECT * FROM atestv2; -- fail (even though regress_priv_user2 can access underlying atest2)
-
+ERROR:  permission denied for table atest2
 -- Test column level permissions
-
 SET SESSION AUTHORIZATION regress_priv_user1;
 CREATE TABLE atest5 (one int, two int unique, three int, four int unique) distributed replicated;
 CREATE TABLE atest6 (one int, two int, blue int);
 GRANT SELECT (one), INSERT (two), UPDATE (three) ON atest5 TO regress_priv_user4;
 GRANT ALL (one) ON atest5 TO regress_priv_user3;
-
 INSERT INTO atest5 VALUES (1,2,3);
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT * FROM atest5; -- fail
+ERROR:  permission denied for table atest5
 SELECT one FROM atest5; -- ok
-COPY atest5 (one) TO stdout; -- ok
-SELECT two FROM atest5; -- fail
-COPY atest5 (two) TO stdout; -- fail
-SELECT atest5 FROM atest5; -- fail
-COPY atest5 (one,two) TO stdout; -- fail
-SELECT 1 FROM atest5; -- ok
-SELECT 1 FROM atest5 a JOIN atest5 b USING (one); -- ok
-SELECT 1 FROM atest5 a JOIN atest5 b USING (two); -- fail
-SELECT 1 FROM atest5 a NATURAL JOIN atest5 b; -- fail
-SELECT (j.*) IS NULL FROM (atest5 a JOIN atest5 b USING (one)) j; -- fail
-SELECT 1 FROM atest5 WHERE two = 2; -- fail
-SELECT * FROM atest1, atest5; -- fail
-SELECT atest1.* FROM atest1, atest5; -- ok
-SELECT atest1.*,atest5.one FROM atest1, atest5; -- ok
-SELECT atest1.*,atest5.one FROM atest1 JOIN atest5 ON (atest1.a = atest5.two); -- fail
-SELECT atest1.*,atest5.one FROM atest1 JOIN atest5 ON (atest1.a = atest5.one); -- ok
-SELECT one, two FROM atest5; -- fail
+ one 
+-----
+   1
+(1 row)
 
+COPY atest5 (one) TO stdout; -- ok
+1
+SELECT two FROM atest5; -- fail
+ERROR:  permission denied for table atest5
+COPY atest5 (two) TO stdout; -- fail
+ERROR:  permission denied for table atest5
+SELECT atest5 FROM atest5; -- fail
+ERROR:  permission denied for table atest5
+COPY atest5 (one,two) TO stdout; -- fail
+ERROR:  permission denied for table atest5
+SELECT 1 FROM atest5; -- ok
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT 1 FROM atest5 a JOIN atest5 b USING (one); -- ok
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT 1 FROM atest5 a JOIN atest5 b USING (two); -- fail
+ERROR:  permission denied for table atest5
+SELECT 1 FROM atest5 a NATURAL JOIN atest5 b; -- fail
+ERROR:  permission denied for table atest5
+SELECT (j.*) IS NULL FROM (atest5 a JOIN atest5 b USING (one)) j; -- fail
+ERROR:  permission denied for table atest5
+SELECT 1 FROM atest5 WHERE two = 2; -- fail
+ERROR:  permission denied for table atest5
+SELECT * FROM atest1, atest5; -- fail
+ERROR:  permission denied for table atest5
+SELECT atest1.* FROM atest1, atest5; -- ok
+ a |  b  
+---+-----
+ 1 | two
+ 1 | two
+(2 rows)
+
+SELECT atest1.*,atest5.one FROM atest1, atest5; -- ok
+ a |  b  | one 
+---+-----+-----
+ 1 | two |   1
+ 1 | two |   1
+(2 rows)
+
+SELECT atest1.*,atest5.one FROM atest1 JOIN atest5 ON (atest1.a = atest5.two); -- fail
+ERROR:  permission denied for table atest5
+SELECT atest1.*,atest5.one FROM atest1 JOIN atest5 ON (atest1.a = atest5.one); -- ok
+ a |  b  | one 
+---+-----+-----
+ 1 | two |   1
+ 1 | two |   1
+(2 rows)
+
+SELECT one, two FROM atest5; -- fail
+ERROR:  permission denied for table atest5
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT (one,two) ON atest6 TO regress_priv_user4;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT one, two FROM atest5 NATURAL JOIN atest6; -- fail still
-
+ERROR:  permission denied for table atest5
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT (two) ON atest5 TO regress_priv_user4;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT one, two FROM atest5 NATURAL JOIN atest6; -- ok now
+ one | two 
+-----+-----
+(0 rows)
 
 -- test column-level privileges for INSERT and UPDATE
 INSERT INTO atest5 (two) VALUES (3); -- ok
 COPY atest5 FROM stdin; -- fail
+ERROR:  permission denied for table atest5
 COPY atest5 (two) FROM stdin; -- ok
-1
-\.
 INSERT INTO atest5 (three) VALUES (4); -- fail
+ERROR:  permission denied for table atest5
 INSERT INTO atest5 VALUES (5,5,5); -- fail
+ERROR:  permission denied for table atest5
 UPDATE atest5 SET three = 10; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Operator Update on replicated tables not supported
 UPDATE atest5 SET one = 8; -- fail
+ERROR:  permission denied for table atest5
 UPDATE atest5 SET three = 5, one = 2; -- fail
+ERROR:  permission denied for table atest5
 -- Check that column level privs are enforced in RETURNING
 -- Ok.
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: ON CONFLICT clause
 -- Error. No SELECT on column three.
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10 RETURNING atest5.three;
+ERROR:  permission denied for table atest5
 -- Ok.  May SELECT on column "one":
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10 RETURNING atest5.one;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: RETURNING clause
+ one 
+-----
+    
+(1 row)
+
 -- Check that column level privileges are enforced for EXCLUDED
 -- Ok. we may select one
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = EXCLUDED.one;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: ON CONFLICT clause
 -- Error. No select rights on three
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = EXCLUDED.three;
+ERROR:  permission denied for table atest5
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set one = 8; -- fails (due to UPDATE)
+ERROR:  permission denied for table atest5
 INSERT INTO atest5(three) VALUES (4) ON CONFLICT (two) DO UPDATE set three = 10; -- fails (due to INSERT)
-
+ERROR:  permission denied for table atest5
 -- Check that the columns in the inference require select privileges
 INSERT INTO atest5(four) VALUES (4); -- fail
-
+ERROR:  permission denied for table atest5
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT INSERT (four) ON atest5 TO regress_priv_user4;
 SET SESSION AUTHORIZATION regress_priv_user4;
-
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT (four) DO UPDATE set three = 3; -- fails (due to SELECT)
+ERROR:  permission denied for table atest5
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT ON CONSTRAINT atest5_four_key DO UPDATE set three = 3; -- fails (due to SELECT)
+ERROR:  permission denied for table atest5
 INSERT INTO atest5(four) VALUES (4); -- ok
-
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT (four) ON atest5 TO regress_priv_user4;
 SET SESSION AUTHORIZATION regress_priv_user4;
-
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT (four) DO UPDATE set three = 3; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: ON CONFLICT clause
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT ON CONSTRAINT atest5_four_key DO UPDATE set three = 3; -- ok
-
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: ON CONFLICT clause
 SET SESSION AUTHORIZATION regress_priv_user1;
 REVOKE ALL (one) ON atest5 FROM regress_priv_user4;
 GRANT SELECT (one,two,blue) ON atest6 TO regress_priv_user4;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT one FROM atest5; -- fail
+ERROR:  permission denied for table atest5
 UPDATE atest5 SET one = 1; -- fail
+ERROR:  permission denied for table atest5
 SELECT atest6 FROM atest6; -- ok
-COPY atest6 TO stdout; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Whole-row variable
+ atest6 
+--------
+(0 rows)
 
+COPY atest6 TO stdout; -- ok
 -- check error reporting with column privs
 SET SESSION AUTHORIZATION regress_priv_user1;
 CREATE TABLE t1 (c1 int, c2 int, c3 int check (c3 < 5), primary key (c1, c2));
 GRANT SELECT (c1) ON t1 TO regress_priv_user2;
 GRANT INSERT (c1, c2, c3) ON t1 TO regress_priv_user2;
 GRANT UPDATE (c1, c2, c3) ON t1 TO regress_priv_user2;
-
 -- seed data
 INSERT INTO t1 VALUES (1, 1, 1);
 INSERT INTO t1 VALUES (1, 2, 1);
 INSERT INTO t1 VALUES (2, 1, 2);
 INSERT INTO t1 VALUES (2, 2, 2);
 INSERT INTO t1 VALUES (3, 1, 3);
-
 SET SESSION AUTHORIZATION regress_priv_user2;
 INSERT INTO t1 (c1, c2) VALUES (1, 1); -- fail, but row not shown
+ERROR:  duplicate key value violates unique constraint "t1_pkey"
 UPDATE t1 SET c2 = 1; -- fail, but row not shown
+ERROR:  duplicate key value violates unique constraint "t1_pkey"
 INSERT INTO t1 (c1, c2) VALUES (null, null); -- fail, but see columns being inserted
+ERROR:  null value in column "c1" violates not-null constraint
+DETAIL:  Failing row contains (c1, c2) = (null, null).
 INSERT INTO t1 (c3) VALUES (null); -- fail, but see columns being inserted or have SELECT
+ERROR:  null value in column "c1" violates not-null constraint
+DETAIL:  Failing row contains (c1, c3) = (null, null).
 INSERT INTO t1 (c1) VALUES (5); -- fail, but see columns being inserted or have SELECT
+ERROR:  null value in column "c2" violates not-null constraint
+DETAIL:  Failing row contains (c1) = (5).
 UPDATE t1 SET c3 = 10; -- fail, but see columns with SELECT rights, or being modified
-
+ERROR:  new row for relation "t1" violates check constraint "t1_c3_check"
+DETAIL:  Failing row contains (c1, c3) = (1, 10).
 SET SESSION AUTHORIZATION regress_priv_user1;
 DROP TABLE t1;
-
 -- check error reporting with column privs on a partitioned table
 CREATE TABLE errtst(a text, b text NOT NULL, c text, secret1 text, secret2 text) PARTITION BY LIST (a);
 CREATE TABLE errtst_part_1(secret2 text, c text, a text, b text NOT NULL, secret1 text) DISTRIBUTED BY (a);
 CREATE TABLE errtst_part_2(secret1 text, secret2 text, a text, c text, b text NOT NULL) DISTRIBUTED BY (a);
-
 ALTER TABLE errtst ATTACH PARTITION errtst_part_1 FOR VALUES IN ('aaa');
 ALTER TABLE errtst ATTACH PARTITION errtst_part_2 FOR VALUES IN ('aaaa');
-
 GRANT SELECT (a, b, c) ON TABLE errtst TO regress_priv_user2;
 GRANT UPDATE (a, b, c) ON TABLE errtst TO regress_priv_user2;
 GRANT INSERT (a, b, c) ON TABLE errtst TO regress_priv_user2;
-
 INSERT INTO errtst_part_1 (a, b, c, secret1, secret2)
 VALUES ('aaa', 'bbb', 'ccc', 'the body', 'is in the attic');
-
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 -- Perform a few updates that violate the NOT NULL constraint. Make sure
 -- the error messages don't leak the secret fields.
-
 -- simple insert.
 INSERT INTO errtst (a, b) VALUES ('aaa', NULL);
+ERROR:  null value in column "b" violates not-null constraint
+DETAIL:  Failing row contains (a, b, c) = (aaa, null, null).
 -- simple update.
 UPDATE errtst SET b = NULL;
+ERROR:  null value in column "b" violates not-null constraint
+DETAIL:  Failing row contains (b) = (null).
 -- partitioning key is updated, doesn't move the row.
 UPDATE errtst SET a = 'aaa', b = NULL;
+ERROR:  null value in column "b" violates not-null constraint
+DETAIL:  Failing row contains (a, b, c) = (aaa, null, ccc).
 -- row is moved to another partition.
 UPDATE errtst SET a = 'aaaa', b = NULL;
-
+ERROR:  null value in column "b" violates not-null constraint
+DETAIL:  Failing row contains (a, b, c) = (aaaa, null, ccc).
 -- row is moved to another partition. This differs from the previous case in
 -- that the new partition is excluded by constraint exclusion, so its
 -- ResultRelInfo is not created at ExecInitModifyTable, but needs to be
 -- constructed on the fly when the updated tuple is routed to it.
 UPDATE errtst SET a = 'aaaa', b = NULL WHERE a = 'aaa';
-
+ERROR:  null value in column "b" violates not-null constraint
+DETAIL:  Failing row contains (a, b, c) = (aaaa, null, ccc).
 SET SESSION AUTHORIZATION regress_priv_user1;
 DROP TABLE errtst;
-
 -- test column-level privileges when involved with DELETE
 SET SESSION AUTHORIZATION regress_priv_user1;
 ALTER TABLE atest6 ADD COLUMN three integer;
@@ -460,30 +750,40 @@ GRANT DELETE ON atest5 TO regress_priv_user3;
 GRANT SELECT (two) ON atest5 TO regress_priv_user3;
 REVOKE ALL (one) ON atest5 FROM regress_priv_user3;
 GRANT SELECT (one) ON atest5 TO regress_priv_user4;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT atest6 FROM atest6; -- fail
+ERROR:  permission denied for table atest6
 SELECT one FROM atest5 NATURAL JOIN atest6; -- fail
-
+ERROR:  permission denied for table atest5
 SET SESSION AUTHORIZATION regress_priv_user1;
 ALTER TABLE atest6 DROP COLUMN three;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT atest6 FROM atest6; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Whole-row variable
+ atest6 
+--------
+(0 rows)
+
 SELECT one FROM atest5 NATURAL JOIN atest6; -- ok
+ one 
+-----
+(0 rows)
 
 SET SESSION AUTHORIZATION regress_priv_user1;
 ALTER TABLE atest6 DROP COLUMN two;
 REVOKE SELECT (one,blue) ON atest6 FROM regress_priv_user4;
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT * FROM atest6; -- fail
+ERROR:  permission denied for table atest6
 SELECT 1 FROM atest6; -- fail
-
+ERROR:  permission denied for table atest6
 SET SESSION AUTHORIZATION regress_priv_user3;
 DELETE FROM atest5 WHERE one = 1; -- fail
+ERROR:  permission denied for table atest5
 DELETE FROM atest5 WHERE two = 2; -- ok
-
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Operator Delete on replicated tables not supported
 -- check inheritance cases
 SET SESSION AUTHORIZATION regress_priv_user1;
 CREATE TABLE atestp1 (f1 int, f2 int);
@@ -491,182 +791,258 @@ CREATE TABLE atestp2 (fx int, fy int);
 CREATE TABLE atestc (fz int) INHERITS (atestp1, atestp2);
 GRANT SELECT(fx,fy,tableoid) ON atestp2 TO regress_priv_user2;
 GRANT SELECT(fx) ON atestc TO regress_priv_user2;
-
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT fx FROM atestp2; -- ok
-SELECT fy FROM atestp2; -- ok
-SELECT atestp2 FROM atestp2; -- ok
-SELECT tableoid FROM atestp2; -- ok
-SELECT fy FROM atestc; -- fail
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ fx 
+----
+(0 rows)
 
+SELECT fy FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ fy 
+----
+(0 rows)
+
+SELECT atestp2 FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ atestp2 
+---------
+(0 rows)
+
+SELECT tableoid FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ tableoid 
+----------
+(0 rows)
+
+SELECT fy FROM atestc; -- fail
+ERROR:  permission denied for table atestc
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT(fy,tableoid) ON atestc TO regress_priv_user2;
-
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT fx FROM atestp2; -- still ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ fx 
+----
+(0 rows)
+
 SELECT fy FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ fy 
+----
+(0 rows)
+
 SELECT atestp2 FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ atestp2 
+---------
+(0 rows)
+
 SELECT tableoid FROM atestp2; -- ok
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+ tableoid 
+----------
+(0 rows)
 
 -- privileges on functions, languages
-
 -- switch to superuser
 \c -
-
 REVOKE ALL PRIVILEGES ON LANGUAGE sql FROM PUBLIC;
 GRANT USAGE ON LANGUAGE sql TO regress_priv_user1; -- ok
 GRANT USAGE ON LANGUAGE c TO PUBLIC; -- fail
-
+ERROR:  language "c" is not trusted
+DETAIL:  GRANT and REVOKE are not allowed on untrusted languages, because only superusers can use untrusted languages.
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT USAGE ON LANGUAGE sql TO regress_priv_user2; -- fail
+WARNING:  no privileges were granted for "sql"
 CREATE FUNCTION priv_testfunc1(int) RETURNS int AS 'select 2 * $1;' LANGUAGE sql;
 CREATE FUNCTION priv_testfunc2(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 CREATE AGGREGATE priv_testagg1(int) (sfunc = int4pl, stype = int4);
 CREATE PROCEDURE priv_testproc1(int) AS 'select $1;' LANGUAGE sql;
-
 REVOKE ALL ON FUNCTION priv_testfunc1(int), priv_testfunc2(int), priv_testagg1(int) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION priv_testfunc1(int), priv_testfunc2(int), priv_testagg1(int) TO regress_priv_user2;
 REVOKE ALL ON FUNCTION priv_testproc1(int) FROM PUBLIC; -- fail, not a function
+ERROR:  priv_testproc1(integer) is not a function
 REVOKE ALL ON PROCEDURE priv_testproc1(int) FROM PUBLIC;
 GRANT EXECUTE ON PROCEDURE priv_testproc1(int) TO regress_priv_user2;
 GRANT USAGE ON FUNCTION priv_testfunc1(int) TO regress_priv_user3; -- semantic error
+ERROR:  invalid privilege type USAGE for function
 GRANT USAGE ON FUNCTION priv_testagg1(int) TO regress_priv_user3; -- semantic error
+ERROR:  invalid privilege type USAGE for function
 GRANT USAGE ON PROCEDURE priv_testproc1(int) TO regress_priv_user3; -- semantic error
+ERROR:  invalid privilege type USAGE for procedure
 GRANT ALL PRIVILEGES ON FUNCTION priv_testfunc1(int) TO regress_priv_user4;
 GRANT ALL PRIVILEGES ON FUNCTION priv_testfunc_nosuch(int) TO regress_priv_user4;
+ERROR:  function priv_testfunc_nosuch(integer) does not exist
 GRANT ALL PRIVILEGES ON FUNCTION priv_testagg1(int) TO regress_priv_user4;
 GRANT ALL PRIVILEGES ON PROCEDURE priv_testproc1(int) TO regress_priv_user4;
-
 CREATE FUNCTION priv_testfunc4(boolean) RETURNS text
   AS 'select col1 from atest2 where col2 = $1;'
   LANGUAGE sql SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION priv_testfunc4(boolean) TO regress_priv_user3;
-
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT priv_testfunc1(5), priv_testfunc2(5); -- ok
-CREATE FUNCTION priv_testfunc3(int) RETURNS int AS 'select 2 * $1;' LANGUAGE sql; -- fail
-SELECT priv_testagg1(x) FROM (VALUES (1), (2), (3)) _(x); -- ok
-CALL priv_testproc1(6); -- ok
+ priv_testfunc1 | priv_testfunc2 
+----------------+----------------
+             10 |             15
+(1 row)
 
+CREATE FUNCTION priv_testfunc3(int) RETURNS int AS 'select 2 * $1;' LANGUAGE sql; -- fail
+ERROR:  permission denied for language sql
+SELECT priv_testagg1(x) FROM (VALUES (1), (2), (3)) _(x); -- ok
+ priv_testagg1 
+---------------
+             6
+(1 row)
+
+CALL priv_testproc1(6); -- ok
 SET SESSION AUTHORIZATION regress_priv_user3;
 SELECT priv_testfunc1(5); -- fail
+ERROR:  permission denied for function priv_testfunc1
 SELECT priv_testagg1(x) FROM (VALUES (1), (2), (3)) _(x); -- fail
+ERROR:  permission denied for aggregate priv_testagg1
 CALL priv_testproc1(6); -- fail
+ERROR:  permission denied for procedure priv_testproc1
 SELECT col1 FROM atest2 WHERE col2 = true; -- fail
+ERROR:  permission denied for table atest2
 SELECT priv_testfunc4(true); -- ok
+ priv_testfunc4 
+----------------
+ bar
+(1 row)
 
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT priv_testfunc1(5); -- ok
+ priv_testfunc1 
+----------------
+             10
+(1 row)
+
 SELECT priv_testagg1(x) FROM (VALUES (1), (2), (3)) _(x); -- ok
+ priv_testagg1 
+---------------
+             6
+(1 row)
+
 CALL priv_testproc1(6); -- ok
-
 DROP FUNCTION priv_testfunc1(int); -- fail
+ERROR:  must be owner of function priv_testfunc1
 DROP AGGREGATE priv_testagg1(int); -- fail
+ERROR:  must be owner of aggregate priv_testagg1
 DROP PROCEDURE priv_testproc1(int); -- fail
-
+ERROR:  must be owner of procedure priv_testproc1
 \c -
-
 DROP FUNCTION priv_testfunc1(int); -- ok
 -- restore to sanity
 GRANT ALL PRIVILEGES ON LANGUAGE sql TO PUBLIC;
-
 -- verify privilege checks on array-element coercions
 BEGIN;
 SELECT '{1}'::int4[]::int8[];
+ int8 
+------
+ {1}
+(1 row)
+
 REVOKE ALL ON FUNCTION int8(integer) FROM PUBLIC;
 SELECT '{1}'::int4[]::int8[]; --superuser, succeed
+ int8 
+------
+ {1}
+(1 row)
+
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT '{1}'::int4[]::int8[]; --other user, fail
+ERROR:  permission denied for function int8
 ROLLBACK;
-
 -- privileges on types
-
 -- switch to superuser
 \c -
-
 CREATE TYPE priv_testtype1 AS (a int, b text);
 REVOKE USAGE ON TYPE priv_testtype1 FROM PUBLIC;
 GRANT USAGE ON TYPE priv_testtype1 TO regress_priv_user2;
 GRANT USAGE ON TYPE _priv_testtype1 TO regress_priv_user2; -- fail
+ERROR:  cannot set privileges of array types
+HINT:  Set the privileges of the element type instead.
 GRANT USAGE ON DOMAIN priv_testtype1 TO regress_priv_user2; -- fail
-
+ERROR:  "priv_testtype1" is not a domain
 CREATE DOMAIN priv_testdomain1 AS int;
 REVOKE USAGE on DOMAIN priv_testdomain1 FROM PUBLIC;
 GRANT USAGE ON DOMAIN priv_testdomain1 TO regress_priv_user2;
 GRANT USAGE ON TYPE priv_testdomain1 TO regress_priv_user2; -- ok
-
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 -- commands that should fail
-
 CREATE AGGREGATE priv_testagg1a(priv_testdomain1) (sfunc = int4_sum, stype = bigint);
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE DOMAIN priv_testdomain2a AS priv_testdomain1;
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE DOMAIN priv_testdomain3a AS int;
 CREATE FUNCTION castfunc(int) RETURNS priv_testdomain3a AS $$ SELECT $1::priv_testdomain3a $$ LANGUAGE SQL;
 CREATE CAST (priv_testdomain1 AS priv_testdomain3a) WITH FUNCTION castfunc(int);
+ERROR:  permission denied for type priv_testdomain1
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3a;
-
 CREATE FUNCTION priv_testfunc5a(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
+ERROR:  permission denied for type priv_testdomain1
 CREATE FUNCTION priv_testfunc6a(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE OPERATOR !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = priv_testdomain1);
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test5a (a int, b priv_testdomain1);
+ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test6a OF priv_testtype1;
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test10a (a int[], b priv_testtype1[]);
-
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test9a (a int, b int);
 ALTER TABLE test9a ADD COLUMN c priv_testdomain1;
+ERROR:  permission denied for type priv_testdomain1
 ALTER TABLE test9a ALTER COLUMN b TYPE priv_testdomain1;
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test7a AS (a int, b priv_testdomain1);
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test8a AS (a int, b int);
 ALTER TYPE test8a ADD ATTRIBUTE c priv_testdomain1;
+ERROR:  permission denied for type priv_testdomain1
 ALTER TYPE test8a ALTER ATTRIBUTE b TYPE priv_testdomain1;
-
+ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test11a AS (SELECT 1::priv_testdomain1 AS a);
-
+ERROR:  permission denied for type priv_testdomain1
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
-
+ERROR:  permission denied for type priv_testtype1
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 -- commands that should succeed
-
 CREATE AGGREGATE priv_testagg1b(priv_testdomain1) (sfunc = int4_sum, stype = bigint);
-
 CREATE DOMAIN priv_testdomain2b AS priv_testdomain1;
-
 CREATE DOMAIN priv_testdomain3b AS int;
 CREATE FUNCTION castfunc(int) RETURNS priv_testdomain3b AS $$ SELECT $1::priv_testdomain3b $$ LANGUAGE SQL;
 CREATE CAST (priv_testdomain1 AS priv_testdomain3b) WITH FUNCTION castfunc(int);
-
+WARNING:  cast will be ignored because the source data type is a domain
 CREATE FUNCTION priv_testfunc5b(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE FUNCTION priv_testfunc6b(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
-
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
-
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
 CREATE TABLE test10b (a int[], b priv_testtype1[]);
-
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
 ALTER TABLE test9b ALTER COLUMN b TYPE priv_testdomain1;
-
 CREATE TYPE test7b AS (a int, b priv_testdomain1);
-
 CREATE TYPE test8b AS (a int, b int);
 ALTER TYPE test8b ADD ATTRIBUTE c priv_testdomain1;
 ALTER TYPE test8b ALTER ATTRIBUTE b TYPE priv_testdomain1;
-
 CREATE TABLE test11b AS (SELECT 1::priv_testdomain1 AS a);
-
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
-
+WARNING:  no privileges could be revoked for "priv_testtype1"
+NOTICE:  no privileges could be revoked
 \c -
 DROP AGGREGATE priv_testagg1b(priv_testdomain1);
 DROP DOMAIN priv_testdomain2b;
@@ -683,169 +1059,398 @@ DROP CAST (priv_testdomain1 AS priv_testdomain3b);
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3b;
 DROP TABLE test11b;
-
 DROP TYPE priv_testtype1; -- ok
 DROP DOMAIN priv_testdomain1; -- ok
-
-
 -- truncate
 SET SESSION AUTHORIZATION regress_priv_user5;
 TRUNCATE atest2; -- ok
 TRUNCATE atest3; -- fail
-
+ERROR:  permission denied for table atest3
 -- has_table_privilege function
-
 -- bad-input checks
 select has_table_privilege(NULL,'pg_authid','select');
+ has_table_privilege 
+---------------------
+ 
+(1 row)
+
 select has_table_privilege('pg_shad','select');
+ERROR:  relation "pg_shad" does not exist
 select has_table_privilege('nosuchuser','pg_authid','select');
+ERROR:  role "nosuchuser" does not exist
 select has_table_privilege('pg_authid','sel');
+ERROR:  unrecognized privilege type: "sel"
 select has_table_privilege(-999999,'pg_authid','update');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege(1,'select');
+ has_table_privilege 
+---------------------
+ 
+(1 row)
 
 -- superuser
 \c -
-
 select has_table_privilege(current_user,'pg_authid','select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(current_user,'pg_authid','insert');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 select has_table_privilege(t2.oid,'pg_authid','update')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t2.oid,'pg_authid','delete')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 -- 'rule' privilege no longer exists, but for backwards compatibility
 -- has_table_privilege still recognizes the keyword and says FALSE
 select has_table_privilege(current_user,t1.oid,'rule')
 from (select oid from pg_class where relname = 'pg_authid') as t1;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege(current_user,t1.oid,'references')
 from (select oid from pg_class where relname = 'pg_authid') as t1;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 select has_table_privilege(t2.oid,t1.oid,'select')
 from (select oid from pg_class where relname = 'pg_authid') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t2.oid,t1.oid,'insert')
 from (select oid from pg_class where relname = 'pg_authid') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 select has_table_privilege('pg_authid','update');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege('pg_authid','delete');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege('pg_authid','truncate');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 select has_table_privilege(t1.oid,'select')
 from (select oid from pg_class where relname = 'pg_authid') as t1;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t1.oid,'trigger')
 from (select oid from pg_class where relname = 'pg_authid') as t1;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 -- non-superuser
 SET SESSION AUTHORIZATION regress_priv_user3;
-
 select has_table_privilege(current_user,'pg_class','select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(current_user,'pg_class','insert');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t2.oid,'pg_class','update')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege(t2.oid,'pg_class','delete')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(current_user,t1.oid,'references')
 from (select oid from pg_class where relname = 'pg_class') as t1;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t2.oid,t1.oid,'select')
 from (select oid from pg_class where relname = 'pg_class') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t2.oid,t1.oid,'insert')
 from (select oid from pg_class where relname = 'pg_class') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege('pg_class','update');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege('pg_class','delete');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege('pg_class','truncate');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t1.oid,'select')
 from (select oid from pg_class where relname = 'pg_class') as t1;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t1.oid,'trigger')
 from (select oid from pg_class where relname = 'pg_class') as t1;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(current_user,'atest1','select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(current_user,'atest1','insert');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t2.oid,'atest1','update')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege(t2.oid,'atest1','delete')
 from (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(current_user,t1.oid,'references')
 from (select oid from pg_class where relname = 'atest1') as t1;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t2.oid,t1.oid,'select')
 from (select oid from pg_class where relname = 'atest1') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t2.oid,t1.oid,'insert')
 from (select oid from pg_class where relname = 'atest1') as t1,
   (select oid from pg_roles where rolname = current_user) as t2;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege('atest1','update');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege('atest1','delete');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 select has_table_privilege('atest1','truncate');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 select has_table_privilege(t1.oid,'select')
 from (select oid from pg_class where relname = 'atest1') as t1;
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 select has_table_privilege(t1.oid,'trigger')
 from (select oid from pg_class where relname = 'atest1') as t1;
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 -- has_column_privilege function
-
 -- bad-input checks (as non-super-user)
 select has_column_privilege('pg_authid',NULL,'select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 select has_column_privilege('pg_authid','nosuchcol','select');
+ERROR:  column "nosuchcol" of relation "pg_authid" does not exist
 select has_column_privilege(9999,'nosuchcol','select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 select has_column_privilege(9999,99::int2,'select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 select has_column_privilege('pg_authid',99::int2,'select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 select has_column_privilege(9999,99::int2,'select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
 
 create temp table mytable(f1 int, f2 int, f3 int);
 alter table mytable drop column f2;
 select has_column_privilege('mytable','f2','select');
+ERROR:  column "f2" of relation "mytable" does not exist
 select has_column_privilege('mytable','........pg.dropped.2........','select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 select has_column_privilege('mytable',2::int2,'select');
+ has_column_privilege 
+----------------------
+ t
+(1 row)
+
 revoke select on table mytable from regress_priv_user3;
 select has_column_privilege('mytable',2::int2,'select');
+ has_column_privilege 
+----------------------
+ 
+(1 row)
+
 drop table mytable;
-
 -- Grant options
-
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 CREATE TABLE atest4 (a int);
-
 GRANT SELECT ON atest4 TO regress_priv_user2 WITH GRANT OPTION;
 GRANT UPDATE ON atest4 TO regress_priv_user2;
 GRANT SELECT ON atest4 TO GROUP regress_priv_group1 WITH GRANT OPTION;
-
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 GRANT SELECT ON atest4 TO regress_priv_user3;
 GRANT UPDATE ON atest4 TO regress_priv_user3; -- fail
-
+WARNING:  no privileges were granted for "atest4"
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 REVOKE SELECT ON atest4 FROM regress_priv_user3; -- does nothing
+NOTICE:  no privileges could be revoked
 SELECT has_table_privilege('regress_priv_user3', 'atest4', 'SELECT'); -- true
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 REVOKE SELECT ON atest4 FROM regress_priv_user2; -- fail
+ERROR:  dependent privileges exist
+HINT:  Use CASCADE to revoke them too.
 REVOKE GRANT OPTION FOR SELECT ON atest4 FROM regress_priv_user2 CASCADE; -- ok
 SELECT has_table_privilege('regress_priv_user2', 'atest4', 'SELECT'); -- true
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user3', 'atest4', 'SELECT'); -- false
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 SELECT has_table_privilege('regress_priv_user1', 'atest4', 'SELECT WITH GRANT OPTION'); -- true
-
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 -- security-restricted operations
 \c -
 CREATE ROLE regress_sro_user;
-
 -- Check that index expressions and predicates are run as the table's owner
-
 -- A dummy index function checking current_user
 CREATE FUNCTION sro_ifun(int) RETURNS int AS $$
 BEGIN
@@ -870,6 +1475,7 @@ CREATE INDEX sro_idx ON sro_tab ((sro_ifun(a) + sro_ifun(0)))
 REINDEX TABLE sro_tab;
 REINDEX INDEX sro_idx;
 REINDEX TABLE CONCURRENTLY sro_tab;
+ERROR:  REINDEX CONCURRENTLY is not supported
 DROP INDEX sro_idx;
 -- CLUSTER
 CREATE INDEX sro_cluster_idx ON sro_tab ((sro_ifun(a) + sro_ifun(0)));
@@ -878,7 +1484,16 @@ DROP INDEX sro_cluster_idx;
 -- BRIN index
 CREATE INDEX sro_brin ON sro_tab USING brin ((sro_ifun(a) + sro_ifun(0)));
 SELECT brin_desummarize_range('sro_brin', 0);
+ brin_desummarize_range 
+------------------------
+(0 rows)
+
 SELECT brin_summarize_range('sro_brin', 0);
+ brin_summarize_range 
+----------------------
+                    2
+(1 row)
+
 DROP TABLE sro_tab;
 -- Check with a partitioned table
 CREATE TABLE sro_ptab (a int) PARTITION BY RANGE (a);
@@ -890,7 +1505,7 @@ CREATE INDEX sro_pidx ON sro_ptab ((sro_ifun(a) + sro_ifun(0)))
 	WHERE sro_ifun(a + 10) > sro_ifun(10);
 REINDEX TABLE sro_ptab;
 REINDEX INDEX CONCURRENTLY sro_pidx;
-
+ERROR:  REINDEX CONCURRENTLY is not supported
 SET SESSION AUTHORIZATION regress_sro_user;
 CREATE FUNCTION unwanted_grant() RETURNS void LANGUAGE sql AS
 	'GRANT regress_priv_group2 TO regress_sro_user';
@@ -899,9 +1514,12 @@ CREATE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
 -- REFRESH of this MV will queue a GRANT at end of transaction
 CREATE MATERIALIZED VIEW sro_mv AS SELECT mv_action() WITH NO DATA;
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 \c -
 REFRESH MATERIALIZED VIEW sro_mv;
-
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 SET SESSION AUTHORIZATION regress_sro_user;
 -- INSERT to this table will queue a GRANT at end of transaction
 CREATE TABLE sro_trojan_table ();
@@ -913,10 +1531,18 @@ CREATE CONSTRAINT TRIGGER t AFTER INSERT ON sro_trojan_table
 CREATE OR REPLACE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
 	'INSERT INTO sro_trojan_table DEFAULT VALUES; SELECT true';
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 \c -
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 BEGIN; SET CONSTRAINTS ALL IMMEDIATE; REFRESH MATERIALIZED VIEW sro_mv; COMMIT;
-
+ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement
+CONTEXT:  SQL function "unwanted_grant" during startup
+SQL statement "SELECT unwanted_grant()"
+PL/pgSQL function sro_trojan() line 1 at PERFORM
+SQL function "mv_action" statement 1
 -- REFRESH MATERIALIZED VIEW CONCURRENTLY use of eval_const_expressions()
 SET SESSION AUTHORIZATION regress_sro_user;
 CREATE FUNCTION unwanted_grant_nofail(int) RETURNS int
@@ -933,299 +1559,520 @@ CREATE UNIQUE INDEX ON sro_index_mv (c) WHERE unwanted_grant_nofail(1) > 0;
 \c -
 REFRESH MATERIALIZED VIEW CONCURRENTLY sro_index_mv;
 REFRESH MATERIALIZED VIEW sro_index_mv;
-
 DROP OWNED BY regress_sro_user;
 DROP ROLE regress_sro_user;
-
-
 -- Admin options
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 CREATE FUNCTION dogrant_ok() RETURNS void LANGUAGE sql SECURITY DEFINER AS
 	'GRANT regress_priv_group2 TO regress_priv_user5';
 GRANT regress_priv_group2 TO regress_priv_user5; -- ok: had ADMIN OPTION
 SET ROLE regress_priv_group2;
 GRANT regress_priv_group2 TO regress_priv_user5; -- fails: SET ROLE suspended privilege
-
+ERROR:  must have admin option on role "regress_priv_group2"
 SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT regress_priv_group2 TO regress_priv_user5; -- fails: no ADMIN OPTION
+ERROR:  must have admin option on role "regress_priv_group2"
 SELECT dogrant_ok();			-- ok: SECURITY DEFINER conveys ADMIN
+NOTICE:  role "regress_priv_user5" is already a member of role "regress_priv_group2"
+ dogrant_ok 
+------------
+ 
+(1 row)
+
 SET ROLE regress_priv_group2;
 GRANT regress_priv_group2 TO regress_priv_user5; -- fails: SET ROLE did not help
-
+ERROR:  must have admin option on role "regress_priv_group2"
 SET SESSION AUTHORIZATION regress_priv_group2;
 GRANT regress_priv_group2 TO regress_priv_user5; -- ok: a role can self-admin
+NOTICE:  role "regress_priv_user5" is already a member of role "regress_priv_group2"
 CREATE FUNCTION dogrant_fails() RETURNS void LANGUAGE sql SECURITY DEFINER AS
 	'GRANT regress_priv_group2 TO regress_priv_user5';
 SELECT dogrant_fails();			-- fails: no self-admin in SECURITY DEFINER
+ERROR:  must have admin option on role "regress_priv_group2"
+CONTEXT:  SQL function "dogrant_fails" statement 1
 DROP FUNCTION dogrant_fails();
-
 SET SESSION AUTHORIZATION regress_priv_user4;
 DROP FUNCTION dogrant_ok();
 REVOKE regress_priv_group2 FROM regress_priv_user5;
-
-
 -- has_sequence_privilege tests
 \c -
-
 CREATE SEQUENCE x_seq;
-
 GRANT USAGE on x_seq to regress_priv_user2;
-
 SELECT has_sequence_privilege('regress_priv_user1', 'atest1', 'SELECT');
+ERROR:  "atest1" is not a sequence
 SELECT has_sequence_privilege('regress_priv_user1', 'x_seq', 'INSERT');
+ERROR:  unrecognized privilege type: "INSERT"
 SELECT has_sequence_privilege('regress_priv_user1', 'x_seq', 'SELECT');
+ has_sequence_privilege 
+------------------------
+ f
+(1 row)
 
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 SELECT has_sequence_privilege('x_seq', 'USAGE');
+ has_sequence_privilege 
+------------------------
+ t
+(1 row)
 
 -- largeobject privilege tests
 \c -
 SET SESSION AUTHORIZATION regress_priv_user1;
-
 -- start_ignore
 SELECT lo_create(1001);
+ lo_create 
+-----------
+      1001
+(1 row)
+
 SELECT lo_create(1002);
+ lo_create 
+-----------
+      1002
+(1 row)
+
 SELECT lo_create(1003);
+ lo_create 
+-----------
+      1003
+(1 row)
+
 SELECT lo_create(1004);
+ lo_create 
+-----------
+      1004
+(1 row)
+
 SELECT lo_create(1005);
+ lo_create 
+-----------
+      1005
+(1 row)
 
 GRANT ALL ON LARGE OBJECT 1001 TO PUBLIC;
 GRANT SELECT ON LARGE OBJECT 1003 TO regress_priv_user2;
 GRANT SELECT,UPDATE ON LARGE OBJECT 1004 TO regress_priv_user2;
 GRANT ALL ON LARGE OBJECT 1005 TO regress_priv_user2;
 GRANT SELECT ON LARGE OBJECT 1005 TO regress_priv_user2 WITH GRANT OPTION;
-
 GRANT SELECT, INSERT ON LARGE OBJECT 1001 TO PUBLIC;	-- to be failed
+ERROR:  invalid privilege type INSERT for large object
 GRANT SELECT, UPDATE ON LARGE OBJECT 1001 TO nosuchuser;	-- to be failed
+ERROR:  role "nosuchuser" does not exist
 GRANT SELECT, UPDATE ON LARGE OBJECT  999 TO PUBLIC;	-- to be failed
+ERROR:  large object 999 does not exist
 -- end_ignore
-
 \c -
 SET SESSION AUTHORIZATION regress_priv_user2;
-
 -- start_ignore
 SELECT lo_create(2001);
+ lo_create 
+-----------
+      2001
+(1 row)
+
 SELECT lo_create(2002);
+ lo_create 
+-----------
+      2002
+(1 row)
 
 SELECT loread(lo_open(1001, x'20000'::int), 32);	-- allowed, for now
-SELECT lowrite(lo_open(1001, x'40000'::int), 'abcd');	-- fail, wrong mode
+ loread 
+--------
+ \x
+(1 row)
 
+SELECT lowrite(lo_open(1001, x'40000'::int), 'abcd');	-- fail, wrong mode
+ERROR:  large object descriptor 0 was not opened for writing
 SELECT loread(lo_open(1001, x'40000'::int), 32);
+ loread 
+--------
+ \x
+(1 row)
+
 SELECT loread(lo_open(1002, x'40000'::int), 32);	-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT loread(lo_open(1003, x'40000'::int), 32);
+ loread 
+--------
+ \x
+(1 row)
+
 SELECT loread(lo_open(1004, x'40000'::int), 32);
+ loread 
+--------
+ \x
+(1 row)
 
 SELECT lowrite(lo_open(1001, x'20000'::int), 'abcd');
+ lowrite 
+---------
+       4
+(1 row)
+
 SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');	-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT lowrite(lo_open(1003, x'20000'::int), 'abcd');	-- to be denied
+ERROR:  permission denied for large object 1003
 SELECT lowrite(lo_open(1004, x'20000'::int), 'abcd');
+ lowrite 
+---------
+       4
+(1 row)
 
 GRANT SELECT ON LARGE OBJECT 1005 TO regress_priv_user3;
 GRANT UPDATE ON LARGE OBJECT 1006 TO regress_priv_user3;	-- to be denied
+ERROR:  large object 1006 does not exist
 REVOKE ALL ON LARGE OBJECT 2001, 2002 FROM PUBLIC;
 GRANT ALL ON LARGE OBJECT 2001 TO regress_priv_user3;
-
 SELECT lo_unlink(1001);		-- to be denied
+ERROR:  must be owner of large object 1001
 SELECT lo_unlink(2002);
--- end_ignore
+ lo_unlink 
+-----------
+         1
+(1 row)
 
+-- end_ignore
 \c -
 -- start_ignore
 -- confirm ACL setting
 SELECT oid, pg_get_userbyid(lomowner) ownername, lomacl FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
+ oid  |     ownername      |                                                            lomacl                                                            
+------+--------------------+------------------------------------------------------------------------------------------------------------------------------
+ 1001 | regress_priv_user1 | {regress_priv_user1=rw/regress_priv_user1,=rw/regress_priv_user1}
+ 1002 | regress_priv_user1 | 
+ 1003 | regress_priv_user1 | {regress_priv_user1=rw/regress_priv_user1,regress_priv_user2=r/regress_priv_user1}
+ 1004 | regress_priv_user1 | {regress_priv_user1=rw/regress_priv_user1,regress_priv_user2=rw/regress_priv_user1}
+ 1005 | regress_priv_user1 | {regress_priv_user1=rw/regress_priv_user1,regress_priv_user2=r*w/regress_priv_user1,regress_priv_user3=r/regress_priv_user2}
+ 2001 | regress_priv_user2 | {regress_priv_user2=rw/regress_priv_user2,regress_priv_user3=rw/regress_priv_user2}
+(6 rows)
+
 -- end_ignore
-
 SET SESSION AUTHORIZATION regress_priv_user3;
-
 -- start_ignore
 SELECT loread(lo_open(1001, x'40000'::int), 32);
+   loread   
+------------
+ \x61626364
+(1 row)
+
 SELECT loread(lo_open(1003, x'40000'::int), 32);	-- to be denied
+ERROR:  permission denied for large object 1003
 SELECT loread(lo_open(1005, x'40000'::int), 32);
+ loread 
+--------
+ \x
+(1 row)
 
 SELECT lo_truncate(lo_open(1005, x'20000'::int), 10);	-- to be denied
+ERROR:  permission denied for large object 1005
 SELECT lo_truncate(lo_open(2001, x'20000'::int), 10);
--- end_ignore
+ lo_truncate 
+-------------
+           0
+(1 row)
 
+-- end_ignore
 -- compatibility mode in largeobject permission
 \c -
 SET lo_compat_privileges = false;	-- default setting
 SET SESSION AUTHORIZATION regress_priv_user4;
-
 -- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);	-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');	-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT lo_truncate(lo_open(1002, x'20000'::int), 10);	-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT lo_put(1002, 1, 'abcd');				-- to be denied
+ERROR:  permission denied for large object 1002
 SELECT lo_unlink(1002);					-- to be denied
+ERROR:  must be owner of large object 1002
 SELECT lo_export(1001, '/dev/null');			-- to be denied
+ERROR:  permission denied for function lo_export
 SELECT lo_import('/dev/null');				-- to be denied
+ERROR:  permission denied for function lo_import
 SELECT lo_import('/dev/null', 2003);			-- to be denied
+ERROR:  permission denied for function lo_import
 -- end_ignore
-
 \c -
 SET lo_compat_privileges = true;	-- compatibility mode
 SET SESSION AUTHORIZATION regress_priv_user4;
-
 -- start_ignore
 SELECT loread(lo_open(1002, x'40000'::int), 32);
-SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');
-SELECT lo_truncate(lo_open(1002, x'20000'::int), 10);
-SELECT lo_unlink(1002);
-SELECT lo_export(1001, '/dev/null');			-- to be denied
--- end_ignore
+ loread 
+--------
+ \x
+(1 row)
 
+SELECT lowrite(lo_open(1002, x'20000'::int), 'abcd');
+ lowrite 
+---------
+       4
+(1 row)
+
+SELECT lo_truncate(lo_open(1002, x'20000'::int), 10);
+ lo_truncate 
+-------------
+           0
+(1 row)
+
+SELECT lo_unlink(1002);
+ lo_unlink 
+-----------
+         1
+(1 row)
+
+SELECT lo_export(1001, '/dev/null');			-- to be denied
+ERROR:  permission denied for function lo_export
+-- end_ignore
 -- don't allow unpriv users to access pg_largeobject contents
 \c -
 SELECT * FROM pg_largeobject LIMIT 0;
+ loid | pageno | data 
+------+--------+------
+(0 rows)
 
 SET SESSION AUTHORIZATION regress_priv_user1;
 SELECT * FROM pg_largeobject LIMIT 0;			-- to be denied
-
+ERROR:  permission denied for table pg_largeobject
 -- test default ACLs
 \c -
-
 CREATE SCHEMA testns;
 GRANT ALL ON SCHEMA testns TO regress_priv_user1;
-
 CREATE TABLE testns.acltest1 (x int);
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'SELECT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'INSERT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 -- placeholder for test with duplicated schema and role names
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns,testns GRANT SELECT ON TABLES TO public,public;
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'SELECT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'INSERT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 DROP TABLE testns.acltest1;
 CREATE TABLE testns.acltest1 (x int);
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'SELECT'); -- yes
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'INSERT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT INSERT ON TABLES TO regress_priv_user1;
-
 DROP TABLE testns.acltest1;
 CREATE TABLE testns.acltest1 (x int);
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'SELECT'); -- yes
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'INSERT'); -- yes
+ has_table_privilege 
+---------------------
+ t
+(1 row)
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns REVOKE INSERT ON TABLES FROM regress_priv_user1;
-
 DROP TABLE testns.acltest1;
 CREATE TABLE testns.acltest1 (x int);
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'SELECT'); -- yes
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.acltest1', 'INSERT'); -- no
+ has_table_privilege 
+---------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES FOR ROLE regress_priv_user1 REVOKE EXECUTE ON FUNCTIONS FROM public;
-
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT USAGE ON SCHEMAS TO regress_priv_user2; -- error
-
+ERROR:  cannot use IN SCHEMA clause when using GRANT/REVOKE ON SCHEMAS
 --
 -- Testing blanket default grants is very hazardous since it might change
 -- the privileges attached to objects created by concurrent regression tests.
 -- To avoid that, be sure to revoke the privileges again before committing.
 --
 BEGIN;
-
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO regress_priv_user2;
-
 CREATE SCHEMA testns2;
-
 SELECT has_schema_privilege('regress_priv_user2', 'testns2', 'USAGE'); -- yes
+ has_schema_privilege 
+----------------------
+ t
+(1 row)
+
 SELECT has_schema_privilege('regress_priv_user2', 'testns2', 'CREATE'); -- no
+ has_schema_privilege 
+----------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES REVOKE USAGE ON SCHEMAS FROM regress_priv_user2;
-
 CREATE SCHEMA testns3;
-
 SELECT has_schema_privilege('regress_priv_user2', 'testns3', 'USAGE'); -- no
+ has_schema_privilege 
+----------------------
+ f
+(1 row)
+
 SELECT has_schema_privilege('regress_priv_user2', 'testns3', 'CREATE'); -- no
+ has_schema_privilege 
+----------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO regress_priv_user2;
-
 CREATE SCHEMA testns4;
-
 SELECT has_schema_privilege('regress_priv_user2', 'testns4', 'USAGE'); -- yes
+ has_schema_privilege 
+----------------------
+ t
+(1 row)
+
 SELECT has_schema_privilege('regress_priv_user2', 'testns4', 'CREATE'); -- yes
+ has_schema_privilege 
+----------------------
+ t
+(1 row)
 
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM regress_priv_user2;
-
 COMMIT;
-
 CREATE SCHEMA testns5;
-
 SELECT has_schema_privilege('regress_priv_user2', 'testns5', 'USAGE'); -- no
+ has_schema_privilege 
+----------------------
+ f
+(1 row)
+
 SELECT has_schema_privilege('regress_priv_user2', 'testns5', 'CREATE'); -- no
+ has_schema_privilege 
+----------------------
+ f
+(1 row)
 
 SET ROLE regress_priv_user1;
-
 CREATE FUNCTION testns.foo() RETURNS int AS 'select 1' LANGUAGE sql;
 CREATE AGGREGATE testns.agg1(int) (sfunc = int4pl, stype = int4);
 CREATE PROCEDURE testns.bar() AS 'select 1' LANGUAGE sql;
-
 SELECT has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE'); -- no
+ has_function_privilege 
+------------------------
+ f
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user2', 'testns.agg1(int)', 'EXECUTE'); -- no
+ has_function_privilege 
+------------------------
+ f
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user2', 'testns.bar()', 'EXECUTE'); -- no
+ has_function_privilege 
+------------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT EXECUTE ON ROUTINES to public;
-
 DROP FUNCTION testns.foo();
 CREATE FUNCTION testns.foo() RETURNS int AS 'select 1' LANGUAGE sql;
 DROP AGGREGATE testns.agg1(int);
 CREATE AGGREGATE testns.agg1(int) (sfunc = int4pl, stype = int4);
 DROP PROCEDURE testns.bar();
 CREATE PROCEDURE testns.bar() AS 'select 1' LANGUAGE sql;
-
 SELECT has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE'); -- yes
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user2', 'testns.agg1(int)', 'EXECUTE'); -- yes
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user2', 'testns.bar()', 'EXECUTE'); -- yes (counts as function here)
+ has_function_privilege 
+------------------------
+ t
+(1 row)
 
 DROP FUNCTION testns.foo();
 DROP AGGREGATE testns.agg1(int);
 DROP PROCEDURE testns.bar();
-
 ALTER DEFAULT PRIVILEGES FOR ROLE regress_priv_user1 REVOKE USAGE ON TYPES FROM public;
-
 CREATE DOMAIN testns.priv_testdomain1 AS int;
-
 SELECT has_type_privilege('regress_priv_user2', 'testns.priv_testdomain1', 'USAGE'); -- no
+ has_type_privilege 
+--------------------
+ f
+(1 row)
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT USAGE ON TYPES to public;
-
 DROP DOMAIN testns.priv_testdomain1;
 CREATE DOMAIN testns.priv_testdomain1 AS int;
-
 SELECT has_type_privilege('regress_priv_user2', 'testns.priv_testdomain1', 'USAGE'); -- yes
+ has_type_privilege 
+--------------------
+ t
+(1 row)
 
 DROP DOMAIN testns.priv_testdomain1;
-
 RESET ROLE;
-
 SELECT count(*)
   FROM pg_default_acl d LEFT JOIN pg_namespace n ON defaclnamespace = n.oid
   WHERE nspname = 'testns';
+ count 
+-------
+     3
+(1 row)
 
 DROP SCHEMA testns CASCADE;
+NOTICE:  drop cascades to table testns.acltest1
 DROP SCHEMA testns2 CASCADE;
 DROP SCHEMA testns3 CASCADE;
 DROP SCHEMA testns4 CASCADE;
 DROP SCHEMA testns5 CASCADE;
-
 SELECT d.*     -- check that entries went away
   FROM pg_default_acl d LEFT JOIN pg_namespace n ON defaclnamespace = n.oid
   WHERE nspname IS NULL AND defaclnamespace != 0;
-
+ oid | defaclrole | defaclnamespace | defaclobjtype | defaclacl 
+-----+------------+-----------------+---------------+-----------
+(0 rows)
 
 -- Grant on all objects of given type in a schema
 \c -
-
 -- GPDB: Create a helper function to inspect the segment information also
 DROP FUNCTION IF EXISTS has_table_privilege_seg(u text, r text, p text);
+NOTICE:  function has_table_privilege_seg(text,text,text) does not exist, skipping
 CREATE FUNCTION has_table_privilege_seg(us text, rel text, priv text)
 RETURNS TABLE (
 	segid int,
@@ -1238,91 +2085,235 @@ RETURNS TABLE (
 		has_table_privilege($1, $2, $3) p
 $$ LANGUAGE SQL VOLATILE
 CONTAINS SQL EXECUTE ON ALL SEGMENTS;
-
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
 CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
 CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
-
+NOTICE:  merging column "f1" with inherited definition
 SELECT has_table_privilege('regress_priv_user1', 'testns.t1', 'SELECT'); -- false
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t1', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     2 | f
+     0 | f
+     1 | f
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t4', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
 
 GRANT ALL ON ALL TABLES IN SCHEMA testns TO regress_priv_user1;
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.t1', 'SELECT'); -- true
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.t2', 'SELECT'); -- true
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t1', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t4', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+     0 | t
+     1 | t
+     2 | t
+(3 rows)
 
 REVOKE ALL ON ALL TABLES IN SCHEMA testns FROM regress_priv_user1;
-
 SELECT has_table_privilege('regress_priv_user1', 'testns.t1', 'SELECT'); -- false
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 SELECT has_table_privilege('regress_priv_user1', 'testns.t2', 'SELECT'); -- false
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
+
 SELECT * FROM has_table_privilege_seg('regress_priv_user1', 'testns.t4', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+     0 | f
+     1 | f
+     2 | f
+(3 rows)
 
 CREATE FUNCTION testns.priv_testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 CREATE AGGREGATE testns.priv_testagg(int) (sfunc = int4pl, stype = int4);
 CREATE PROCEDURE testns.priv_testproc(int) AS 'select 3' LANGUAGE sql;
-
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- true by default
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testagg(int)', 'EXECUTE'); -- true by default
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- true by default
+ has_function_privilege 
+------------------------
+ t
+(1 row)
 
 REVOKE ALL ON ALL FUNCTIONS IN SCHEMA testns FROM PUBLIC;
-
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- false
+ has_function_privilege 
+------------------------
+ f
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testagg(int)', 'EXECUTE'); -- false
+ has_function_privilege 
+------------------------
+ f
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- still true, not a function
+ has_function_privilege 
+------------------------
+ t
+(1 row)
 
 REVOKE ALL ON ALL PROCEDURES IN SCHEMA testns FROM PUBLIC;
-
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- now false
+ has_function_privilege 
+------------------------
+ f
+(1 row)
 
 GRANT ALL ON ALL ROUTINES IN SCHEMA testns TO PUBLIC;
-
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- true
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testagg(int)', 'EXECUTE'); -- true
+ has_function_privilege 
+------------------------
+ t
+(1 row)
+
 SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- true
+ has_function_privilege 
+------------------------
+ t
+(1 row)
 
 DROP SCHEMA testns CASCADE;
-
-
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table testns.t1
+drop cascades to table testns.t2
+drop cascades to table testns.t3
+drop cascades to table testns.t4
+drop cascades to function testns.priv_testfunc(integer)
+drop cascades to function testns.priv_testagg(integer)
+drop cascades to function testns.priv_testproc(integer)
 -- Change owner of the schema & and rename of new schema owner
 \c -
-
 CREATE ROLE regress_schemauser1 superuser login;
 CREATE ROLE regress_schemauser2 superuser login;
-
 SET SESSION ROLE regress_schemauser1;
 CREATE SCHEMA testns;
-
 SELECT nspname, rolname FROM pg_namespace, pg_roles WHERE pg_namespace.nspname = 'testns' AND pg_namespace.nspowner = pg_roles.oid;
+ nspname |       rolname       
+---------+---------------------
+ testns  | regress_schemauser1
+(1 row)
 
 ALTER SCHEMA testns OWNER TO regress_schemauser2;
 ALTER ROLE regress_schemauser2 RENAME TO regress_schemauser_renamed;
 SELECT nspname, rolname FROM pg_namespace, pg_roles WHERE pg_namespace.nspname = 'testns' AND pg_namespace.nspowner = pg_roles.oid;
+ nspname |          rolname           
+---------+----------------------------
+ testns  | regress_schemauser_renamed
+(1 row)
 
 set session role regress_schemauser_renamed;
 DROP SCHEMA testns CASCADE;
-
 -- clean up
 \c -
-
 DROP ROLE regress_schemauser1;
 DROP ROLE regress_schemauser_renamed;
-
-
 -- test that dependent privileges are revoked (or not) properly
 \c -
-
 set session role regress_priv_user1;
 create table dep_priv_test (a int);
 grant select on dep_priv_test to regress_priv_user2 with grant option;
@@ -1334,20 +2325,46 @@ grant select on dep_priv_test to regress_priv_user4 with grant option;
 set session role regress_priv_user4;
 grant select on dep_priv_test to regress_priv_user5;
 \dp dep_priv_test
+                                               Access privileges
+ Schema |     Name      | Type  |               Access privileges               | Column privileges | Policies 
+--------+---------------+-------+-----------------------------------------------+-------------------+----------
+ public | dep_priv_test | table | regress_priv_user1=arwdDxt/regress_priv_user1+|                   | 
+        |               |       | regress_priv_user2=r*/regress_priv_user1     +|                   | 
+        |               |       | regress_priv_user3=r*/regress_priv_user1     +|                   | 
+        |               |       | regress_priv_user4=r*/regress_priv_user2     +|                   | 
+        |               |       | regress_priv_user4=r*/regress_priv_user3     +|                   | 
+        |               |       | regress_priv_user5=r/regress_priv_user4       |                   | 
+(1 row)
+
 set session role regress_priv_user2;
 revoke select on dep_priv_test from regress_priv_user4 cascade;
 \dp dep_priv_test
+                                               Access privileges
+ Schema |     Name      | Type  |               Access privileges               | Column privileges | Policies 
+--------+---------------+-------+-----------------------------------------------+-------------------+----------
+ public | dep_priv_test | table | regress_priv_user1=arwdDxt/regress_priv_user1+|                   | 
+        |               |       | regress_priv_user2=r*/regress_priv_user1     +|                   | 
+        |               |       | regress_priv_user3=r*/regress_priv_user1     +|                   | 
+        |               |       | regress_priv_user4=r*/regress_priv_user3     +|                   | 
+        |               |       | regress_priv_user5=r/regress_priv_user4       |                   | 
+(1 row)
+
 set session role regress_priv_user3;
 revoke select on dep_priv_test from regress_priv_user4 cascade;
 \dp dep_priv_test
+                                               Access privileges
+ Schema |     Name      | Type  |               Access privileges               | Column privileges | Policies 
+--------+---------------+-------+-----------------------------------------------+-------------------+----------
+ public | dep_priv_test | table | regress_priv_user1=arwdDxt/regress_priv_user1+|                   | 
+        |               |       | regress_priv_user2=r*/regress_priv_user1     +|                   | 
+        |               |       | regress_priv_user3=r*/regress_priv_user1      |                   | 
+(1 row)
+
 set session role regress_priv_user1;
 drop table dep_priv_test;
-
-
 -- security-restricted operations
 \c -
 CREATE ROLE regress_sro_user;
-
 SET SESSION AUTHORIZATION regress_sro_user;
 CREATE FUNCTION unwanted_grant() RETURNS void LANGUAGE sql AS
 	'GRANT regress_priv_group2 TO regress_sro_user';
@@ -1356,9 +2373,12 @@ CREATE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
 -- REFRESH of this MV will queue a GRANT at end of transaction
 CREATE MATERIALIZED VIEW sro_mv AS SELECT mv_action() WITH NO DATA;
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 \c -
 REFRESH MATERIALIZED VIEW sro_mv;
-
+ERROR:  cannot create a cursor WITH HOLD within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 SET SESSION AUTHORIZATION regress_sro_user;
 -- INSERT to this table will queue a GRANT at end of transaction
 CREATE TABLE sro_trojan_table ();
@@ -1370,14 +2390,20 @@ CREATE CONSTRAINT TRIGGER t AFTER INSERT ON sro_trojan_table
 CREATE OR REPLACE FUNCTION mv_action() RETURNS bool LANGUAGE sql AS
 	'INSERT INTO sro_trojan_table DEFAULT VALUES; SELECT true';
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 \c -
 REFRESH MATERIALIZED VIEW sro_mv;
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "mv_action" statement 1
 BEGIN; SET allow_segment_DML = ON; SET CONSTRAINTS ALL IMMEDIATE; REFRESH MATERIALIZED VIEW sro_mv; COMMIT;
-
+ERROR:  must have admin option on role "regress_priv_group2"
+CONTEXT:  SQL function "unwanted_grant" statement 1
+SQL statement "SELECT unwanted_grant()"
+PL/pgSQL function sro_trojan() line 1 at PERFORM
+SQL function "mv_action" statement 1
 DROP OWNED BY regress_sro_user;
 DROP ROLE regress_sro_user;
-
-
 -- Test sandbox escape with CVE-2020-25695 on Greenplum.
 --
 -- The idea of CVE-2020-25695 is to make superuser fire a defered
@@ -1392,61 +2418,57 @@ DROP ROLE regress_sro_user;
 -- "Executor" table has a defered insert trigger with security invoker
 -- function that executes malicious code under superuser. In a current example
 -- we give superuser to our unprivileged user on segments (not on coordinator node).
-
 \c -
-
 CREATE ROLE regress_sro_user;
 SET SESSION AUTHORIZATION regress_sro_user;
-
 CREATE TABLE executor (s varchar) DISTRIBUTED REPLICATED;
 CREATE TABLE trap (a int) WITH(appendonly = true) DISTRIBUTED REPLICATED;
-
 -- Create a "firestarter" stable index funcion
 CREATE OR REPLACE FUNCTION trap_sfunc(integer) RETURNS integer
 LANGUAGE sql IMMUTABLE AS
 'SELECT $1';
-
 CREATE INDEX trap_idx ON trap (trap_sfunc(a));
-
 -- and replace it with volatile security invoker to prodice insert operation on ANALYZE.
 CREATE OR REPLACE FUNCTION trap_sfunc(integer) RETURNS integer
 LANGUAGE sql SECURITY INVOKER AS
 'SET allow_segment_DML = ON; INSERT INTO executor VALUES (current_user); SELECT $1';
-
 -- Populate data in a "trap" table to run ANALYZE on.
 SET allow_segment_DML = ON;
 INSERT INTO trap VALUES(1);
-
 -- Create malicious function to run in defered trigger
 CREATE OR REPLACE FUNCTION executor_sfunc(integer) RETURNS integer
 LANGUAGE sql SECURITY INVOKER AS
 'SET allow_segment_DML = ON; ALTER USER regress_sro_user WITH superuser; SELECT $1';
-
 -- and the trigger itself.
 CREATE OR REPLACE FUNCTION executor_trig_sfunc() RETURNS trigger
 AS $$
 BEGIN PERFORM executor_sfunc(1000); RETURN NEW; END
 $$ LANGUAGE plpgsql;
-
 CREATE CONSTRAINT TRIGGER executor_trig
 AFTER INSERT ON executor
 INITIALLY DEFERRED FOR EACH ROW
 EXECUTE PROCEDURE executor_trig_sfunc();
-
 -- Check "regress_sro_user" superuser privileges on segments.
 CREATE OR REPLACE FUNCTION is_superuser_on_segments(username text) RETURNS setof boolean AS $$
 SELECT rolsuper FROM pg_roles WHERE rolname = $1;
 $$ LANGUAGE sql EXECUTE ON ALL SEGMENTS;
-
 SELECT DISTINCT is_superuser_on_segments('regress_sro_user');
+ is_superuser_on_segments 
+--------------------------
+ f
+(1 row)
 
 -- Execute a trap with superuser.
 RESET SESSION AUTHORIZATION;
-
 ANALYZE trap;
-
+ERROR:  cannot fire deferred trigger within security-restricted operation
+CONTEXT:  SQL function "trap_sfunc" statement 2
 -- Check "regress_sro_user" superuser privileges on segments.
 SELECT DISTINCT is_superuser_on_segments('regress_sro_user');
+ is_superuser_on_segments 
+--------------------------
+ f
+(1 row)
 
 DROP TABLE trap;
 DROP TABLE executor;
@@ -1455,27 +2477,22 @@ DROP FUNCTION executor_sfunc(integer);
 DROP FUNCTION executor_trig_sfunc();
 DROP FUNCTION is_superuser_on_segments(text);
 DROP ROLE regress_sro_user;
-
-
 -- clean up
-
 \c
-
 drop sequence x_seq;
-
 DROP AGGREGATE priv_testagg1(int);
 DROP FUNCTION priv_testfunc2(int);
 DROP FUNCTION priv_testfunc4(boolean);
 DROP PROCEDURE priv_testproc1(int);
-
 DROP VIEW atestv0;
 DROP VIEW atestv1;
 DROP VIEW atestv2;
 -- this should cascade to drop atestv4
 DROP VIEW atestv3 CASCADE;
+NOTICE:  drop cascades to view atestv4
 -- this should complain "does not exist"
 DROP VIEW atestv4;
-
+ERROR:  view "atestv4" does not exist
 DROP TABLE atest1;
 DROP TABLE atest2;
 DROP TABLE atest3;
@@ -1486,45 +2503,49 @@ DROP TABLE atestc;
 DROP TABLE atestp1;
 DROP TABLE atestp2;
 DROP TABLE atest2_ctas_ok;
-
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
--- end_ignore
+ lo_unlink 
+-----------
+         1
+         1
+         1
+         1
+         1
+(5 rows)
 
+-- end_ignore
 DROP GROUP regress_priv_group1;
 DROP GROUP regress_priv_group2;
-
 -- these are needed to clean up permissions
 REVOKE USAGE ON LANGUAGE sql FROM regress_priv_user1;
 DROP OWNED BY regress_priv_user1;
-
 DROP USER regress_priv_user1;
 DROP USER regress_priv_user2;
 DROP USER regress_priv_user3;
 DROP USER regress_priv_user4;
 DROP USER regress_priv_user5;
 DROP USER regress_priv_user6;
-
-
+ERROR:  role "regress_priv_user6" does not exist
 -- permissions with LOCK TABLE
 CREATE USER regress_locktable_user;
 CREATE TABLE lock_table (a int);
-
 -- LOCK TABLE and SELECT permission
 GRANT SELECT ON lock_table TO regress_locktable_user;
 SET SESSION AUTHORIZATION regress_locktable_user;
 BEGIN;
 LOCK TABLE lock_table IN ROW EXCLUSIVE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS SHARE MODE; -- should pass
 COMMIT;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 \c
 REVOKE SELECT ON lock_table FROM regress_locktable_user;
-
 -- LOCK TABLE and INSERT permission
 GRANT INSERT ON lock_table TO regress_locktable_user;
 SET SESSION AUTHORIZATION regress_locktable_user;
@@ -1533,13 +2554,14 @@ LOCK TABLE lock_table IN ROW EXCLUSIVE MODE; -- should pass
 COMMIT;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS SHARE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 \c
 REVOKE INSERT ON lock_table FROM regress_locktable_user;
-
 -- LOCK TABLE and UPDATE permission
 GRANT UPDATE ON lock_table TO regress_locktable_user;
 SET SESSION AUTHORIZATION regress_locktable_user;
@@ -1548,13 +2570,13 @@ LOCK TABLE lock_table IN ROW EXCLUSIVE MODE; -- should pass
 COMMIT;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS SHARE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should pass
 COMMIT;
 \c
 REVOKE UPDATE ON lock_table FROM regress_locktable_user;
-
 -- LOCK TABLE and DELETE permission
 GRANT DELETE ON lock_table TO regress_locktable_user;
 SET SESSION AUTHORIZATION regress_locktable_user;
@@ -1563,13 +2585,13 @@ LOCK TABLE lock_table IN ROW EXCLUSIVE MODE; -- should pass
 COMMIT;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS SHARE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should pass
 COMMIT;
 \c
 REVOKE DELETE ON lock_table FROM regress_locktable_user;
-
 -- LOCK TABLE and TRUNCATE permission
 GRANT TRUNCATE ON lock_table TO regress_locktable_user;
 SET SESSION AUTHORIZATION regress_locktable_user;
@@ -1578,13 +2600,13 @@ LOCK TABLE lock_table IN ROW EXCLUSIVE MODE; -- should pass
 COMMIT;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS SHARE MODE; -- should fail
+ERROR:  permission denied for table lock_table
 ROLLBACK;
 BEGIN;
 LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should pass
 COMMIT;
 \c
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
-
 -- clean up
 DROP TABLE lock_table;
 DROP USER regress_locktable_user;


### PR DESCRIPTION
**Background:**
ICW test privileges was turned off on ORCA in 2014 after ORCA generated plans
requesting incorrect privilege, causing queries that should be executed denied.
To revive the test, we have a few issues to address --

1. Some tests in the suite failed the non-NULL target list assertion in DXL ->
planned statement translation. This issue was fixed by 
PR https://github.com/greenplum-db/gpdb/pull/15939, and the
assertion is no more considered necessary.

2. Duplicate rte's in planned statement. ORCA may generate plans with duplicate
range table entries, each annotated with a different required permission. This
issue was fixed by PR https://github.com/greenplum-db/gpdb/pull/14304. 
Now we reuse rte's in the range table entries list, and update the permission in 
the process.

3. ORCA requires more privilege than needed, which is addressed by this PR. ORCA
constructs required permissions when building DML plan nodes. For
INSERT/UPDATE/DELETE operations, ORCA requests SELECT permission as well. This
is usually the right thing to do, cause most non trivial DML operations would
require SELECT permission as well. However, there are DML queries that don't
require SELECT permission.

**Example:**
Requires UPDATE permission only
```
update my_table set my_col = 1;
```

Requires UPDATE and SELECT permissions
```
update my_table set my_col = 1 where my_col = 2;
```

**Implementation:**
As of now, ORCA's translator discards the required permission info from the
query parse tree. Instead, ORCA configures the permission at a much later stage
when building the plan nodes for DML operations based on the operation type. To
avoid invoking unnecessary permissions, we pass the required permission from the
parse tree to the planned statement. Specifically, when serializing a query rte
into a table descriptor, we attach the required permission to the table
descriptor. Eventually, when building the DML plan nodes, we use the table
descriptor's permission for the plan rte.

Required permission is of the type AclMode, which is essentially 32-bit unsigned
integer. Since ORCA doesn't have access to Postgres utilities, we cannot use the
AclMode alias within ORCA. Instead, we use 32-bit integer, and cast it back to
AclMode when exiting ORCA.

**Test:**
By default, table created by CTAS with planner is hash distributed, and is
randomly distributed with ORCA. We specify the distribution spec for a CTAS
statement in the test suite, so that ORCA falls back onto the same planner plan
using nested loop join.

**Notes for reviewers:**
The PR is split into three commits for ease of review, and will be squash
merged.

1. The first commit adds the ORCA output for the privileges test. The best way
to review is by comparing the planner and ORCA outputs, as we expect the planner
and ORCA to display the same behavior in granting privileges.

2. The second commit refactors the rte deduplication logic from
PR https://github.com/greenplum-db/gpdb/pull/14304. One main change is that 
we only update the rte look up map after appending a new rte.

3. The third commit passes through the query's required permission.