### PR TITLE
Add an command option for gpfdist to disable client ssl identity verification.

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1385,57 +1385,47 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		/* cert is stored PEM coded in file... */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERTTYPE, "PEM");
 
-		if ( verify_gpfdists_cert ) {
-			/* set the cert for client authentication */
-			if (extssl_cert != NULL)
-			{
-				memset(extssl_cer_full, 0, MAXPGPATH);
-				snprintf(extssl_cer_full, MAXPGPATH, "%s/%s", DataDir, extssl_cert);
+		
+		/* set the cert for client authentication */
+		if (extssl_cert != NULL)
+		{
+			memset(extssl_cer_full, 0, MAXPGPATH);
+			snprintf(extssl_cer_full, MAXPGPATH, "%s/%s", DataDir, extssl_cert);
 
-				if (!is_file_exists(extssl_cer_full))
-					ereport(ERROR,
-							(errcode_for_file_access(),
-							errmsg("could not open certificate file \"%s\": %m",
-									extssl_cer_full)));
-
+			if (!is_file_exists(extssl_cer_full))
+				elog(LOG, "could not open certificate file \"%s\": %m", extssl_cer_full);
+			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERT, extssl_cer_full);
-			}
+		}
 
-			/* set the key passphrase */
-			if (extssl_pass != NULL)
-				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_KEYPASSWD, extssl_pass);
+		/* set the key passphrase */
+		if (extssl_pass != NULL)
+			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_KEYPASSWD, extssl_pass);
 
-			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEYTYPE,"PEM");
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEYTYPE,"PEM");
 
-			/* set the private key (file or ID in engine) */
-			if (extssl_key != NULL)
-			{
-				memset(extssl_key_full, 0, MAXPGPATH);
-				snprintf(extssl_key_full, MAXPGPATH, "%s/%s", DataDir, extssl_key);
+		/* set the private key (file or ID in engine) */
+		if (extssl_key != NULL)
+		{
+			memset(extssl_key_full, 0, MAXPGPATH);
+			snprintf(extssl_key_full, MAXPGPATH, "%s/%s", DataDir, extssl_key);
 
-				if (!is_file_exists(extssl_key_full))
-					ereport(ERROR,
-							(errcode_for_file_access(),
-							errmsg("could not open private key file \"%s\": %m",
-									extssl_key_full)));
-
+			if (!is_file_exists(extssl_key_full))
+				elog(LOG, "could not open private key file \"%s\": %m", extssl_key_full);
+			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEY, extssl_key_full);
-			}
+		}
 
-			/* set the file with the CA certificates, for validating the server */
-			if (extssl_ca != NULL)
-			{
-				memset(extssl_cas_full, 0, MAXPGPATH);
-				snprintf(extssl_cas_full, MAXPGPATH, "%s/%s", DataDir, extssl_ca);
+		/* set the file with the CA certificates, for validating the server */
+		if (extssl_ca != NULL)
+		{
+			memset(extssl_cas_full, 0, MAXPGPATH);
+			snprintf(extssl_cas_full, MAXPGPATH, "%s/%s", DataDir, extssl_ca);
 
-				if (!is_file_exists(extssl_cas_full))
-					ereport(ERROR,
-							(errcode_for_file_access(),
-							errmsg("could not open private key file \"%s\": %m",
-									extssl_cas_full)));
-
+			if (!is_file_exists(extssl_cas_full))
+				elog(LOG, "could not open private key file \"%s\": %m", extssl_cas_full);
+			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_CAINFO, extssl_cas_full);
-			}
 		}
 
 		/* set cert verification */

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1385,55 +1385,57 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		/* cert is stored PEM coded in file... */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERTTYPE, "PEM");
 
-		/* set the cert for client authentication */
-		if (extssl_cert != NULL)
-		{
-			memset(extssl_cer_full, 0, MAXPGPATH);
-			snprintf(extssl_cer_full, MAXPGPATH, "%s/%s", DataDir, extssl_cert);
+		if ( verify_gpfdists_cert ) {
+			/* set the cert for client authentication */
+			if (extssl_cert != NULL)
+			{
+				memset(extssl_cer_full, 0, MAXPGPATH);
+				snprintf(extssl_cer_full, MAXPGPATH, "%s/%s", DataDir, extssl_cert);
 
-			if (!is_file_exists(extssl_cer_full))
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not open certificate file \"%s\": %m",
-								extssl_cer_full)));
+				if (!is_file_exists(extssl_cer_full))
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							errmsg("could not open certificate file \"%s\": %m",
+									extssl_cer_full)));
 
