### PR TITLE
Fix the policy of foreign tables

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -127,7 +127,48 @@ SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
 TRUNCATE TABLE postgres_fdw_gp."GP 1";
 \c
 set search_path=postgres_fdw_gp;
-alter server loopback options(add num_segments '2');
+alter server loopback options(add num_segments '4');
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: f1, f2, f3
+   ->  Foreign Scan on postgres_fdw_gp.gp_ft1
+         Output: f1, f2, f3
+         Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(7 rows)
+
+EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert on gp_ft1
+   ->  Redistribute Motion 3:4  (slice1; segments: 3)
+         ->  Seq Scan on table_dist_rand
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+ f1 | f2 | f3 
+----+----+----
+  1 | a  | aa
+  2 | b  | bb
+  3 | c  | cc
+  4 | d  | dd
+  5 | e  | ee
+  6 | f  | ff
+  7 | g  | gg
+  8 | h  | hh
+  9 | i  | ii
+ 10 | j  | jj
+ 11 | k  | kk
+ 12 | l  | ll
+(12 rows)
+
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
+alter server loopback options(set num_segments '2');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
                             QUERY PLAN                             
 -------------------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -140,12 +140,13 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 (6 rows)
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
-             QUERY PLAN
--------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Insert on gp_ft1
-   ->  Seq Scan on table_dist_rand
+   ->  Redistribute Motion 3:2  (slice1; segments: 3)
+         ->  Seq Scan on table_dist_rand
  Optimizer: Postgres query optimizer
-(3 rows)
+(4 rows)
 
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -127,7 +127,47 @@ SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
 TRUNCATE TABLE postgres_fdw_gp."GP 1";
 \c
 set search_path=postgres_fdw_gp;
-alter server loopback options(add num_segments '2');
+alter server loopback options(add num_segments '4');
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: f1, f2, f3
+   ->  Foreign Scan on postgres_fdw_gp.gp_ft1
+         Output: f1, f2, f3
+         Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert on gp_ft1
+   ->  Redistribute Motion 3:4  (slice1; segments: 3)
+         ->  Seq Scan on table_dist_rand
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+ f1 | f2 | f3 
+----+----+----
+  1 | a  | aa
+  2 | b  | bb
+  3 | c  | cc
+  4 | d  | dd
+  5 | e  | ee
+  6 | f  | ff
+  7 | g  | gg
+  8 | h  | hh
+  9 | i  | ii
+ 10 | j  | jj
+ 11 | k  | kk
+ 12 | l  | ll
+(12 rows)
+
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
+alter server loopback options(set num_segments '2');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
                             QUERY PLAN                             
 -------------------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -131,21 +131,22 @@ alter server loopback options(add num_segments '2');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
                             QUERY PLAN                             
 -------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 2:1  (slice1; segments: 2)
    Output: f1, f2, f3
    ->  Foreign Scan on postgres_fdw_gp.gp_ft1
          Output: f1, f2, f3
          Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: Postgres query optimizer
 (6 rows)
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
-             QUERY PLAN              
--------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Insert on gp_ft1
-   ->  Seq Scan on table_dist_rand
+   ->  Redistribute Motion 3:2  (slice1; segments: 3)
+         ->  Seq Scan on table_dist_rand
  Optimizer: Postgres query optimizer
-(3 rows)
+(4 rows)
 
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -108,7 +108,13 @@ TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 \c
 set search_path=postgres_fdw_gp;
-alter server loopback options(add num_segments '2');
+alter server loopback options(add num_segments '4');
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
+EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
+alter server loopback options(set num_segments '2');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -386,6 +386,7 @@ GpPolicyFetch(Oid tbloid)
 
 			if (f->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
 			{
+				ForeignServer *server = GetForeignServer(f->serverid);
 				/*
 				 * Currently, foreign tables do not support a distribution
 				 * policy, as opposed to writable external tables. For now,
@@ -394,7 +395,10 @@ GpPolicyFetch(Oid tbloid)
 				 * to foreign tables from all segments when the mpp_execute
 				 * option is set to 'all segments'
 				 */
-				return createRandomPartitionedPolicy(getgpsegmentCount());
+				if (server)
+					return createRandomPartitionedPolicy(server->num_segments);
+				else
+					return createRandomPartitionedPolicy(getgpsegmentCount());
 			}
 		}
 	}

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -821,6 +821,15 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 		/*
 		 * 1. for entrydb, it's never be writer.
 		 * 2. for first QE, it must be a writer.
+		 *
+		 * This block ignores the segmentType of the not-first QEs and
+		 * sets it as a reader, foreign tables have to workaround this
+		 * if we'd like to have more QEs writing the external data than
+		 * the segment count.
+		 *
+		 * This is too critical that we'd better not change the logic of
+		 * other kind tables.
+		 *
 		 */
 		isWriter = contentId == -1 ? false: (cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0);
 		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, nextQEIdentifer(cdbinfo->cdbs), isWriter);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1124,10 +1124,6 @@ FillSliceGangInfo(ExecSlice *slice, PlanSlice *ps)
 			slice->planNumSegments = 1;
 			break;
 		case GANGTYPE_PRIMARY_WRITER:
