### PR TITLE
Remove deprecated distutils

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -10,7 +10,6 @@ import pwd
 import sys
 import re
 from contextlib import closing
-from distutils.version import LooseVersion
 from optparse import OptionParser
 import pgdb
 from gppylib.utils import formatInsertValuesList, Escape


### PR DESCRIPTION
Long log:

The `distutils `module was deprecated in Python 3.10 and is scheduled for removal in Python 3.12.
At the same time, it is also dead code.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>