-			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERT, extssl_cer_full);
-		}
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERT, extssl_cer_full);
+			}
 
-		/* set the key passphrase */
-		if (extssl_pass != NULL)
-			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_KEYPASSWD, extssl_pass);
+			/* set the key passphrase */
+			if (extssl_pass != NULL)
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_KEYPASSWD, extssl_pass);
 
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEYTYPE,"PEM");
+			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEYTYPE,"PEM");
 
-		/* set the private key (file or ID in engine) */
-		if (extssl_key != NULL)
-		{
-			memset(extssl_key_full, 0, MAXPGPATH);
-			snprintf(extssl_key_full, MAXPGPATH, "%s/%s", DataDir, extssl_key);
+			/* set the private key (file or ID in engine) */
+			if (extssl_key != NULL)
+			{
+				memset(extssl_key_full, 0, MAXPGPATH);
+				snprintf(extssl_key_full, MAXPGPATH, "%s/%s", DataDir, extssl_key);
 
-			if (!is_file_exists(extssl_key_full))
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not open private key file \"%s\": %m",
-								extssl_key_full)));
+				if (!is_file_exists(extssl_key_full))
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							errmsg("could not open private key file \"%s\": %m",
+									extssl_key_full)));
 
-			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEY, extssl_key_full);
-		}
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEY, extssl_key_full);
+			}
 
-		/* set the file with the CA certificates, for validating the server */
-		if (extssl_ca != NULL)
-		{
-			memset(extssl_cas_full, 0, MAXPGPATH);
-			snprintf(extssl_cas_full, MAXPGPATH, "%s/%s", DataDir, extssl_ca);
+			/* set the file with the CA certificates, for validating the server */
+			if (extssl_ca != NULL)
+			{
+				memset(extssl_cas_full, 0, MAXPGPATH);
+				snprintf(extssl_cas_full, MAXPGPATH, "%s/%s", DataDir, extssl_ca);
 
-			if (!is_file_exists(extssl_cas_full))
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not open private key file \"%s\": %m",
-								extssl_cas_full)));
+				if (!is_file_exists(extssl_cas_full))
+					ereport(ERROR,
+							(errcode_for_file_access(),
+							errmsg("could not open private key file \"%s\": %m",
+									extssl_cas_full)));
 
-			CURL_EASY_SETOPT(file->curl->handle, CURLOPT_CAINFO, extssl_cas_full);
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_CAINFO, extssl_cas_full);
+			}
 		}
 
 		/* set cert verification */

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1393,7 +1393,10 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 			snprintf(extssl_cer_full, MAXPGPATH, "%s/%s", DataDir, extssl_cert);
 
 			if (!is_file_exists(extssl_cer_full))
+			{
 				elog(LOG, "could not open certificate file \"%s\": %m", extssl_cer_full);
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERT, NULL);
+			}
 			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLCERT, extssl_cer_full);
 		}
@@ -1411,7 +1414,10 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 			snprintf(extssl_key_full, MAXPGPATH, "%s/%s", DataDir, extssl_key);
 
 			if (!is_file_exists(extssl_key_full))
+			{
 				elog(LOG, "could not open private key file \"%s\": %m", extssl_key_full);
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEY, NULL);
+			}
 			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_SSLKEY, extssl_key_full);
 		}
@@ -1423,7 +1429,10 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 			snprintf(extssl_cas_full, MAXPGPATH, "%s/%s", DataDir, extssl_ca);
 
 			if (!is_file_exists(extssl_cas_full))
