### PR TITLE
Optimize gpfdist external table logic

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -421,7 +421,7 @@ char	   *gp_default_storage_options = NULL;
 /* Fall back to using zstd if quicklz compresstpye specified */
 bool		gp_quicklz_fallback = false;
 
-int			writable_external_table_bufsize = 64;
+int			writable_external_table_bufsize = 1024;
 
 bool		gp_external_enable_filter_pushdown = true;
 
@@ -3010,7 +3010,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_KB | GUC_NOT_IN_SAMPLE
 		},
 		&writable_external_table_bufsize,
-		64, 32, 131072,
+		1024, 32, 131072,
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -3,6 +3,7 @@
 -- exists in cdbunit.
 --
 set optimizer_print_missing_stats = off;
+show writable_external_table_bufsize;
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 
 -- start_ignore

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -3,6 +3,12 @@
 -- exists in cdbunit.
 --
 set optimizer_print_missing_stats = off;
+show writable_external_table_bufsize;
+ writable_external_table_bufsize 
+---------------------------------
+ 1MB
+(1 row)
+
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 -- start_ignore
 -- end_ignore


### PR DESCRIPTION
This PR wants to adjust some default configurations of gpfdist and libcurl on segments.

1. Adjust `writable_external_table_bufsize` default value to 1M.
This will increate the throughput when writing into gpfdist writable external table.

2. Enable keepalive for libcurl socket for gpfdist readable external tables. 
In some particular scenarios like select from readable external tables that gpfdist server and 
segments are not in the same network region, some of the long connections between gpfdist
and segments will broken, in this case gpfdist will fail to send EOF to segment so that may be
one of the QEs will hung in waiting for data coming. As the legacy code of libcurl socket does
not enable keepalive probes, so it will hung forever and fails to detect the broken of the 
connection.
This commit will help segment detect the breaking of the connection to avoid hanging forever.
But it is not easy to simulate the such scenario, so we do not add testing cases for this case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
