### PR TITLE
[6x]: Fix intermittent pipeline failures (#15910)

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -6,6 +6,7 @@ from gppylib.db import dbconn
 from gppylib.gparray import GpArray, ROLE_MIRROR
 from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
 from gppylib.commands.gp import get_masterdatadir
+from gppylib.commands import unix
 
 @then('a sample recovery_progress.file is created from saved lines')
 def impl(context):
@@ -22,6 +23,8 @@ def impl(context):
 @given('a sample gprecoverseg.lock directory is created using the background pid in master_data_directory')
 def impl(context):
     bg_pid = context.bg_pid
+    if not unix.check_pid(bg_pid):
+        raise Exception("The background process with PID {} is not running.".format(bg_pid))
     gprecoverseg_lock_dir = os.path.join(get_masterdatadir() + '/gprecoverseg.lock')
     os.mkdir(gprecoverseg_lock_dir)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1427,7 +1427,7 @@ def stop_segments_immediate(context, where_clause):
 @when('user can start transactions')
 @then('user can start transactions')
 def impl(context):
-    wait_for_unblocked_transactions(context)
+    wait_for_unblocked_transactions(context, 600)
 
 
 @given('the environment variable "{var}" is set to "{val}"')
@@ -1630,6 +1630,9 @@ def impl(context, seg):
     for pid in pids:
         cmd = Command(name="killbg pid", cmdStr='kill -9 %s' % pid, remoteHost=hostname, ctxt=REMOTE)
         cmd.run(validateAfter=True)
+
+    cmd = Command(name="remove pid", cmdStr='rm -rf /tmp/bgpid', remoteHost=hostname, ctxt=REMOTE)
+    cmd.run(validateAfter=True)
 
 
 @when('{process} is killed on mirror with content {contentids}')

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -1,12 +1,14 @@
 import pipes
 import tempfile
+import time
 
 from behave import given, then
 from pygresql import pg
 
 from gppylib.db import dbconn
 from gppylib.gparray import GpArray
-from test.behave_utils.utils import run_cmd
+from test.behave_utils.utils import run_cmd,wait_for_database_dropped
+from gppylib.commands.base import Command, REMOTE
 
 class Tablespace:
     def __init__(self, name):
@@ -36,6 +38,7 @@ class Tablespace:
         with dbconn.connect(dbconn.DbURL(dbname="postgres"), unsetSearchPath=False) as conn:
             db = pg.DB(conn)
             db.query("DROP DATABASE IF EXISTS %s" % self.dbname)
+            wait_for_database_dropped(self.dbname)
             db.query("DROP TABLESPACE IF EXISTS %s" % self.name)
 
             # Without synchronous_commit = 'remote_apply' introduced in 9.6, there


### PR DESCRIPTION
This is a cherry-pick of https://github.com/greenplum-db/gpdb/pull/15910

gprecoverseg job has been failing recently on pipeline due to few testcase failures

Failure 1:
"HOOK-ERROR in after_scenario: OperationalError: ERROR:  tablespace "outerspace" is not empty" 
Testcase: differential recovery works with tablespaces -- @1.2 
Root cause: In after scenario during cleanup of tablespace, first database is dropped before dropping the tablespace. Looks like when we try to drop tablespace, database is not dropped yet as it is taking time to delete database. Hence the error
Solution:  while cleaning up the tablespace, after executing query to drop database added a check to verify that database has been dropped. If database has been dropped then only proceed to drop the tablespace.

Failure 2: Step "gpstate should print "Segments in recovery" to stdout" is failing
Testcase: gprecoverseg creates recovery_progress.file in gpAdminLogs 
Root cause: It is taking old bg_pid to create gprecoverseg.lock directory in the coordinator_data_directory. 
Solution: In step "the background pid is killed on "{seg}" segment", while killing background pid added command to also remove /tmp/bgpid. Also added check to verify the existence of the pid  while creating gprecoverseg.lock directory in step "a sample gprecoverseg.lock directory is created using the background pid in coordinator_data_directory"

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