+			{
 				elog(LOG, "could not open private key file \"%s\": %m", extssl_cas_full);
+				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_CAINFO, NULL);
+			}
 			else
 				CURL_EASY_SETOPT(file->curl->handle, CURLOPT_CAINFO, extssl_cas_full);
 		}

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -690,7 +690,7 @@ static void parse_command_line(int argc, const char* const argv[],
 	{ NULL, 'S', 0, "use O_SYNC when opening files for write" },
 	{ NULL, 'z', 1, "internal - queue size for listen call" },
 	{ "ssl", 257, 1, "ssl - certificates files under this directory" },
-	{ "ssl_verify_peer", 260, 1, "ssl_server_verify - enable the certification for gpdb identity" },
+	{ "ssl_verify_peer", 260, 1, "ssl_verify_peer - enable or disable the authentication for gpdb identity" },
 #ifdef GPFXDIST
 	{ NULL, 'c', 1, "transform configuration file" },
 #endif
@@ -779,10 +779,10 @@ static void parse_command_line(int argc, const char* const argv[],
 			break;
 #else
 		case 257:
-			usage_error("SSL is not supported by this build", 0);
+			usage_error("Flag ssl is not supported by this build", 0);
 			break;
 		case 260:
-			usage_error("SSL is not supported by this build", 0);
+			usage_error("Flag ssl_verify_peer is not supported by this build", 0);
 			break;
 #endif
 		case 256:

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -201,11 +201,12 @@ static struct
 	const char* c; /* config file */
 	struct transform* trlist; /* transforms from config file */
 	const char* ssl; /* path to certificates in case we use gpfdist with ssl */
+	bool		signature_auth; /* enable SSL certificate authentication on the GPDB side */
 	int			w; /* The time used for session timeout in seconds */
 	int 		k; /* The time used to clean up sessions in seconds */
 	int			compress; /* The flag to indicate whether comopression transmission is open */
 	int			multi_thread; /* The number of working threads for compression transmission */
-} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0, 300, 0, 0};
+} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, false, 0, 300, 0, 0};
 
 #define START_BUFFER_SIZE (1 << 20) /* 1M as start size */
 #define MAXIMUM_BUFFER_SIZE (1 << 30) /* 1G as Maximum size */
@@ -689,6 +690,7 @@ static void parse_command_line(int argc, const char* const argv[],
 	{ NULL, 'S', 0, "use O_SYNC when opening files for write" },
 	{ NULL, 'z', 1, "internal - queue size for listen call" },
 	{ "ssl", 257, 1, "ssl - certificates files under this directory" },
+	{ "ssl_server_verify", 260, 0, "ssl_server_verify - enable the certification for gpdb identity" },
 #ifdef GPFXDIST
 	{ NULL, 'c', 1, "transform configuration file" },
 #endif
@@ -772,8 +774,14 @@ static void parse_command_line(int argc, const char* const argv[],
 		case 257:
 			opt.ssl = arg;
 			break;
+		case 260:
+			opt.signature_auth = true;
+			break;
 #else
 		case 257:
+			usage_error("SSL is not supported by this build", 0);
+			break;
+		case 260:
 			usage_error("SSL is not supported by this build", 0);
 			break;
 #endif
@@ -4604,27 +4612,32 @@ static SSL_CTX *initialize_ctx(void)
 		}
 	}
 
-	/* Copy the path + the filename */
-	snprintf(fileName,stringSize,"%s%c%s",opt.ssl,slash,TrustedCaFilename);
-
-	/* Load the CAs we trust*/
-	if (!(SSL_CTX_load_verify_locations(ctx, fileName,0)))
-	{
-		gfatal (NULL,"Unable to to load CA from file: \"%s\"", fileName);
-	}
-	else
-	{
-		if ( opt.v )
-		{
-			gprint(NULL, "The CA file successfully loaded from \"%s\"\n",fileName);
-		}
-	}
-
 	/* 
 	 * Set the verification flags for ctx
 	 * We always require client certificate
 	 */