-			/* Writer gangs could not have more backends than getgpsegmentCount() */
-			if (numsegments > getgpsegmentCount())
-				numsegments = getgpsegmentCount();
-			/* fall through */
 		case GANGTYPE_PRIMARY_READER:
 			slice->planNumSegments = numsegments;
 			if (dd->isDirectDispatch)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1125,7 +1125,10 @@ FillSliceGangInfo(ExecSlice *slice, PlanSlice *ps)
 			break;
 		case GANGTYPE_PRIMARY_WRITER:
 		case GANGTYPE_PRIMARY_READER:
-			slice->planNumSegments = numsegments;
+			/* Writer gangs could not have more backends than getgpsegmentCount() */
+			if (slice->gangType == GANGTYPE_PRIMARY_WRITER && numsegments > getgpsegmentCount())
+				numsegments = getgpsegmentCount();
+
 			if (dd->isDirectDispatch)
 			{
 				slice->segments = list_copy(dd->contentIds);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1124,11 +1124,12 @@ FillSliceGangInfo(ExecSlice *slice, PlanSlice *ps)
 			slice->planNumSegments = 1;
 			break;
 		case GANGTYPE_PRIMARY_WRITER:
-		case GANGTYPE_PRIMARY_READER:
 			/* Writer gangs could not have more backends than getgpsegmentCount() */
-			if (slice->gangType == GANGTYPE_PRIMARY_WRITER && numsegments > getgpsegmentCount())
+			if (numsegments > getgpsegmentCount())
 				numsegments = getgpsegmentCount();
-
+			/* fall through */
+		case GANGTYPE_PRIMARY_READER:
+			slice->planNumSegments = numsegments;
 			if (dd->isDirectDispatch)
 			{
 				slice->segments = list_copy(dd->contentIds);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2389,7 +2389,7 @@ ExecModifyTable(PlanState *pstate)
 	 * external data via foreign tables.
 	 */
 	if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer &&
-		!resultRelInfo->ri_RelationDesc->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+		resultRelInfo->ri_RelationDesc->rd_rel->relkind != RELKIND_FOREIGN_TABLE)
 	{
 		/*
 		 * Current Greenplum MPP architecture only support one writer gang, and

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2375,7 +2375,21 @@ ExecModifyTable(PlanState *pstate)
 	if (node->mt_done)
 		return NULL;
 
-	if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
+	/* Preload local variables */
+	resultRelInfo = node->resultRelInfo + node->mt_whichplan;
+	subplanstate = node->mt_plans[node->mt_whichplan];
+	junkfilter = resultRelInfo->ri_junkFilter;
+	action_attno = resultRelInfo->ri_action_attno;
+	segid_attno = resultRelInfo->ri_segid_attno;
+
+	/*
+	 * Check cdbcomponent_allocateIdleQE()
+	 *
+	 * In some cases Greenplum has more than one QE on on segment writing the
+	 * external data via foreign tables.
+	 */
+	if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer &&
+		!resultRelInfo->ri_RelationDesc->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 	{
 		/*
 		 * Current Greenplum MPP architecture only support one writer gang, and
@@ -2400,13 +2414,6 @@ ExecModifyTable(PlanState *pstate)
 		fireBSTriggers(node);
 		node->fireBSTriggers = false;
 	}
-
-	/* Preload local variables */
-	resultRelInfo = node->resultRelInfo + node->mt_whichplan;
-	subplanstate = node->mt_plans[node->mt_whichplan];
-	junkfilter = resultRelInfo->ri_junkFilter;
-	action_attno = resultRelInfo->ri_action_attno;
-	segid_attno = resultRelInfo->ri_segid_attno;
 
 	/*
 	 * es_result_relation_info must point to the currently active result

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3100,7 +3100,6 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 			break;
 
 		case CdbLocusType_General:
-			/*  */
 			sendSlice->gangType = GANGTYPE_SINGLETON_READER;
 			sendSlice->numsegments = 1;
 			sendSlice->segindex = gp_session_id % getgpsegmentCount();

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3344,19 +3344,13 @@ make_cdbpathlocus_for_foreign_relations(struct PlannerInfo   *root,
                           struct RelOptInfo    *rel,
 						  ForeignPath *pathnode)
 {
-	ForeignServer *server = NULL;
-	
 	switch (rel->exec_location)
 	{
 		case FTEXECLOCATION_ANY:
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus));
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			server = GetForeignServer(rel->serverid);
-			if (server)
-				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), server->num_segments);
-			else
-				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
+			pathnode->path.locus = cdbpathlocus_from_baserel(root, rel);
 			break;
 		case FTEXECLOCATION_COORDINATOR:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));


### PR DESCRIPTION
In some special FDW cases, Greenplum could have more or less backends than the number of actual segments in one gang, this commit sets the policy correctly.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
