### PR TITLE
[7x]: Fix for gprecoverseg test case failure

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -752,5 +752,7 @@ def impl(context, filename):
 def get_host_address(hostname):
     cmd = Command("get the address of the host", cmdStr="hostname -I", ctxt=REMOTE, remoteHost=hostname)
     cmd.run(validateAfter=True)
-    return cmd.get_stdout().strip()
+    host_address = cmd.get_stdout().strip().split(' ')
+    return host_address[0]
+
 


### PR DESCRIPTION
For ubuntu20.04 gprecoverseg test case fail.

Problem : In test case we use  hostname -I command to get host address and it will gives all the address associated with hostname. so while creating the input config file it taking an extra space and the format of the file becomes incorrect thats throwing error.

Solution: Split hostname -I command output and return the first element so there will be no extra space and It will make input config file format correct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