-	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+	if (opt.signature_auth) {
+		/* Copy the path + the filename */
+		snprintf(fileName,stringSize,"%s%c%s",opt.ssl,slash,TrustedCaFilename);
+
+		/* Load the CAs we trust*/
+		if (!(SSL_CTX_load_verify_locations(ctx, fileName,0)))
+		{
+			gfatal (NULL,"Unable to to load CA from file: \"%s\"", fileName);
+		}
+		else
+		{
+			if ( opt.v )
+			{
+				gprint(NULL, "The CA file successfully loaded from \"%s\"\n",fileName);
+			}
+		}
+		
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+	}
+	else {
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0); 
+	}
 
 	/* 
 	 * Consider using these - experinments on Mac showed no improvement,

--- a/src/bin/gpfdist/regress/.gitignore
+++ b/src/bin/gpfdist/regress/.gitignore
@@ -8,5 +8,6 @@ data/gpfdist_ssl/tbl2.tbl
 data/gpfdist_ssl/certs_matching
 data/gpfdist_ssl/certs_multiCA
 data/gpfdist_ssl/certs_not_matching/root.crt
+data/gpfdist_ssl/certs_server_no_verify
 regression.diffs
 regression.out

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -20,6 +20,8 @@ REGRESS_OPTS = --init-file=init_file
 installcheck: watchdog ipv4v6_ports
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
+	rm -rf data/gpfdist_ssl/certs_server_no_verify
+	mkdir data/gpfdist_ssl/certs_server_no_verify
 	rm -rf data/gpfdist_ssl/certs_matching
 	mkdir data/gpfdist_ssl/certs_matching
 	cp -rf $(COORDINATOR_DATA_DIRECTORY)/gpfdists/* data/gpfdist_ssl/certs_matching

--- a/src/bin/gpfdist/regress/change_cert.bash
+++ b/src/bin/gpfdist/regress/change_cert.bash
@@ -10,8 +10,33 @@ if [ "$1" = "client" ]; then
 	done
 fi
 
+# Create a new CA direrctory for gpfdist with a random root.crt
 if [ "$1" = "gpfdist" ]; then
 	mkdir data/gpfdist_ssl/certs_server_no_verify
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=root" -out data/gpfdist_ssl/certs_server_no_verify/root.crt
 	cp data/gpfdist_ssl/certs_matching/server.* data/gpfdist_ssl/certs_server_no_verify
+fi
+
+# Clear gpdb client and root CA certification.
+if [ "$1" = "clear" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/client.crt $(dirname $dir)/gpfdists/client.crt.bak
+			mv $(dirname $dir)/gpfdists/client.key $(dirname $dir)/gpfdists/client.key.bak
+			mv $(dirname $dir)/gpfdists/root.crt $(dirname $dir)/gpfdists/root.crt.bak
+		fi
+	done
+fi
+
+# Reset gpdb client and root CA certification.
+if [ "$1" = "recover" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/client.crt.bak $(dirname $dir)/gpfdists/client.crt
+			mv $(dirname $dir)/gpfdists/client.key.bak $(dirname $dir)/gpfdists/client.key
+			mv $(dirname $dir)/gpfdists/root.crt.bak $(dirname $dir)/gpfdists/root.crt
+		fi
+	done
 fi

--- a/src/bin/gpfdist/regress/change_cert.bash
+++ b/src/bin/gpfdist/regress/change_cert.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" = "client" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			cp $(dirname $dir)/gpfdists/client2.crt $(dirname $dir)/gpfdists/client.crt
@@ -11,74 +11,66 @@ if [ "$1" = "client" ]; then
 fi
 
 # Create a new CA direrctory for gpfdist with a random root.crt
-if [ "$1" = "gpfdist" ]; then
-	mkdir data/gpfdist_ssl/certs_server_no_verify
-	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=root" -out data/gpfdist_ssl/certs_server_no_verify/root.crt
+if [ "$1" = "gpfdist_create" ]; then
 	cp data/gpfdist_ssl/certs_matching/server.* data/gpfdist_ssl/certs_server_no_verify
+	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_server_no_verify
+	echo $(ls data/gpfdist_ssl/certs_server_no_verify)
 fi
 
-# Clear gpdb client and root CA certification.
-if [ "$1" = "clear_gpdb_client_root" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
-		do
-		if [ -d $(dirname $dir)/gpfdists ]; then
-			mv $(dirname $dir)/gpfdists/client.crt $(dirname $dir)/gpfdists/client.crt.bak
-			mv $(dirname $dir)/gpfdists/client.key $(dirname $dir)/gpfdists/client.key.bak
-			mv $(dirname $dir)/gpfdists/root.crt $(dirname $dir)/gpfdists/root.crt.bak
-		fi
-	done
+if [ "$1" = "gpfdist_replace_root" ]; then
+	mv data/gpfdist_ssl/certs_server_no_verify/root.crt data/gpfdist_ssl/certs_server_no_verify/root.crt.bak
+	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=root" -out data/gpfdist_ssl/certs_server_no_verify/root.crt
+	echo $(ls data/gpfdist_ssl/certs_server_no_verify)
+fi
+
+if [ "$1" = "gpfdist_reset_root" ]; then
+	rm -rf data/gpfdist_ssl/certs_server_no_verify/root.crt
+	mv data/gpfdist_ssl/certs_server_no_verify/root.crt.bak data/gpfdist_ssl/certs_server_no_verify/root.crt
+	echo $(ls data/gpfdist_ssl/certs_server_no_verify)
 fi
 
 # Clear gpdb root CA certification.
 if [ "$1" = "clear_gpdb_root" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			mv $(dirname $dir)/gpfdists/root.crt $(dirname $dir)/gpfdists/root.crt.bak
+			echo $(ls $(dirname $dir)/gpfdists)
 		fi
 	done
 fi
 
 # Clear gpdb client CA certification.
 if [ "$1" = "clear_gpdb_client" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			mv $(dirname $dir)/gpfdists/client.crt $(dirname $dir)/gpfdists/client.crt.bak
 			mv $(dirname $dir)/gpfdists/client.key $(dirname $dir)/gpfdists/client.key.bak
-		fi
-	done
-fi
-
-# Reset gpdb client and root CA certification.
-if [ "$1" = "recover_gpdb_client_root" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
-		do
-		if [ -d $(dirname $dir)/gpfdists ]; then
-			mv $(dirname $dir)/gpfdists/client.crt.bak $(dirname $dir)/gpfdists/client.crt
-			mv $(dirname $dir)/gpfdists/client.key.bak $(dirname $dir)/gpfdists/client.key
-			mv $(dirname $dir)/gpfdists/root.crt.bak $(dirname $dir)/gpfdists/root.crt
+			echo $(ls $(dirname $dir)/gpfdists)
 		fi
 	done
 fi
 
 # Reset gpdb root CA certification.
 if [ "$1" = "recover_gpdb_root" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			mv $(dirname $dir)/gpfdists/root.crt.bak $(dirname $dir)/gpfdists/root.crt
+			echo $(ls $(dirname $dir)/gpfdists)
 		fi
 	done
 fi
 
 # Reset gpdb root CA certification.
 if [ "$1" = "recover_gpdb_client" ]; then
-	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			mv $(dirname $dir)/gpfdists/client.crt.bak $(dirname $dir)/gpfdists/client.crt
 			mv $(dirname $dir)/gpfdists/client.key.bak $(dirname $dir)/gpfdists/client.key
+			echo $(ls $(dirname $dir)/gpfdists)
 		fi
 	done
 fi

--- a/src/bin/gpfdist/regress/change_cert.bash
+++ b/src/bin/gpfdist/regress/change_cert.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$1" = "client" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			cp $(dirname $dir)/gpfdists/client2.crt $(dirname $dir)/gpfdists/client.crt
+			cp $(dirname $dir)/gpfdists/client2.key $(dirname $dir)/gpfdists/client.key
+		fi
+	done
+fi
+
+if [ "$1" = "gpfdist" ]; then
+	mkdir data/gpfdist_ssl/certs_server_no_verify
+	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=root" -out data/gpfdist_ssl/certs_server_no_verify/root.crt
+	cp data/gpfdist_ssl/certs_matching/server.* data/gpfdist_ssl/certs_server_no_verify
+fi

--- a/src/bin/gpfdist/regress/change_cert.bash
+++ b/src/bin/gpfdist/regress/change_cert.bash
@@ -18,7 +18,7 @@ if [ "$1" = "gpfdist" ]; then
 fi
 
 # Clear gpdb client and root CA certification.
-if [ "$1" = "clear" ]; then
+if [ "$1" = "clear_gpdb_client_root" ]; then
 	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
@@ -29,14 +29,56 @@ if [ "$1" = "clear" ]; then
 	done
 fi
 
+# Clear gpdb root CA certification.
+if [ "$1" = "clear_gpdb_root" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/root.crt $(dirname $dir)/gpfdists/root.crt.bak
+		fi
+	done
+fi
+
+# Clear gpdb client CA certification.
+if [ "$1" = "clear_gpdb_client" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/client.crt $(dirname $dir)/gpfdists/client.crt.bak
+			mv $(dirname $dir)/gpfdists/client.key $(dirname $dir)/gpfdists/client.key.bak
+		fi
+	done
+fi
+
 # Reset gpdb client and root CA certification.
-if [ "$1" = "recover" ]; then
+if [ "$1" = "recover_gpdb_client_root" ]; then
 	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
 		do
 		if [ -d $(dirname $dir)/gpfdists ]; then
 			mv $(dirname $dir)/gpfdists/client.crt.bak $(dirname $dir)/gpfdists/client.crt
 			mv $(dirname $dir)/gpfdists/client.key.bak $(dirname $dir)/gpfdists/client.key
 			mv $(dirname $dir)/gpfdists/root.crt.bak $(dirname $dir)/gpfdists/root.crt
+		fi
+	done
+fi
+
+# Reset gpdb root CA certification.
+if [ "$1" = "recover_gpdb_root" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/root.crt.bak $(dirname $dir)/gpfdists/root.crt
+		fi
+	done
+fi
+
+# Reset gpdb root CA certification.
+if [ "$1" = "recover_gpdb_client" ]; then
+	for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+		do
+		if [ -d $(dirname $dir)/gpfdists ]; then
+			mv $(dirname $dir)/gpfdists/client.crt.bak $(dirname $dir)/gpfdists/client.crt
+			mv $(dirname $dir)/gpfdists/client.key.bak $(dirname $dir)/gpfdists/client.key
 		fi
 	done
 fi

--- a/src/bin/gpfdist/regress/change_client_cert.bash
+++ b/src/bin/gpfdist/regress/change_client_cert.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-for dir in $(find $COORDINATOR_DATA_DIRECTORY/../../.. -name pg_hba.conf)
-    do
-	if [ -d $(dirname $dir)/gpfdists ]; then
-	    cp $(dirname $dir)/gpfdists/client2.crt $(dirname $dir)/gpfdists/client.crt
-	    cp $(dirname $dir)/gpfdists/client2.key $(dirname $dir)/gpfdists/client.key
-	fi
-done

--- a/src/bin/gpfdist/regress/init_file
+++ b/src/bin/gpfdist/regress/init_file
@@ -3,3 +3,8 @@ m/^DETAIL:.*/
 
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 -- end_matchignore
+
+-- start_matchsubs
+m/"\/.*root\.crt"/
+s/"\/.*root\.crt"/root.crt/
+-- end_matchsubs

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -316,6 +316,7 @@ SET verify_gpfdists_cert=off;
 SELECT * FROM tbl;
 
 -- start_ignore
+\! bash change_cert.bash recover_gpdb_root
 \! bash change_cert.bash clear_gpdb_client
 SET verify_gpfdists_cert=on;
 -- end_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -197,6 +197,18 @@ SELECT * FROM tbl;
 -- start_ignore
 select * from gpfdist_ssl_stop;
 select * from gpfdist_ssl_start_no_ca_verify;
+\! bash change_cert.bash clear
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover
+-- end_ignore
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_no_ca_verify;
 SET verify_gpfdists_cert=on; 
 \! bash change_cert.bash gpfdist
 -- end_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -194,35 +194,177 @@ SELECT * FROM tbl;
 SET verify_gpfdists_cert=off; 
 SELECT * FROM tbl;
 
--- start_ignore
-select * from gpfdist_ssl_stop;
-select * from gpfdist_ssl_start_no_ca_verify;
-\! bash change_cert.bash clear_gpdb_client_root
--- end_ignore
-
-SELECT * FROM tbl;
-
--- start_ignore
-\! bash change_cert.bash recover_gpdb_client_root
--- end_ignore
-
--- start_ignore
-select * from gpfdist_ssl_stop;
-select * from gpfdist_ssl_start_no_ca_verify;
-SET verify_gpfdists_cert=on; 
-\! bash change_cert.bash gpfdist
--- end_ignore
-
 -- gpfdist_ssl case 7
+-- start_ignore
+\! bash change_cert.bash gpfdist_create
+\! bash change_cert.bash clear_gpdb_root
+\! bash change_cert.bash clear_gpdb_client
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_no_ca_verify;
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
+
 SELECT * FROM tbl;
 
 -- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash gpfdist_replace_root
+\! bash change_cert.bash clear_gpdb_root
+\! bash change_cert.bash clear_gpdb_client
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_no_ca_verify;
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- gpfdist_ssl case 8
+-- start_ignore
+\! bash change_cert.bash gpfdist_reset_root
 select * from gpfdist_ssl_stop;
 select * from gpfdist_ssl_start_ca_verify;
+SET verify_gpfdists_cert=on; 
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash clear_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash clear_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash gpfdist_replace_root
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_ca_verify;
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+
+SELECT * FROM tbl;
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
 -- end_ignore
 
 SELECT * FROM tbl;

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -35,6 +35,16 @@ execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/dat
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_ca_verify (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_server_verify </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_no_ca_verify (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
 execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
@@ -182,6 +192,27 @@ LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
 SET verify_gpfdists_cert=off; 
+SELECT * FROM tbl;
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_no_ca_verify;
+SET verify_gpfdists_cert=on; 
+\! bash change_cert.bash gpfdist
+-- end_ignore
+
+-- gpfdist_ssl case 7
+DROP EXTERNAL TABLE IF EXISTS tbl;
+CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+SELECT * FROM tbl;
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start_ca_verify;
+-- end_ignore
+
 SELECT * FROM tbl;
 
 -- start_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -36,12 +36,12 @@ on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_ca_verify (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_server_verify </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_verify_peer on </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_no_ca_verify (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_verify_peer off </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
@@ -197,13 +197,13 @@ SELECT * FROM tbl;
 -- start_ignore
 select * from gpfdist_ssl_stop;
 select * from gpfdist_ssl_start_no_ca_verify;
-\! bash change_cert.bash clear
+\! bash change_cert.bash clear_gpdb_client_root
 -- end_ignore
 
 SELECT * FROM tbl;
 
 -- start_ignore
-\! bash change_cert.bash recover
+\! bash change_cert.bash recover_gpdb_client_root
 -- end_ignore
 
 -- start_ignore

--- a/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
@@ -83,7 +83,7 @@ INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
 
 -- start_ignore
-\! bash change_client_cert.bash 
+\! bash change_cert.bash client
 -- end_ignore
 
 -- gpfdists_multiCA case 4

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -285,7 +285,7 @@ CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, 
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg1 slice1 127.0.0.1:7001 pid=6426)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
@@ -400,10 +400,9 @@ select * from gpfdist_ssl_start_no_ca_verify;
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg1 slice1 127.0.0.1:7001 pid=28366)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
-WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
@@ -555,10 +554,9 @@ client.crt client.key root.crt.bak server.crt server.key
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
-WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -10,6 +10,14 @@ CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
 execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_ca_verify (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_server_verify </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_no_ca_verify (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
 execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
@@ -257,6 +265,57 @@ SELECT * FROM tbl;
  jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (10 rows)
 
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start;
+       x       
+---------------
+ 21621 gpfdist
+(1 row)
+
+SET verify_gpfdists_cert=on;
+-- end_ignore
+-- gpfdist_ssl case 7
+DROP EXTERNAL TABLE IF EXISTS tbl;
+CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start_ca_verify;
+       x       
+---------------
+ 21669 gpfdist
+(1 row)
+
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; Peer does not recognize and trust the CA that issued your certificate.  (seg1 slice1 127.0.0.1:7001 pid=23257)
 -- start_ignore
 select * from gpfdist_ssl_stop;
       x      

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -278,6 +278,35 @@ select * from gpfdist_ssl_start;
  21621 gpfdist
 (1 row)
 
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start;
+       x       
+---------------
+ 21621 gpfdist
+(1 row)
+
 SET verify_gpfdists_cert=on;
 -- end_ignore
 -- gpfdist_ssl case 7

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -11,11 +11,11 @@ execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/dat
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_ca_verify (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_server_verify </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_verify_peer on </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start_no_ca_verify (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_server_no_verify -l /tmp/gpfdist_certs_matching.log --ssl_verify_peer off </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
@@ -265,56 +265,32 @@ SELECT * FROM tbl;
  jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (10 rows)
 
--- start_ignore
-select * from gpfdist_ssl_stop;
-      x      
--------------
- stopping...
-(1 row)
-
-select * from gpfdist_ssl_start;
-       x       
----------------
- 21621 gpfdist
-(1 row)
-
--- end_ignore
-SELECT * FROM tbl;
- s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
------+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
- aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
- jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
-(10 rows)
-
--- start_ignore
-select * from gpfdist_ssl_stop;
-      x      
--------------
- stopping...
-(1 row)
-
-select * from gpfdist_ssl_start;
-       x       
----------------
- 21621 gpfdist
-(1 row)
-
-SET verify_gpfdists_cert=on;
--- end_ignore
 -- gpfdist_ssl case 7
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start_no_ca_verify;
+       x       
+---------------
+ 21621 gpfdist
+(1 row)
+
+-- end_ignore
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg1 slice1 127.0.0.1:7001 pid=6426)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
 -----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
  aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
@@ -330,6 +306,200 @@ SELECT * FROM tbl;
 (10 rows)
 
 -- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash gpfdist_replace_root
+\! bash change_cert.bash clear_gpdb_root
+\! bash change_cert.bash clear_gpdb_client
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start_no_ca_verify;
+       x       
+---------------
+ 28725 gpfdist
+(1 row)
+
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg1 slice1 127.0.0.1:7001 pid=28366)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- gpfdist_ssl case 8
+-- start_ignore
+\! bash change_cert.bash gpfdist_reset_root
+root.crt server.crt server.key
 select * from gpfdist_ssl_stop;
       x      
 -------------
@@ -339,12 +509,144 @@ select * from gpfdist_ssl_stop;
 select * from gpfdist_ssl_start_ca_verify;
        x       
 ---------------
- 21669 gpfdist
+  1777 gpfdist
 (1 row)
 
+SET verify_gpfdists_cert=on; 
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; Peer does not recognize and trust the CA that issued your certificate.  (seg1 slice1 127.0.0.1:7001 pid=23257)
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash clear_gpdb_root
+client.crt client.key root.crt.bak server.crt server.key
+client.crt client.key root.crt.bak server.crt server.key
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
+-----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------
+ aaa | twoa | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ bbb | twob | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ddd | twod | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ eee | twoe | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ fff | twof | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ ggg | twog | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ hhh | twoh | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ iii | twoi | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+ jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
+(10 rows)
+
+-- start_ignore
+\! bash change_cert.bash clear_gpdb_client
+client.crt.bak client.key.bak root.crt.bak server.crt server.key
+client.crt.bak client.key.bak root.crt.bak server.crt server.key
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+\! bash change_cert.bash gpfdist_replace_root
+Generating a RSA private key
+.......++++
+.........................................................................................................++++
+writing new private key to 'privkey.pem'
+-----
+root.crt root.crt.bak server.crt server.key
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start_ca_verify;
+       x       
+---------------
+  1777 gpfdist
+(1 row)
+
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_root
+client.crt.bak client.key.bak root.crt server.crt server.key
+client.crt.bak client.key.bak root.crt server.crt server.key
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+-- start_ignore
+\! bash change_cert.bash recover_gpdb_client
+client.crt client.key root.crt server.crt server.key
+client.crt client.key root.crt server.crt server.key
+SET verify_gpfdists_cert=on;
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 127.0.0.1:7000 pid=19723)
+-- start_ignore
+SET verify_gpfdists_cert=off;
+WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
+-- end_ignore
+SELECT * FROM tbl;
+ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 127.0.0.1:7000 pid=19723)
 -- start_ignore
 select * from gpfdist_ssl_stop;
       x      


### PR DESCRIPTION
To simplify the ssl authentication of `gpfdist`, we provide one more configuration option to `gpfdist` and changed the gpdb side SSL identity authentication behavior when verify_gpfdist_cert=off. 

The new command flag is `ssl_verify_peer`. If the flag is 'on', `gpfdist` will be forced to check the identity of clients, and  CA certification file (root.crt) is necessary to be laid in the SSL certification directory. 

If the flag is 'off', even the GUC `verify_gpfdists_cert=on`, `gpfdist` will not check the identity of clients, and it doesn't matter whether the CA certification file exists on the gpfdist side.  And SSL certificate files and SSL private key files on the gpdb segments' side are no longer necessary. This greatly simplifies the configuration burden when using the `gpfdists` protocol for data transfer.

 **Note that The default value of `ssl_verify_peer` is 'on'.**

Another change is regarding the changes to gpdb identity authentication when `verify_gpfdist_cert=off`. When verify_gpfdist_cert=off, the CA certification file is unnecessary for gpdb segments. 

Finally, the existence checks for the certification files and private key files on the GPDB segment are no longer mandatory. This means that we can only determine if the files are configured correctly based on the error message received during the SSL connection.

The table below demonstrates the effectiveness of using these two types of indicators.：

- verify_gpfdists_cert = on,  ssl_verify_peer=on: Certification files, CA certification files, and private key files are necessary for both gpfdist and gpdb segments.

- verify_gpfdists_cert = on,  ssl_verify_peer=off: Certification file and private key file for gpfdist are necessary, CA certification files are necessary for gpdb segments.

- verify_gpfdists_cert = off,  ssl_verify_peer=on: Certification files and private key files are necessary for gpdb segments, while CA certification files are unnecessary. A certification file, CA certification file and private key file are necessary for gpfdist.

- verify_gpfdists_cert = off,  ssl_verify_peer=off: Certification file and private key file are necessary for gpfdist. SSL related files are not necessary for gpdb segments.
