### PR TITLE
Enhance Orca's cardinality estimation for local aggregate

### DIFF
--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -28,25 +28,24 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
 LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
-LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.0.1:7000 pid=80795)
-LOG:  duration: 11.889 ms  plan:
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.0.1:7000 pid=87670)
+LOG:  duration: 10.281 ms  plan:
 Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
-Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=11.860..11.866 rows=1 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=11.762..11.838 rows=3 loops=1)
-        ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=6.350..6.352 rows=1 loops=1)
-              ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..6.339 rows=0 loops=1)
-                    Hash Cond: (t1.i = t2.i)
-                    ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                          Hash Key: t1.i
-                          ->  Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..6.691 rows=0 loops=1)
-                                ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..6.682 rows=0 loops=1)
-                                      ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..2.398 rows=0 loops=1)
-                    ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.115 rows=0 loops=1)
-                          Buckets: 524288  Batches: 1  Memory Usage: 4096kB
-                          ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.112 rows=0 loops=1)
+Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=10.250..10.256 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=1) (actual time=10.231..10.234 rows=0 loops=1)
+        ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..9.508 rows=0 loops=1)
+              Hash Cond: (t1.i = t2.i)
+              ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                    Hash Key: t1.i
+                    ->  Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..4.895 rows=0 loops=1)
+                          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..4.884 rows=0 loops=1)
+                                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..1.909 rows=0 loops=1)
+              ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.170 rows=0 loops=1)
+                    Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.166 rows=0 loops=1)
 Optimizer: Pivotal Optimizer (GPORCA)
-  (slice0)    Executor memory: 52K bytes.
-  (slice1)    Executor memory: 4123K bytes avg x 3 workers, 4123K bytes max (seg0).  Work_mem: 4096K bytes max.
+  (slice0)    Executor memory: 45K bytes.
+  (slice1)    Executor memory: 4116K bytes avg x 3 workers, 4116K bytes max (seg0).  Work_mem: 4096K bytes max.
   (slice2)    Executor memory: 38K bytes (entry db).
   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
 Memory used:  128000kB

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -4672,13 +4672,13 @@ select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls la
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Aggregate
-                     Output: NULL::integer, sum(share0_ref2.c1)
+               ->  HashAggregate
+                     Output: share0_ref2.c2, sum(share0_ref2.c1)
+                     Group Key: share0_ref2.c2
                      ->  Shared Scan (share slice:id 0:0)
                            Output: share0_ref2.c2, share0_ref2.c1
-               ->  HashAggregate
-                     Output: share0_ref3.c2, sum(share0_ref3.c1)
-                     Group Key: share0_ref3.c2
+               ->  Aggregate
+                     Output: NULL::integer, sum(share0_ref3.c1)
                      ->  Shared Scan (share slice:id 0:0)
                            Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -1105,17 +1105,15 @@ CREATE OPERATOR === (
 -- built-in operators and functions can be shipped for remote execution
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
-                                   QUERY PLAN
---------------------------------------------------------------------------------
- Finalize Aggregate
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = abs(c2)))
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = abs(c2)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
  count 
@@ -1125,17 +1123,15 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
-                                QUERY PLAN
----------------------------------------------------------------------------
- Finalize Aggregate
+                             QUERY PLAN
+---------------------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = c2))
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
  count 
@@ -1146,18 +1142,16 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
 -- by default, user-defined ones cannot
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                           QUERY PLAN
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN
+-----------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Filter: (ft1.c1 = postgres_fdw_abs(ft1.c2))
-               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Filter: (ft1.c1 = postgres_fdw_abs(ft1.c2))
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -1169,18 +1163,16 @@ DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
-                           QUERY PLAN
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN
+-----------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Filter: (ft1.c1 === ft1.c2)
-               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Filter: (ft1.c1 === ft1.c2)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
  count 
@@ -1218,17 +1210,15 @@ ALTER SERVER pgserver OPTIONS (ADD extensions 'postgres_fdw');
 -- ... now they can be shipped
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = public.postgres_fdw_abs(c2)))
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = public.postgres_fdw_abs(c2)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
  count 
@@ -1238,17 +1228,15 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
-                                          QUERY PLAN
-----------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
  count 
@@ -2858,47 +2846,41 @@ SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 
 ---------------------------------------------------------------------------------------
  Limit
    Output: ft1.c1, (avg((ft1.c1 + ft2.c1)))
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Output: ft1.c1, avg((ft1.c1 + ft2.c1))
          Group Key: ft1.c1
-         ->  Partial GroupAggregate
-               Output: PARTIAL avg((ft1.c1 + ft2.c1)), ft1.c1
-               Group Key: ft1.c1
-               ->  GroupAggregate
+         ->  GroupAggregate
+               Output: ft1.c1, ft2.c1
+               Group Key: ft1.c1, ft2.c1
+               ->  Sort
                      Output: ft1.c1, ft2.c1
-                     Group Key: ft1.c1, ft2.c1
-                     ->  GroupAggregate
-                           Output: ft1.c1, ft2.c1
-                           Group Key: ft1.c1, ft2.c1
-                           ->  Sort
+                     Sort Key: ft1.c1, ft2.c1
+                     ->  Append
+                           ->  Hash Join
                                  Output: ft1.c1, ft2.c1
-                                 Sort Key: ft1.c1, ft2.c1
-                                 ->  Append
-                                       ->  Hash Join
-                                             Output: ft1.c1, ft2.c1
-                                             Hash Cond: (ft1.c1 = ft2.c1)
-                                             ->  Foreign Scan on public.ft1
-                                                   Output: ft1.c1
-                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                             ->  Hash
-                                                   Output: ft2.c1
-                                                   ->  Foreign Scan on public.ft2
-                                                         Output: ft2.c1
-                                                         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                       ->  Hash Join
-                                             Output: ft1_1.c1, ft2_1.c1
-                                             Hash Cond: (ft1_1.c1 = ft2_1.c1)
-                                             ->  Foreign Scan on public.ft1 ft1_1
-                                                   Output: ft1_1.c1
-                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                             ->  Hash
-                                                   Output: ft2_1.c1
-                                                   ->  Foreign Scan on public.ft2 ft2_1
-                                                         Output: ft2_1.c1
-                                                         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 Hash Cond: (ft1.c1 = ft2.c1)
+                                 ->  Foreign Scan on public.ft1
+                                       Output: ft1.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: ft2.c1
+                                       ->  Foreign Scan on public.ft2
+                                             Output: ft2.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                           ->  Hash Join
+                                 Output: ft1_1.c1, ft2_1.c1
+                                 Hash Cond: (ft1_1.c1 = ft2_1.c1)
+                                 ->  Foreign Scan on public.ft1 ft1_1
+                                       Output: ft1_1.c1
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 ->  Hash
+                                       Output: ft2_1.c1
+                                       ->  Foreign Scan on public.ft2 ft2_1
+                                             Output: ft2_1.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_mergejoin = 'on'
-(42 rows)
+(36 rows)
 
 SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) UNION SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) AS t (t1c1, t2c1) GROUP BY t1c1 ORDER BY t1c1 OFFSET 100 LIMIT 10;
  t1c1 |         avg          
@@ -3346,17 +3328,14 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
    ->  Sort
          Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), (sum(c1)), c2
          Sort Key: (count(ft1.c6)), (sum(ft1.c1))
-         ->  Finalize HashAggregate
+         ->  HashAggregate
                Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1), c2
                Group Key: ft1.c2
-               ->  Streaming Partial HashAggregate
-                     Output: PARTIAL count(c6), PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL min(c2), PARTIAL max(c1), PARTIAL stddev(c2), PARTIAL sum(c1), c2
-                     Group Key: ft1.c2
-                     ->  Foreign Scan on public.ft1
-                           Output: c1, c2, c6
-                           Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
+               ->  Foreign Scan on public.ft1
+                     Output: c1, c2, c6
+                     Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(12 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2;
  count |  sum  |         avg          | min | max  | stddev | sum2  
@@ -3379,17 +3358,14 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
          ->  Sort
                Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), (sum(c1)), c2
                Sort Key: (count(ft1.c6)), (sum(ft1.c1))
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1), c2
                      Group Key: ft1.c2
-                     ->  Streaming Partial HashAggregate
-                           Output: PARTIAL count(c6), PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL min(c2), PARTIAL max(c1), PARTIAL stddev(c2), PARTIAL sum(c1), c2
-                           Group Key: ft1.c2
-                           ->  Foreign Scan on public.ft1
-                                 Output: c1, c2, c6
-                                 Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
+                     ->  Foreign Scan on public.ft1
+                           Output: c1, c2, c6
+                           Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(14 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2 limit 1;
  count |  sum  |         avg          | min | max | stddev | sum2  
@@ -3400,40 +3376,36 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
 -- Aggregate is not pushed down as aggregation contains random()
 explain (verbose, costs off)
 select sum(c1 * (random() <= 1)::int) as sum, avg(c1) from ft1;
-                                           QUERY PLAN
-------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Aggregate
    Output: sum((c1 * int4((random() <= '1'::double precision)))), avg(c1)
-   ->  Partial Aggregate
-         Output: PARTIAL sum((c1 * int4((random() <= '1'::double precision)))), PARTIAL avg(c1)
-         ->  Foreign Scan on public.ft1
-               Output: c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+   ->  Foreign Scan on public.ft1
+         Output: c1
+         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 -- Aggregate over join query
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
-                                        QUERY PLAN
-------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
+ Aggregate
    Output: count(), sum(ft1.c1), avg(ft1_1.c1)
-   ->  Partial Aggregate
-         Output: PARTIAL count(), PARTIAL sum(ft1.c1), PARTIAL avg(ft1_1.c1)
-         ->  Hash Join
-               Output: ft1.c1, ft1_1.c1
-               Hash Cond: (ft1.c2 = ft1_1.c2)
-               ->  Foreign Scan on public.ft1
-                     Output: ft1.c1, ft1.c2
-                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
-               ->  Hash
+   ->  Hash Join
+         Output: ft1.c1, ft1_1.c1
+         Hash Cond: (ft1.c2 = ft1_1.c2)
+         ->  Foreign Scan on public.ft1
+               Output: ft1.c1, ft1.c2
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
+         ->  Hash
+               Output: ft1_1.c1, ft1_1.c2
+               ->  Foreign Scan on public.ft1 ft1_1
                      Output: ft1_1.c1, ft1_1.c2
-                     ->  Foreign Scan on public.ft1 ft1_1
-                           Output: ft1_1.c1, ft1_1.c2
-                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(14 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
  count |   sum   |         avg          
@@ -3444,46 +3416,43 @@ select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 
 -- Not pushed down due to local conditions present in underneath input rel
 explain (verbose, costs off)
 select sum(t1.c1), count(t2.c1) from ft1 t1 inner join ft2 t2 on (t1.c1 = t2.c1) where ((t1.c1 * t2.c1)/(t1.c1 * t2.c1)) * random() <= 1;
-                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                        QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    Output: sum(ft1.c1), count(ft2.c1)
-   ->  Partial Aggregate
-         Output: PARTIAL sum(ft1.c1), PARTIAL count(ft2.c1)
-         ->  Hash Join
-               Output: ft1.c1, ft2.c1
-               Hash Cond: (ft1.c1 = ft2.c1)
-               Join Filter: (((((ft1.c1 * ft2.c1) / (ft1.c1 * ft2.c1)))::double precision * random()) <= '1'::double precision)
-               ->  Foreign Scan on public.ft1
-                     Output: ft1.c1
-                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-               ->  Hash
+   ->  Hash Join
+         Output: ft1.c1, ft2.c1
+         Hash Cond: (ft1.c1 = ft2.c1)
+         Join Filter: (((((ft1.c1 * ft2.c1) / (ft1.c1 * ft2.c1)))::double precision * random()) <= '1'::double precision)
+         ->  Foreign Scan on public.ft1
+               Output: ft1.c1
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+         ->  Hash
+               Output: ft2.c1
+               ->  Foreign Scan on public.ft2
                      Output: ft2.c1
-                     ->  Foreign Scan on public.ft2
-                           Output: ft2.c1
-                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                     Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(15 rows)
 
 -- GROUP BY clause having expressions
 explain (verbose, costs off)
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
-   Output: ((c2 / 2)), (sum(c2) * ((c2 / 2)))
-   Group Key: ((ft1.c2 / 2))
+ Result
+   Output: ((c2 / 2)), ((sum(c2)) * ((c2 / 2)))
    ->  Sort
-         Output: (PARTIAL sum(c2)), ((c2 / 2))
+         Output: (sum(c2)), ((c2 / 2))
          Sort Key: ((ft1.c2 / 2))
-         ->  Streaming Partial HashAggregate
-               Output: PARTIAL sum(c2), ((c2 / 2))
+         ->  HashAggregate
+               Output: sum(c2), ((c2 / 2))
                Group Key: (ft1.c2 / 2)
                ->  Foreign Scan on public.ft1
                      Output: (c2 / 2), c2
                      Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
  ?column? | ?column? 
@@ -3498,23 +3467,18 @@ select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
 -- Aggregates in subquery are pushed down.
 explain (verbose, costs off)
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Finalize Aggregate
+                         QUERY PLAN
+-------------------------------------------------------------
+ Aggregate
    Output: count(c2), sum(c2)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c2), PARTIAL sum(c2)
-         ->  HashAggregate
-               Output: c2, (sqrt((c1)::double precision))
-               Group Key: ft1.c2, (sqrt((ft1.c1)::double precision))
-               ->  Streaming HashAggregate
-                     Output: c2, (sqrt((c1)::double precision))
-                     Group Key: ft1.c2, sqrt((ft1.c1)::double precision)
-                     ->  Foreign Scan on public.ft1
-                           Output: sqrt((c1)::double precision), c2
-                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+   ->  HashAggregate
+         Output: c2, (sqrt((c1)::double precision))
+         Group Key: ft1.c2, sqrt((ft1.c1)::double precision)
+         ->  Foreign Scan on public.ft1
+               Output: sqrt((c1)::double precision), c2
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(9 rows)
 
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
  count | sum  
@@ -3530,17 +3494,14 @@ select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by
  Sort
    Output: ((c2 * int4((random() <= '1'::double precision)))), ((sum(c1) * c2))
    Sort Key: ((ft1.c2 * int4((random() <= '1'::double precision)))), ((sum(ft1.c1) * ft1.c2))
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Output: (c2 * int4((random() <= '1'::double precision))), (sum(c1) * c2)
          Group Key: ft1.c2
-         ->  Streaming Partial HashAggregate
-               Output: PARTIAL sum(c1), c2
-               Group Key: ft1.c2
-               ->  Foreign Scan on public.ft1
-                     Output: c1, c2
-                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Foreign Scan on public.ft1
+               Output: c1, c2
+               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(10 rows)
 
 select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by c2 order by 1, 2;
  sum1 |  sum2  
@@ -3562,9 +3523,9 @@ explain (verbose, costs off)
 select c2 * (random() <= 1)::int as c2 from ft2 group by c2 * (random() <= 1)::int order by 1;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- GroupAggregate
+ Sort
    Output: ((c2 * int4((random() <= '1'::double precision))))
-   Group Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
+   Sort Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
    ->  GroupAggregate
          Output: ((c2 * int4((random() <= '1'::double precision))))
          Group Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
@@ -3582,20 +3543,19 @@ explain (verbose, costs off)
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
-   Output: count(c2), c2, (5), 7.0
-   Group Key: ft1.c2, (5), (9)
+ Result
+   Output: (count(c2)), c2, (5), 7.0
    ->  Sort
-         Output: (PARTIAL count(c2)), c2, (5), (9)
-         Sort Key: ft1.c2, (5), (9)
-         ->  Streaming Partial HashAggregate
-               Output: PARTIAL count(c2), c2, (5), (9)
+         Output: (count(c2)), c2, (5), (9)
+         Sort Key: ft1.c2
+         ->  HashAggregate
+               Output: count(c2), c2, (5), (9)
                Group Key: ft1.c2, 5, 9
                ->  Foreign Scan on public.ft1
                      Output: 5, 9, c2
                      Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
   w  | x | y |  z  
@@ -3623,20 +3583,14 @@ select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
    ->  Sort
          Output: c2, c2, (sum(c1))
          Sort Key: (sum(ft1.c1))
-         ->  Finalize GroupAggregate
+         ->  HashAggregate
                Output: c2, c2, sum(c1)
                Group Key: ft1.c2, ft1.c2
-               ->  Sort
-                     Output: (PARTIAL sum(c1)), c2
-                     Sort Key: ft1.c2, ft1.c2
-                     ->  Streaming Partial HashAggregate
-                           Output: PARTIAL sum(c1), c2
-                           Group Key: ft1.c2, ft1.c2
-                           ->  Foreign Scan on public.ft1
-                                 Output: c1, c2
-                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 > 6))
+               ->  Foreign Scan on public.ft1
+                     Output: c1, c2
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 > 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(12 rows)
 
 select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
  c2 | c2 
@@ -3657,20 +3611,17 @@ select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800
    ->  Result
          Output: c2, (sum(c1))
          Filter: (((avg(ft2.c1)) < '500'::numeric) AND ((sum(ft2.c1)) < 49800))
-         ->  Finalize GroupAggregate
+         ->  GroupAggregate
                Output: sum(c1), avg(c1), sum(c1), c2
                Group Key: ft2.c2
-               ->  Partial GroupAggregate
-                     Output: PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL sum(c1), c2
-                     Group Key: ft2.c2
-                     ->  Sort
+               ->  Sort
+                     Output: c1, c2
+                     Sort Key: ft2.c2
+                     ->  Foreign Scan on public.ft2
                            Output: c1, c2
-                           Sort Key: ft2.c2
-                           ->  Foreign Scan on public.ft2
-                                 Output: c1, c2
-                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(16 rows)
 
 select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800 order by c2;
  c2 |  sum  
@@ -3682,28 +3633,23 @@ select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800
 -- Unshippable HAVING clause will be evaluated locally, and other qual in HAVING clause is pushed down
 explain (verbose, costs off)
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
-                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Aggregate
    Output: count()
-   ->  Partial Aggregate
-         Output: PARTIAL count()
+   ->  Result
+         Filter: (((((avg(ft1.c1)) / (avg(ft1.c1))))::double precision * random()) <= '1'::double precision)
          ->  Result
-               Filter: (((((avg(ft1.c1)) / (avg(ft1.c1))))::double precision * random()) <= '1'::double precision)
-               ->  Result
-                     Output: (avg(c1)), (avg(c1))
-                     Filter: ((avg(ft1.c1)) < '500'::numeric)
-                     ->  Finalize HashAggregate
-                           Output: avg(c1), avg(c1), avg(c1), c5, (sqrt((c2)::double precision))
-                           Group Key: ft1.c5, (sqrt((ft1.c2)::double precision))
-                           ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL avg(c1), PARTIAL avg(c1), PARTIAL avg(c1), c5, (sqrt((c2)::double precision))
-                                 Group Key: ft1.c5, sqrt((ft1.c2)::double precision)
-                                 ->  Foreign Scan on public.ft1
-                                       Output: sqrt((c2)::double precision), c1, c5
-                                       Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
+               Output: (avg(c1)), (avg(c1))
+               Filter: ((avg(ft1.c1)) < '500'::numeric)
+               ->  HashAggregate
+                     Output: avg(c1), avg(c1), avg(c1), c5, (sqrt((c2)::double precision))
+                     Group Key: ft1.c5, sqrt((ft1.c2)::double precision)
+                     ->  Foreign Scan on public.ft1
+                           Output: sqrt((c2)::double precision), c1, c5
+                           Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(14 rows)
 
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
  count 
@@ -3722,17 +3668,14 @@ select sum(c1) from ft1 group by c2 having avg(c1 * (random() <= 1)::int) > 100 
    ->  Result
          Output: (sum(c1))
          Filter: ((avg((ft1.c1 * int4((random() <= '1'::double precision))))) > '100'::numeric)
-         ->  Finalize HashAggregate
+         ->  HashAggregate
                Output: sum(c1), avg((c1 * int4((random() <= '1'::double precision)))), c2
                Group Key: ft1.c2
-               ->  Streaming Partial HashAggregate
-                     Output: PARTIAL sum(c1), PARTIAL avg((c1 * int4((random() <= '1'::double precision)))), c2
-                     Group Key: ft1.c2
-                     ->  Foreign Scan on public.ft1
-                           Output: c1, c2
-                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Foreign Scan on public.ft1
+                     Output: c1, c2
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(13 rows)
 
 -- Remote aggregate in combination with a local Param (for the output
 -- of an initplan) can be trouble, per bug #15781
@@ -4412,25 +4355,23 @@ drop operator public.<^(int, int);
 -- the aggregate cannot be pushed down to foreign server.
 explain (verbose, costs off)
 select count(t1.c3) from ft2 t1 left join ft2 t2 on (t1.c1 = random() * t2.c2);
-                                            QUERY PLAN
----------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+ Aggregate
    Output: count(ft2.c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(ft2.c3)
-         ->  Hash Left Join
-               Output: ft2.c3
-               Hash Cond: ((ft2.c1)::double precision = (random() * (ft2_1.c2)::double precision))
-               ->  Foreign Scan on public.ft2
-                     Output: ft2.c1, ft2.c3
-                     Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
-               ->  Hash
+   ->  Hash Left Join
+         Output: ft2.c3
+         Hash Cond: ((ft2.c1)::double precision = (random() * (ft2_1.c2)::double precision))
+         ->  Foreign Scan on public.ft2
+               Output: ft2.c1, ft2.c3
+               Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+         ->  Hash
+               Output: ft2_1.c2
+               ->  Foreign Scan on public.ft2 ft2_1
                      Output: ft2_1.c2
-                     ->  Foreign Scan on public.ft2 ft2_1
-                           Output: ft2_1.c2
-                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(14 rows)
 
 -- Subquery in FROM clause having aggregate
 explain (verbose, costs off)
@@ -4440,31 +4381,25 @@ select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x w
  Sort
    Output: (count()), (sum(ft1_1.c1))
    Sort Key: (count()), (sum(ft1_1.c1))
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Output: count(), (sum(ft1_1.c1))
          Group Key: (sum(ft1_1.c1))
-         ->  Streaming Partial HashAggregate
-               Output: PARTIAL count(), (sum(ft1_1.c1))
-               Group Key: (sum(ft1_1.c1))
-               ->  Hash Join
-                     Output: (sum(ft1_1.c1))
-                     Hash Cond: (ft1.c2 = ft1_1.c2)
-                     ->  Foreign Scan on public.ft1
-                           Output: ft1.c2
-                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
-                     ->  Hash
-                           Output: (sum(ft1_1.c1)), ft1_1.c2
-                           ->  Finalize HashAggregate
-                                 Output: sum(ft1_1.c1), ft1_1.c2
-                                 Group Key: ft1_1.c2
-                                 ->  Streaming Partial HashAggregate
-                                       Output: PARTIAL sum(ft1_1.c1), ft1_1.c2
-                                       Group Key: ft1_1.c2
-                                       ->  Foreign Scan on public.ft1 ft1_1
-                                             Output: ft1_1.c1, ft1_1.c2
-                                             Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Hash Join
+               Output: (sum(ft1_1.c1))
+               Hash Cond: (ft1.c2 = ft1_1.c2)
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.c2
+                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
+               ->  Hash
+                     Output: (sum(ft1_1.c1)), ft1_1.c2
+                     ->  HashAggregate
+                           Output: sum(ft1_1.c1), ft1_1.c2
+                           Group Key: ft1_1.c2
+                           ->  Foreign Scan on public.ft1 ft1_1
+                                 Output: ft1_1.c1, ft1_1.c2
+                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(27 rows)
+(21 rows)
 
 select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x where ft1.c2 = x.a group by x.b order by 1, 2;
  count |   b   
@@ -4492,29 +4427,26 @@ select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) gr
    ->  Result
          Output: (avg(ft4.c1)), (sum(ft5.c1))
          Filter: ((((avg(ft4.c1)) IS NULL) AND ((sum(ft5.c1)) < 10)) OR ((sum(ft5.c1)) IS NULL))
-         ->  Finalize HashAggregate
+         ->  HashAggregate
                Output: avg(ft4.c1), sum(ft5.c1), avg(ft4.c1), sum(ft5.c1), sum(ft5.c1), ft5.c1
                Group Key: ft5.c1
-               ->  Streaming Partial HashAggregate
-                     Output: PARTIAL avg(ft4.c1), PARTIAL sum(ft5.c1), PARTIAL avg(ft4.c1), PARTIAL sum(ft5.c1), PARTIAL sum(ft5.c1), ft5.c1
-                     Group Key: ft5.c1
-                     ->  Merge Full Join
-                           Output: ft4.c1, ft5.c1
-                           Merge Cond: (ft4.c1 = ft5.c1)
-                           ->  Sort
+               ->  Merge Full Join
+                     Output: ft4.c1, ft5.c1
+                     Merge Cond: (ft4.c1 = ft5.c1)
+                     ->  Sort
+                           Output: ft4.c1
+                           Sort Key: ft4.c1
+                           ->  Foreign Scan on public.ft4
                                  Output: ft4.c1
-                                 Sort Key: ft4.c1
-                                 ->  Foreign Scan on public.ft4
-                                       Output: ft4.c1
-                                       Remote SQL: SELECT c1 FROM "S 1"."T 3"
-                           ->  Sort
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                     ->  Sort
+                           Output: ft5.c1
+                           Sort Key: ft5.c1
+                           ->  Foreign Scan on public.ft5
                                  Output: ft5.c1
-                                 Sort Key: ft5.c1
-                                 ->  Foreign Scan on public.ft5
-                                       Output: ft5.c1
-                                       Remote SQL: SELECT c1 FROM "S 1"."T 4"
+                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(25 rows)
 
 select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) group by t2.c1 having (avg(t1.c1) is null and sum(t2.c1) < 10) or sum(t2.c1) is null order by 1 nulls last, 2;
          avg         | sum 
@@ -4528,29 +4460,27 @@ select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) gr
 -- subqueries.
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
-                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Aggregate
    Output: count(), sum(ft4.c1), avg(ft5.c1)
-   ->  Partial Aggregate
-         Output: PARTIAL count(), PARTIAL sum(ft4.c1), PARTIAL avg(ft5.c1)
-         ->  Merge Full Join
-               Output: ft4.c1, ft5.c1
-               Merge Cond: (ft4.c1 = ft5.c1)
-               ->  Sort
+   ->  Merge Full Join
+         Output: ft4.c1, ft5.c1
+         Merge Cond: (ft4.c1 = ft5.c1)
+         ->  Sort
+               Output: ft4.c1
+               Sort Key: ft4.c1
+               ->  Foreign Scan on public.ft4
                      Output: ft4.c1
-                     Sort Key: ft4.c1
-                     ->  Foreign Scan on public.ft4
-                           Output: ft4.c1
-                           Remote SQL: SELECT c1 FROM "S 1"."T 3" WHERE (((c1 >= 50) AND (c1 <= 60)))
-               ->  Sort
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3" WHERE (((c1 >= 50) AND (c1 <= 60)))
+         ->  Sort
+               Output: ft5.c1
+               Sort Key: ft5.c1
+               ->  Foreign Scan on public.ft5
                      Output: ft5.c1
-                     Sort Key: ft5.c1
-                     ->  Foreign Scan on public.ft5
-                           Output: ft5.c1
-                           Remote SQL: SELECT c1 FROM "S 1"."T 4" WHERE (((c1 >= 50) AND (c1 <= 60)))
+                     Remote SQL: SELECT c1 FROM "S 1"."T 4" WHERE (((c1 >= 50) AND (c1 <= 60)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(18 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
  count | sum |         avg         
@@ -4567,15 +4497,13 @@ select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
  Sort
    Output: ((sum(c2) * int4((random() <= '1'::double precision))))
    Sort Key: ((sum(ft1.c2) * int4((random() <= '1'::double precision))))
-   ->  Finalize Aggregate
+   ->  Aggregate
          Output: (sum(c2) * int4((random() <= '1'::double precision)))
-         ->  Partial Aggregate
-               Output: PARTIAL sum(c2)
-               ->  Foreign Scan on public.ft1
-                     Output: c2
-                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
+         ->  Foreign Scan on public.ft1
+               Output: c2
+               Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(9 rows)
 
 select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
  sum  
@@ -4693,37 +4621,33 @@ DETAIL:  Feature not supported: LATERAL
 -- Check with placeHolderVars
 explain (verbose, costs off)
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
-                                         QUERY PLAN
----------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
    Output: sum((13)), count((avg(ft1.c1)))
-   ->  Partial Aggregate
-         Output: PARTIAL sum((13)), PARTIAL count((avg(ft1.c1)))
-         ->  Nested Loop Left Join
-               Output: (avg(ft1.c1)), (13)
-               Join Filter: ((ft4.c1)::numeric <= (avg(ft1.c1)))
-               ->  Foreign Scan on public.ft4
-                     Output: ft4.c1
-                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
-               ->  Materialize
-                     Output: (13), (avg(ft1.c1))
-                     ->  Finalize Aggregate
-                           Output: 13, avg(ft1.c1)
-                           ->  Partial Aggregate
-                                 Output: PARTIAL avg(ft1.c1)
-                                 ->  Hash Left Join
+   ->  Nested Loop Left Join
+         Output: (avg(ft1.c1)), (13)
+         Join Filter: ((ft4.c1)::numeric <= (avg(ft1.c1)))
+         ->  Foreign Scan on public.ft4
+               Output: ft4.c1
+               Remote SQL: SELECT c1 FROM "S 1"."T 3"
+         ->  Materialize
+               Output: (13), (avg(ft1.c1))
+               ->  Aggregate
+                     Output: 13, avg(ft1.c1)
+                     ->  Hash Left Join
+                           Output: ft1.c1
+                           Hash Cond: (ft2.c1 = ft1.c1)
+                           ->  Foreign Scan on public.ft2
+                                 Output: ft2.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                           ->  Hash
+                                 Output: ft1.c1
+                                 ->  Foreign Scan on public.ft1
                                        Output: ft1.c1
-                                       Hash Cond: (ft2.c1 = ft1.c1)
-                                       ->  Foreign Scan on public.ft2
-                                             Output: ft2.c1
-                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                       ->  Hash
-                                             Output: ft1.c1
-                                             ->  Foreign Scan on public.ft1
-                                                   Output: ft1.c1
-                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(24 rows)
 
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
  sum | count 
@@ -4748,25 +4672,17 @@ select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls la
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Finalize GroupAggregate
-                     Output: share0_ref2.c2, sum(share0_ref2.c1)
-                     Group Key: share0_ref2.c2
-                     ->  Sort
-                           Output: (PARTIAL sum(share0_ref2.c1)), share0_ref2.c2
-                           Sort Key: share0_ref2.c2
-                           ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c2
-                                 Group Key: share0_ref2.c2
-                                 ->  Shared Scan (share slice:id 0:0)
-                                       Output: share0_ref2.c2, share0_ref2.c1
-               ->  Finalize Aggregate
-                     Output: NULL::integer, sum(share0_ref3.c1)
-                     ->  Partial Aggregate
-                           Output: PARTIAL sum(share0_ref3.c1)
-                           ->  Shared Scan (share slice:id 0:0)
-                                 Output: share0_ref3.c2, share0_ref3.c1
+               ->  Aggregate
+                     Output: NULL::integer, sum(share0_ref2.c1)
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref2.c2, share0_ref2.c1
+               ->  HashAggregate
+                     Output: share0_ref3.c2, sum(share0_ref3.c1)
+                     Group Key: share0_ref3.c2
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(29 rows)
+(21 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls last;
  c2 |  sum   
@@ -4792,25 +4708,17 @@ select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Finalize GroupAggregate
+               ->  HashAggregate
                      Output: share0_ref2.c2, sum(share0_ref2.c1)
                      Group Key: share0_ref2.c2
-                     ->  Sort
-                           Output: (PARTIAL sum(share0_ref2.c1)), share0_ref2.c2
-                           Sort Key: share0_ref2.c2
-                           ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c2
-                                 Group Key: share0_ref2.c2
-                                 ->  Shared Scan (share slice:id 0:0)
-                                       Output: share0_ref2.c2, share0_ref2.c1
-               ->  Finalize Aggregate
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref2.c2, share0_ref2.c1
+               ->  Aggregate
                      Output: NULL::integer, sum(share0_ref3.c1)
-                     ->  Partial Aggregate
-                           Output: PARTIAL sum(share0_ref3.c1)
-                           ->  Shared Scan (share slice:id 0:0)
-                                 Output: share0_ref3.c2, share0_ref3.c1
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(29 rows)
+(21 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last;
  c2 |  sum   
@@ -4836,27 +4744,18 @@ select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) orde
                      Output: c2, c6, c1
                      Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Output: NULL::integer, share0_ref2.c6, sum(share0_ref2.c1)
                      Group Key: share0_ref2.c6
-                     ->  Streaming Partial HashAggregate
-                           Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c6
-                           Group Key: share0_ref2.c6
-                           ->  Shared Scan (share slice:id 0:0)
-                                 Output: share0_ref2.c2, share0_ref2.c6, share0_ref2.c1
-               ->  Finalize GroupAggregate
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref2.c2, share0_ref2.c6, share0_ref2.c1
+               ->  HashAggregate
                      Output: share0_ref3.c2, NULL::character varying, sum(share0_ref3.c1)
                      Group Key: share0_ref3.c2
-                     ->  Sort
-                           Output: (PARTIAL sum(share0_ref3.c1)), share0_ref3.c2
-                           Sort Key: share0_ref3.c2
-                           ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL sum(share0_ref3.c1), share0_ref3.c2
-                                 Group Key: share0_ref3.c2
-                                 ->  Shared Scan (share slice:id 0:0)
-                                       Output: share0_ref3.c2, share0_ref3.c6, share0_ref3.c1
+                     ->  Shared Scan (share slice:id 0:0)
+                           Output: share0_ref3.c2, share0_ref3.c6, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(31 rows)
+(22 rows)
 
 select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) order by 1 nulls last, 2 nulls last;
  c2 | c6 |  sum  
@@ -4873,20 +4772,19 @@ explain (verbose, costs off)
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Output: c2, sum(c1), 0
-   Group Key: ft1.c2
+ Result
+   Output: c2, (sum(c1)), 0
    ->  Sort
-         Output: (PARTIAL sum(c1)), c2
+         Output: (sum(c1)), c2
          Sort Key: ft1.c2
-         ->  Streaming Partial HashAggregate
-               Output: PARTIAL sum(c1), c2
+         ->  HashAggregate
+               Output: sum(c1), c2
                Group Key: ft1.c2
                ->  Foreign Scan on public.ft1
                      Output: c1, c2
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
  c2 |  sum  | grouping 
@@ -4904,23 +4802,17 @@ select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
  GroupAggregate
    Output: ((sum(c1) / 1000))
    Group Key: ((sum(ft2.c1) / 1000))
-   ->  GroupAggregate
+   ->  Sort
          Output: ((sum(c1) / 1000))
-         Group Key: ((sum(ft2.c1) / 1000))
-         ->  Sort
-               Output: ((sum(c1) / 1000))
-               Sort Key: ((sum(ft2.c1) / 1000))
-               ->  Finalize HashAggregate
-                     Output: (sum(c1) / 1000)
-                     Group Key: ft2.c2
-                     ->  Streaming Partial HashAggregate
-                           Output: PARTIAL sum(c1), c2
-                           Group Key: ft2.c2
-                           ->  Foreign Scan on public.ft2
-                                 Output: c1, c2
-                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 6))
+         Sort Key: ((sum(ft2.c1) / 1000))
+         ->  HashAggregate
+               Output: (sum(c1) / 1000)
+               Group Key: ft2.c2
+               ->  Foreign Scan on public.ft2
+                     Output: c1, c2
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(13 rows)
 
 select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
  s  
@@ -4945,17 +4837,14 @@ select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 gr
                ->  Sort
                      Output: ((c2 % 2)), c2, (sum(c2))
                      Sort Key: ((ft2.c2 % 2))
-                     ->  Finalize HashAggregate
+                     ->  HashAggregate
                            Output: (c2 % 2), c2, sum(c2)
                            Group Key: ft2.c2
-                           ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL sum(c2), c2
-                                 Group Key: ft2.c2
-                                 ->  Foreign Scan on public.ft2
-                                       Output: c2
-                                       Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                           ->  Foreign Scan on public.ft2
+                                 Output: c2
+                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(18 rows)
 
 select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 group by c2 order by 1;
  c2 | sum | count 
@@ -4988,20 +4877,14 @@ select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 wher
                ->  Sort
                      Output: ((c2 % 2)), c2
                      Sort Key: ((ft1.c2 % 2)), ft1.c2 DESC
-                     ->  GroupAggregate
+                     ->  HashAggregate
                            Output: (c2 % 2), c2
                            Group Key: ft1.c2
-                           ->  Sort
+                           ->  Foreign Scan on public.ft1
                                  Output: c2
-                                 Sort Key: ft1.c2
-                                 ->  Streaming HashAggregate
-                                       Output: c2
-                                       Group Key: ft1.c2
-                                       ->  Foreign Scan on public.ft1
-                                             Output: c2
-                                             Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(19 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
@@ -5034,20 +4917,14 @@ select c2, array_agg(c2) over (partition by c2%2 order by c2 range between curre
                ->  Sort
                      Output: ((c2 % 2)), c2
                      Sort Key: ((ft1.c2 % 2)), ft1.c2
-                     ->  GroupAggregate
+                     ->  HashAggregate
                            Output: (c2 % 2), c2
                            Group Key: ft1.c2
-                           ->  Sort
+                           ->  Foreign Scan on public.ft1
                                  Output: c2
-                                 Sort Key: ft1.c2
-                                 ->  Streaming HashAggregate
-                                       Output: c2
-                                       Group Key: ft1.c2
-                                       ->  Foreign Scan on public.ft1
-                                             Output: c2
-                                             Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(19 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 range between current row and unbounded following) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
@@ -5358,32 +5235,28 @@ ALTER TABLE
 ALTER FOREIGN TABLE ft1 OPTIONS (SET table_name 'T 1');
 PREPARE st8 AS SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st8;
-                                          QUERY PLAN
-----------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 ALTER SERVER pgserver OPTIONS (DROP extensions);
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st8;
-                           QUERY PLAN
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN
+-----------------------------------------------------------
+ Aggregate
    Output: count(c3)
-   ->  Partial Aggregate
-         Output: PARTIAL count(c3)
-         ->  Foreign Scan on public.ft1
-               Output: c3
-               Filter: (ft1.c1 === ft1.c2)
-               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Foreign Scan on public.ft1
+         Output: c3
+         Filter: (ft1.c1 === ft1.c2)
+         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 EXECUTE st8;
  count 
@@ -11697,17 +11570,14 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
          Sort Key: a
          ->  Result
                Filter: ((avg(b)) < '22'::numeric)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: a
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     ->  Redistribute Motion 1:3  (slice2)
                            Hash Key: a
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: a
-                                 ->  Redistribute Motion 1:3  (slice3)
-                                       ->  Dynamic Foreign Scan on pagg_tab
-                                             Number of partitions to scan: 3 (out of 3)
+                           ->  Dynamic Foreign Scan on pagg_tab
+                                 Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(13 rows)
 
 -- Plan with partitionwise aggregates is enabled
 SET enable_partitionwise_aggregate TO true;
@@ -11721,17 +11591,14 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
          Sort Key: a
          ->  Result
                Filter: ((avg(b)) < '22'::numeric)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: a
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     ->  Redistribute Motion 1:3  (slice2)
                            Hash Key: a
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: a
-                                 ->  Redistribute Motion 1:3  (slice3)
-                                       ->  Dynamic Foreign Scan on pagg_tab
-                                             Number of partitions to scan: 3 (out of 3)
+                           ->  Dynamic Foreign Scan on pagg_tab
+                                 Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(13 rows)
 
 SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
  a  | sum  | min | count 
@@ -11805,17 +11672,14 @@ SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 
          Sort Key: b
          ->  Result
                Filter: ((sum(a)) < 700)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     ->  Redistribute Motion 1:3  (slice2)
                            Hash Key: b
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: b
-                                 ->  Redistribute Motion 1:3  (slice3)
-                                       ->  Dynamic Foreign Scan on pagg_tab
-                                             Number of partitions to scan: 3 (out of 3)
+                           ->  Dynamic Foreign Scan on pagg_tab
+                                 Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(13 rows)
 
 SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 ORDER BY 1;
  b  |         avg         | max | count 

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -1397,13 +1397,9 @@ explain (costs false) update t1 set b = b + 1 where b in (select a from gp_any w
                                  ->  Sort
                                        Sort Key: a
                                        ->  Result
-                                             ->  GroupAggregate
-                                                   Group Key: a
-                                                   ->  Sort
-                                                         Sort Key: a
-                                                         ->  Foreign Scan on gp_any
+                                             ->  Foreign Scan on gp_any
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(17 rows)
 
 explain (costs false) update t1 set b = b + 1 where b in (select a from gp_coord where gp_coord.a > 10);
                                           QUERY PLAN                                           

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -471,7 +471,7 @@
     <dxl:Plan Id="0" SpaceSize="3378">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>
+          <dxl:Cost StartupCost="0" TotalCost="1389253302070.343018" Rows="1.000000" Width="15"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -488,7 +488,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>
+            <dxl:Cost StartupCost="0" TotalCost="1389253302070.343018" Rows="1.000000" Width="15"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -538,27 +538,27 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691815.784935" Rows="5.400000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356691815.803030" Rows="5.400000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691815.784933" Rows="5.400000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356691815.803028" Rows="5.400000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691815.784901" Rows="1.800000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356691815.802996" Rows="1.800000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691815.784901" Rows="1.800000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356691815.802996" Rows="1.800000" Width="1"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -595,7 +595,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356691815.784878" Rows="1.800000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356691815.802974" Rows="1.800000" Width="22"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -634,7 +634,7 @@
                     <dxl:LimitOffset/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1356691815.784878" Rows="1.800000" Width="22"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1356691815.802974" Rows="1.800000" Width="22"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="a">
@@ -687,7 +687,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1356691815.784681" Rows="4.500000" Width="22"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1356691815.802776" Rows="4.500000" Width="22"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="a">
@@ -718,7 +718,7 @@
                         </dxl:JoinFilter>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.351153" Rows="2.250000" Width="21"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.351171" Rows="2.250000" Width="21"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="10"/>
@@ -751,7 +751,7 @@
                           <dxl:Filter/>
                           <dxl:Sort SortDiscardDuplicates="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324032.351120" Rows="2.250000" Width="21"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324032.351138" Rows="2.250000" Width="21"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="10" Alias="a">
@@ -786,7 +786,7 @@
                             <dxl:LimitOffset/>
                             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324032.351120" Rows="2.250000" Width="21"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1324032.351138" Rows="2.250000" Width="21"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="10" Alias="a">
@@ -832,7 +832,7 @@
                               </dxl:HashExprList>
                               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1324032.351067" Rows="2.250000" Width="21"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324032.351084" Rows="2.250000" Width="21"/>
                                 </dxl:Properties>
                                 <dxl:GroupingColumns>
                                   <dxl:GroupingColumn ColId="10"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -318,7 +318,7 @@
     <dxl:Plan Id="0" SpaceSize="154">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="831.034094" Rows="10.000000" Width="66"/>
+          <dxl:Cost StartupCost="0" TotalCost="831.034278" Rows="10.000000" Width="66"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="message_id">
@@ -332,7 +332,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="831.032623" Rows="10.000000" Width="66"/>
+            <dxl:Cost StartupCost="0" TotalCost="831.032807" Rows="10.000000" Width="66"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="message_id">
@@ -348,7 +348,7 @@
           </dxl:JoinFilter>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="441.907091" Rows="10.000000" Width="33"/>
+              <dxl:Cost StartupCost="0" TotalCost="441.907275" Rows="10.000000" Width="33"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="6"/>
@@ -361,7 +361,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="441.907040" Rows="10.000000" Width="33"/>
+                <dxl:Cost StartupCost="0" TotalCost="441.907224" Rows="10.000000" Width="33"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="6" Alias="message_id">
@@ -376,7 +376,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="441.907040" Rows="10.000000" Width="33"/>
+                  <dxl:Cost StartupCost="0" TotalCost="441.907224" Rows="10.000000" Width="33"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="6" Alias="message_id">
@@ -392,7 +392,7 @@
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="441.907009" Rows="10.000000" Width="33"/>
+                    <dxl:Cost StartupCost="0" TotalCost="441.907193" Rows="10.000000" Width="33"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="6"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -426,7 +426,7 @@
     <dxl:Plan Id="0" SpaceSize="157890951632">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356250698.553420" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356250698.553440" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="41" Alias="?column?">
@@ -437,7 +437,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356250698.553405" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356250698.553425" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="41" Alias="?column?">
@@ -448,7 +448,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356250698.553403" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356250698.553424" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -465,7 +465,7 @@
             </dxl:HashCondList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356250267.552745" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356250267.552765" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="15"/>
@@ -490,7 +490,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356250267.552745" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="15" Alias="d">
@@ -515,7 +515,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356250267.552745" Rows="1.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="15" Alias="d">
@@ -543,7 +543,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356250267.552669" Rows="1.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356250267.552689" Rows="1.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="15"/>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3763,7 +3763,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
     <dxl:Plan Id="0" SpaceSize="49018816">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="57937323.544671" Rows="2959212724800.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="122" Alias="?column?">
@@ -3774,14 +3774,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="46100478.841568" Rows="2959212724800.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="46100472.645471" Rows="2959212724800.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35072479.420480" Rows="2959212724800.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="35072473.224383" Rows="2959212724800.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -3804,33 +3804,33 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
             </dxl:TableScan>
             <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="14147.738846" Rows="361329.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="14146.706163" Rows="361329.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="14147.618403" Rows="361329.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="14146.585720" Rows="361329.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:Append IsTarget="false" IsZapped="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="14145.462473" Rows="120443.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="14144.429790" Rows="120443.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7064.686786" Rows="118963.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="7064.227816" Rows="118963.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                     <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="7064.647131" Rows="118963.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="7064.188161" Rows="118963.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
@@ -3839,14 +3839,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                       </dxl:JoinFilter>
                       <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="894.082840" Rows="3.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="893.968098" Rows="3.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="894.082787" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="893.968044" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter>
@@ -3858,7 +3858,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                           <dxl:OneTimeFilter/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="894.082754" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="893.968011" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="186" Alias="ColRef_0186">
@@ -3883,7 +3883,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                             <dxl:OneTimeFilter/>
                             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="894.082746" Rows="1.000000" Width="16"/>
+                                <dxl:Cost StartupCost="0" TotalCost="893.968003" Rows="1.000000" Width="16"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns/>
                               <dxl:ProjList>
@@ -3911,7 +3911,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                               <dxl:Filter/>
                               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="894.082739" Rows="1.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="893.967996" Rows="1.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="187" Alias="ColRef_0187">
@@ -3925,7 +3925,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                 <dxl:SortingColumnList/>
                                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="894.082679" Rows="1.000000" Width="16"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="893.967936" Rows="1.000000" Width="16"/>
                                   </dxl:Properties>
                                   <dxl:GroupingColumns/>
                                   <dxl:ProjList>
@@ -3951,7 +3951,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                   <dxl:Filter/>
                                   <dxl:Result>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="894.068289" Rows="48179.200000" Width="4"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="893.953547" Rows="48179.200000" Width="4"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="183" Alias="ColRef_0183">
@@ -3968,7 +3968,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                     <dxl:OneTimeFilter/>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="894.004050" Rows="48179.200000" Width="4"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="893.889308" Rows="48179.200000" Width="4"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="121" Alias="?column?">
@@ -3989,7 +3989,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                       <dxl:OneTimeFilter/>
                                       <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="892.683192" Rows="120443.000000" Width="4"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="892.568450" Rows="120443.000000" Width="4"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="121" Alias="?column?">
@@ -4000,7 +4000,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                         <dxl:OneTimeFilter/>
                                         <dxl:Append IsTarget="false" IsZapped="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="892.522602" Rows="120443.000000" Width="1"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="892.407859" Rows="120443.000000" Width="1"/>
                                           </dxl:Properties>
                                           <dxl:ProjList/>
                                           <dxl:Filter/>
@@ -4028,14 +4028,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                           </dxl:Result>
                                           <dxl:Result>
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="451.598215" Rows="1480.000000" Width="1"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="451.483472" Rows="1480.000000" Width="1"/>
                                             </dxl:Properties>
                                             <dxl:ProjList/>
                                             <dxl:Filter/>
                                             <dxl:OneTimeFilter/>
                                             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="451.597721" Rows="1480.000000" Width="1"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="451.482979" Rows="1480.000000" Width="1"/>
                                               </dxl:Properties>
                                               <dxl:GroupingColumns>
                                                 <dxl:GroupingColumn ColId="94"/>
@@ -4052,7 +4052,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                               <dxl:Filter/>
                                               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="451.478934" Rows="1480.000000" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="451.364192" Rows="1480.000000" Width="11"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="94" Alias="element_id">
@@ -4074,7 +4074,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                 </dxl:HashExprList>
                                                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="451.461949" Rows="1480.000000" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="451.347206" Rows="1480.000000" Width="11"/>
                                                   </dxl:Properties>
                                                   <dxl:GroupingColumns>
                                                     <dxl:GroupingColumn ColId="94"/>
@@ -4155,14 +4155,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                   </dxl:Result>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7080.735540" Rows="1480.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="7080.161827" Rows="1480.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="7080.735046" Rows="1480.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="7080.161334" Rows="1480.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="41"/>
@@ -4179,7 +4179,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                       <dxl:Filter/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="7080.616259" Rows="1480.000000" Width="11"/>
+                          <dxl:Cost StartupCost="0" TotalCost="7080.042546" Rows="1480.000000" Width="11"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="41" Alias="element_id">
@@ -4201,7 +4201,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="7080.599274" Rows="1480.000000" Width="11"/>
+                            <dxl:Cost StartupCost="0" TotalCost="7080.025561" Rows="1480.000000" Width="11"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="41"/>
@@ -4218,7 +4218,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                           <dxl:Filter/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="7070.860650" Rows="118963.000000" Width="11"/>
+                              <dxl:Cost StartupCost="0" TotalCost="7070.401680" Rows="118963.000000" Width="11"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="66" Alias="?column?">
@@ -4232,7 +4232,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                             <dxl:OneTimeFilter/>
                             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="7070.424452" Rows="118963.000000" Width="7"/>
+                                <dxl:Cost StartupCost="0" TotalCost="7069.965482" Rows="118963.000000" Width="7"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="41" Alias="element_id">
@@ -4264,20 +4264,20 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                               </dxl:TableScan>
                               <dxl:Materialize Eager="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="894.082841" Rows="3.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="893.968099" Rows="3.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
                                 <dxl:Filter/>
                                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="894.082840" Rows="3.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="893.968098" Rows="3.000000" Width="1"/>
                                   </dxl:Properties>
                                   <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:SortingColumnList/>
                                   <dxl:Result>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="894.082787" Rows="1.000000" Width="1"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="893.968044" Rows="1.000000" Width="1"/>
                                     </dxl:Properties>
                                     <dxl:ProjList/>
                                     <dxl:Filter>
@@ -4289,7 +4289,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                     <dxl:OneTimeFilter/>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="894.082754" Rows="1.000000" Width="8"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="893.968011" Rows="1.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="180" Alias="ColRef_0180">
@@ -4314,7 +4314,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                       <dxl:OneTimeFilter/>
                                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="894.082746" Rows="1.000000" Width="16"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="893.968003" Rows="1.000000" Width="16"/>
                                         </dxl:Properties>
                                         <dxl:GroupingColumns/>
                                         <dxl:ProjList>
@@ -4342,7 +4342,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                         <dxl:Filter/>
                                         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="894.082739" Rows="1.000000" Width="16"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="893.967996" Rows="1.000000" Width="16"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="181" Alias="ColRef_0181">
@@ -4356,7 +4356,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                           <dxl:SortingColumnList/>
                                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="894.082679" Rows="1.000000" Width="16"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="893.967936" Rows="1.000000" Width="16"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>
@@ -4382,7 +4382,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                             <dxl:Filter/>
                                             <dxl:Result>
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="894.068289" Rows="48179.200000" Width="4"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="893.953547" Rows="48179.200000" Width="4"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="177" Alias="ColRef_0177">
@@ -4399,7 +4399,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                               <dxl:OneTimeFilter/>
                                               <dxl:Result>
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="894.004050" Rows="48179.200000" Width="4"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="893.889308" Rows="48179.200000" Width="4"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="176" Alias="?column?">
@@ -4420,7 +4420,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                 <dxl:OneTimeFilter/>
                                                 <dxl:Result>
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="892.683192" Rows="120443.000000" Width="4"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="892.568450" Rows="120443.000000" Width="4"/>
                                                   </dxl:Properties>
                                                   <dxl:ProjList>
                                                     <dxl:ProjElem ColId="176" Alias="?column?">
@@ -4431,7 +4431,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                   <dxl:OneTimeFilter/>
                                                   <dxl:Append IsTarget="false" IsZapped="false">
                                                     <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="892.522602" Rows="120443.000000" Width="1"/>
+                                                      <dxl:Cost StartupCost="0" TotalCost="892.407859" Rows="120443.000000" Width="1"/>
                                                     </dxl:Properties>
                                                     <dxl:ProjList/>
                                                     <dxl:Filter/>
@@ -4459,14 +4459,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                     </dxl:Result>
                                                     <dxl:Result>
                                                       <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="451.598215" Rows="1480.000000" Width="1"/>
+                                                        <dxl:Cost StartupCost="0" TotalCost="451.483472" Rows="1480.000000" Width="1"/>
                                                       </dxl:Properties>
                                                       <dxl:ProjList/>
                                                       <dxl:Filter/>
                                                       <dxl:OneTimeFilter/>
                                                       <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                                                         <dxl:Properties>
-                                                          <dxl:Cost StartupCost="0" TotalCost="451.597721" Rows="1480.000000" Width="1"/>
+                                                          <dxl:Cost StartupCost="0" TotalCost="451.482979" Rows="1480.000000" Width="1"/>
                                                         </dxl:Properties>
                                                         <dxl:GroupingColumns>
                                                           <dxl:GroupingColumn ColId="149"/>
@@ -4483,7 +4483,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                         <dxl:Filter/>
                                                         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                                           <dxl:Properties>
-                                                            <dxl:Cost StartupCost="0" TotalCost="451.478934" Rows="1480.000000" Width="11"/>
+                                                            <dxl:Cost StartupCost="0" TotalCost="451.364192" Rows="1480.000000" Width="11"/>
                                                           </dxl:Properties>
                                                           <dxl:ProjList>
                                                             <dxl:ProjElem ColId="149" Alias="element_id">
@@ -4505,7 +4505,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                           </dxl:HashExprList>
                                                           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                                             <dxl:Properties>
-                                                              <dxl:Cost StartupCost="0" TotalCost="451.461949" Rows="1480.000000" Width="11"/>
+                                                              <dxl:Cost StartupCost="0" TotalCost="451.347206" Rows="1480.000000" Width="11"/>
                                                             </dxl:Properties>
                                                             <dxl:GroupingColumns>
                                                               <dxl:GroupingColumn ColId="149"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10888,7 +10888,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
     <dxl:Plan Id="0" SpaceSize="98">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>
+          <dxl:Cost StartupCost="0" TotalCost="102935.426692" Rows="13.696907" Width="127"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -10905,7 +10905,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="102938.683718" Rows="13.696907" Width="127"/>
+            <dxl:Cost StartupCost="0" TotalCost="102935.418881" Rows="13.696907" Width="127"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -10926,7 +10926,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="102938.680472" Rows="13.696907" Width="127"/>
+              <dxl:Cost StartupCost="0" TotalCost="102935.415636" Rows="13.696907" Width="127"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -10954,7 +10954,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
             </dxl:HashExprList>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="102938.677750" Rows="13.696907" Width="127"/>
+                <dxl:Cost StartupCost="0" TotalCost="102935.412913" Rows="13.696907" Width="127"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -299,7 +299,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
     <dxl:Plan Id="0" SpaceSize="66">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001143" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001181" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="16" Alias="?column?">
@@ -310,14 +310,14 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001139" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001177" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001135" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001173" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter>
@@ -342,7 +342,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001113" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001151" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -383,7 +383,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001114" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cidr">
@@ -411,7 +411,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.001114" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="cidr">
@@ -442,7 +442,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.001008" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="cidr">
@@ -465,7 +465,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.001008" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ComputedGroupByCol.mdp
@@ -330,7 +330,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="515.600123" Rows="84.375000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="513.914658" Rows="84.375000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="count">
@@ -341,7 +341,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="515.597093" Rows="84.375000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="513.911627" Rows="84.375000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="count">
@@ -352,7 +352,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="515.597093" Rows="84.375000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="513.911627" Rows="84.375000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="11"/>
@@ -361,7 +361,7 @@
               <dxl:ProjElem ColId="12" Alias="count">
                 <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -375,7 +375,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="515.591803" Rows="84.375000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="513.906338" Rows="84.375000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="?column?">
@@ -394,7 +394,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="515.590219" Rows="84.375000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="513.904753" Rows="84.375000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="?column?">
@@ -408,7 +408,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="515.590219" Rows="84.375000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="513.904753" Rows="84.375000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="11"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
@@ -352,7 +352,7 @@
     <dxl:Plan Id="0" SpaceSize="126">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324039.636059" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324039.639123" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="bar">
@@ -363,7 +363,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324039.636044" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324039.639108" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="bar">
@@ -423,14 +423,14 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="8"/>
@@ -439,7 +439,7 @@
                 <dxl:ProjElem ColId="9" Alias="a">
                   <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -453,7 +453,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="?column?">
@@ -471,7 +471,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="?column?">
@@ -490,7 +490,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="8" Alias="?column?">
@@ -504,7 +504,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="8"/>
@@ -513,7 +513,7 @@
                         <dxl:ProjElem ColId="19" Alias="ColRef_0019">
                           <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -441,7 +441,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
     <dxl:Plan Id="0" SpaceSize="30837">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.684415" Rows="70.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.685279" Rows="70.000000" Width="10"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -458,7 +458,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.681272" Rows="70.000000" Width="10"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.682136" Rows="70.000000" Width="10"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -482,7 +482,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2155.678969" Rows="70.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.679833" Rows="70.000000" Width="18"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -529,7 +529,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2155.677076" Rows="70.000000" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.677939" Rows="70.000000" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -571,7 +571,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2155.632288" Rows="70.000000" Width="44"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2155.633152" Rows="70.000000" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -626,7 +626,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2155.627467" Rows="70.000000" Width="44"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2155.628331" Rows="70.000000" Width="44"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -658,7 +658,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2155.627467" Rows="70.000000" Width="44"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2155.628331" Rows="70.000000" Width="44"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -441,7 +441,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
     <dxl:Plan Id="0" SpaceSize="30837">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.684415" Rows="70.000000" Width="10"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -458,7 +458,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.681036" Rows="70.000000" Width="10"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.681272" Rows="70.000000" Width="10"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -482,7 +482,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2155.678733" Rows="70.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.678969" Rows="70.000000" Width="18"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -529,7 +529,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2155.676840" Rows="70.000000" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.677076" Rows="70.000000" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -571,7 +571,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2155.632052" Rows="70.000000" Width="44"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2155.632288" Rows="70.000000" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -626,7 +626,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2155.627232" Rows="70.000000" Width="44"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2155.627467" Rows="70.000000" Width="44"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -658,7 +658,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2155.627232" Rows="70.000000" Width="44"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2155.627467" Rows="70.000000" Width="44"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -707,7 +707,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                     <dxl:Filter/>
                     <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2155.625003" Rows="70.000000" Width="39"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2155.625239" Rows="70.000000" Width="39"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -758,7 +758,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                       </dxl:JoinFilter>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.250303" Rows="70.000000" Width="36"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.250538" Rows="70.000000" Width="36"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -797,7 +797,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                         <dxl:LimitOffset/>
                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.213658" Rows="70.000000" Width="36"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.213894" Rows="70.000000" Width="36"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -843,11 +843,11 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                           </dxl:JoinFilter>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.015706" Rows="70.000000" Width="20"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.015941" Rows="70.000000" Width="20"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="21" Alias="substr">
-                                <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                   <dxl:Ident ColId="20" ColName="max" TypeMdid="0.25.1.0"/>
                                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
@@ -864,7 +864,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                             <dxl:OneTimeFilter/>
                             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.011506" Rows="70.000000" Width="12"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.011741" Rows="70.000000" Width="12"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns>
                                 <dxl:GroupingColumn ColId="10"/>
@@ -887,7 +887,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                               <dxl:Filter/>
                               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.007023" Rows="70.000000" Width="12"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.007259" Rows="70.000000" Width="12"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="10" Alias="u_vtgnr">
@@ -906,7 +906,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                 </dxl:HashExprList>
                                 <dxl:Result>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.005708" Rows="70.000000" Width="12"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.005944" Rows="70.000000" Width="12"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="10" Alias="u_vtgnr">
@@ -920,7 +920,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                   <dxl:OneTimeFilter/>
                                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.005708" Rows="70.000000" Width="12"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.005944" Rows="70.000000" Width="12"/>
                                     </dxl:Properties>
                                     <dxl:GroupingColumns>
                                       <dxl:GroupingColumn ColId="10"/>
@@ -931,7 +931,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                           <dxl:ValuesList ParamType="aggargs">
                                             <dxl:If TypeMdid="0.25.1.0">
                                               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                                                <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                                <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0" FuncVariadic="false">
                                                   <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
                                                 </dxl:FuncExpr>
                                                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
@@ -278,7 +278,7 @@
     <dxl:Plan Id="0" SpaceSize="42">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="577.928905" Rows="4.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="575.682217" Rows="4.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -292,7 +292,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="577.928618" Rows="4.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="575.681929" Rows="4.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -306,7 +306,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="577.928618" Rows="4.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="575.681929" Rows="4.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -315,7 +315,7 @@
               <dxl:ProjElem ColId="10" Alias="count">
                 <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -325,7 +325,7 @@
               <dxl:ProjElem ColId="11" Alias="sum">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -339,7 +339,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="577.928510" Rows="11.250000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="575.681821" Rows="11.250000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -349,7 +349,7 @@
                 <dxl:ProjElem ColId="13" Alias="ColRef_0013">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Intermediate" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -366,7 +366,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="577.928370" Rows="11.250000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="575.681681" Rows="11.250000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -388,7 +388,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="577.927098" Rows="11.250000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="575.680409" Rows="11.250000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -410,7 +410,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="577.926816" Rows="11.250000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="575.680127" Rows="11.250000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
@@ -427,7 +427,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="577.926816" Rows="11.250000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="575.680127" Rows="11.250000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="1"/>
@@ -437,7 +437,7 @@
                         <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
@@ -323,7 +323,7 @@
     <dxl:Plan Id="0" SpaceSize="42">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="579.950342" Rows="4.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="576.580308" Rows="4.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -340,7 +340,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="579.949911" Rows="4.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="576.579877" Rows="4.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -357,7 +357,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="579.949911" Rows="4.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="576.579877" Rows="4.000000" Width="24"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -366,7 +366,7 @@
               <dxl:ProjElem ColId="10" Alias="count">
                 <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -376,7 +376,7 @@
               <dxl:ProjElem ColId="11" Alias="sum">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -386,7 +386,7 @@
               <dxl:ProjElem ColId="12" Alias="avg">
                 <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="16" ColName="ColRef_0016" TypeMdid="0.17.1.0"/>
+                    <dxl:Ident ColId="16" ColName="ColRef_0016" TypeMdid="0.17.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -400,7 +400,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="579.949194" Rows="11.250000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="576.579160" Rows="11.250000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -410,7 +410,7 @@
                 <dxl:ProjElem ColId="14" Alias="ColRef_0014">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Intermediate" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -420,7 +420,7 @@
                 <dxl:ProjElem ColId="16" Alias="ColRef_0016">
                   <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Intermediate" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
+                      <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -437,7 +437,7 @@
               <dxl:Filter/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="579.947738" Rows="11.250000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="576.577704" Rows="11.250000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -462,7 +462,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="579.947315" Rows="11.250000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="576.577282" Rows="11.250000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -482,7 +482,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="579.947315" Rows="11.250000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="576.577282" Rows="11.250000" Width="24"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>
@@ -492,7 +492,7 @@
                       <dxl:ProjElem ColId="13" Alias="ColRef_0013">
                         <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -502,7 +502,7 @@
                       <dxl:ProjElem ColId="15" Alias="ColRef_0015">
                         <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-NonRedistributableCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-NonRedistributableCol.mdp
@@ -241,7 +241,7 @@ explain select count(distinct h) from testhstore;
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@ explain select count(distinct h) from testhstore;
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="5"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="5"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -272,7 +272,7 @@ explain select count(distinct h) from testhstore;
           <dxl:Filter/>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="5"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="5"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="h">
@@ -285,7 +285,7 @@ explain select count(distinct h) from testhstore;
             </dxl:SortingColumnList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="5"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="5"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
@@ -341,14 +341,14 @@ drop table if exists foo;
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.120390" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.119502" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="count">
             <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -359,7 +359,7 @@ drop table if exists foo;
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.120389" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.119501" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -370,7 +370,7 @@ drop table if exists foo;
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.119244" Rows="2.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.118356" Rows="2.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -383,7 +383,7 @@ drop table if exists foo;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.119238" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.118350" Rows="2.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -398,7 +398,7 @@ drop table if exists foo;
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.119238" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.118350" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -414,7 +414,7 @@ drop table if exists foo;
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.119235" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.118347" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
@@ -353,14 +353,14 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.791035" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.619703" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="count">
             <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -370,7 +370,7 @@
           <dxl:ProjElem ColId="10" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -381,7 +381,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.791025" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="438.619692" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -395,7 +395,7 @@
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.790917" Rows="2.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="438.619584" Rows="2.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="b">
@@ -409,7 +409,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="438.790917" Rows="2.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="438.619584" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -418,7 +418,7 @@
                 <dxl:ProjElem ColId="12" Alias="ColRef_0012">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Intermediate" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -432,7 +432,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="438.790898" Rows="2.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="438.619565" Rows="2.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -450,7 +450,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="438.790898" Rows="2.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="438.619565" Rows="2.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -469,7 +469,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="438.790861" Rows="2.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="438.619528" Rows="2.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
@@ -483,7 +483,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="438.790861" Rows="2.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="438.619528" Rows="2.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="1"/>
@@ -492,7 +492,7 @@
                         <dxl:ProjElem ColId="11" Alias="ColRef_0011">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
@@ -340,14 +340,14 @@ explain select count(distinct b ) from foo;
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.327583" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.272743" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="count">
             <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -358,7 +358,7 @@ explain select count(distinct b ) from foo;
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.327582" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="438.272742" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -369,7 +369,7 @@ explain select count(distinct b ) from foo;
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.327546" Rows="2.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="438.272706" Rows="2.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -382,7 +382,7 @@ explain select count(distinct b ) from foo;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="438.327539" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="438.272700" Rows="2.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -397,7 +397,7 @@ explain select count(distinct b ) from foo;
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="438.327539" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="438.272700" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -413,7 +413,7 @@ explain select count(distinct b ) from foo;
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="438.327527" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="438.272688" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -722,7 +722,7 @@
     <dxl:Plan Id="0" SpaceSize="274">
       <dxl:DMLDelete Columns="0" ActionCol="21" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.965580" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.965595" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -744,7 +744,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.942142" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.942157" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -764,7 +764,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.942136" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.942151" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -816,7 +816,7 @@
             </dxl:TableScan>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.941257" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.941272" Rows="10.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="8"/>
@@ -829,7 +829,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.941236" Rows="10.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.941251" Rows="10.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">
@@ -844,7 +844,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.941105" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.941120" Rows="10.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="a">
@@ -860,7 +860,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.941063" Rows="10.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.941078" Rows="10.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Distinct-LegacyOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Distinct-LegacyOpfamily.mdp
@@ -239,7 +239,7 @@
     <dxl:Plan Id="0" SpaceSize="17">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000236" Rows="1.000000" Width="29"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000247" Rows="1.000000" Width="29"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -252,7 +252,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.000000" Width="29"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="1.000000" Width="29"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="test_array">
@@ -265,7 +265,7 @@
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="29"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="29"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="test_array">
@@ -280,7 +280,7 @@
             <dxl:LimitOffset/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="29"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="29"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
@@ -454,7 +454,7 @@ Physical plan:
     <dxl:Plan Id="0" SpaceSize="22212">
       <dxl:DMLInsert Columns="0,1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1765376.357206" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1765376.357208" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -480,7 +480,7 @@ Physical plan:
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1765376.333768" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1765376.333770" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -497,7 +497,7 @@ Physical plan:
           <dxl:OneTimeFilter/>
           <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1765376.333762" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1765376.333764" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -511,7 +511,7 @@ Physical plan:
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1765376.333750" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1765376.333752" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -528,7 +528,7 @@ Physical plan:
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1765376.333739" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1765376.333742" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -547,7 +547,7 @@ Physical plan:
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1765376.333739" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1765376.333742" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -569,7 +569,7 @@ Physical plan:
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1765376.333724" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1765376.333726" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -635,7 +635,7 @@ Physical plan:
                               <dxl:Ident ColId="10" ColName="column2" TypeMdid="0.23.1.0"/>
                             </dxl:Comparison>
                           </dxl:JoinFilter>
-                          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                          <dxl:DynamicTableScan SelectorIds="">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
@@ -701,7 +701,7 @@ Physical plan:
                               <dxl:Ident ColId="21" ColName="column2" TypeMdid="0.23.1.0"/>
                             </dxl:Comparison>
                           </dxl:JoinFilter>
-                          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+                          <dxl:DynamicTableScan SelectorIds="">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DqaHavingMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaHavingMax.mdp
@@ -628,7 +628,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="669.090667" Rows="800000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="675.074667" Rows="800000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -639,7 +639,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="657.165333" Rows="800000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="663.149333" Rows="800000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">
@@ -655,7 +655,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="635.232000" Rows="2000000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="641.216000" Rows="2000000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -664,7 +664,7 @@
               <dxl:ProjElem ColId="10" Alias="max">
                 <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -678,7 +678,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="551.642667" Rows="2000000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="557.626667" Rows="2000000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -697,7 +697,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="534.949333" Rows="2000000.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="540.933333" Rows="2000000.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -711,7 +711,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="534.949333" Rows="2000000.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="540.933333" Rows="2000000.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -720,7 +720,7 @@
                     <dxl:ProjElem ColId="11" Alias="ColRef_0011">
                       <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DuplicateGrpCol.mdp
@@ -405,7 +405,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="445.481435" Rows="20.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="445.253113" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -416,7 +416,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="445.480717" Rows="20.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="445.252394" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
@@ -427,7 +427,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="445.480717" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="445.252394" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -437,7 +437,7 @@
               <dxl:ProjElem ColId="10" Alias="count">
                 <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -454,7 +454,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="445.478254" Rows="20.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="445.249932" Rows="20.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -479,7 +479,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="445.477753" Rows="20.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="445.249431" Rows="20.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -496,7 +496,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="445.477753" Rows="20.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="445.249431" Rows="20.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
@@ -334,7 +334,7 @@
     <dxl:Plan Id="0" SpaceSize="380">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000677" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000682" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -354,7 +354,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000632" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000637" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -370,7 +370,7 @@
             <dxl:ProjElem ColId="20" Alias="min">
               <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -381,7 +381,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000623" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -403,7 +403,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000623" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -428,7 +428,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000599" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
@@ -445,7 +445,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000599" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -455,7 +455,7 @@
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
                       <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggExpression.mdp
@@ -3328,7 +3328,7 @@
     <dxl:Plan Id="0" SpaceSize="44">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="13815.579946" Rows="999.999998" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="13734.880549" Rows="999.999998" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="min">
@@ -3339,7 +3339,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="13815.565040" Rows="999.999998" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="13734.865642" Rows="999.999998" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="min">
@@ -3350,7 +3350,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="13815.565040" Rows="999.999998" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="13734.865642" Rows="999.999998" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -3359,7 +3359,7 @@
               <dxl:ProjElem ColId="20" Alias="min">
                 <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -3373,7 +3373,7 @@
             <dxl:Filter/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="11548.062944" Rows="56476687.387047" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="11467.363547" Rows="56476687.387047" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -3393,7 +3393,7 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="10223.579128" Rows="5615437.486519" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="10142.879731" Rows="5615437.486519" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="j1">
@@ -3415,7 +3415,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10153.273851" Rows="5615437.486519" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="10072.574453" Rows="5615437.486519" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="j1">
@@ -3432,7 +3432,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="10153.273851" Rows="5615437.486519" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="10072.574453" Rows="5615437.486519" Width="12"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -3442,10 +3442,10 @@
                       <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                         <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
-                            <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                          </dxl:OpExpr>
+                            <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
+                              <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                            </dxl:OpExpr>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -330,7 +330,7 @@
     <dxl:Plan Id="0" SpaceSize="120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000607" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -347,7 +347,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000559" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000562" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -374,7 +374,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000556" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -396,7 +396,7 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000556" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -419,7 +419,7 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
@@ -438,7 +438,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="g1">
@@ -452,7 +452,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
@@ -333,7 +333,7 @@
     <dxl:Plan Id="0" SpaceSize="380">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000677" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000682" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -353,7 +353,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000632" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000637" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -369,7 +369,7 @@
             <dxl:ProjElem ColId="20" Alias="max">
               <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -380,7 +380,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000623" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -402,7 +402,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000623" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -427,7 +427,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000599" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
@@ -444,7 +444,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000599" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -454,7 +454,7 @@
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
                       <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
@@ -4295,7 +4295,7 @@
         <dxl:Plan Id="0" SpaceSize="1425">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3919924663.003983" Rows="562499.998313" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="3875633760.983334" Rows="562499.998313" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="11" Alias="g1">
@@ -4315,7 +4315,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3919924637.848983" Rows="562499.998313" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="3875633735.828334" Rows="562499.998313" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="11"/>
@@ -4331,7 +4331,7 @@
             <dxl:ProjElem ColId="30" Alias="max">
               <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -4342,7 +4342,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3919924634.336733" Rows="562499.998313" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="3875633732.316084" Rows="562499.998313" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g2">
@@ -4364,7 +4364,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3919924410.869588" Rows="562499.998313" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="3875633508.848939" Rows="562499.998313" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g2">
@@ -4389,7 +4389,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3919924403.827088" Rows="562499.998313" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3875633501.806439" Rows="562499.998313" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g2">
@@ -4406,7 +4406,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3919924403.827088" Rows="562499.998313" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3875633501.806439" Rows="562499.998313" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="11"/>
@@ -4416,7 +4416,7 @@
                     <dxl:ProjElem ColId="32" Alias="ColRef_0032">
                       <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="12" ColName="s1" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="12" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
@@ -3335,7 +3335,7 @@
     <dxl:Plan Id="0" SpaceSize="44">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="14184.950195" Rows="999.999998" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="14077.350999" Rows="999.999998" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="min">
@@ -3349,7 +3349,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="14184.920382" Rows="999.999998" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="14077.321186" Rows="999.999998" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="min">
@@ -3363,7 +3363,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="14184.920382" Rows="999.999998" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="14077.321186" Rows="999.999998" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -3372,7 +3372,7 @@
               <dxl:ProjElem ColId="20" Alias="min">
                 <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -3382,7 +3382,7 @@
               <dxl:ProjElem ColId="21" Alias="max">
                 <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -3396,7 +3396,7 @@
             <dxl:Filter/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="11908.983687" Rows="56476687.387047" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="11801.384490" Rows="56476687.387047" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -3419,7 +3419,7 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="10316.382261" Rows="5615437.486519" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="10208.783064" Rows="5615437.486519" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="j1">
@@ -3444,7 +3444,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="10222.641891" Rows="5615437.486519" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="10115.042695" Rows="5615437.486519" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="j1">
@@ -3464,7 +3464,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="10222.641891" Rows="5615437.486519" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="10115.042695" Rows="5615437.486519" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -3474,7 +3474,7 @@
                       <dxl:ProjElem ColId="22" Alias="ColRef_0022">
                         <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -3484,7 +3484,7 @@
                       <dxl:ProjElem ColId="23" Alias="ColRef_0023">
                         <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
@@ -379,7 +379,7 @@
     <dxl:Plan Id="0" SpaceSize="18944">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.236868" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.236886" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -396,7 +396,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324463.236808" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324463.236826" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -412,7 +412,7 @@
             <dxl:ProjElem ColId="30" Alias="sum">
               <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -423,7 +423,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324463.236807" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -445,7 +445,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324463.236807" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -470,7 +470,7 @@
               </dxl:HashExprList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324463.236764" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324463.236782" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
@@ -493,7 +493,7 @@
                 </dxl:HashCondList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.236242" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.236260" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -503,7 +503,7 @@
                     <dxl:ProjElem ColId="33" Alias="ColRef_0033">
                       <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
@@ -3371,7 +3371,7 @@
     <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="64737.800943" Rows="999.999996" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="62877.699863" Rows="999.999996" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -3391,7 +3391,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="64737.726409" Rows="999.999996" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="62877.625329" Rows="999.999996" Width="20"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -3403,7 +3403,7 @@
             <dxl:ProjElem ColId="20" Alias="min">
               <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -3413,7 +3413,7 @@
             <dxl:ProjElem ColId="21" Alias="max">
               <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -3423,7 +3423,7 @@
             <dxl:ProjElem ColId="22" Alias="count2">
               <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -3434,7 +3434,7 @@
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="64737.681923" Rows="999.999996" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="62877.580843" Rows="999.999996" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -3459,7 +3459,7 @@
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="64737.661056" Rows="999.999996" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="62877.559976" Rows="999.999996" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -3479,7 +3479,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="64737.661056" Rows="999.999996" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="62877.559976" Rows="999.999996" Width="20"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="1"/>
@@ -3488,7 +3488,7 @@
                   <dxl:ProjElem ColId="23" Alias="ColRef_0023">
                     <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -3498,7 +3498,7 @@
                   <dxl:ProjElem ColId="24" Alias="ColRef_0024">
                     <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -3508,12 +3508,12 @@
                   <dxl:ProjElem ColId="25" Alias="ColRef_0025">
                     <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                        <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                          <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:OpExpr>
-                      </dxl:Cast>
+                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                          <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                            <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                          </dxl:OpExpr>
+                        </dxl:Cast>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -441,7 +441,7 @@
     <dxl:Plan Id="0" SpaceSize="85">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691750.457889" Rows="1.600000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356691750.476271" Rows="1.600000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -458,7 +458,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691750.457811" Rows="1.600000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356691750.476194" Rows="1.600000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -475,7 +475,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691750.457811" Rows="1.600000" Width="13"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356691750.476194" Rows="1.600000" Width="13"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -512,7 +512,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691750.457782" Rows="1.600000" Width="25"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356691750.476165" Rows="1.600000" Width="25"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -551,7 +551,7 @@
               <dxl:LimitOffset/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691750.457782" Rows="1.600000" Width="25"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356691750.476165" Rows="1.600000" Width="25"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -606,7 +606,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691750.457585" Rows="4.000000" Width="25"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356691750.475968" Rows="4.000000" Width="25"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -637,7 +637,7 @@
                   </dxl:JoinFilter>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.287334" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.287352" Rows="2.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -670,7 +670,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.287297" Rows="2.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.287315" Rows="2.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">
@@ -705,7 +705,7 @@
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.287297" Rows="2.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.287315" Rows="2.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
@@ -751,7 +751,7 @@
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.287240" Rows="2.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.287258" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -459,7 +459,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
     <dxl:Plan Id="0" SpaceSize="3310">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.002856" Rows="1.000000" Width="64"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cid">
@@ -494,7 +494,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.002565" Rows="1.000000" Width="64"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.002569" Rows="1.000000" Width="64"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cid">
@@ -558,7 +558,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.001065" Rows="1.000000" Width="40"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001070" Rows="1.000000" Width="40"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cid">
@@ -589,7 +589,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
             </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000987" Rows="1.000000" Width="40"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000991" Rows="1.000000" Width="40"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="cid">
@@ -652,7 +652,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
               </dxl:TableScan>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000193" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="cid">
@@ -674,7 +674,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000143" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000147" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="cid">
@@ -702,7 +702,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000115" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="22"/>
@@ -712,7 +712,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                       <dxl:ProjElem ColId="32" Alias="tickets_cnt">
                         <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -729,7 +729,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="22" Alias="cid">
@@ -751,7 +751,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="16"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="16"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="22" Alias="cid">
@@ -776,7 +776,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                         </dxl:HashExprList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="1.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="22" Alias="cid">
@@ -793,7 +793,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="16"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="1.000000" Width="16"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="22"/>
@@ -803,7 +803,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                               <dxl:ProjElem ColId="33" Alias="ColRef_0033">
                                 <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                   <dxl:ValuesList ParamType="aggargs">
-                                  <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="21" ColName="ticket_number" TypeMdid="0.23.1.0"/>
                                   </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -11021,7 +11021,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
     <dxl:Plan Id="0" SpaceSize="98">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="458.857269" Rows="3.941034" Width="127"/>
+          <dxl:Cost StartupCost="0" TotalCost="458.857409" Rows="3.941034" Width="127"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -11038,7 +11038,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="458.855022" Rows="3.941034" Width="127"/>
+            <dxl:Cost StartupCost="0" TotalCost="458.855162" Rows="3.941034" Width="127"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -11059,7 +11059,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="458.854088" Rows="3.941034" Width="127"/>
+              <dxl:Cost StartupCost="0" TotalCost="458.854228" Rows="3.941034" Width="127"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="i_item_id">
@@ -11087,7 +11087,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
             </dxl:HashExprList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="458.853304" Rows="3.941034" Width="127"/>
+                <dxl:Cost StartupCost="0" TotalCost="458.853445" Rows="3.941034" Width="127"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -11241,7 +11241,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                       <dxl:Ident ColId="0" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:IndexCondList>
-	<dxl:Partitions/>
+                  <dxl:Partitions/>
                   <dxl:IndexDescriptor Mdid="0.673571.1.0" IndexName="store_sales_pkey"/>
                   <dxl:TableDescriptor Mdid="6.673545.1.1" TableName="store_sales">
                     <dxl:Columns>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6377,7 +6377,7 @@ ORDER BY s_name;
     <dxl:Plan Id="0" SpaceSize="4053120">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>
+          <dxl:Cost StartupCost="0" TotalCost="24685091.846062" Rows="49.989277" Width="65"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6393,7 +6393,7 @@ ORDER BY s_name;
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="24583535.979185" Rows="49.989277" Width="65"/>
+            <dxl:Cost StartupCost="0" TotalCost="24685091.831473" Rows="49.989277" Width="65"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6411,7 +6411,7 @@ ORDER BY s_name;
           <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="24583535.936410" Rows="49.989277" Width="65"/>
+              <dxl:Cost StartupCost="0" TotalCost="24685091.788698" Rows="49.989277" Width="65"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6431,7 +6431,7 @@ ORDER BY s_name;
             </dxl:HashCondList>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="24583104.920334" Rows="24.994638" Width="69"/>
+                <dxl:Cost StartupCost="0" TotalCost="24684660.772622" Rows="24.994638" Width="69"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6453,7 +6453,7 @@ ORDER BY s_name;
               </dxl:HashExprList>
               <dxl:HashJoin JoinType="In">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="24583104.917635" Rows="24.994638" Width="69"/>
+                  <dxl:Cost StartupCost="0" TotalCost="24684660.769923" Rows="24.994638" Width="69"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6507,7 +6507,7 @@ ORDER BY s_name;
                 </dxl:TableScan>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="24552588.344232" Rows="24.994638" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="24654144.196520" Rows="24.994638" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="ps_suppkey">
@@ -6523,7 +6523,7 @@ ORDER BY s_name;
                   </dxl:HashExprList>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="24552588.344076" Rows="24.994638" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="24654144.196364" Rows="24.994638" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="ps_suppkey">
@@ -6647,7 +6647,7 @@ ORDER BY s_name;
                     </dxl:RedistributeMotion>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="11420998.371520" Rows="22628309333.333336" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="11522554.223808" Rows="22628309333.333336" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="57" Alias="?column?">
@@ -6667,7 +6667,7 @@ ORDER BY s_name;
                       <dxl:OneTimeFilter/>
                       <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="11239971.896853" Rows="22628309333.333336" Width="16"/>
+                          <dxl:Cost StartupCost="0" TotalCost="11341527.749141" Rows="22628309333.333336" Width="16"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="38"/>
@@ -6677,7 +6677,7 @@ ORDER BY s_name;
                           <dxl:ProjElem ColId="56" Alias="sum">
                             <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                               <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.1700.1.0"/>
+                                <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.1700.1.0"/>
                               </dxl:ValuesList>
                               <dxl:ValuesList ParamType="aggdirectargs"/>
                               <dxl:ValuesList ParamType="aggorder"/>
@@ -6694,7 +6694,7 @@ ORDER BY s_name;
                         <dxl:Filter/>
                         <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="8382468.994240" Rows="22628309333.333336" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="8484024.846528" Rows="22628309333.333336" Width="16"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="38" Alias="l_partkey">
@@ -6719,7 +6719,7 @@ ORDER BY s_name;
                           </dxl:HashExprList>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="7815856.128533" Rows="22628309333.333336" Width="16"/>
+                              <dxl:Cost StartupCost="0" TotalCost="7917411.980821" Rows="22628309333.333336" Width="16"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="38" Alias="l_partkey">
@@ -6736,7 +6736,7 @@ ORDER BY s_name;
                             <dxl:OneTimeFilter/>
                             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="7815856.128533" Rows="22628309333.333336" Width="16"/>
+                                <dxl:Cost StartupCost="0" TotalCost="7917411.980821" Rows="22628309333.333336" Width="16"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns>
                                 <dxl:GroupingColumn ColId="38"/>
@@ -6746,7 +6746,7 @@ ORDER BY s_name;
                                 <dxl:ProjElem ColId="60" Alias="ColRef_0060">
                                   <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                     <dxl:ValuesList ParamType="aggargs">
-                                    <dxl:Ident ColId="41" ColName="l_quantity" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Ident ColId="41" ColName="l_quantity" TypeMdid="0.1700.1.0"/>
                                     </dxl:ValuesList>
                                     <dxl:ValuesList ParamType="aggdirectargs"/>
                                     <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -756,7 +756,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.000793" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000794" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -769,7 +769,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000775" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000776" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -784,7 +784,7 @@ ORDER BY 1 asc ;
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.000775" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000776" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -797,7 +797,7 @@ ORDER BY 1 asc ;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="437.000770" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.000771" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -812,7 +812,7 @@ ORDER BY 1 asc ;
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="437.000770" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.000771" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -828,7 +828,7 @@ ORDER BY 1 asc ;
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="437.000762" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="437.000763" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -903,7 +903,7 @@ ORDER BY 1 asc ;
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
                       </dxl:BroadcastMotion>
-                      <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+                      <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="6.000506" Rows="1.000000" Width="1"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
@@ -511,7 +511,7 @@
     <dxl:Plan Id="0" SpaceSize="173">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000970" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000973" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -525,7 +525,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000940" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000943" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -601,16 +601,16 @@
           </dxl:RedistributeMotion>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000106" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="10"/>
             </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="max">
-                <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -624,14 +624,14 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="b">
                   <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                  <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -642,14 +642,14 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="a">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="10" Alias="b">
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                    <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -659,99 +659,41 @@
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="a">
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="10" Alias="b">
                       <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                      <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="10"/>
-                    </dxl:GroupingColumns>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="b">
-                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="9" Alias="a">
-                          <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="b">
-                          <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="9" Alias="a">
-                            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="10" Alias="b">
-                            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:Partitions>
-                          <dxl:Partition Mdid="6.133379001.1.0"/>
-                        </dxl:Partitions>
-                        <dxl:TableDescriptor Mdid="6.133379.1.0" TableName="bar">
-                          <dxl:Columns>
-                            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:DynamicTableScan>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Result>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:Partitions>
+                    <dxl:Partition Mdid="6.133379001.1.0"/>
+                  </dxl:Partitions>
+                  <dxl:TableDescriptor Mdid="6.133379.1.0" TableName="bar">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
               </dxl:RedistributeMotion>
             </dxl:Sort>
           </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesFromExistsSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesFromExistsSubquery.mdp
@@ -347,7 +347,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="192">
+    <dxl:Plan Id="0" SpaceSize="648">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000984" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4044,7 +4044,7 @@
     <dxl:Plan Id="0" SpaceSize="80990">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3422679.547303" Rows="19136.250000" Width="31"/>
+          <dxl:Cost StartupCost="0" TotalCost="3397460.370461" Rows="19136.250000" Width="31"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="year">
@@ -4064,7 +4064,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
+            <dxl:Cost StartupCost="0" TotalCost="3397457.706886" Rows="19136.250000" Width="31"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="year">
@@ -4084,7 +4084,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
+              <dxl:Cost StartupCost="0" TotalCost="3397457.706886" Rows="19136.250000" Width="31"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -4119,7 +4119,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3422671.991747" Rows="19136.250000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="3397452.814905" Rows="19136.250000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="year">
@@ -4156,7 +4156,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3397451.796665" Rows="19136.250000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="year">
@@ -4179,7 +4179,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3397451.796665" Rows="19136.250000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="27"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
@@ -296,7 +296,7 @@
     <dxl:Plan Id="0" SpaceSize="42">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000555" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000560" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="count">
@@ -310,7 +310,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000511" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -333,7 +333,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000496" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000501" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">
@@ -351,7 +351,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000496" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000501" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="c">
@@ -370,7 +370,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000482" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="c">
@@ -384,7 +384,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000482" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="9"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5772,7 +5772,7 @@
     <dxl:Plan Id="0" SpaceSize="26759194">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2587.327598" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2587.327611" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5787,7 +5787,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2587.327574" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="2587.327587" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5807,7 +5807,7 @@
           </dxl:SortingColumnList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2587.327484" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="2587.327497" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5824,7 +5824,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2587.327476" Rows="1.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="2587.327489" Rows="1.000000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="110" Alias="count">
@@ -5843,7 +5843,7 @@
               <dxl:LimitOffset/>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2587.327476" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2587.327489" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="1"/>
@@ -5866,7 +5866,7 @@
                 <dxl:Filter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2587.327436" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2587.327449" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
@@ -5883,7 +5883,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2587.327383" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2587.327396" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="s_name">
@@ -5902,7 +5902,7 @@
                     <dxl:LimitOffset/>
                     <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2587.327383" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2587.327396" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="s_name">
@@ -5921,7 +5921,7 @@
                       </dxl:HashExprList>
                       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2587.327329" Rows="1.000000" Width="34"/>
+                          <dxl:Cost StartupCost="0" TotalCost="2587.327342" Rows="1.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
@@ -701,7 +701,7 @@ where coalesce(t2.fname, t3.fname) is not null;
     <dxl:Plan Id="0" SpaceSize="126">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1678.860841" Rows="2.250000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1678.285454" Rows="2.250000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="fname">
@@ -712,7 +712,7 @@ where coalesce(t2.fname, t3.fname) is not null;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1678.860760" Rows="2.250000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1678.285373" Rows="2.250000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="26"/>
@@ -725,7 +725,7 @@ where coalesce(t2.fname, t3.fname) is not null;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1678.860746" Rows="2.250000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1678.285359" Rows="2.250000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="26" Alias="fname">
@@ -740,7 +740,7 @@ where coalesce(t2.fname, t3.fname) is not null;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1678.860738" Rows="2.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1678.285351" Rows="2.250000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="26" Alias="fname">
@@ -756,7 +756,7 @@ where coalesce(t2.fname, t3.fname) is not null;
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1678.860709" Rows="2.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1678.285322" Rows="2.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="26"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinBroadcastTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinBroadcastTableHashSpec.mdp
@@ -367,7 +367,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
     <dxl:Plan Id="0" SpaceSize="130">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000593" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000598" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="11" Alias="b2">
@@ -383,7 +383,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000549" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="b2">
@@ -401,7 +401,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000549" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="11"/>
@@ -424,7 +424,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000534" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000539" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="b2">
@@ -442,7 +442,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000534" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000539" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="b2">
@@ -461,7 +461,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000520" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="11" Alias="b2">
@@ -475,7 +475,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY 
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000520" Rows="1.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="11"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
@@ -355,7 +355,7 @@
     <dxl:Plan Id="0" SpaceSize="131">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="585.939124" Rows="5.000000" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="583.692435" Rows="5.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="c">
@@ -377,7 +377,7 @@
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="585.938495" Rows="5.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="583.691806" Rows="5.000000" Width="28"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="2"/>
@@ -420,7 +420,7 @@
           <dxl:Filter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="585.938366" Rows="11.250000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="583.691677" Rows="11.250000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="2"/>
@@ -447,7 +447,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="585.938226" Rows="11.250000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="583.691537" Rows="11.250000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="c">
@@ -469,7 +469,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="585.936954" Rows="11.250000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="583.690265" Rows="11.250000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="c">
@@ -491,7 +491,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="585.936672" Rows="11.250000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="583.689983" Rows="11.250000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="2" Alias="c">
@@ -508,7 +508,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="585.936672" Rows="11.250000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="583.689983" Rows="11.250000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="2"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -510,7 +510,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
     <dxl:Plan Id="0" SpaceSize="711603200">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2586.144662" Rows="134.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.144639" Rows="134.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -527,7 +527,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2586.132629" Rows="134.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.132606" Rows="134.000000" Width="20"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -548,7 +548,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
           <dxl:Filter/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2586.107307" Rows="134.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.107284" Rows="134.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -917,7 +917,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
             </dxl:Sequence>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.039175" Rows="23.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.039152" Rows="23.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="b">
@@ -1014,7 +1014,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.033807" Rows="23.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.033784" Rows="23.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="b">
@@ -1197,7 +1197,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                 </dxl:Aggregate>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.008553" Rows="23.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.008530" Rows="23.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="32"/>
@@ -1220,7 +1220,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Filter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.008430" Rows="23.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008406" Rows="23.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="32"/>
@@ -1233,7 +1233,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.008358" Rows="23.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008334" Rows="23.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="32" Alias="b">
@@ -1248,7 +1248,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.007439" Rows="23.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.007415" Rows="23.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="32" Alias="b">
@@ -1264,7 +1264,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.007295" Rows="23.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.007271" Rows="23.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="32"/>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -586,7 +586,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13648900">
+    <dxl:Plan Id="0" SpaceSize="25456900">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/MissingBoolColStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MissingBoolColStats.mdp
@@ -197,7 +197,7 @@ select b from foo_bool group by b;
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="436.242410" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="436.167622" Rows="3.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -208,7 +208,7 @@ select b from foo_bool group by b;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="436.242321" Rows="3.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="436.167533" Rows="3.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -221,7 +221,7 @@ select b from foo_bool group by b;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="436.242308" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="436.167520" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="b">
@@ -236,7 +236,7 @@ select b from foo_bool group by b;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="436.242308" Rows="3.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="436.167520" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -252,7 +252,7 @@ select b from foo_bool group by b;
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="436.242283" Rows="3.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="436.167495" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -447,7 +447,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
     <dxl:Plan Id="0" SpaceSize="117">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="199109.213873" Rows="9846.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="198511.250411" Rows="9846.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="k">
@@ -461,7 +461,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="199108.626788" Rows="9846.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="198510.663327" Rows="9846.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="k">
@@ -477,7 +477,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="48914.890287" Rows="3.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="48765.399422" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="k">
@@ -491,7 +491,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
             <dxl:SortingColumnList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="48914.890001" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="48765.399136" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="k">
@@ -505,7 +505,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="48914.890001" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="48765.399136" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="subq">
@@ -613,7 +613,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="11365.140389" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="11327.767672" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -630,7 +630,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
                   <dxl:Filter/>
                   <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="11365.140148" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="11327.767432" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i">
@@ -652,7 +652,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
                     </dxl:HashExprList>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="11365.140142" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="11327.767425" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -598,7 +598,7 @@
     <dxl:Plan Id="0" SpaceSize="166212000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2592.940588" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="department">
@@ -612,7 +612,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2592.974188" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="2592.940534" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="13"/>
@@ -629,7 +629,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2592.974172" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="2592.940519" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="name">
@@ -648,7 +648,7 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="LeftAntiSemiJoin">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2592.974172" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="2592.940519" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="name">
@@ -680,7 +680,7 @@
               </dxl:HashCondList>
               <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1728.648662" Rows="2.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1728.626226" Rows="2.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="name">
@@ -693,7 +693,7 @@
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="864.324319" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.313101" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="13" Alias="name">
@@ -707,7 +707,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="864.324307" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.313089" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="13"/>
@@ -720,7 +720,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.313077" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="13" Alias="name">
@@ -735,7 +735,7 @@
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.313077" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="13" Alias="name">
@@ -751,7 +751,7 @@
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="864.324279" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="864.313061" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="13"/>
@@ -862,7 +862,7 @@
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="864.324319" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.313101" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="35" Alias="name">
@@ -876,7 +876,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="864.324307" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.313089" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="35"/>
@@ -889,7 +889,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.313077" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="35" Alias="name">
@@ -904,7 +904,7 @@
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="864.324294" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.313077" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="35" Alias="name">
@@ -920,7 +920,7 @@
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="864.324279" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="864.313061" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="35"/>
@@ -1032,7 +1032,7 @@
               </dxl:Append>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="864.324286" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="864.313068" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="65" Alias="emp_id">
@@ -1046,7 +1046,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="864.324274" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="864.313056" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="57"/>
@@ -1059,7 +1059,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="864.324262" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="864.313044" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="57" Alias="name">
@@ -1074,7 +1074,7 @@
                     <dxl:LimitOffset/>
                     <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="864.324262" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="864.313044" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="57" Alias="name">
@@ -1090,7 +1090,7 @@
                       </dxl:HashExprList>
                       <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="864.324246" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="864.313028" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="57"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
@@ -341,7 +341,7 @@
     <dxl:Plan Id="0" SpaceSize="108">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000549" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000554" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -355,7 +355,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000478" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000482" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -372,7 +372,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000457" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000462" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -391,7 +391,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000457" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000462" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -413,7 +413,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000426" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000430" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
@@ -427,7 +427,7 @@ GROUP BY b;
     <dxl:Plan Id="0" SpaceSize="257608796160">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.000796" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.000800" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="48" Alias="b">
@@ -441,7 +441,7 @@ GROUP BY b;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.000766" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.000771" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="48" Alias="b">
@@ -455,7 +455,7 @@ GROUP BY b;
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2155.000764" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.000768" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="48"/>
@@ -468,7 +468,7 @@ GROUP BY b;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2155.000759" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.000763" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="48" Alias="b">
@@ -483,7 +483,7 @@ GROUP BY b;
               <dxl:LimitOffset/>
               <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2155.000759" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2155.000763" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="48" Alias="b">
@@ -493,7 +493,7 @@ GROUP BY b;
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="48" Alias="b">
@@ -504,7 +504,7 @@ GROUP BY b;
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="48"/>
@@ -517,7 +517,7 @@ GROUP BY b;
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="48" Alias="b">
@@ -532,7 +532,7 @@ GROUP BY b;
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="48" Alias="b">
@@ -548,7 +548,7 @@ GROUP BY b;
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="48"/>
@@ -606,7 +606,7 @@ GROUP BY b;
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000363" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000365" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="58" Alias="b">
@@ -617,7 +617,7 @@ GROUP BY b;
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000359" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000361" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="58"/>
@@ -630,7 +630,7 @@ GROUP BY b;
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="862.000353" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000355" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="58" Alias="b">
@@ -645,7 +645,7 @@ GROUP BY b;
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="862.000353" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000355" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="58" Alias="b">
@@ -661,7 +661,7 @@ GROUP BY b;
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="862.000347" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="862.000348" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="58"/>
@@ -773,7 +773,7 @@ GROUP BY b;
                 </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000363" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000365" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="77" Alias="b">
@@ -784,7 +784,7 @@ GROUP BY b;
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000359" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000361" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="77"/>
@@ -797,7 +797,7 @@ GROUP BY b;
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="862.000353" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000355" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="77" Alias="b">
@@ -812,7 +812,7 @@ GROUP BY b;
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="862.000353" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000355" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="77" Alias="b">
@@ -828,7 +828,7 @@ GROUP BY b;
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="862.000347" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="862.000348" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="77"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -445,7 +445,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21200">
+    <dxl:Plan Id="0" SpaceSize="106000">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712060318.276298" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
@@ -355,7 +355,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
     <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1325244.228342" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1325233.008439" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="8" Alias="percentile_cont">
@@ -364,7 +364,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="10,11">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1211.960343" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1200.740440" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="a">
@@ -376,7 +376,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1211.960342" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1200.740439" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -390,7 +390,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1211.960297" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="1200.740395" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="10"/>
@@ -413,7 +413,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1211.960283" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1200.740380" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -431,7 +431,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1211.960283" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1200.740380" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="a">
@@ -450,7 +450,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1211.960264" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1200.740361" Rows="1.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -464,7 +464,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1211.960264" Rows="1.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1200.740361" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="10"/>
@@ -634,7 +634,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="ColRef_0036">
-                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0" FuncVariadic="false">
                           <dxl:Ident ColId="35" ColName="ColRef_0035" TypeMdid="0.1700.1.0"/>
                         </dxl:FuncExpr>
                       </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -498,7 +498,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1311240">
+    <dxl:Plan Id="0" SpaceSize="6556200">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1390608583331.788818" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
@@ -436,7 +436,7 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="26">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.268099" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
@@ -651,7 +651,7 @@ union
     <dxl:Plan Id="0" SpaceSize="146760864">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="7327.003324" Rows="2.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="7327.003353" Rows="2.000000" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="35" Alias="district_pop">
@@ -674,7 +674,7 @@ union
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="7327.003001" Rows="2.000000" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="7327.003030" Rows="2.000000" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="35" Alias="population">
@@ -697,7 +697,7 @@ union
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="7327.003001" Rows="2.000000" Width="36"/>
+              <dxl:Cost StartupCost="0" TotalCost="7327.003030" Rows="2.000000" Width="36"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="35" Alias="population">
@@ -872,7 +872,7 @@ union
             </dxl:CTEProducer>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6034.002603" Rows="2.000000" Width="36"/>
+                <dxl:Cost StartupCost="0" TotalCost="6034.002632" Rows="2.000000" Width="36"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="35"/>
@@ -909,7 +909,7 @@ union
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6034.002531" Rows="2.000000" Width="52"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6034.002560" Rows="2.000000" Width="52"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="35" Alias="population">
@@ -948,7 +948,7 @@ union
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6034.002531" Rows="2.000000" Width="52"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6034.002560" Rows="2.000000" Width="52"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="35" Alias="population">
@@ -1000,7 +1000,7 @@ union
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6034.002368" Rows="2.000000" Width="52"/>
+                      <dxl:Cost StartupCost="0" TotalCost="6034.002397" Rows="2.000000" Width="52"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="35"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
@@ -2328,7 +2328,7 @@
     <dxl:Plan Id="0" SpaceSize="812">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1307.986991" Rows="201.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1307.912752" Rows="201.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -2339,7 +2339,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1307.983995" Rows="201.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1307.909756" Rows="201.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -2352,7 +2352,7 @@
           <dxl:Filter/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1307.967784" Rows="400.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1307.893545" Rows="400.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -2399,7 +2399,7 @@
             </dxl:Aggregate>
             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="436.006089" Rows="200.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="435.969063" Rows="200.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="10"/>
@@ -2412,7 +2412,7 @@
               <dxl:Filter/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="435.997909" Rows="200.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="435.960883" Rows="200.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="val">
@@ -2428,7 +2428,7 @@
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="435.997075" Rows="200.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="435.960049" Rows="200.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -2468,7 +2468,7 @@
             </dxl:Aggregate>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="436.001487" Rows="100.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="435.964274" Rows="100.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="18"/>
@@ -2481,7 +2481,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="436.001279" Rows="100.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="435.964066" Rows="100.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="id">
@@ -2496,7 +2496,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="435.997455" Rows="100.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="435.960242" Rows="100.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="id">
@@ -2512,7 +2512,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="435.997037" Rows="100.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="435.959824" Rows="100.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="18"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -695,7 +695,7 @@
     <dxl:Plan Id="0" SpaceSize="17398">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="908.045287" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="907.696995" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="b">
@@ -706,7 +706,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="908.045269" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="907.696977" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -719,7 +719,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="908.045264" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="907.696972" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="one">
@@ -734,7 +734,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="908.045264" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="907.696972" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="one">
@@ -750,7 +750,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="908.045256" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="907.696964" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="9"/>
@@ -763,7 +763,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="908.045251" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="907.696959" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="one">
@@ -778,7 +778,7 @@
                   <dxl:LimitOffset/>
                   <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="908.045251" Rows="2.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="907.696959" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="one">
@@ -789,7 +789,7 @@
                     <dxl:SortingColumnList/>
                     <dxl:Append IsTarget="false" IsZapped="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="908.045229" Rows="2.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="907.696937" Rows="2.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="one">
@@ -799,7 +799,7 @@
                       <dxl:Filter/>
                       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.741665" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.736056" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="9"/>
@@ -812,7 +812,7 @@
                         <dxl:Filter/>
                         <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.741658" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.736050" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="9" Alias="one">
@@ -827,7 +827,7 @@
                           <dxl:LimitOffset/>
                           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.741658" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.736050" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="one">
@@ -843,7 +843,7 @@
                             </dxl:HashExprList>
                             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.741651" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.736042" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns>
                                 <dxl:GroupingColumn ColId="9"/>
@@ -891,7 +891,7 @@
                       </dxl:Aggregate>
                       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="476.303557" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="475.960873" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="19"/>
@@ -904,7 +904,7 @@
                         <dxl:Filter/>
                         <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="476.303550" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="475.960866" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="19" Alias="one">
@@ -919,7 +919,7 @@
                           <dxl:LimitOffset/>
                           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="476.303550" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="475.960866" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="19" Alias="one">
@@ -935,7 +935,7 @@
                             </dxl:HashExprList>
                             <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="476.303542" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="475.960858" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns>
                                 <dxl:GroupingColumn ColId="19"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -695,7 +695,7 @@
     <dxl:Plan Id="0" SpaceSize="17398">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="907.696995" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="907.696996" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="b">
@@ -706,7 +706,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="907.696977" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="907.696978" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -719,7 +719,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="907.696972" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="907.696973" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="one">
@@ -734,7 +734,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="907.696972" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="907.696973" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="one">
@@ -750,7 +750,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="907.696964" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="907.696965" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="9"/>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -888,7 +888,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000302" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000306" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -902,7 +902,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000248" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000252" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -925,7 +925,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000233" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000236" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -943,7 +943,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000233" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000236" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -962,7 +962,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.000209" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000213" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -976,7 +976,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.000209" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.000213" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -1018,7 +1018,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
-                    <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+                    <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="6.000159" Rows="1.000000" Width="24"/>
                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution.mdp
@@ -527,7 +527,7 @@ explain select i, count(j) from pt2 group by i;
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000131" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -541,7 +541,7 @@ explain select i, count(j) from pt2 group by i;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000080" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -564,7 +564,7 @@ explain select i, count(j) from pt2 group by i;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -582,7 +582,7 @@ explain select i, count(j) from pt2 group by i;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -601,7 +601,7 @@ explain select i, count(j) from pt2 group by i;
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -615,7 +615,7 @@ explain select i, count(j) from pt2 group by i;
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -654,7 +654,7 @@ explain select i, count(j) from pt2 group by i;
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
-                    <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                    <dxl:DynamicTableScan SelectorIds="">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
                       </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinTVF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinTVF.mdp
@@ -319,7 +319,7 @@
     <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.266712" Rows="10.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.266353" Rows="10.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="a">
@@ -330,7 +330,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.266563" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.266204" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="3"/>
@@ -343,7 +343,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.266542" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.266183" Rows="10.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="a">
@@ -358,7 +358,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.266410" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.266051" Rows="10.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="a">
@@ -374,7 +374,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.266369" Rows="10.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.266010" Rows="10.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="3"/>

--- a/src/backend/gporca/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
@@ -304,10 +304,10 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
       </dxl:LogicalGet>
     </dxl:LogicalProject>
   </dxl:Query>
-  <dxl:Plan Id="0" SpaceSize="20">
+  <dxl:Plan Id="0" SpaceSize="100">
     <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
       <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="862.000673" Rows="1.000000" Width="8"/>
+        <dxl:Cost StartupCost="0" TotalCost="862.000718" Rows="1.000000" Width="8"/>
       </dxl:Properties>
       <dxl:ProjList>
         <dxl:ProjElem ColId="19" Alias="?column?">
@@ -318,7 +318,7 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
       <dxl:SortingColumnList/>
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000643" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000688" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -332,7 +332,7 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000685" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="ColRef_0020">
@@ -343,7 +343,7 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000635" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000680" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="count">
@@ -383,15 +383,17 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
             </dxl:TableScan>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="9"/>
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                    <dxl:ValuesList ParamType="aggargs"/>
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                    </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
                     <dxl:ValuesList ParamType="aggdistinct"/>
@@ -404,11 +406,14 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="c">
                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -417,29 +422,114 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
                 </dxl:SortingColumnList>
                 <dxl:LimitCount/>
                 <dxl:LimitOffset/>
-                <dxl:TableScan>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="c">
                       <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="c">
+                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="9"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="c">
+                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="c">
+                            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="c">
+                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="c">
+                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
+                              <dxl:Columns>
+                                <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RandomMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
               </dxl:Sort>
             </dxl:Aggregate>
           </dxl:HashJoin>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStar.mdp
@@ -294,10 +294,10 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000585" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000630" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -308,7 +308,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000555" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000600" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="?column?">
@@ -319,7 +319,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000598" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="20" Alias="ColRef_0020">
@@ -330,7 +330,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
             <dxl:OneTimeFilter/>
             <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000547" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000592" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
@@ -362,7 +362,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
               </dxl:TableScan>
               <dxl:Materialize Eager="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000509" Rows="3.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000555" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
@@ -372,7 +372,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                 <dxl:Filter/>
                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000501" Rows="3.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000547" Rows="3.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="count">
@@ -383,7 +383,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000117" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
@@ -392,7 +392,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                     </dxl:ProjList>
                     <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000109" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="count">
@@ -403,7 +403,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                       <dxl:SortingColumnList/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="18" Alias="count">
@@ -414,15 +414,17 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                         <dxl:OneTimeFilter/>
                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="9"/>
                           </dxl:GroupingColumns>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="count">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                                <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                 <dxl:ValuesList ParamType="aggorder"/>
                                 <dxl:ValuesList ParamType="aggdistinct"/>
@@ -435,11 +437,14 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                           <dxl:Filter/>
                           <dxl:Sort SortDiscardDuplicates="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="c">
                                 <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
@@ -448,29 +453,114 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                             </dxl:SortingColumnList>
                             <dxl:LimitCount/>
                             <dxl:LimitOffset/>
-                            <dxl:TableScan>
+                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="c">
                                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
+                                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.922002.1.1" TableName="bar">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="c">
+                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
+                                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                                  </dxl:Properties>
+                                  <dxl:GroupingColumns>
+                                    <dxl:GroupingColumn ColId="9"/>
+                                  </dxl:GroupingColumns>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                        <dxl:ValuesList ParamType="aggargs"/>
+                                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                                        <dxl:ValuesList ParamType="aggorder"/>
+                                        <dxl:ValuesList ParamType="aggdistinct"/>
+                                      </dxl:AggFunc>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="9" Alias="c">
+                                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:Sort SortDiscardDuplicates="false">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="9" Alias="c">
+                                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList>
+                                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    </dxl:SortingColumnList>
+                                    <dxl:LimitCount/>
+                                    <dxl:LimitOffset/>
+                                    <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="9" Alias="c">
+                                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="9" Alias="c">
+                                            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="6.922002.1.1" TableName="bar">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:RandomMotion>
+                                  </dxl:Sort>
+                                </dxl:Aggregate>
+                              </dxl:Result>
+                            </dxl:RedistributeMotion>
                           </dxl:Sort>
                         </dxl:Aggregate>
                       </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -396,10 +396,10 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="464">
+    <dxl:Plan Id="0" SpaceSize="12800">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.000816" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000907" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="29" Alias="?column?">
@@ -410,7 +410,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.000786" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000877" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="29" Alias="?column?">
@@ -424,7 +424,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.000784" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000874" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="ColRef_0030">
@@ -435,7 +435,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.000778" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.000869" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="28" Alias="count">
@@ -475,7 +475,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
               </dxl:TableScan>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000183" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000273" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="e">
@@ -491,15 +491,17 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                 </dxl:JoinFilter>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="19"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="28" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                        </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
                         <dxl:ValuesList ParamType="aggdistinct"/>
@@ -512,11 +514,14 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="e">
                         <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                        <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -525,74 +530,161 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
-                    <dxl:TableScan>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="e">
                           <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                          <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
-                        <dxl:Columns>
-                          <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="e">
+                            <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                            <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="19"/>
+                          </dxl:GroupingColumns>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                <dxl:ValuesList ParamType="aggargs"/>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="19" Alias="e">
+                              <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="19" Alias="e">
+                                <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="19" Alias="e">
+                                  <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="19" Alias="e">
+                                    <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:RandomMotion>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:RedistributeMotion>
                   </dxl:Sort>
                 </dxl:Aggregate>
                 <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000137" Rows="3.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="3.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:Limit>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="9"/>
                             </dxl:GroupingColumns>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="18" Alias="count">
-                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                                  <dxl:ValuesList ParamType="aggargs"/>
+                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                                  </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>
                                   <dxl:ValuesList ParamType="aggdistinct"/>
@@ -605,11 +697,14 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                             <dxl:Filter/>
                             <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="c">
                                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
@@ -618,29 +713,114 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                               </dxl:SortingColumnList>
                               <dxl:LimitCount/>
                               <dxl:LimitOffset/>
-                              <dxl:TableScan>
+                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="12"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="9" Alias="c">
                                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
+                                <dxl:SortingColumnList/>
+                                <dxl:HashExprList>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                </dxl:HashExprList>
+                                <dxl:Result>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="9" Alias="c">
+                                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                      <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:OneTimeFilter/>
+                                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="12"/>
+                                    </dxl:Properties>
+                                    <dxl:GroupingColumns>
+                                      <dxl:GroupingColumn ColId="9"/>
+                                    </dxl:GroupingColumns>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                          <dxl:ValuesList ParamType="aggargs"/>
+                                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                                          <dxl:ValuesList ParamType="aggorder"/>
+                                          <dxl:ValuesList ParamType="aggdistinct"/>
+                                        </dxl:AggFunc>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="9" Alias="c">
+                                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:Sort SortDiscardDuplicates="false">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="9" Alias="c">
+                                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList>
+                                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      </dxl:SortingColumnList>
+                                      <dxl:LimitCount/>
+                                      <dxl:LimitOffset/>
+                                      <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="9" Alias="c">
+                                            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:SortingColumnList/>
+                                        <dxl:TableScan>
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="9" Alias="c">
+                                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
+                                            <dxl:Columns>
+                                              <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                            </dxl:Columns>
+                                          </dxl:TableDescriptor>
+                                        </dxl:TableScan>
+                                      </dxl:RandomMotion>
+                                    </dxl:Sort>
+                                  </dxl:Aggregate>
+                                </dxl:Result>
+                              </dxl:RedistributeMotion>
                             </dxl:Sort>
                           </dxl:Aggregate>
                         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -822,7 +822,7 @@ AND
     <dxl:Plan Id="0" SpaceSize="692">
       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1373.906987" Rows="512.000000" Width="106"/>
+          <dxl:Cost StartupCost="0" TotalCost="1373.907573" Rows="512.000000" Width="106"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="rolname">
@@ -949,7 +949,7 @@ AND
         </dxl:JoinFilter>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="511.683613" Rows="64.000000" Width="82"/>
+            <dxl:Cost StartupCost="0" TotalCost="511.684199" Rows="64.000000" Width="82"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -1110,7 +1110,7 @@ AND
           <dxl:Filter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="511.679624" Rows="10.240000" Width="102"/>
+              <dxl:Cost StartupCost="0" TotalCost="511.680210" Rows="10.240000" Width="102"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -1599,7 +1599,7 @@ AND
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="88" Alias="role_name">
                         <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
-                          <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
+                          <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" FuncVariadic="false">
                             <dxl:Ident ColId="63" ColName="rolname" TypeMdid="0.19.1.0"/>
                           </dxl:FuncExpr>
                         </dxl:CoerceToDomain>
@@ -1617,7 +1617,7 @@ AND
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0" FuncVariadic="false">
                           <dxl:Ident ColId="81" ColName="oid" TypeMdid="0.26.1.0"/>
                           <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
                         </dxl:FuncExpr>
@@ -1712,7 +1712,7 @@ AND
                         </dxl:Cast>
                       </dxl:Comparison>
                     </dxl:IndexCondList>
-	<dxl:Partitions/>
+                    <dxl:Partitions/>
                     <dxl:IndexDescriptor Mdid="0.2676.1.0" IndexName="pg_authid_rolname_index"/>
                     <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
                       <dxl:Columns>
@@ -1815,7 +1815,7 @@ AND
                       <dxl:Ident ColId="18" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:Comparison>
                   </dxl:IndexCondList>
-	<dxl:Partitions/>
+                  <dxl:Partitions/>
                   <dxl:IndexDescriptor Mdid="0.2677.1.0" IndexName="pg_authid_oid_index"/>
                   <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
                     <dxl:Columns>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -676,7 +676,7 @@
     <dxl:Plan Id="0" SpaceSize="1960">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.004114" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.004123" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="30" Alias="s1">
@@ -693,7 +693,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.004025" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.004034" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="30"/>
@@ -714,7 +714,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.004005" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="s1">
@@ -737,7 +737,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.004005" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="s1">
@@ -765,7 +765,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.003959" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.003968" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="30"/>
@@ -882,16 +882,16 @@
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="s1">
-                              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="54">
+                              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" FuncVariadic="false" TypeModifier="54">
                                 <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
                                   <dxl:Coalesce TypeMdid="0.25.1.0">
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                         <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                       </dxl:Cast>
                                     </dxl:FuncExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
+                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                         <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                           <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                         </dxl:Cast>
@@ -906,9 +906,9 @@
                               </dxl:FuncExpr>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="31" Alias="s2">
-                              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="259">
+                              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" FuncVariadic="false" TypeModifier="259">
                                 <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                     <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                       <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
                                     </dxl:Cast>
@@ -943,7 +943,7 @@
                             <dxl:JoinFilter/>
                             <dxl:HashCondList>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                                <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                   <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                     <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                   </dxl:Cast>
@@ -970,8 +970,8 @@
                               <dxl:JoinFilter/>
                               <dxl:HashCondList>
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                    <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
+                                    <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                         <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                       </dxl:Cast>
@@ -979,7 +979,7 @@
                                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                                     </dxl:FuncExpr>
                                   </dxl:FuncExpr>
-                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                     <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                       <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                     </dxl:Cast>
@@ -999,8 +999,8 @@
                                 <dxl:SortingColumnList/>
                                 <dxl:HashExprList>
                                   <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
+                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                         <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                           <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                         </dxl:Cast>
@@ -1022,7 +1022,7 @@
                                   <dxl:Filter>
                                     <dxl:And>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
@@ -1033,7 +1033,7 @@
                                         <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
@@ -1073,7 +1073,7 @@
                                 <dxl:SortingColumnList/>
                                 <dxl:HashExprList>
                                   <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                         <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                       </dxl:Cast>
@@ -1095,7 +1095,7 @@
                                   <dxl:Filter>
                                     <dxl:And>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
@@ -1106,7 +1106,7 @@
                                         <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
@@ -1149,7 +1149,7 @@
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="29" Alias="btrim">
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                       <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                         <dxl:Ident ColId="20" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                       </dxl:Cast>
@@ -1170,7 +1170,7 @@
                                   <dxl:Filter>
                                     <dxl:And>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="21" ColName="att2" TypeMdid="0.1042.1.0" TypeModifier="5"/>
@@ -1181,7 +1181,7 @@
                                         <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Ident ColId="20" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
@@ -383,7 +383,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="35">
+    <dxl:Plan Id="0" SpaceSize="47">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.428517" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -382,7 +382,7 @@
     <dxl:Plan Id="0" SpaceSize="34">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.644735" Rows="2.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.644779" Rows="2.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -399,7 +399,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.644639" Rows="2.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.644682" Rows="2.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -437,7 +437,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.644573" Rows="2.000000" Width="29"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.644617" Rows="2.000000" Width="29"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -486,7 +486,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.644567" Rows="2.000000" Width="39"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -520,7 +520,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.644567" Rows="2.000000" Width="39"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -557,7 +557,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.644445" Rows="2.000000" Width="39"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -586,7 +586,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.644445" Rows="2.000000" Width="39"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -525,7 +525,7 @@
     <dxl:Plan Id="0" SpaceSize="439">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356698083.900615" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356698084.004784" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -553,7 +553,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356698083.900608" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356698084.004777" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -567,7 +567,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356698083.900548" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356698084.004717" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -727,7 +727,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324038.442350" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324038.442452" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -772,7 +772,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324038.442224" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324038.442326" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -803,7 +803,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324038.441496" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324038.441598" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -837,7 +837,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324038.441314" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -863,7 +863,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324038.441314" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -598,7 +598,7 @@
     <dxl:Plan Id="0" SpaceSize="449">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356695750.944685" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356695751.048855" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -626,7 +626,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356695750.944678" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356695751.048847" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="52" Alias="ColRef_0052">
@@ -640,7 +640,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356695750.944618" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356695751.048788" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -800,7 +800,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164175" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -845,7 +845,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.164048" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -876,7 +876,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163321" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -910,7 +910,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -936,7 +936,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -665,7 +665,7 @@
     <dxl:Plan Id="0" SpaceSize="3143">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712065392.494522" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712065392.598691" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -693,7 +693,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712065392.494514" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712065392.598684" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="61" Alias="ColRef_0061">
@@ -707,7 +707,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2712065392.494455" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2712065392.598624" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -946,7 +946,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164175" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -991,7 +991,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.164048" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -1022,7 +1022,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163321" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -1056,7 +1056,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -1082,7 +1082,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
@@ -407,7 +407,7 @@
     <dxl:Plan Id="0" SpaceSize="134">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.002549" Rows="10.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002553" Rows="10.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="c">
@@ -420,7 +420,7 @@
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.002369" Rows="10.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002374" Rows="10.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="c">
@@ -435,7 +435,7 @@
           <dxl:LimitOffset/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.002106" Rows="10.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.002111" Rows="10.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="c">
@@ -456,7 +456,7 @@
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.002086" Rows="10.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.002091" Rows="10.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -523,7 +523,7 @@
               </dxl:RedistributeMotion>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000467" Rows="2.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000472" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="10"/>
@@ -532,7 +532,7 @@
                   <dxl:ProjElem ColId="18" Alias="max">
                     <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -546,7 +546,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000455" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000459" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="j">
@@ -564,7 +564,7 @@
                   <dxl:LimitOffset/>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000455" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000459" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="j">
@@ -583,7 +583,7 @@
                     </dxl:HashExprList>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000429" Rows="2.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000434" Rows="2.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="j">
@@ -597,7 +597,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000429" Rows="2.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000434" Rows="2.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns>
                           <dxl:GroupingColumn ColId="10"/>
@@ -606,7 +606,7 @@
                           <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                             <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                               <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                               </dxl:ValuesList>
                               <dxl:ValuesList ParamType="aggdirectargs"/>
                               <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
@@ -273,7 +273,7 @@
     <dxl:Plan Id="0" SpaceSize="51">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="579.912290" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="578.788946" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -284,7 +284,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="579.912146" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="578.788802" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -295,7 +295,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="579.912146" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="578.788802" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -304,7 +304,7 @@
               <dxl:ProjElem ColId="10" Alias="sum">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -318,7 +318,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="579.912092" Rows="11.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="578.788748" Rows="11.250000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -335,7 +335,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="579.912022" Rows="11.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="578.788678" Rows="11.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -354,7 +354,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="579.911386" Rows="11.250000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="578.788042" Rows="11.250000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -373,7 +373,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="579.911246" Rows="11.250000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="578.787901" Rows="11.250000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
@@ -263,7 +263,7 @@
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="507.148946" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="506.587261" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -274,7 +274,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="507.148802" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="506.587117" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -285,7 +285,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="507.148802" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="506.587117" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -294,7 +294,7 @@
               <dxl:ProjElem ColId="10" Alias="sum">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -308,7 +308,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="507.148785" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="506.587100" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -321,7 +321,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="507.148772" Rows="4.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="506.587088" Rows="4.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -336,7 +336,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="507.148727" Rows="4.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="506.587043" Rows="4.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -352,7 +352,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="507.148702" Rows="4.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="506.587018" Rows="4.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
@@ -263,7 +263,7 @@
     <dxl:Plan Id="0" SpaceSize="42">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="572.182779" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="571.059435" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -274,7 +274,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="572.182635" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="571.059291" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -285,7 +285,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="572.182635" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="571.059291" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -294,7 +294,7 @@
               <dxl:ProjElem ColId="10" Alias="sum">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -308,7 +308,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="572.182581" Rows="11.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="571.059237" Rows="11.250000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="1"/>
@@ -325,7 +325,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="572.182511" Rows="11.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="571.059167" Rows="11.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
@@ -344,7 +344,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="572.181875" Rows="11.250000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="571.058531" Rows="11.250000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -363,7 +363,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="572.181734" Rows="11.250000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="571.058390" Rows="11.250000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -14884,7 +14884,7 @@ with results as
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="21917.445554" Rows="20.062500" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="21917.445999" Rows="20.062500" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="842" Alias="total_sum">
@@ -14907,7 +14907,7 @@ with results as
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="21917.445554" Rows="20.062500" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="21917.445999" Rows="20.062500" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="842" Alias="sum">
@@ -14937,7 +14937,7 @@ with results as
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="21917.443486" Rows="20.062500" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="21917.443930" Rows="20.062500" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="842" Alias="sum">
@@ -14969,7 +14969,7 @@ with results as
             <dxl:LimitOffset/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21917.443486" Rows="20.062500" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="21917.443930" Rows="20.062500" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -15687,7 +15687,7 @@ with results as
               </dxl:CTEProducer>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="20.062500" Width="44"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000996" Rows="20.062500" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="842" Alias="sum">
@@ -15720,7 +15720,7 @@ with results as
                 <dxl:OneTimeFilter/>
                 <dxl:Window PartitionColumns="847,1477">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.000524" Rows="20.062500" Width="31"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000968" Rows="20.062500" Width="31"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1478" Alias="rank">
@@ -15745,7 +15745,7 @@ with results as
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000949" Rows="20.062500" Width="31"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -15774,7 +15774,7 @@ with results as
                     <dxl:LimitOffset/>
                     <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000949" Rows="20.062500" Width="31"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="842" Alias="sum">
@@ -15805,7 +15805,7 @@ with results as
                       </dxl:HashExprList>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000888" Rows="20.062500" Width="31"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="842" Alias="sum">
@@ -15828,7 +15828,7 @@ with results as
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000888" Rows="20.062500" Width="31"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1477" Alias="?column?">
@@ -15858,7 +15858,7 @@ with results as
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.000424" Rows="20.062500" Width="34"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.000869" Rows="20.062500" Width="34"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="842"/>
@@ -15891,7 +15891,7 @@ with results as
                             <dxl:Filter/>
                             <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1293.000819" Rows="20.062500" Width="38"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -15926,7 +15926,7 @@ with results as
                               <dxl:LimitOffset/>
                               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1293.000819" Rows="20.062500" Width="38"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="842" Alias="sum">
@@ -15972,7 +15972,7 @@ with results as
                                 </dxl:HashExprList>
                                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1293.000289" Rows="20.062500" Width="38"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="1293.000733" Rows="20.062500" Width="38"/>
                                   </dxl:Properties>
                                   <dxl:GroupingColumns>
                                     <dxl:GroupingColumn ColId="842"/>
@@ -16005,7 +16005,7 @@ with results as
                                   <dxl:Filter/>
                                   <dxl:Sort SortDiscardDuplicates="false">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="1293.000281" Rows="20.062500" Width="38"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -16040,7 +16040,7 @@ with results as
                                     <dxl:LimitOffset/>
                                     <dxl:Append IsTarget="false" IsZapped="false">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="1293.000281" Rows="20.062500" Width="38"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="842" Alias="sum">
@@ -16114,7 +16114,7 @@ with results as
                                       </dxl:Result>
                                       <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="5.000000" Width="31"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="5.000000" Width="31"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="1259" Alias="sum">
@@ -16140,7 +16140,7 @@ with results as
                                         <dxl:OneTimeFilter/>
                                         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="5.000000" Width="11"/>
                                           </dxl:Properties>
                                           <dxl:GroupingColumns>
                                             <dxl:GroupingColumn ColId="1053"/>
@@ -16163,7 +16163,7 @@ with results as
                                           <dxl:Filter/>
                                           <dxl:Sort SortDiscardDuplicates="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
                                               <dxl:ProjElem ColId="1053" Alias="s_state">
@@ -16181,7 +16181,7 @@ with results as
                                             <dxl:LimitOffset/>
                                             <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="1053" Alias="s_state">
@@ -16200,7 +16200,7 @@ with results as
                                               </dxl:HashExprList>
                                               <dxl:Result>
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="1053" Alias="s_state">
@@ -16214,7 +16214,7 @@ with results as
                                                 <dxl:OneTimeFilter/>
                                                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
                                                   </dxl:Properties>
                                                   <dxl:GroupingColumns>
                                                     <dxl:GroupingColumn ColId="1053"/>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -14884,7 +14884,7 @@ with results as
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="21949.250066" Rows="20.062500" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="21917.445554" Rows="20.062500" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="842" Alias="total_sum">
@@ -14907,7 +14907,7 @@ with results as
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="21949.250066" Rows="20.062500" Width="36"/>
+            <dxl:Cost StartupCost="0" TotalCost="21917.445554" Rows="20.062500" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="842" Alias="sum">
@@ -14937,7 +14937,7 @@ with results as
           </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="21949.247997" Rows="20.062500" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="21917.443486" Rows="20.062500" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="842" Alias="sum">
@@ -14969,7 +14969,7 @@ with results as
             <dxl:LimitOffset/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21949.247997" Rows="20.062500" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="21917.443486" Rows="20.062500" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="842" Alias="sum">
@@ -14993,7 +14993,7 @@ with results as
               </dxl:ProjList>
               <dxl:CTEProducer CTEId="0" Columns="204,89,88,205,206">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20656.247418" Rows="14.062500" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="20624.442907" Rows="14.062500" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="204" Alias="sum">
@@ -15014,7 +15014,7 @@ with results as
                 </dxl:ProjList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="20656.247418" Rows="14.062500" Width="32"/>
+                    <dxl:Cost StartupCost="0" TotalCost="20624.442906" Rows="14.062500" Width="32"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="204" Alias="sum">
@@ -15037,7 +15037,7 @@ with results as
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="20656.247404" Rows="14.062500" Width="26"/>
+                      <dxl:Cost StartupCost="0" TotalCost="20624.442892" Rows="14.062500" Width="26"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="89"/>
@@ -15047,7 +15047,7 @@ with results as
                       <dxl:ProjElem ColId="204" Alias="sum">
                         <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
+                            <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -15064,7 +15064,7 @@ with results as
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="20656.247371" Rows="14.062500" Width="26"/>
+                        <dxl:Cost StartupCost="0" TotalCost="20624.442860" Rows="14.062500" Width="26"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15086,7 +15086,7 @@ with results as
                       <dxl:LimitOffset/>
                       <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="20656.247371" Rows="14.062500" Width="26"/>
+                          <dxl:Cost StartupCost="0" TotalCost="20624.442860" Rows="14.062500" Width="26"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15111,7 +15111,7 @@ with results as
                         </dxl:HashExprList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="20656.247324" Rows="14.062500" Width="26"/>
+                            <dxl:Cost StartupCost="0" TotalCost="20624.442812" Rows="14.062500" Width="26"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="88" Alias="s_county">
@@ -15128,7 +15128,7 @@ with results as
                           <dxl:OneTimeFilter/>
                           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="20656.247324" Rows="14.062500" Width="26"/>
+                              <dxl:Cost StartupCost="0" TotalCost="20624.442812" Rows="14.062500" Width="26"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="89"/>
@@ -15138,7 +15138,7 @@ with results as
                               <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
                                 <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                   <dxl:ValuesList ParamType="aggargs">
-                                  <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                    <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
                                   </dxl:ValuesList>
                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -15155,7 +15155,7 @@ with results as
                             <dxl:Filter/>
                             <dxl:HashJoin JoinType="Inner">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="20119.800634" Rows="67819601.064540" Width="26"/>
+                                <dxl:Cost StartupCost="0" TotalCost="20103.452432" Rows="67819601.064540" Width="26"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="22" Alias="ss_net_profit">
@@ -15273,7 +15273,7 @@ with results as
                               </dxl:HashJoin>
                               <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="10825.822451" Rows="4147.200000" Width="22"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="10809.474248" Rows="4147.200000" Width="22"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15290,7 +15290,7 @@ with results as
                                 <dxl:SortingColumnList/>
                                 <dxl:HashJoin JoinType="In">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="10825.814178" Rows="129.600000" Width="22"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="10809.465975" Rows="129.600000" Width="22"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="65" Alias="s_store_sk">
@@ -15344,7 +15344,7 @@ with results as
                                   </dxl:TableScan>
                                   <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="10394.806977" Rows="64.000000" Width="3"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="10378.458774" Rows="64.000000" Width="3"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15355,7 +15355,7 @@ with results as
                                     <dxl:SortingColumnList/>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="10394.806698" Rows="2.000000" Width="3"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="10378.458496" Rows="2.000000" Width="3"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15371,7 +15371,7 @@ with results as
                                       <dxl:OneTimeFilter/>
                                       <dxl:Window PartitionColumns="155">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="10394.806665" Rows="5.000000" Width="11"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="10378.458463" Rows="5.000000" Width="11"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="203" Alias="ranking">
@@ -15387,7 +15387,7 @@ with results as
                                         <dxl:Filter/>
                                         <dxl:Sort SortDiscardDuplicates="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="10394.806654" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="10378.458452" Rows="5.000000" Width="11"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="202" Alias="att_2">
@@ -15406,7 +15406,7 @@ with results as
                                           <dxl:LimitOffset/>
                                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="10394.806654" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="10378.458452" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns>
                                               <dxl:GroupingColumn ColId="155"/>
@@ -15415,7 +15415,7 @@ with results as
                                               <dxl:ProjElem ColId="202" Alias="att_2">
                                                 <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                                                   <dxl:ValuesList ParamType="aggargs">
-                                                  <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                    <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
                                                   </dxl:ValuesList>
                                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -15429,7 +15429,7 @@ with results as
                                             <dxl:Filter/>
                                             <dxl:Sort SortDiscardDuplicates="false">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="10394.806637" Rows="5.000000" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="10378.458435" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15447,7 +15447,7 @@ with results as
                                               <dxl:LimitOffset/>
                                               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="10394.806637" Rows="5.000000" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="10378.458435" Rows="5.000000" Width="11"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
                                                   <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15466,7 +15466,7 @@ with results as
                                                 </dxl:HashExprList>
                                                 <dxl:Result>
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="10394.806624" Rows="5.000000" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="10378.458422" Rows="5.000000" Width="11"/>
                                                   </dxl:Properties>
                                                   <dxl:ProjList>
                                                     <dxl:ProjElem ColId="155" Alias="s_state">
@@ -15480,7 +15480,7 @@ with results as
                                                   <dxl:OneTimeFilter/>
                                                   <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                                     <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="10394.806624" Rows="5.000000" Width="11"/>
+                                                      <dxl:Cost StartupCost="0" TotalCost="10378.458422" Rows="5.000000" Width="11"/>
                                                     </dxl:Properties>
                                                     <dxl:GroupingColumns>
                                                       <dxl:GroupingColumn ColId="155"/>
@@ -15489,7 +15489,7 @@ with results as
                                                       <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
                                                         <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                                           <dxl:ValuesList ParamType="aggargs">
-                                                          <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                            <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
                                                           </dxl:ValuesList>
                                                           <dxl:ValuesList ParamType="aggdirectargs"/>
                                                           <dxl:ValuesList ParamType="aggorder"/>
@@ -16149,7 +16149,7 @@ with results as
                                             <dxl:ProjElem ColId="1259" Alias="sum">
                                               <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                                                 <dxl:ValuesList ParamType="aggargs">
-                                                <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                                  <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
                                                 </dxl:ValuesList>
                                                 <dxl:ValuesList ParamType="aggdirectargs"/>
                                                 <dxl:ValuesList ParamType="aggorder"/>
@@ -16223,7 +16223,7 @@ with results as
                                                     <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
                                                       <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                                         <dxl:ValuesList ParamType="aggargs">
-                                                        <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                          <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
                                                         </dxl:ValuesList>
                                                         <dxl:ValuesList ParamType="aggdirectargs"/>
                                                         <dxl:ValuesList ParamType="aggorder"/>
@@ -16337,7 +16337,7 @@ with results as
                                               <dxl:ProjElem ColId="1471" Alias="sum">
                                                 <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                                                   <dxl:ValuesList ParamType="aggargs">
-                                                  <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
+                                                    <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
                                                   </dxl:ValuesList>
                                                   <dxl:ValuesList ParamType="aggdirectargs"/>
                                                   <dxl:ValuesList ParamType="aggorder"/>
@@ -16366,7 +16366,7 @@ with results as
                                                   <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
                                                     <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                                                       <dxl:ValuesList ParamType="aggargs">
-                                                      <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                        <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
                                                       </dxl:ValuesList>
                                                       <dxl:ValuesList ParamType="aggdirectargs"/>
                                                       <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -290,7 +290,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
     <dxl:Plan Id="0" SpaceSize="2958">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001805" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001808" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="f3">
@@ -301,7 +301,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.001776" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001779" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="2"/>
@@ -314,7 +314,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.001766" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001769" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="f3">
@@ -329,7 +329,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.001766" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.001769" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="2" Alias="f3">
@@ -345,7 +345,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.001753" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001756" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="2"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-Over-UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Over-UnionAll.mdp
@@ -304,7 +304,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
     <dxl:Plan Id="0" SpaceSize="696">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001535" Rows="11.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001552" Rows="11.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -315,7 +315,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001371" Rows="11.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001388" Rows="11.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -328,7 +328,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001348" Rows="11.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001365" Rows="11.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -343,7 +343,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001192" Rows="11.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001209" Rows="11.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -359,7 +359,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.001146" Rows="11.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001163" Rows="11.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
@@ -236,7 +236,7 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16458">
+    <dxl:Plan Id="0" SpaceSize="64620">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithCTE.mdp
@@ -279,10 +279,10 @@
         </dxl:UnionAll>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000263" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000308" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="id">
@@ -299,7 +299,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000203" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000249" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="id">
@@ -314,7 +314,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="0,9">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -326,7 +326,7 @@
             </dxl:ProjList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -336,9 +336,9 @@
                   <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="c">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -349,11 +349,14 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="id">
                     <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                    <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -362,29 +365,116 @@
                 </dxl:SortingColumnList>
                 <dxl:LimitCount/>
                 <dxl:LimitOffset/>
-                <dxl:TableScan>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="id">
                       <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                      <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.81932.1.0" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="id">
+                        <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                        <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="0"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="0" Alias="id">
+                          <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="id">
+                            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="id">
+                              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="id">
+                                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.81932.1.0" TableName="t1">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RandomMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
               </dxl:Sort>
             </dxl:Aggregate>
           </dxl:CTEProducer>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1282,7 +1282,7 @@ WHERE
     <dxl:Plan Id="0" SpaceSize="51358">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="1306.828702" Rows="199.680000" Width="148"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="oid">
@@ -1305,7 +1305,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1306.714368" Rows="199.680000" Width="148"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.718569" Rows="199.680000" Width="148"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="oid">
@@ -1336,7 +1336,7 @@ WHERE
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1306.698971" Rows="702.000000" Width="150"/>
+              <dxl:Cost StartupCost="0" TotalCost="1306.703172" Rows="702.000000" Width="150"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="ColRef_0073">
@@ -1365,7 +1365,7 @@ WHERE
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1306.663871" Rows="702.000000" Width="158"/>
+                <dxl:Cost StartupCost="0" TotalCost="1306.668072" Rows="702.000000" Width="158"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="amname">
@@ -1554,7 +1554,7 @@ WHERE
                           <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                         </dxl:Comparison>
                       </dxl:IndexCondList>
-	<dxl:Partitions/>
+                      <dxl:Partitions/>
                       <dxl:IndexDescriptor Mdid="0.2686.1.0" IndexName="pg_opclass_am_name_nsp_index"/>
                       <dxl:TableDescriptor Mdid="6.2616.1.1" TableName="pg_opclass">
                         <dxl:Columns>
@@ -1603,7 +1603,7 @@ WHERE
               </dxl:RedistributeMotion>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.176521" Rows="702.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="60"/>
@@ -1613,7 +1613,7 @@ WHERE
                   <dxl:ProjElem ColId="72" Alias="count">
                     <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                        <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -1630,7 +1630,7 @@ WHERE
                 <dxl:Filter/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.117422" Rows="702.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1655,7 +1655,7 @@ WHERE
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.105703" Rows="702.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1672,7 +1672,7 @@ WHERE
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.105703" Rows="702.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="60"/>

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -623,12 +623,13 @@ CCostModelGPDB::CostStreamAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	DOUBLE num_input_rows = pci->PdRows()[0];  // estimated input rows
 	DOUBLE dWidthOuter = pci->GetWidth()[0];
 
-	// To improve the local stream aggregation cost, we compute the
-	// cardinality out by multiplying the number of output rows
-	// (num_output_rows) with the number of segments.  This decision takes
-	// into account the uncertainty in the order of tuples received by
-	// local stream aggregation, leading to more accurate estimations in
-	// the query execution plan.
+	//To improve the local stream aggregation cost, by considering the
+	//uncertainty in the order of tuples received by local hash agg, which
+	//can affect the cardinality. We set the cardinality out as an upper
+	//bound for the number of output rows. This is achieved by multiplying
+	//the number of output rows (num_output_rows) with the number of
+	//segments.
+
 	DOUBLE num_output_rows = pci->Rows();  // estimated output rows
 	CPhysicalStreamAgg *popAgg = CPhysicalStreamAgg::PopConvert(exprhdl.Pop());
 	if ((COperator::EgbaggtypeLocal == popAgg->Egbaggtype()) &&
@@ -806,12 +807,13 @@ CCostModelGPDB::CostHashAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	// by grouping columns, which allows it to complete all local aggregation in memory and produce exactly tuples as
 	// the number of groups.
 	//
-	// To improve the local hash aggregation cost, we compute the
-	// cardinality out by multiplying the number of output rows
-	// (num_output_rows) with the number of segments.  This decision takes
-	// into account the uncertainty in the order of tuples received by
-	// local hash aggregation, leading to more accurate estimations in the
-	// query execution plan.
+	//To improve the local hash aggregation cost, by considering the
+	//uncertainty in the order of tuples received by local hash agg, which
+	//can affect the cardinality. We set the cardinality out as an upper
+	//bound for the number of output rows. This is achieved by multiplying
+	//the number of output rows (num_output_rows) with the number of
+	//segments.
+
 	DOUBLE num_output_rows = pci->Rows();  // estimated output rows
 	CPhysicalHashAgg *popAgg = CPhysicalHashAgg::PopConvert(exprhdl.Pop());
 	if ((COperator::EgbaggtypeLocal == popAgg->Egbaggtype()) &&

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -623,12 +623,12 @@ CCostModelGPDB::CostStreamAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	DOUBLE num_input_rows = pci->PdRows()[0];  // estimated input rows
 	DOUBLE dWidthOuter = pci->GetWidth()[0];
 
-	//To improve the local stream aggregation cost, by considering the
-	//uncertainty in the order of tuples received by local hash agg, which
-	//can affect the cardinality. We set the cardinality out as an upper
-	//bound for the number of output rows. This is achieved by multiplying
-	//the number of output rows (num_output_rows) with the number of
-	//segments.
+	// To improve the local stream aggregation cost, by considering the
+	// uncertainty in the order of tuples received by local hash agg, which
+	// can affect the cardinality. We set the cardinality out as an upper
+	// bound for the number of output rows. This is achieved by multiplying
+	// the number of output rows (num_output_rows) with the number of
+	// segments.
 
 	DOUBLE num_output_rows = pci->Rows();  // estimated output rows
 	CPhysicalStreamAgg *popAgg = CPhysicalStreamAgg::PopConvert(exprhdl.Pop());
@@ -807,12 +807,12 @@ CCostModelGPDB::CostHashAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	// by grouping columns, which allows it to complete all local aggregation in memory and produce exactly tuples as
 	// the number of groups.
 	//
-	//To improve the local hash aggregation cost, by considering the
-	//uncertainty in the order of tuples received by local hash agg, which
-	//can affect the cardinality. We set the cardinality out as an upper
-	//bound for the number of output rows. This is achieved by multiplying
-	//the number of output rows (num_output_rows) with the number of
-	//segments.
+	// To improve the local hash aggregation cost, by considering the
+	// uncertainty in the order of tuples received by local hash agg, which
+	// can affect the cardinality. We set the cardinality out as an upper
+	// bound for the number of output rows. This is achieved by multiplying
+	// the number of output rows (num_output_rows) with the number of
+	// segments.
 
 	DOUBLE num_output_rows = pci->Rows();  // estimated output rows
 	CPhysicalHashAgg *popAgg = CPhysicalHashAgg::PopConvert(exprhdl.Pop());

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -793,13 +793,13 @@ CCostModelGPDB::CostHashAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	// Since we do not know the order of tuples received by local hash agg, we assume the number of output rows from local
 	// agg is the average between input and output rows
 
-	// the cardinality out as (rows + num_rows_outer)/2 to increase the local hash agg cost
+	// the cardinality out as rows * number_of_segments to increase the local hash agg cost
 	DOUBLE rows = pci->Rows();
 	CPhysicalHashAgg *popAgg = CPhysicalHashAgg::PopConvert(exprhdl.Pop());
 	if ((COperator::EgbaggtypeLocal == popAgg->Egbaggtype()) &&
 		popAgg->FGeneratesDuplicates())
 	{
-		rows = (rows + num_rows_outer) / 2.0;
+		rows = rows * pcmgpdb->UlHosts();
 	}
 
 	// get the number of grouping columns

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2326,7 +2326,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/spilling_hashagg_optimizer.out
+++ b/src/test/isolation2/expected/spilling_hashagg_optimizer.out
@@ -41,18 +41,16 @@ SET
 CREATE TABLE test_hashagg_off AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 SELECT 100
 EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
- QUERY PLAN                                       
---------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)         
-   ->  GroupAggregate                             
-         Group Key: a                             
-         ->  GroupAggregate                       
-               Group Key: a, b                    
-               ->  Sort                           
-                     Sort Key: a, b               
-                     ->  Seq Scan on test_src_tbl 
- Optimizer: Pivotal Optimizer (GPORCA)            
-(9 rows)
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  GroupAggregate                       
+         Group Key: a                       
+         ->  Sort                           
+               Sort Key: a                  
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)      
+(7 rows)
 
 -- Results should match
 SELECT (n_total=n_matches) AS match FROM ( SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches FROM test_hashagg_on t1 JOIN test_hashagg_off t2 ON t1.a = t2.a) t;

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1267,13 +1267,9 @@ explain (costs off) select a,c from t1 group by a,c,d;
                Sort Key: a, c, d
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: a, c, d
-                     ->  GroupAggregate
-                           Group Key: a, c, d
-                           ->  Sort
-                                 Sort Key: a, c, d
-                                 ->  Seq Scan on t1
+                     ->  Seq Scan on t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 -- Test removal across multiple relations
 explain (costs off) select *

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1729,24 +1729,22 @@ SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GR
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: pagg_tab1.x, pagg_tab2.y
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: pagg_tab1.x, pagg_tab2.y
-               ->  Streaming Partial HashAggregate
-                     Group Key: pagg_tab1.x, pagg_tab2.y
-                     ->  Merge Full Join
-                           Merge Cond: (pagg_tab1.x = pagg_tab2.y)
-                           ->  Sort
-                                 Sort Key: pagg_tab1.x
-                                 ->  Seq Scan on pagg_tab1
-                           ->  Sort
-                                 Sort Key: pagg_tab2.y
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: pagg_tab2.y
-                                       ->  Seq Scan on pagg_tab2
+               ->  Merge Full Join
+                     Merge Cond: (pagg_tab1.x = pagg_tab2.y)
+                     ->  Sort
+                           Sort Key: pagg_tab1.x
+                           ->  Seq Scan on pagg_tab1
+                     ->  Sort
+                           Sort Key: pagg_tab2.y
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: pagg_tab2.y
+                                 ->  Seq Scan on pagg_tab2
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(16 rows)
 
 SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
  x  | y  | count 
@@ -1997,19 +1995,15 @@ explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  GroupAggregate
          Group Key: gp_segment_id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: gp_segment_id
-               ->  GroupAggregate
-                     Group Key: gp_segment_id, b
-                     ->  Sort
-                           Sort Key: gp_segment_id, b
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: gp_segment_id, b, b
-                                 ->  Seq Scan on t
+         ->  Sort
+               Sort Key: gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: gp_segment_id
+                     ->  Seq Scan on t
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
  count | gp_segment_id 

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -129,27 +129,26 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                       Join Filter: true
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                             Number of partitions to scan: 21 (out of 21)
-                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                             Filter: (id = bfv_tab2_dimtabl1.id)
-                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
+         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                           Hash Key: bfv_tab2_facttable1.wk_id
+                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                       Number of partitions to scan: 21 (out of 21)
+                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                       Filter: (id = bfv_tab2_dimtabl1.id)
+                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
@@ -157,27 +156,26 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                       Join Filter: true
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                             Number of partitions to scan: 21 (out of 21)
-                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                             Filter: (id = bfv_tab2_dimtabl1.id)
-                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
+         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                           Hash Key: bfv_tab2_facttable1.wk_id
+                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                       Number of partitions to scan: 21 (out of 21)
+                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                       Filter: (id = bfv_tab2_dimtabl1.id)
+                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
@@ -1130,15 +1128,14 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
 insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
 explain select count(*) from bfv_index_only_ao where a < 100;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
-                     Filter: (a < 100)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 100)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 select count(*) from bfv_index_only_ao where a < 100;
  count 
@@ -1147,15 +1144,14 @@ select count(*) from bfv_index_only_ao where a < 100;
 (1 row)
 
 explain select count(*) from bfv_index_only_ao where a < 1000;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
-                     Filter: (a < 1000)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 1000)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 select count(*) from bfv_index_only_ao where a < 1000;
  count 
@@ -1169,15 +1165,14 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
 insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
 explain select count(*) from bfv_index_only_aocs where a < 100;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
-                     Filter: (a < 100)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 100)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 select count(*) from bfv_index_only_aocs where a < 100;
  count 
@@ -1186,15 +1181,14 @@ select count(*) from bfv_index_only_aocs where a < 100;
 (1 row)
 
 explain select count(*) from bfv_index_only_aocs where a < 1000;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
-                     Filter: (a < 1000)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 1000)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 select count(*) from bfv_index_only_aocs where a < 1000;
  count 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -956,13 +956,12 @@ explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                           ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(9 rows)
 
 --
 -- Test for wrong results in window functions under joins #1

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -469,28 +469,22 @@ explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn
                      ->  Sort
                            Sort Key: share0_ref2.cn, share0_ref2.vn, share0_ref2.pn
                            ->  Shared Scan (share slice:id 1:0)
-               ->  Finalize GroupAggregate
+               ->  GroupAggregate
                      Group Key: share0_ref3.cn, share0_ref3.vn
                      ->  Sort
                            Sort Key: share0_ref3.cn, share0_ref3.vn
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: share0_ref3.cn, share0_ref3.vn
-                                 ->  Partial GroupAggregate
-                                       Group Key: share0_ref3.cn, share0_ref3.vn
-                                       ->  Sort
-                                             Sort Key: share0_ref3.cn, share0_ref3.vn
-                                             ->  Shared Scan (share slice:id 2:0)
-               ->  Finalize GroupAggregate
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 2:0)
+               ->  GroupAggregate
                      Group Key: share0_ref4.cn
                      ->  Sort
                            Sort Key: share0_ref4.cn
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: share0_ref4.cn
-                                 ->  Partial GroupAggregate
-                                       Group Key: share0_ref4.cn
-                                       ->  Sort
-                                             Sort Key: share0_ref4.cn
-                                             ->  Shared Scan (share slice:id 3:0)
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 3:0)
                ->  Result
                      ->  Redistribute Motion 1:3  (slice4)
                            ->  Finalize Aggregate
@@ -498,7 +492,7 @@ explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn
                                        ->  Partial Aggregate
                                              ->  Shared Scan (share slice:id 5:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(39 rows)
+(33 rows)
 
 select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
  cn | vn | pn  |   sum   
@@ -563,30 +557,24 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
                            Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                 ->  GroupAggregate
-                                       Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                       ->  Sort
-                                             Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                             ->  Shared Scan (share slice:id 3:0)
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 3:0)
                ->  GroupAggregate
                      Group Key: share0_ref4.dt, share0_ref4.cn
                      ->  Sort
                            Sort Key: share0_ref4.dt, share0_ref4.cn
                            ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                  Hash Key: share0_ref4.dt, share0_ref4.cn
-                                 ->  GroupAggregate
-                                       Group Key: share0_ref4.dt, share0_ref4.cn
-                                       ->  Sort
-                                             Sort Key: share0_ref4.dt, share0_ref4.cn
-                                             ->  Shared Scan (share slice:id 4:0)
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 4:0)
                ->  Result
                      ->  Redistribute Motion 1:3  (slice5)
                            ->  Aggregate
                                  ->  Gather Motion 3:1  (slice6; segments: 3)
-                                       ->  Aggregate
+                                       ->  Result
                                              ->  Shared Scan (share slice:id 6:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(45 rows)
+(39 rows)
 
 SELECT sale.vn
 FROM sale,vendor
@@ -644,53 +632,43 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
                Sort Key: share0_ref2.vn
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: share0_ref2.vn
-                     ->  GroupAggregate
-                           Group Key: share0_ref2.vn
-                           ->  Sort
-                                 Sort Key: share0_ref2.vn
-                                 ->  Sequence
-                                       ->  Shared Scan (share slice:id 2:0)
-                                             ->  Nested Loop
-                                                   Join Filter: true
-                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                                         Hash Key: sale.vn
-                                                         ->  Seq Scan on sale
-                                                   ->  Index Scan using vendor_pkey on vendor
-                                                         Index Cond: (vn = sale.vn)
-                                       ->  Append
-                                             ->  GroupAggregate
-                                                   Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                                                   ->  Sort
-                                                         Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                                                         ->  Shared Scan (share slice:id 2:0)
-                                             ->  GroupAggregate
-                                                   Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                   ->  Sort
-                                                         Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                               Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                               ->  GroupAggregate
-                                                                     Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                                     ->  Sort
-                                                                           Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                                           ->  Shared Scan (share slice:id 4:0)
-                                             ->  GroupAggregate
-                                                   Group Key: share0_ref4.dt, share0_ref4.cn
-                                                   ->  Sort
-                                                         Sort Key: share0_ref4.dt, share0_ref4.cn
-                                                         ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                                               Hash Key: share0_ref4.dt, share0_ref4.cn
-                                                               ->  GroupAggregate
-                                                                     Group Key: share0_ref4.dt, share0_ref4.cn
-                                                                     ->  Sort
-                                                                           Sort Key: share0_ref4.dt, share0_ref4.cn
-                                                                           ->  Shared Scan (share slice:id 5:0)
-                                             ->  Result
-                                                   ->  Redistribute Motion 1:3  (slice6)
-                                                         ->  Aggregate
-                                                               ->  Gather Motion 3:1  (slice7; segments: 3)
-                                                                     ->  Aggregate
-                                                                           ->  Shared Scan (share slice:id 7:0)
+                     ->  Sequence
+                           ->  Shared Scan (share slice:id 2:0)
+                                 ->  Nested Loop
+                                       Join Filter: true
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Hash Key: sale.vn
+                                             ->  Seq Scan on sale
+                                       ->  Index Scan using vendor_pkey on vendor
+                                             Index Cond: (vn = sale.vn)
+                           ->  Append
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                                       ->  Sort
+                                             Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                                             ->  Shared Scan (share slice:id 2:0)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                       ->  Sort
+                                             Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                   ->  Result
+                                                         ->  Shared Scan (share slice:id 4:0)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref4.dt, share0_ref4.cn
+                                       ->  Sort
+                                             Sort Key: share0_ref4.dt, share0_ref4.cn
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                                   Hash Key: share0_ref4.dt, share0_ref4.cn
+                                                   ->  Result
+                                                         ->  Shared Scan (share slice:id 5:0)
+                                 ->  Result
+                                       ->  Redistribute Motion 1:3  (slice6)
+                                             ->  Aggregate
+                                                   ->  Gather Motion 3:1  (slice7; segments: 3)
+                                                         ->  Result
+                                                               ->  Shared Scan (share slice:id 7:0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (55 rows)
 

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -814,19 +814,15 @@ from t2_github_issue_10143 a
 group by a.code;
                                                 QUERY PLAN                                                
 ------------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..1324055.42 rows=2 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.42 rows=2 width=16)
-         ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
+ WindowAgg  (cost=0.00..1324055.40 rows=2 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.40 rows=2 width=16)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
                Group Key: t2_github_issue_10143.code
-               ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+               ->  Sort  (cost=0.00..431.00 rows=1 width=11)
                      Sort Key: t2_github_issue_10143.code
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=11)
                            Hash Key: t2_github_issue_10143.code
-                           ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
-                                 Group Key: t2_github_issue_10143.code
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=11)
-                                       Sort Key: t2_github_issue_10143.code
-                                       ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
+                           ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
                SubPlan 1
                  ->  Limit  (cost=0.00..431.00 rows=1 width=6)
                        ->  Result  (cost=0.00..431.00 rows=1 width=6)
@@ -835,7 +831,7 @@ group by a.code;
                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                          ->  Seq Scan on t1_github_issue_10143  (cost=0.00..431.00 rows=1 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(17 rows)
 
 select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
 ,sum(sum(a.salary)) over()

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -515,16 +515,13 @@ explain (costs off) select * from t_hashdist cross join (select a, sum(random())
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Finalize HashAggregate
-               Group Key: generate_series.generate_series
-               ->  Redistribute Motion 1:3  (slice3)
-                     Hash Key: generate_series.generate_series
-                     ->  Streaming Partial HashAggregate
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  HashAggregate
                            Group Key: generate_series.generate_series
                            ->  Function Scan on generate_series
-         ->  Materialize
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on t_hashdist
  Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
@@ -534,14 +531,11 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Finalize HashAggregate
+         ->  HashAggregate
                Group Key: (random())
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+               ->  Redistribute Motion 1:3  (slice3)
                      Hash Key: (random())
-                     ->  Streaming Partial HashAggregate
-                           Group Key: (random())
-                           ->  Redistribute Motion 1:3  (slice4)
-                                 ->  Function Scan on generate_series
+                     ->  Function Scan on generate_series
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on t_hashdist
@@ -614,13 +608,8 @@ explain (costs off) create table t_rep as select i from generate_series(5, 15) a
                Filter: (generate_series < nextval('test_seq'::regclass))
                ->  HashAggregate
                      Group Key: generate_series
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: generate_series
-                           ->  Streaming HashAggregate
-                                 Group Key: generate_series
-                                 ->  Result
-                                       One-Time Filter: (gp_execution_segment() = 1)
-                                       ->  Function Scan on generate_series
+                     ->  Result
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
@@ -643,17 +632,14 @@ explain (costs off) create table t_rep as select i > nextval('test_seq') from ge
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Result
-   ->  Broadcast Motion 1:3  (slice1)
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)
          ->  GroupAggregate
                Group Key: ((generate_series > nextval('test_seq'::regclass)))
-               ->  Gather Motion 3:1  (slice2; segments: 3)
-                     Merge Key: ((generate_series > nextval('test_seq'::regclass)))
-                     ->  GroupAggregate
-                           Group Key: ((generate_series > nextval('test_seq'::regclass)))
-                           ->  Sort
-                                 Sort Key: ((generate_series > nextval('test_seq'::regclass)))
-                                 ->  Redistribute Motion 1:3  (slice3)
-                                       ->  Function Scan on generate_series
+               ->  Sort
+                     Sort Key: ((generate_series > nextval('test_seq'::regclass)))
+                     ->  Redistribute Motion 1:3  (slice2)
+                           Hash Key: ((generate_series > nextval('test_seq'::regclass)))
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -1020,19 +1020,22 @@ select gp_inject_fault('simulate_bitmap_and', 'skip', dbid) from gp_segment_conf
 (1 row)
 
 explain (costs off) select count(*) from bmunion where a = 53 and b < 3;
-                          QUERY PLAN                          
---------------------------------------------------------------
- Aggregate
+NOTICE:  One or more columns in the following table(s) do not have statistics: bmunion
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Bitmap Heap Scan on bmunion
-               Recheck Cond: ((a = 53) AND (b < 3))
-               ->  BitmapAnd
-                     ->  Bitmap Index Scan on bmu_i_bmtest2_a
-                           Index Cond: (a = 53)
-                     ->  Bitmap Index Scan on bmu_i_bmtest2_b
-                           Index Cond: (b < 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on bmunion
+                     Recheck Cond: ((a = 53) AND (b < 3))
+                     ->  BitmapAnd
+                           ->  Bitmap Index Scan on bmu_i_bmtest2_a
+                                 Index Cond: (a = 53)
+                           ->  Bitmap Index Scan on bmu_i_bmtest2_b
+                                 Index Cond: (b < 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 select gp_inject_fault('simulate_bitmap_and', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -1020,20 +1020,19 @@ select gp_inject_fault('simulate_bitmap_and', 'skip', dbid) from gp_segment_conf
 (1 row)
 
 explain (costs off) select count(*) from bmunion where a = 53 and b < 3;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Finalize Aggregate
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Bitmap Heap Scan on bmunion
-                     Recheck Cond: ((a = 53) AND (b < 3))
-                     ->  BitmapAnd
-                           ->  Bitmap Index Scan on bmu_i_bmtest2_a
-                                 Index Cond: (a = 53)
-                           ->  Bitmap Index Scan on bmu_i_bmtest2_b
-                                 Index Cond: (b < 3)
+         ->  Bitmap Heap Scan on bmunion
+               Recheck Cond: ((a = 53) AND (b < 3))
+               ->  BitmapAnd
+                     ->  Bitmap Index Scan on bmu_i_bmtest2_a
+                           Index Cond: (a = 53)
+                     ->  Bitmap Index Scan on bmu_i_bmtest2_b
+                           Index Cond: (b < 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(10 rows)
 
 select gp_inject_fault('simulate_bitmap_and', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -54,7 +54,7 @@ CREATE INDEX i_bmtest2_b ON bmscantest2 USING BITMAP(b);
 CREATE INDEX i_bmtest2_c ON bmscantest2(c);
 CREATE INDEX i_bmtest2_d ON bmscantest2(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
-                          QUERY PLAN                           
+                          QUERY PLAN
 ---------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
@@ -63,7 +63,7 @@ EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c
                      Index Cond: (c = 1)
                      Filter: ((a = 1) AND (b = 1))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -78,7 +78,7 @@ SELECT count(*) FROM bmscantest2 WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest2 WHERE a = 1 OR b = 1 OR c = 1;
-                              QUERY PLAN                              
+                              QUERY PLAN
 ----------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -121,7 +121,7 @@ CREATE INDEX i_bmtest_ao_b ON bmscantest_ao USING BITMAP(b);
 CREATE INDEX i_bmtest_ao_c ON bmscantest_ao(c);
 CREATE INDEX i_bmtest_ao_d ON bmscantest_ao(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
-                               QUERY PLAN                               
+                               QUERY PLAN
 ------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
@@ -137,7 +137,7 @@ EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND
                            ->  Bitmap Index Scan on i_bmtest_ao_c
                                  Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -146,26 +146,25 @@ SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+                                             QUERY PLAN
+----------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (c = 1)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (d = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (d = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 
@@ -174,7 +173,7 @@ SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_ao WHERE a = 1 OR b = 1 OR c = 1;
-                               QUERY PLAN                               
+                               QUERY PLAN
 ------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -239,7 +238,7 @@ CREATE INDEX i_bmtest_aocs_b ON bmscantest_aocs USING BITMAP(b);
 CREATE INDEX i_bmtest_aocs_c ON bmscantest_aocs(c);
 CREATE INDEX i_bmtest_aocs_d ON bmscantest_aocs(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
-                                QUERY PLAN                                
+                                QUERY PLAN
 --------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
@@ -255,7 +254,7 @@ EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 A
                            ->  Bitmap Index Scan on i_bmtest_aocs_c
                                  Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -264,26 +263,25 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+                                              QUERY PLAN
+------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (c = 1)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (d = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (d = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 
@@ -292,7 +290,7 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR b = 1 OR c = 1;
-                                QUERY PLAN                                
+                                QUERY PLAN
 --------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -317,7 +315,7 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR b = 1 OR c = 1;
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_aocs WHERE a = 1 OR (b = 1 AND c = 1) OR d = 1;
-                                   QUERY PLAN                                    
+                                   QUERY PLAN
 ---------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -54,14 +54,13 @@ CREATE INDEX i_bmtest2_b ON bmscantest2 USING BITMAP(b);
 CREATE INDEX i_bmtest2_c ON bmscantest2(c);
 CREATE INDEX i_bmtest2_d ON bmscantest2(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
-                          QUERY PLAN
----------------------------------------------------------------
- Finalize Aggregate
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using i_bmtest2_c on bmscantest2
-                     Index Cond: (c = 1)
-                     Filter: ((a = 1) AND (b = 1))
+         ->  Index Scan using i_bmtest2_c on bmscantest2
+               Index Cond: (c = 1)
+               Filter: ((a = 1) AND (b = 1))
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
@@ -121,21 +120,20 @@ CREATE INDEX i_bmtest_ao_b ON bmscantest_ao USING BITMAP(b);
 CREATE INDEX i_bmtest_ao_c ON bmscantest_ao(c);
 CREATE INDEX i_bmtest_ao_d ON bmscantest_ao(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Finalize Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Bitmap Heap Scan on bmscantest_ao
-                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+         ->  Bitmap Heap Scan on bmscantest_ao
+               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+               ->  BitmapAnd
                      ->  BitmapAnd
-                           ->  BitmapAnd
-                                 ->  Bitmap Index Scan on i_bmtest_ao_b
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a
-                                       Index Cond: (a = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_c
-                                 Index Cond: (c = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_b
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a
+                                 Index Cond: (a = 1)
+                     ->  Bitmap Index Scan on i_bmtest_ao_c
+                           Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -238,21 +236,20 @@ CREATE INDEX i_bmtest_aocs_b ON bmscantest_aocs USING BITMAP(b);
 CREATE INDEX i_bmtest_aocs_c ON bmscantest_aocs(c);
 CREATE INDEX i_bmtest_aocs_d ON bmscantest_aocs(d);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
-                                QUERY PLAN
---------------------------------------------------------------------------
- Finalize Aggregate
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Bitmap Heap Scan on bmscantest_aocs
-                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+         ->  Bitmap Heap Scan on bmscantest_aocs
+               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+               ->  BitmapAnd
                      ->  BitmapAnd
-                           ->  BitmapAnd
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_b
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a
-                                       Index Cond: (a = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_c
-                                 Index Cond: (c = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_b
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a
+                                 Index Cond: (a = 1)
+                     ->  Bitmap Index Scan on i_bmtest_aocs_c
+                           Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -409,16 +409,15 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
  count 
@@ -428,16 +427,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
  count 
@@ -447,16 +445,15 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
-                     Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+               Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
  count 
@@ -466,16 +463,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
-                     Filter: (f1 <@ '<(50,50),50>'::circle)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '<(50,50),50>'::circle)
+               Filter: (f1 <@ '<(50,50),50>'::circle)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
  count 
@@ -485,16 +481,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 << '(0,0)'::point)
-                     Filter: (f1 << '(0,0)'::point)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 << '(0,0)'::point)
+               Filter: (f1 << '(0,0)'::point)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
  count 
@@ -504,16 +499,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >> '(0,0)'::point)
-                     Filter: (f1 >> '(0,0)'::point)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >> '(0,0)'::point)
+               Filter: (f1 >> '(0,0)'::point)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
  count 
@@ -523,16 +517,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <^ '(0,0)'::point)
-                     Filter: (f1 <^ '(0,0)'::point)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <^ '(0,0)'::point)
+               Filter: (f1 <^ '(0,0)'::point)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
  count 
@@ -542,16 +535,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >^ '(0,0)'::point)
-                     Filter: (f1 >^ '(0,0)'::point)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >^ '(0,0)'::point)
+               Filter: (f1 >^ '(0,0)'::point)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
  count 
@@ -561,16 +553,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 ~= '(-5,-12)'::point)
-                     Filter: (f1 ~= '(-5,-12)'::point)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 ~= '(-5,-12)'::point)
+               Filter: (f1 ~= '(-5,-12)'::point)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
  count 
@@ -1935,16 +1926,15 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Finalize Aggregate
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using tenk1_hundred on tenk1
-                     Index Cond: (hundred = 42)
-                     Filter: ((thousand = 42) OR (thousand = 99))
+         ->  Index Scan using tenk1_hundred on tenk1
+               Index Cond: (hundred = 42)
+               Filter: ((thousand = 42) OR (thousand = 99))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -672,19 +672,15 @@ explain (costs off) select gp_segment_id, count(*) from bar_randDistr group by g
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: gp_segment_id
-                     ->  Partial GroupAggregate
-                           Group Key: gp_segment_id
-                           ->  Sort
-                                 Sort Key: gp_segment_id
-                                 ->  Seq Scan on bar_randdistr
+                     ->  Seq Scan on bar_randdistr
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 -- Case2: Conjunction scenario with filter condition on gp_segment_id and column
 explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0 and col1 between 1 and 10;
@@ -923,17 +919,13 @@ explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid grou
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: gp_segment_id
-                     ->  Partial GroupAggregate
-                           Group Key: gp_segment_id
-                           ->  Sort
-                                 Sort Key: gp_segment_id
-                                 ->  Seq Scan on t_test_dd_via_segid
+                     ->  Seq Scan on t_test_dd_via_segid
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -41,29 +41,26 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=4.569..4.579 rows=20 loops=1)
-   ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=4.288..4.292 rows=7 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=9.408..9.419 rows=20 loops=1)
+   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=9.064..9.081 rows=7 loops=1)
          Group Key: d
-         Peak Memory Usage: 0 kB
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=3.857..4.268 rows=7 loops=1)
-               Hash Key: d
-               ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.621..0.663 rows=10 loops=1)
-                     Group Key: d
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.613..0.639 rows=50 loops=1)
-                           Sort Key: d
-                           Sort Method:  quicksort  Memory: 79kB
-                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.570..0.584 rows=50 loops=1)
+         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=9.053..9.059 rows=35 loops=1)
+               Sort Key: d
+               Sort Method:  quicksort  Memory: 78kB
+               Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=7.715..9.035 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=1.822..1.837 rows=50 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.472 ms
-   (slice0)    Executor memory: 42K bytes.
-   (slice1)    Executor memory: 19K bytes avg x 3 workers, 19K bytes max (seg1).  Work_mem: 24K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+ Planning Time: 6.667 ms
+   (slice0)    Executor memory: 40K bytes.
+   (slice1)    Executor memory: 45K bytes avg x 3 workers, 45K bytes max (seg1).  Work_mem: 27K bytes max.
+   (slice2)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 5.246 ms
-(20 rows)
+ Execution Time: 10.080 ms
+(17 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -115,33 +112,22 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.581..2.582 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=4) (actual time=2.564..2.572 rows=20 loops=1)
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=2.201..2.228 rows=7 loops=1)
-               Group Key: d
-               ->  Sort  (cost=0.00..431.01 rows=7 width=4) (actual time=2.194..2.197 rows=7 loops=1)
-                     Sort Key: d
-                     Sort Method:  quicksort  Memory: 75kB
-                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=4) (actual time=1.939..2.186 rows=7 loops=1)
-                           Hash Key: d
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=0.292..0.318 rows=10 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.286..0.301 rows=50 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 79kB
-                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.211..0.238 rows=50 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=2.034..2.035 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.997..2.027 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.793..1.794 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.731..1.750 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.171..0.183 rows=50 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 8.216 ms
-   (slice0)    Executor memory: 47K bytes.
-   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg1).  Work_mem: 26K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+ Planning Time: 6.734 ms
+   (slice0)    Executor memory: 40K bytes.
+   (slice1)    Executor memory: 26K bytes avg x 3 workers, 26K bytes max (seg0).
+   (slice2)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 3.390 ms
-(24 rows)
+ Execution Time: 2.798 ms
+(13 rows)
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
@@ -151,27 +137,22 @@ select count(distinct d) from bigt;
 (1 row)
 
 explain analyze select count(distinct d) from bigt;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..485.86 rows=1 width=8) (actual time=225.557..225.558 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..485.84 rows=50255 width=4) (actual time=202.093..218.151 rows=50000 loops=1)
-         ->  HashAggregate  (cost=0.00..485.09 rows=16752 width=4) (actual time=201.285..211.834 rows=16746 loops=1)
-               Group Key: d
-               Peak Memory Usage: 0 kB
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..483.03 rows=16752 width=4) (actual time=58.428..184.750 rows=27966 loops=1)
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=350.470..350.471 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=348.085..350.457 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=350.167..350.168 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=1.924..179.216 rows=334920 loops=1)
                      Hash Key: d
-                     ->  Streaming HashAggregate  (cost=0.00..482.82 rows=16752 width=4) (actual time=56.534..182.870 rows=27917 loops=1)
-                           Group Key: d
-                           Peak Memory Usage: 0 kB
-                           ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.124..68.046 rows=334620 loops=1)
+                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.221..87.726 rows=334620 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.376 ms
-   (slice0)    Executor memory: 829K bytes.
-   (slice1)    Executor memory: 876K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 1553K bytes max.
-   (slice2)    Executor memory: 705K bytes avg x 3 workers, 705K bytes max (seg0).  Work_mem: 1425K bytes max.
+ Planning Time: 6.802 ms
+   (slice0)    Executor memory: 40K bytes.
+   (slice1)    Executor memory: 2523K bytes avg x 3 workers, 2523K bytes max (seg0).
+   (slice2)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  2560kB
- Execution Time: 225.988 ms
-(18 rows)
+ Execution Time: 351.126 ms
+(13 rows)
 
 set statement_mem=128000;
 set gp_enable_agg_distinct=on;
@@ -212,44 +193,38 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=3.382..3.462 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=2.744..3.066 rows=7 loops=1)
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=11.048..11.274 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=10.448..10.806 rows=7 loops=1)
          Hash Cond: (smallt.d = smallt_1.d)
          Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.
-         ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.135..0.138 rows=7 loops=1)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.037..0.067 rows=7 loops=1)
                Group Key: smallt.d
-               Peak Memory Usage: 0 kB
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.004..0.112 rows=7 loops=1)
-                     Hash Key: smallt.d
-                     ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.288..0.314 rows=10 loops=1)
-                           Group Key: smallt.d
-                           ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.280..0.292 rows=50 loops=1)
-                                 Sort Key: smallt.d
-                                 Sort Method:  quicksort  Memory: 79kB
-                                 Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.245..0.258 rows=50 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=2.479..2.479 rows=7 loops=1)
+               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.031..0.035 rows=35 loops=1)
+                     Sort Key: smallt.d
+                     Sort Method:  quicksort  Memory: 78kB
+                     Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.007..0.015 rows=35 loops=1)
+                           Hash Key: smallt.d
+                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.155..0.185 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=10.197..10.197 rows=7 loops=1)
                Buckets: 131072  Batches: 1  Memory Usage: 1025kB
-               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.467..2.471 rows=7 loops=1)
+               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=10.188..10.191 rows=7 loops=1)
                      Group Key: smallt_1.d
                      Peak Memory Usage: 0 kB
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=2.280..2.449 rows=7 loops=1)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=8.293..10.151 rows=35 loops=1)
                            Hash Key: smallt_1.d
-                           ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.481..0.485 rows=10 loops=1)
-                                 Group Key: smallt_1.d
-                                 Peak Memory Usage: 0 kB
-                                 ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.438..0.451 rows=50 loops=1)
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=2.744..2.766 rows=50 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 19.398 ms
-   (slice0)    Executor memory: 83K bytes.
-   (slice1)    Executor memory: 1096K bytes avg x 3 workers, 1096K bytes max (seg2).  Work_mem: 1025K bytes max.
-   (slice2)    Executor memory: 40K bytes avg x 3 workers, 40K bytes max (seg0).  Work_mem: 27K bytes max.
-   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
+ Planning Time: 16.545 ms
+   (slice0)    Executor memory: 61K bytes.
+   (slice1)    Executor memory: 1124K bytes avg x 3 workers, 1124K bytes max (seg2).  Work_mem: 1025K bytes max.
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+   (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 4.233 ms
-(35 rows)
+ Execution Time: 11.966 ms
+(29 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -353,31 +328,28 @@ select d, count(*) from smallt group by d limit 5; --ignore
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=5 width=12) (actual time=2.045..2.048 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.043..2.045 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.704..1.708 rows=5 loops=1)
-               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.703..1.705 rows=5 loops=1)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.01 rows=5 width=12) (actual time=2.103..2.107 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.101..2.103 rows=5 loops=1)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.795..1.806 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.794..1.804 rows=5 loops=1)
                      Group Key: d
-                     Peak Memory Usage: 0 kB
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.592..1.709 rows=7 loops=1)
-                           Hash Key: d
-                           ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.174..0.205 rows=10 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.167..0.184 rows=50 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 79kB
-                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.134..0.146 rows=50 loops=1)
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.782..1.786 rows=26 loops=1)
+                           Sort Key: d
+                           Sort Method:  quicksort  Memory: 78kB
+                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.771..1.785 rows=35 loops=1)
+                                 Hash Key: d
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.161..0.173 rows=50 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.540 ms
-   (slice0)    Executor memory: 52K bytes.
-   (slice1)    Executor memory: 22K bytes avg x 3 workers, 22K bytes max (seg1).  Work_mem: 24K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+ Planning Time: 6.260 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 49K bytes avg x 3 workers, 49K bytes max (seg1).  Work_mem: 27K bytes max.
+   (slice2)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 2.958 ms
-(22 rows)
+ Execution Time: 2.895 ms
+(19 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -1401,20 +1373,21 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=0.788..1.687 rows=500 loops=2)
-   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=0.402..1.244 rows=200 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 4 of 524288 buckets.
- 
-         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.002..0.008 rows=20 loops=2)
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.034..0.034 rows=20 loops=2)
-               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.019..0.023 rows=20 loops=2)
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4198K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=3.003..4.822 rows=1000 loops=1)
+   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=2.335..4.141 rows=500 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 5 of 524288 buckets.
+         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.006..0.015 rows=50 loops=1)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.225..0.225 rows=50 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
+               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.195..0.206 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 6.933 ms
+   (slice0)    Executor memory: 37K bytes.
+   (slice1)    Executor memory: 4159K bytes avg x 3 workers, 4161K bytes max (seg0).  Work_mem: 4098K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 4.129 ms
-(13 rows)
+ Execution Time: 5.477 ms
+(14 rows)
 
 -- Rescan on HashJoin
 --select t1.* from (select t11.* from smallt as t11, smallt as t22 where t11.i = t22.i and t11.i < 2) as t1,
@@ -2053,18 +2026,16 @@ explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
                                        Group Key: smallt.d
                                        ->  Nested Loop  (cost=0.00..1324055.39 rows=334 width=12)
                                              Join Filter: true
-                                             ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12)
+                                             ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12)
                                                    Group Key: smallt.d
-                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.01 rows=7 width=12)
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
                                                          Hash Key: smallt.d
-                                                         ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12)
-                                                               Group Key: smallt.d
-                                                               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
                                              ->  Materialize  (cost=0.00..431.00 rows=50 width=1)
                                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=50 width=1)
                                                          ->  Seq Scan on smallt2 smallt2_1  (cost=0.00..431.00 rows=17 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(24 rows)
 
 --end_ignore
 -- Nested Subplan

--- a/src/test/regress/expected/gp_aggregates_costs_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_costs_optimizer.out
@@ -37,18 +37,15 @@ explain select avg(b) from cost_agg_t1 group by c;
 explain select avg(b) from cost_agg_t2 group by c;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..509.21 rows=281319 width=8)
-   ->  Finalize HashAggregate  (cost=0.00..500.83 rows=93773 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..501.31 rows=287713 width=8)
+   ->  HashAggregate  (cost=0.00..492.74 rows=95905 width=8)
          Group Key: c
          Planned Partitions: 8
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..489.07 rows=93773 width=12)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..452.01 rows=333334 width=8)
                Hash Key: c
-               ->  Streaming Partial HashAggregate  (cost=0.00..485.55 rows=93773 width=12)
-                     Group Key: c
-                     Planned Partitions: 8
-                     ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
+               ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(8 rows)
 
 -- But if there are a lot more duplicate values, the two-stage plan becomes
 -- cheaper again, even though it doesn't git in memory and has to spill.
@@ -89,19 +86,15 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Partial GroupAggregate
-                           Group Key: b
-                           ->  Sort
-                                 Sort Key: b
-                                 ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 set gp_eager_two_phase_agg = on;
 -- when forcing two stage, it should generate two stage agg plan.
@@ -109,19 +102,15 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Partial GroupAggregate
-                           Group Key: b
-                           ->  Sort
-                                 Sort Key: b
-                                 ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -342,21 +342,19 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: dqa_t2.dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dqa_t2.dt
-               ->  Partial GroupAggregate
-                     Group Key: dqa_t2.dt
-                     ->  Sort
-                           Sort Key: dqa_t2.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t2.d = dqa_t1.d)
-                                 ->  Seq Scan on dqa_t2
-                                 ->  Hash
-                                       ->  Seq Scan on dqa_t1
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t2.d = dqa_t1.d)
+                           ->  Seq Scan on dqa_t2
+                           ->  Hash
+                                 ->  Seq Scan on dqa_t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(13 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -366,23 +364,16 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  GroupAggregate
-               Group Key: c
-               ->  Sort
-                     Sort Key: c
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: c
-                           ->  GroupAggregate
-                                 Group Key: c
-                                 ->  Sort
-                                       Sort Key: c
-                                       ->  Seq Scan on dqa_t1
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(7 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
  count 
@@ -427,19 +418,15 @@ explain (costs off) select count(distinct c) from dqa_t1 group by dt;
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dt
-               ->  Partial GroupAggregate
-                     Group Key: dt
-                     ->  Sort
-                           Sort Key: dt, c
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: c
-                                 ->  Seq Scan on dqa_t1
+         ->  Sort
+               Sort Key: dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dt
+                     ->  Seq Scan on dqa_t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -475,13 +462,11 @@ explain (costs off) select count(distinct c) from dqa_t1 group by d;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  GroupAggregate
          Group Key: d
-         ->  GroupAggregate
-               Group Key: d, c
-               ->  Sort
-                     Sort Key: d, c
-                     ->  Seq Scan on dqa_t1
+         ->  Sort
+               Sort Key: d
+               ->  Seq Scan on dqa_t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 select count(distinct i), sum(distinct i) from dqa_t1 group by c;
  count | sum 
@@ -502,19 +487,15 @@ explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group 
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: c
-               ->  Partial GroupAggregate
-                     Group Key: c
-                     ->  Sort
-                           Sort Key: c, i
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: i
-                                 ->  Seq Scan on dqa_t1
+         ->  Sort
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -644,29 +625,24 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Aggregate
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  GroupAggregate
-               Group Key: dqa_t1.dt
-               ->  Sort
-                     Sort Key: dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: dqa_t1.dt
-                           ->  Streaming HashAggregate
-                                 Group Key: dqa_t1.dt
-                                 ->  Hash Join
-                                       Hash Cond: (dqa_t1.c = dqa_t2.c)
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Hash Key: dqa_t1.c
-                                             ->  Seq Scan on dqa_t1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: dqa_t2.c
-                                                   ->  Seq Scan on dqa_t2
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t1.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(15 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
  count 
@@ -733,25 +709,23 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  GroupAggregate
          Group Key: dqa_t2.dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dqa_t2.dt
-               ->  HashAggregate
-                     Group Key: dqa_t2.dt, dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: dqa_t2.dt, dqa_t1.dt, dqa_t1.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: dqa_t1.c
-                                       ->  Seq Scan on dqa_t1
-                                 ->  Hash
-                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                             Hash Key: dqa_t2.c
-                                             ->  Seq Scan on dqa_t2
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(17 rows)
 
 -- multidqa with groupby and order by
 select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
@@ -2599,7 +2573,7 @@ explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                                  Output: b, c
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
-(17 rows)
+(20 rows)
 
 select count(distinct b), sum(c) from multiagg1;
  count | sum 
@@ -2961,35 +2935,29 @@ explain (verbose on, costs off) select distinct sum(Distinct c), count(a), sum(d
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: (sum(c)), (count(a)), (sum(d))
                      Hash Key: (sum(c)), (count(a)), (sum(d))
-                     ->  GroupAggregate
-                           Output: (sum(c)), (count(a)), (sum(d))
-                           Group Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
-                           ->  Sort
-                                 Output: (sum(c)), (count(a)), (sum(d)), b
-                                 Sort Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
-                                 ->  Finalize HashAggregate
-                                       Output: sum(c), count(a), sum(d), b
-                                       Group Key: dqa_f3.b
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     ->  Finalize HashAggregate
+                           Output: sum(c), count(a), sum(d)
+                           Group Key: dqa_f3.b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                 Hash Key: b
+                                 ->  Partial GroupAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Sort
                                              Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                             Hash Key: b
-                                             ->  Partial GroupAggregate
-                                                   Output: b, c, PARTIAL count(a), PARTIAL sum(d)
-                                                   Group Key: dqa_f3.b, dqa_f3.c
-                                                   ->  Sort
-                                                         Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                                         Sort Key: dqa_f3.b, dqa_f3.c
-                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                               Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                                               Hash Key: b, c
-                                                               ->  Streaming Partial HashAggregate
-                                                                     Output: b, c, PARTIAL count(a), PARTIAL sum(d)
-                                                                     Group Key: dqa_f3.b, dqa_f3.c
-                                                                     ->  Seq Scan on public.dqa_f3
-                                                                           Output: a, b, c, d
+                                             Sort Key: dqa_f3.b, dqa_f3.c
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                                   Hash Key: b, c
+                                                   ->  Streaming Partial HashAggregate
+                                                         Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                                         Group Key: dqa_f3.b, dqa_f3.c
+                                                         ->  Seq Scan on public.dqa_f3
+                                                               Output: a, b, c, d
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
-(39 rows)
+(33 rows)
 
 select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
  sum | count | sum  
@@ -3260,18 +3228,18 @@ explain (verbose on, costs off) select count(distinct a), count(distinct b) from
                                                                                                                              QUERY PLAN                                                                                                                             
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: (count(share0_ref3.a)), (count(share0_ref2.b))
+   Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
    ->  Sequence
-         Output: (count(share0_ref3.a)), (count(share0_ref2.b))
+         Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
          ->  Shared Scan (share slice:id 1:0)
                Output: share0_ref1.a, share0_ref1.b, share0_ref1.c, share0_ref1.ctid, share0_ref1.xmin, share0_ref1.cmin, share0_ref1.xmax, share0_ref1.cmax, share0_ref1.tableoid, share0_ref1.gp_segment_id
                ->  Seq Scan on public.dqa_f4
                      Output: dqa_f4.a, dqa_f4.b, dqa_f4.c, dqa_f4.ctid, dqa_f4.xmin, dqa_f4.cmin, dqa_f4.xmax, dqa_f4.cmax, dqa_f4.tableoid, dqa_f4.gp_segment_id
          ->  Hash Join
-               Output: (count(share0_ref3.a)), (count(share0_ref2.b))
+               Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
                Hash Cond: (NOT (share0_ref3.c IS DISTINCT FROM share0_ref2.c))
                ->  GroupAggregate
-                     Output: count(share0_ref3.a), share0_ref3.c
+                     Output: count(DISTINCT share0_ref3.a), share0_ref3.c
                      Group Key: share0_ref3.c
                      ->  Sort
                            Output: share0_ref3.a, share0_ref3.c
@@ -3279,18 +3247,14 @@ explain (verbose on, costs off) select count(distinct a), count(distinct b) from
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Output: share0_ref3.a, share0_ref3.c
                                  Hash Key: share0_ref3.c
-                                 ->  GroupAggregate
+                                 ->  Result
                                        Output: share0_ref3.a, share0_ref3.c
-                                       Group Key: share0_ref3.c, share0_ref3.a
-                                       ->  Sort
+                                       ->  Shared Scan (share slice:id 2:0)
                                              Output: share0_ref3.a, share0_ref3.b, share0_ref3.c, share0_ref3.ctid, share0_ref3.xmin, share0_ref3.cmin, share0_ref3.xmax, share0_ref3.cmax, share0_ref3.tableoid, share0_ref3.gp_segment_id
-                                             Sort Key: share0_ref3.c, share0_ref3.a
-                                             ->  Shared Scan (share slice:id 2:0)
-                                                   Output: share0_ref3.a, share0_ref3.b, share0_ref3.c, share0_ref3.ctid, share0_ref3.xmin, share0_ref3.cmin, share0_ref3.xmax, share0_ref3.cmax, share0_ref3.tableoid, share0_ref3.gp_segment_id
                ->  Hash
-                     Output: (count(share0_ref2.b)), share0_ref2.c
+                     Output: (count(DISTINCT share0_ref2.b)), share0_ref2.c
                      ->  GroupAggregate
-                           Output: count(share0_ref2.b), share0_ref2.c
+                           Output: count(DISTINCT share0_ref2.b), share0_ref2.c
                            Group Key: share0_ref2.c
                            ->  Sort
                                  Output: share0_ref2.b, share0_ref2.c
@@ -3298,22 +3262,13 @@ explain (verbose on, costs off) select count(distinct a), count(distinct b) from
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Output: share0_ref2.b, share0_ref2.c
                                        Hash Key: share0_ref2.c
-                                       ->  GroupAggregate
+                                       ->  Result
                                              Output: share0_ref2.b, share0_ref2.c
-                                             Group Key: share0_ref2.c, share0_ref2.b
-                                             ->  Sort
-                                                   Output: share0_ref2.b, share0_ref2.c
-                                                   Sort Key: share0_ref2.c, share0_ref2.b
-                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                         Output: share0_ref2.b, share0_ref2.c
-                                                         Hash Key: share0_ref2.c, share0_ref2.b, share0_ref2.b
-                                                         ->  Result
-                                                               Output: share0_ref2.b, share0_ref2.c
-                                                               ->  Shared Scan (share slice:id 4:0)
-                                                                     Output: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.ctid, share0_ref2.xmin, share0_ref2.cmin, share0_ref2.xmax, share0_ref2.cmax, share0_ref2.tableoid, share0_ref2.gp_segment_id
+                                             ->  Shared Scan (share slice:id 3:0)
+                                                   Output: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.ctid, share0_ref2.xmin, share0_ref2.cmin, share0_ref2.xmax, share0_ref2.cmax, share0_ref2.tableoid, share0_ref2.gp_segment_id
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_enable_multiple_distinct_aggs = 'on'
-(54 rows)
+(41 rows)
 
 select count(distinct a), count(distinct b) from dqa_f4 group by c;
  count | count 

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2566,17 +2566,14 @@ explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: b, (PARTIAL sum(c))
                      Hash Key: b
-                     ->  Partial GroupAggregate
+                     ->  Streaming Partial HashAggregate
                            Output: b, PARTIAL sum(c)
                            Group Key: multiagg1.b
-                           ->  Sort
+                           ->  Seq Scan on public.multiagg1
                                  Output: b, c
-                                 Sort Key: multiagg1.b
-                                 ->  Seq Scan on public.multiagg1
-                                       Output: b, c
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
-(20 rows)
+(17 rows)
 
 select count(distinct b), sum(c) from multiagg1;
  count | sum 

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2566,11 +2566,14 @@ explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: b, (PARTIAL sum(c))
                      Hash Key: b
-                     ->  Streaming Partial HashAggregate
+                     ->  Partial GroupAggregate
                            Output: b, PARTIAL sum(c)
                            Group Key: multiagg1.b
-                           ->  Seq Scan on public.multiagg1
+                           ->  Sort
                                  Output: b, c
+                                 Sort Key: multiagg1.b
+                                 ->  Seq Scan on public.multiagg1
+                                       Output: b, c
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
 (20 rows)

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -139,33 +139,31 @@ set optimizer_segments=4;
 set gp_cost_hashjoin_chainwalk=on;
 set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=1.743..2.097 rows=16 loops=1)
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=12.627..13.309 rows=16 loops=1)
    Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
    Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.282..0.291 rows=64 loops=1)
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.949..1.287 rows=32 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=1.565..1.588 rows=64 loops=1)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=9.768..12.264 rows=32 loops=1)
                Join Filter: true
-               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.776..0.778 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.429..0.449 rows=7 loops=5)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=2.121..2.584 rows=8 loops=1)
-                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.736..0.738 rows=4 loops=1)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=2.959..2.960 rows=1 loops=1)
+               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.271..0.274 rows=4 loops=1)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=1.896..2.391 rows=7 loops=5)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=9.431..11.896 rows=8 loops=1)
+                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=1.802..1.805 rows=4 loops=1)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=10.948..10.949 rows=1 loops=1)
          Buckets: 262144  Batches: 1  Memory Usage: 2049kB
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=2.950..2.952 rows=1 loops=1)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=2.546..2.928 rows=3 loops=1)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.372..0.373 rows=1 loops=1)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.769..0.771 rows=4 loops=1)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=10.938..10.938 rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=7.642..10.908 rows=8 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=4.205..4.207 rows=4 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 18.591 ms
-   (slice0)    Executor memory: 2141K bytes.  Work_mem: 2049K bytes max.
+ Planning Time: 18.292 ms
+   (slice0)    Executor memory: 2133K bytes.  Work_mem: 2049K bytes max.
    (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).  Work_mem: 17K bytes max.
    (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
-   (slice3)    Executor memory: 45K bytes avg x 3 workers, 45K bytes max (seg0).
+   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 17.954 ms
+ Execution Time: 95.501 ms
 (23 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
@@ -181,12 +179,11 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2)
                            ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(14 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -428,15 +428,12 @@ explain (costs off) select distinct test_array from try_distinct_array;
 ------------------------------------------------------
  GroupAggregate
    Group Key: test_array
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: test_array
-         ->  GroupAggregate
-               Group Key: test_array
-               ->  Sort
-                     Sort Key: test_array
-                     ->  Seq Scan on try_distinct_array
+   ->  Sort
+         Sort Key: test_array
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on try_distinct_array
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(7 rows)
 
 select distinct test_array from try_distinct_array;
  test_array 

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -659,17 +659,13 @@ explain (costs off) select even.i from even right outer join odd on (even.i = od
                Sort Key: even.i
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: even.i
-                     ->  GroupAggregate
-                           Group Key: even.i
-                           ->  Sort
-                                 Sort Key: even.i
-                                 ->  Hash Left Join
-                                       Hash Cond: (odd.i = even.i)
-                                       ->  Seq Scan on odd
-                                       ->  Hash
-                                             ->  Seq Scan on even
+                     ->  Hash Left Join
+                           Hash Cond: (odd.i = even.i)
+                           ->  Seq Scan on odd
+                           ->  Hash
+                                 ->  Seq Scan on even
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 -- Check that we can track the distribution through multiple FULL OUTER JOINs.
 -- This query should not need Redistribute Motion.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10319,14 +10319,13 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                                                           QUERY PLAN                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-   Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-         Merge Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-         ->  Partial GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-               Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-                     Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+ Sort  (cost=0.00..862.00 rows=1 width=16)
+   Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+         Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+               Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
                      ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
                            Hash Cond: ((my_tq_agg_opt_part.sym)::bpchar = my_tt_agg_opt.symbol)
                            Join Filter: ((plusone(my_tq_agg_opt_part.bid_price) < my_tt_agg_opt.trade_price) AND (my_tt_agg_opt.event_ts >= my_tq_agg_opt_part.ets) AND (my_tt_agg_opt.event_ts < my_tq_agg_opt_part.end_ts))
@@ -10388,7 +10387,7 @@ where ordernum between 10 and 20;
                      Hash Key: idxscan_inner.productid
                      ->  Index Scan using idxscan_inner_ordernum_key on idxscan_inner  (cost=0.00..6.00 rows=1 width=9)
                            Index Cond: ((ordernum >= 10) AND (ordernum <= 20))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 select id, comment from idxscan_outer as o join idxscan_inner as i on o.id = i.productid
@@ -10961,21 +10960,20 @@ FROM   (SELECT *
         SELECT region,
                code
         FROM   tab_3)a;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
-                           Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
-                           ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
-                     ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
+         ->  Append  (cost=0.00..1293.00 rows=2 width=1)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+                     Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
+                     ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=7)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
+                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+               ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 SELECT Count(*)
 FROM   (SELECT *
@@ -13194,15 +13192,13 @@ select * from foo join (select b, count(*) as cnt from tbtree group by b) grby o
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on foo
          ->  Materialize
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: tbtree.b
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: tbtree.b
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: tbtree.b
-                                 ->  Seq Scan on tbtree
+                           ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(12 rows)
 
 -- 17 group by columns don't intersect - no index scan
 explain (costs off)
@@ -13220,15 +13216,13 @@ select * from foo join (select min_a, count(*) as cnt from (select min(a) as min
                            Hash Key: (min(tbitmap.a))
                            ->  Streaming Partial HashAggregate
                                  Group Key: min(tbitmap.a)
-                                 ->  Finalize HashAggregate
+                                 ->  HashAggregate
                                        Group Key: tbitmap.b
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: tbitmap.b
-                                             ->  Streaming Partial HashAggregate
-                                                   Group Key: tbitmap.b
-                                                   ->  Seq Scan on tbitmap
+                                             ->  Seq Scan on tbitmap
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(17 rows)
 
 reset optimizer_join_order;
 reset optimizer_enable_hashjoin;
@@ -13489,21 +13483,20 @@ default partition def);
 create INDEX y_idx on y (j);
 set optimizer_enable_indexjoin=on;
 explain (costs off) select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Finalize Aggregate
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on x
-                     ->  Dynamic Index Scan on y_idx on y
-                           Index Cond: (j < x.i)
-                           Filter: ((j < x.i) AND (x.j <= i))
-                           Number of partitions to scan: 5 (out of 5)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on x
+               ->  Dynamic Index Scan on y_idx on y
+                     Index Cond: (j < x.i)
+                     Filter: ((j < x.i) AND (x.j <= i))
+                     Number of partitions to scan: 5 (out of 5)
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 reset optimizer_enable_indexjoin;
 -- InferPredicatesBCC-vcpart-txt.mdp
@@ -13737,21 +13730,23 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-   ->  Finalize GroupAggregate
-         Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-         ->  Sort
-               Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                     ->  Partial GroupAggregate
-                           Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                           ->  Sort
-                                 Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
-                                 ->  Dynamic Seq Scan on order_lineitems
-                                       Number of partitions to scan: 3 (out of 12)
-                                       Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
+   ->  Sort
+         Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+         ->  Finalize GroupAggregate
+               Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+               ->  Sort
+                     Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                           ->  Partial GroupAggregate
+                                 Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                                 ->  Sort
+                                       Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
+                                       ->  Dynamic Seq Scan on order_lineitems
+                                             Number of partitions to scan: 3 (out of 12)
+                                             Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(18 rows)
 
 -- test partioned table with no partitions
 create table no_part (a int, b int) partition by list (a) distributed by (b);
@@ -14386,17 +14381,16 @@ EXPLAIN (COSTS OFF) SELECT (
    Join Filter: true
    ->  Result
    ->  Materialize
-         ->  Finalize Aggregate
+         ->  Aggregate
                ->  Gather Motion 3:1  (slice1; segments: 3)
-                     ->  Partial Aggregate
-                           ->  Hash Join
-                                 Hash Cond: (join_null_rej1.i = join_null_rej2.i)
-                                 ->  Seq Scan on join_null_rej1
-                                 ->  Hash
-                                       ->  Seq Scan on join_null_rej2
-                                             Filter: (i < join_null_rej_func())
+                     ->  Hash Join
+                           Hash Cond: (join_null_rej1.i = join_null_rej2.i)
+                           ->  Seq Scan on join_null_rej1
+                           ->  Hash
+                                 ->  Seq Scan on join_null_rej2
+                                       Filter: (i < join_null_rej_func())
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 -- Optional, but let's check we get same result for both, folded and
 -- not folded join_null_rej_func() function.

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -2098,18 +2098,17 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: share0_ref7.twothousand
+                           ->  Result
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(53 rows)
+(52 rows)
 
 explain (costs off)
   select unique1,
@@ -2212,18 +2211,17 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: share0_ref7.twothousand
+                           ->  Result
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(53 rows)
+(52 rows)
 
 -- check collation-sensitive matching between grouping expressions
 -- (similar to a check for aggregates, but there are additional code

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1697,15 +1697,11 @@ explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on 
                            Sort Key: barjoinpruning.t
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: barjoinpruning.t
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                       Group Key: barjoinpruning.t
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: barjoinpruning.t
-                                             ->  Seq Scan on barjoinpruning  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on barjoinpruning  (cost=0.00..431.00 rows=1 width=4)
          ->  Index Scan using idx2 on foojoinpruning  (cost=0.00..6.00 rows=1 width=28)
                Index Cond: (c = barjoinpruning.t)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(14 rows)
 
 explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on fooJoinPruning.g=barJoinPruning.p and fooJoinPruning.a=barJoinPruning.q where fooJoinPruning.c > ANY (select barJoinPruning.t from barJoinPruning );
                                                                    QUERY PLAN                                                                    
@@ -1861,15 +1857,11 @@ explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on 
                                        Sort Key: foojoinpruning.b
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                              Hash Key: foojoinpruning.b
-                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                                   Group Key: foojoinpruning.b
-                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                         Sort Key: foojoinpruning.b
-                                                         ->  Seq Scan on foojoinpruning  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on foojoinpruning  (cost=0.00..431.00 rows=1 width=4)
                            ->  Index Scan using idx2 on barjoinpruning  (cost=0.00..6.00 rows=1 width=1)
                                  Index Cond: (p = foojoinpruning.b)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(19 rows)
 
 -- Unique key of inner relation ie 'p' is present in the join condition and is equal to a column from outer relation and filter contains corelated subquery referencing inner relation column--
 explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on fooJoinPruning.c=barJoinPruning.p  where fooJoinPruning.b in (select barJoinPruning.q from fooJoinPruning);

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -130,19 +130,15 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: a
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                       Group Key: a
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: a
-                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
                                                     QUERY PLAN                                                    
@@ -152,19 +148,15 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: a
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                       Group Key: a
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: a
-                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -22,19 +22,15 @@ EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: type
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: type
-               ->  Partial GroupAggregate
-                     Group Key: type
-                     ->  Sort
-                           Sort Key: type
-                           ->  Seq Scan on mvtest_t
+               ->  Seq Scan on mvtest_t
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(8 rows)
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
@@ -72,19 +68,15 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               ->  Finalize GroupAggregate
+               ->  GroupAggregate
                      Group Key: type
                      ->  Sort
                            Sort Key: type
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: type
-                                 ->  Partial GroupAggregate
-                                       Group Key: type
-                                       ->  Sort
-                                             Sort Key: type
-                                             ->  Seq Scan on mvtest_t
+                                 ->  Seq Scan on mvtest_t
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(12 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvm AS SELECT * FROM mvtest_tv ORDER BY type;
 SELECT * FROM mvtest_tvm;
@@ -111,19 +103,15 @@ EXPLAIN (costs off)
          ->  Finalize Aggregate
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      ->  Partial Aggregate
-                           ->  Finalize GroupAggregate
+                           ->  GroupAggregate
                                  Group Key: type
                                  ->  Sort
                                        Sort Key: type
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: type
-                                             ->  Partial GroupAggregate
-                                                   Group Key: type
-                                                   ->  Sort
-                                                         Sort Key: type
-                                                         ->  Seq Scan on mvtest_t
+                                             ->  Seq Scan on mvtest_t
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvvm AS SELECT * FROM mvtest_tvv;
 CREATE VIEW mvtest_tvvmv AS SELECT * FROM mvtest_tvvm;

--- a/src/test/regress/expected/motion_deadlock_optimizer.out
+++ b/src/test/regress/expected/motion_deadlock_optimizer.out
@@ -39,26 +39,23 @@ from
   t_motion_deadlock_1 x,
   t_motion_deadlock_2 y
 where x.b = y.b;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Finalize Aggregate
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Aggregate
    Output: count(1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(1))
-         ->  Partial Aggregate
-               Output: PARTIAL count(1)
-               ->  Hash Join
-                     Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.b)
-                     ->  Seq Scan on public.t_motion_deadlock_1
-                           Output: t_motion_deadlock_1.b
-                     ->  Hash
+         ->  Hash Join
+               Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.b)
+               ->  Seq Scan on public.t_motion_deadlock_1
+                     Output: t_motion_deadlock_1.b
+               ->  Hash
+                     Output: t_motion_deadlock_2.b
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            Output: t_motion_deadlock_2.b
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on public.t_motion_deadlock_2
                                  Output: t_motion_deadlock_2.b
-                                 ->  Seq Scan on public.t_motion_deadlock_2
-                                       Output: t_motion_deadlock_2.b
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(14 rows)
 
 select count(1)
 from
@@ -82,25 +79,22 @@ from
 where x.b = y.b;
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+ Aggregate
    Output: count(1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(1))
-         ->  Partial Aggregate
-               Output: PARTIAL count(1)
-               ->  Nested Loop
-                     Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.b)
-                     ->  Seq Scan on public.t_motion_deadlock_1
-                           Output: t_motion_deadlock_1.b
-                     ->  Materialize
+         ->  Nested Loop
+               Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.b)
+               ->  Seq Scan on public.t_motion_deadlock_1
+                     Output: t_motion_deadlock_1.b
+               ->  Materialize
+                     Output: t_motion_deadlock_2.b
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            Output: t_motion_deadlock_2.b
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on public.t_motion_deadlock_2
                                  Output: t_motion_deadlock_2.b
-                                 ->  Seq Scan on public.t_motion_deadlock_2
-                                       Output: t_motion_deadlock_2.b
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_hashjoin = 'off', enable_nestloop = 'on', optimizer_enable_hashjoin = 'off', optimizer_enable_mergejoin = 'off'
-(18 rows)
+(15 rows)
 
 select count(1)
 from
@@ -190,41 +184,38 @@ from
   t_motion_deadlock_1 x join t_motion_deadlock_2 y
   on x.b = y.a and
      x.b + y.a > (select count(1) from t_motion_deadlock_3 z where z.b < x.a + y.b);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    Output: count(1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(1))
-         ->  Partial Aggregate
-               Output: PARTIAL count(1)
-               ->  Result
-                     Filter: ((t_motion_deadlock_1.b + t_motion_deadlock_2.a) > (SubPlan 1))
-                     ->  Hash Join
-                           Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                           Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Result
+               Filter: ((t_motion_deadlock_1.b + t_motion_deadlock_2.a) > (SubPlan 1))
+               ->  Hash Join
+                     Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_2.a, t_motion_deadlock_2.b
+                     Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
+                           Hash Key: t_motion_deadlock_1.b
+                           ->  Seq Scan on public.t_motion_deadlock_1
                                  Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                                 Hash Key: t_motion_deadlock_1.b
-                                 ->  Seq Scan on public.t_motion_deadlock_1
-                                       Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                           ->  Hash
+                     ->  Hash
+                           Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
+                           ->  Seq Scan on public.t_motion_deadlock_2
                                  Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                                 ->  Seq Scan on public.t_motion_deadlock_2
-                                       Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                     SubPlan 1
-                       ->  Aggregate
-                             Output: count(1)
-                             ->  Result
-                                   Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
-                                   ->  Materialize
+               SubPlan 1
+                 ->  Aggregate
+                       Output: count(1)
+                       ->  Result
+                             Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
+                             ->  Materialize
+                                   Output: t_motion_deadlock_3.b
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                          Output: t_motion_deadlock_3.b
-                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                         ->  Seq Scan on public.t_motion_deadlock_3
                                                Output: t_motion_deadlock_3.b
-                                               ->  Seq Scan on public.t_motion_deadlock_3
-                                                     Output: t_motion_deadlock_3.b
  Optimizer: Pivotal Optimizer (GPORCA)
-(32 rows)
+(29 rows)
 
 select count(1)
 from
@@ -248,40 +239,37 @@ from
      x.b + y.a > (select count(1) from t_motion_deadlock_3 z where z.b < x.a + y.b);
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+ Aggregate
    Output: count(1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(1))
-         ->  Partial Aggregate
-               Output: PARTIAL count(1)
-               ->  Result
-                     Filter: ((t_motion_deadlock_1.b + t_motion_deadlock_2.a) > (SubPlan 1))
-                     ->  Nested Loop
-                           Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                           Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
-                           ->  Seq Scan on public.t_motion_deadlock_2
-                                 Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                           ->  Materialize
+         ->  Result
+               Filter: ((t_motion_deadlock_1.b + t_motion_deadlock_2.a) > (SubPlan 1))
+               ->  Nested Loop
+                     Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_2.a, t_motion_deadlock_2.b
+                     Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
+                     ->  Seq Scan on public.t_motion_deadlock_2
+                           Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
+                     ->  Materialize
+                           Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: t_motion_deadlock_1.b
+                                 ->  Seq Scan on public.t_motion_deadlock_1
                                        Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                                       Hash Key: t_motion_deadlock_1.b
-                                       ->  Seq Scan on public.t_motion_deadlock_1
-                                             Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                     SubPlan 1
-                       ->  Aggregate
-                             Output: count(1)
-                             ->  Result
-                                   Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
-                                   ->  Materialize
+               SubPlan 1
+                 ->  Aggregate
+                       Output: count(1)
+                       ->  Result
+                             Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
+                             ->  Materialize
+                                   Output: t_motion_deadlock_3.b
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                          Output: t_motion_deadlock_3.b
-                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                         ->  Seq Scan on public.t_motion_deadlock_3
                                                Output: t_motion_deadlock_3.b
-                                               ->  Seq Scan on public.t_motion_deadlock_3
-                                                     Output: t_motion_deadlock_3.b
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_hashjoin = 'off', enable_nestloop = 'on', optimizer_enable_hashjoin = 'off', optimizer_enable_mergejoin = 'off'
-(33 rows)
+(30 rows)
 
 select count(1)
 from
@@ -370,44 +358,38 @@ where
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    Output: count(1)
-   ->  GroupAggregate
-         Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-         Group Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-               Merge Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-               ->  GroupAggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  GroupAggregate
+               Group Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
+               ->  Sort
                      Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                     Group Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                     ->  Sort
+                     Sort Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
+                     ->  Result
                            Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                           Sort Key: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                           ->  Result
+                           Filter: ((t_motion_deadlock_1.a IS NULL) OR CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END)
+                           ->  Nested Loop Left Join
                                  Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                                 Filter: ((t_motion_deadlock_1.a IS NULL) OR CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END)
-                                 ->  Nested Loop Left Join
-                                       Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id, (true)
-                                       Join Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
-                                       ->  Hash Left Join
-                                             Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id
-                                             Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Join Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
+                                 ->  Hash Left Join
+                                       Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id, t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id
+                                       Hash Cond: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id
+                                             Hash Key: t_motion_deadlock_1.b
+                                             ->  Seq Scan on public.t_motion_deadlock_1
                                                    Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id
-                                                   Hash Key: t_motion_deadlock_1.b
-                                                   ->  Seq Scan on public.t_motion_deadlock_1
-                                                         Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b, t_motion_deadlock_1.ctid, t_motion_deadlock_1.gp_segment_id
-                                             ->  Hash
+                                       ->  Hash
+                                             Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id
+                                             ->  Seq Scan on public.t_motion_deadlock_2
                                                    Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id
-                                                   ->  Seq Scan on public.t_motion_deadlock_2
-                                                         Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b, t_motion_deadlock_2.ctid, t_motion_deadlock_2.gp_segment_id
-                                       ->  Materialize
+                                 ->  Materialize
+                                       Output: t_motion_deadlock_3.b, (true)
+                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                              Output: t_motion_deadlock_3.b, (true)
-                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                   Output: t_motion_deadlock_3.b, (true)
-                                                   ->  Seq Scan on public.t_motion_deadlock_3
-                                                         Output: t_motion_deadlock_3.b, true
+                                             ->  Seq Scan on public.t_motion_deadlock_3
+                                                   Output: t_motion_deadlock_3.b, true
  Optimizer: Pivotal Optimizer (GPORCA)
-(39 rows)
+(33 rows)
 
 select count(1)
 from
@@ -433,38 +415,35 @@ where
    x.a is null or exists (select random() from t_motion_deadlock_3 z where z.b < x.a + y.b);
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+ Aggregate
    Output: count(1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(1))
-         ->  Partial Aggregate
-               Output: PARTIAL count(1)
-               ->  Result
-                     Filter: ((t_motion_deadlock_1.a IS NULL) OR (SubPlan 1))
-                     ->  Nested Loop Left Join
-                           Output: t_motion_deadlock_1.a, t_motion_deadlock_2.b
-                           Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
-                           ->  Seq Scan on public.t_motion_deadlock_1
-                                 Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
-                           ->  Materialize
+         ->  Result
+               Filter: ((t_motion_deadlock_1.a IS NULL) OR (SubPlan 1))
+               ->  Nested Loop Left Join
+                     Output: t_motion_deadlock_1.a, t_motion_deadlock_2.b
+                     Join Filter: (t_motion_deadlock_1.b = t_motion_deadlock_2.a)
+                     ->  Seq Scan on public.t_motion_deadlock_1
+                           Output: t_motion_deadlock_1.a, t_motion_deadlock_1.b
+                     ->  Materialize
+                           Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                  Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Seq Scan on public.t_motion_deadlock_2
                                        Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                                       ->  Seq Scan on public.t_motion_deadlock_2
-                                             Output: t_motion_deadlock_2.a, t_motion_deadlock_2.b
-                     SubPlan 1
-                       ->  Result
-                             Output: true
-                             Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
-                             ->  Materialize
+               SubPlan 1
+                 ->  Result
+                       Output: true
+                       Filter: (t_motion_deadlock_3.b < (t_motion_deadlock_1.a + t_motion_deadlock_2.b))
+                       ->  Materialize
+                             Output: t_motion_deadlock_3.a, t_motion_deadlock_3.b
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                    Output: t_motion_deadlock_3.a, t_motion_deadlock_3.b
-                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                   ->  Seq Scan on public.t_motion_deadlock_3
                                          Output: t_motion_deadlock_3.a, t_motion_deadlock_3.b
-                                         ->  Seq Scan on public.t_motion_deadlock_3
-                                               Output: t_motion_deadlock_3.a, t_motion_deadlock_3.b
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_hashjoin = 'off', enable_nestloop = 'on', optimizer_enable_hashjoin = 'off', optimizer_enable_mergejoin = 'off'
-(31 rows)
+(28 rows)
 
 select count(1)
 from

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1196,23 +1196,17 @@ explain select c1 from t1 where c1::absint not in
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
    ->  Result  (cost=0.00..1324035.89 rows=4 width=4)
          Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
-         ->  Finalize GroupAggregate  (cost=0.00..1324035.89 rows=4 width=20)
+         ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Sort  (cost=0.00..1324035.89 rows=4 width=30)
-                     Sort Key: t1.ctid, t1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=4 width=30)
-                           Hash Key: t1.ctid, t1.gp_segment_id
-                           ->  Streaming Partial HashAggregate  (cost=0.00..1324035.89 rows=4 width=30)
-                                 Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-                                 ->  Nested Loop Left Join  (cost=0.00..1324035.89 rows=11 width=19)
-                                       Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
-                                       ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                                       ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
-                                             ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                         ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+               ->  Nested Loop Left Join  (cost=0.00..1324035.89 rows=11 width=19)
+                     Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
+                     ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(13 rows)
 
 select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -142,21 +142,16 @@ select sum(distinct a) from olap_test_single;
 
 -- Otherwise, need a more complicated plans
 explain select sum(distinct b) from olap_test_single;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.51 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=11 width=4)
-         ->  GroupAggregate  (cost=0.00..431.51 rows=4 width=4)
-               Group Key: b
-               ->  Sort  (cost=0.00..431.51 rows=4 width=4)
-                     Sort Key: b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=4 width=4)
-                           Hash Key: b
-                           ->  Streaming HashAggregate  (cost=0.00..431.51 rows=4 width=4)
-                                 Group Key: b
-                                 ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
+                     Hash Key: b
+                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(7 rows)
 
 select sum(distinct b) from olap_test_single;
  sum 
@@ -170,17 +165,14 @@ select sum(distinct b) from olap_test_single;
 explain select sum(distinct d) from olap_test_single;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..432.12 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.12 rows=10000 width=4)
-         ->  HashAggregate  (cost=0.00..431.97 rows=3334 width=4)
-               Group Key: d
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.56 rows=3334 width=4)
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
                      Hash Key: d
-                     ->  Streaming HashAggregate  (cost=0.00..431.52 rows=3334 width=4)
-                           Group Key: d
-                           ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(7 rows)
 
 select sum(distinct d) from olap_test_single;
    sum    
@@ -273,28 +265,27 @@ explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a)
    ->  Sequence  (cost=0.00..1727.67 rows=3341 width=20)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.16 rows=3334 width=1)
                ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=12)
-         ->  Append  (cost=0.00..1296.44 rows=3341 width=20)
-               ->  Finalize HashAggregate  (cost=0.00..432.91 rows=3334 width=16)
+         ->  Append  (cost=0.00..1295.50 rows=3341 width=20)
+               ->  HashAggregate  (cost=0.00..431.99 rows=3334 width=16)
                      Group Key: share0_ref2.b, share0_ref2.d
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.07 rows=3334 width=16)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=8)
                            Hash Key: share0_ref2.b, share0_ref2.d
-                           ->  Streaming Partial HashAggregate  (cost=0.00..431.91 rows=3334 width=16)
-                                 Group Key: share0_ref2.b, share0_ref2.d
+                           ->  Result  (cost=0.00..431.06 rows=3334 width=8)
                                  ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.06 rows=3334 width=8)
-               ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
+               ->  Finalize GroupAggregate  (cost=0.00..431.47 rows=1 width=12)
                      Group Key: share0_ref3.a
-                     ->  Sort  (cost=0.00..431.48 rows=1 width=12)
+                     ->  Sort  (cost=0.00..431.47 rows=1 width=12)
                            Sort Key: share0_ref3.a
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.48 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.47 rows=1 width=12)
                                  Hash Key: share0_ref3.a
-                                 ->  Streaming Partial HashAggregate  (cost=0.00..431.48 rows=1 width=12)
+                                 ->  Streaming Partial HashAggregate  (cost=0.00..431.47 rows=1 width=12)
                                        Group Key: share0_ref3.a
                                        ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.06 rows=3334 width=8)
                ->  HashAggregate  (cost=0.00..431.91 rows=7 width=16)
                      Group Key: share0_ref4.a, share0_ref4.b
                      ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.10 rows=3334 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(24 rows)
 
 -- do not execute this query as it would produce too many tuples.
 -- Test that when the second-stage Agg doesn't try to preserve the

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6431,16 +6431,15 @@ insert into test_listPartition values(2,'2022-10-23');
 insert into test_listPartition values(3,'2022-10-24');
 --Test case with condition on date and timestamp
 explain (costs off) select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -interval '1 day');
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Dynamic Seq Scan on test_listpartition
-                     Number of partitions to scan: 2 (out of 3)
-                     Filter: ((d = '10-23-2022'::date) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
+         ->  Dynamic Seq Scan on test_listpartition
+               Number of partitions to scan: 2 (out of 3)
+               Filter: ((d = '10-23-2022'::date) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -interval '1 day');
     max     
@@ -6450,16 +6449,15 @@ select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::d
 
 --Test case with condition on date and date
 explain (costs off) select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Finalize Aggregate
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Dynamic Seq Scan on test_listpartition
-                     Number of partitions to scan: 2 (out of 3)
-                     Filter: ((d = '10-23-2022'::date) OR (d = '10-22-2022'::date))
+         ->  Dynamic Seq Scan on test_listpartition
+               Number of partitions to scan: 2 (out of 3)
+               Filter: ((d = '10-23-2022'::date) OR (d = '10-22-2022'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
     max     
@@ -6469,16 +6467,15 @@ select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
 
 --Test case with condition on timestamp and timestamp
 explain (costs off) select max(d) from test_listPartition where d=('2022-10-23'::date -interval '0 day') or d=('2022-10-23'::date -interval '1 day');
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Dynamic Seq Scan on test_listpartition
-                     Number of partitions to scan: 2 (out of 3)
-                     Filter: ((d = 'Sun Oct 23 00:00:00 2022'::timestamp without time zone) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
+         ->  Dynamic Seq Scan on test_listpartition
+               Number of partitions to scan: 2 (out of 3)
+               Filter: ((d = 'Sun Oct 23 00:00:00 2022'::timestamp without time zone) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 select max(d) from test_listPartition where d=('2022-10-23'::date -interval '0 day') or d=('2022-10-23'::date -interval '1 day');
     max     

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -294,15 +294,14 @@ analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
 -- up to 5 executions, custom plan is used
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -351,28 +350,26 @@ execute test_mode_pp(1); -- 5x
 
 -- we should now get a really bad plan
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 -- but we can force a custom plan
 set plan_cache_mode to force_custom_plan;
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(5 rows)
 
 drop table test_mode;
 --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -833,34 +833,30 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324467.58 rows=5 width=4)
                                        ->  Hash Join  (cost=0.00..1324467.58 rows=2 width=4)
                                              Hash Cond: (((sum(c.j)) = (a.j)::bigint) AND (c.j = a.j))
-                                             ->  Finalize GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
+                                             ->  GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
                                                    Group Key: c.j
-                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=12)
+                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
                                                          Sort Key: c.j
-                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=12)
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=4)
                                                                Hash Key: c.j
-                                                               ->  Partial GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
-                                                                     Group Key: c.j
-                                                                     ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
-                                                                           Sort Key: c.j
-                                                                           ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
-                                                                                 Filter: (SubPlan 1)
-                                                                                 SubPlan 1
-                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                         Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                     Filter: (c.i = b.i)
-                                                                                                     ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                 ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                       Filter: (i <> 10)
+                                                               ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
+                                                                     Filter: (SubPlan 1)
+                                                                     SubPlan 1
+                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                             Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                         Filter: (c.i = b.i)
+                                                                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                     ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                           Filter: (i <> 10)
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                                                    ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
                                                          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(44 rows)
+(40 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4227,20 +4227,18 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(14 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                       QUERY PLAN                                                       
@@ -4248,19 +4246,17 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(13 rows)
 
 -- Try same two queries, with group agg.
 set enable_groupagg=on;
@@ -4271,18 +4267,16 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
@@ -4292,19 +4286,17 @@ explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_te
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(13 rows)
 
 reset enable_groupagg;
 reset enable_hashagg;
@@ -4585,7 +4577,7 @@ explain select x, "median"(y) from qp_misc_jiras.tbl9613 group by x; -- this sho
 -----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-         Group By: x
+         Group Key: x
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: x
                ->  Seq Scan on tbl9613  (cost=0.00..431.00 rows=1 width=12)
@@ -4604,7 +4596,7 @@ explain select x, median2(y) from qp_misc_jiras.tbl9613 group by x; -- this shou
 -----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-         Group By: x
+         Group Key: x
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: x
                ->  Seq Scan on tbl9613  (cost=0.00..431.00 rows=1 width=12)
@@ -4716,13 +4708,9 @@ else 'Unidentify' end
                Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                      Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                           Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                                 Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                                 ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 reset gp_motion_cost_per_row;
@@ -4958,21 +4946,19 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,2)' and gp_segment_id
 set gp_enable_explain_allstat=on;
 insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
 explain analyze select count(*) from qp_misc_jiras.test_heap;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=8.563..8.564 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=8.510..8.556 rows=3 loops=1)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=8.007..8.027 rows=1 loops=1)
-               allstat: seg_firststart_total_ntuples/seg0_0.555 ms_8.027 ms_1/seg1_0.556 ms_8.104 ms_1/seg2_0.573 ms_7.963 ms_1//end
-               ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.365..5.174 rows=33462 loops=1)
-                     allstat: seg_firststart_total_ntuples/seg0_0.555 ms_5.174 ms_33462/seg1_0.557 ms_5.178 ms_33329/seg2_0.573 ms_4.990 ms_33210//end
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=44.742..44.744 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1) (actual time=1.780..34.433 rows=100001 loops=1)
+         ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.244..7.007 rows=33462 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_0.432 ms_7.007 ms_33462/seg1_0.428 ms_7.145 ms_33329/seg2_0.429 ms_7.013 ms_33210//end
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 3.668 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+ Planning Time: 5.021 ms
+   (slice0)    Executor memory: 111K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 9.297 ms
-(12 rows)
+ Execution Time: 45.187 ms
+(10 rows)
 
 -- This is the to verify MPP-9167:
 --	Gather Motion shows wrong row estimate compared to 3.3
@@ -5010,32 +4996,31 @@ explain select * from qp_misc_jiras.r;
 (4 rows)
 
 explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.26 rows=1000 width=16) (actual time=2.877..3.466 rows=1000 loops=1)
-   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16) (actual time=1.944..2.717 rows=340 loops=1)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.26 rows=1000 width=16) (actual time=13.412..15.188 rows=1000 loops=1)
+   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16) (actual time=12.480..14.413 rows=340 loops=1)
          Hash Cond: (r.a = s.b)
-         allstat: seg_firststart_total_ntuples/seg0_10 ms_2.565 ms_338/seg1_10 ms_2.644 ms_322/seg2_10 ms_2.717 ms_340//end
-         ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8) (actual time=0.047..0.129 rows=340 loops=1)
-               allstat: seg_firststart_total_ntuples/seg0_12 ms_0.124 ms_338/seg1_12 ms_0.133 ms_322/seg2_12 ms_0.129 ms_340//end
-         ->  Hash  (cost=431.02..431.02 rows=334 width=8) (actual time=1.527..1.528 rows=340 loops=1)
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 340 of 524288 buckets.
+         allstat: seg_firststart_total_ntuples/seg0_51 ms_15 ms_338/seg1_51 ms_15 ms_322/seg2_51 ms_14 ms_340//end
+         ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8) (actual time=0.180..0.233 rows=340 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_64 ms_0.249 ms_338/seg1_63 ms_0.228 ms_322/seg2_63 ms_0.233 ms_340//end
+         ->  Hash  (cost=431.02..431.02 rows=334 width=8) (actual time=10.802..10.803 rows=340 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4110kB
-               allstat: seg_firststart_total_ntuples/seg0_11 ms_1.561 ms_338/seg1_11 ms_1.614 ms_322/seg2_11 ms_1.528 ms_340//end
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8) (actual time=1.300..1.387 rows=340 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_52 ms_12 ms_338/seg1_51 ms_12 ms_322/seg2_53 ms_11 ms_340//end
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8) (actual time=9.495..10.709 rows=340 loops=1)
                      Hash Key: s.b
-                     allstat: seg_firststart_total_ntuples/seg0_61 ms_0.076 ms_321/seg1_60 ms_0.081 ms_342/seg2_61 ms_0.117 ms_337//end
-                     ->  Seq Scan on s  (cost=0.00..431.01 rows=334 width=8)
-                           allstat: seg_firststart_total_ntuples/seg0_2.222 ms_2.232 ms_321/seg1_2.265 ms_2.069 ms_342/seg2_2.286 ms_1.974 ms_337//end
- Slice statistics:
-   (slice0)    Executor memory: 267K bytes.
-   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).
-   (slice2)    Executor memory: 131378K bytes avg x 3 workers, 131399K bytes max (seg1).  Work_mem: 11K bytes max.
- Statement statistics:
-   Memory used: 1945600K bytes
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
- Total runtime: 87.064 ms
-(31 rows)
+                     allstat: seg_firststart_total_ntuples/seg0_52 ms_12 ms_338/seg1_51 ms_12 ms_322/seg2_53 ms_11 ms_340//end
+                     ->  Seq Scan on s  (cost=0.00..431.01 rows=334 width=8) (actual time=5.179..5.223 rows=340 loops=1)
+                           allstat: seg_firststart_total_ntuples/seg0_57 ms_6.457 ms_338/seg1_56 ms_6.902 ms_322/seg2_56 ms_5.223 ms_340//end
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 10.288 ms
+   (slice0)    Executor memory: 44K bytes.
+   (slice1)    Executor memory: 4163K bytes avg x 3 workers, 4163K bytes max (seg2).  Work_mem: 4110K bytes max.
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 66.660 ms
+(22 rows)
 
 drop table qp_misc_jiras.r;
 drop table qp_misc_jiras.s;
@@ -5572,10 +5557,9 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                           ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -498,12 +498,11 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select count(*) from mpp7638 where a =1;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
-                     Number of partitions to scan: 9 (out of 9)
-                     Filter: (a = 1)
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
+               Number of partitions to scan: 9 (out of 9)
+               Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
@@ -741,14 +740,13 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a);
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
@@ -780,15 +778,14 @@ explain select a0 from table_a where a0 in (select max(a1) from table_a where a0
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: (a0 = 1)
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (a0 = 1)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 reset test_print_direct_dispatch_info;
 -- the filter is over a window, do not direct dispatch

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -934,19 +934,15 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on t_hashdist
-         ->  Finalize GroupAggregate
+         ->  GroupAggregate
                Group Key: (random())
                ->  Sort
                      Sort Key: (random())
                      ->  Redistribute Motion 1:3  (slice2; segments: 1)
                            Hash Key: (random())
-                           ->  Partial GroupAggregate
-                                 Group Key: (random())
-                                 ->  Sort
-                                       Sort Key: (random())
-                                       ->  Seq Scan on t_replicate_volatile
+                           ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
                                       QUERY PLAN                                      
@@ -1026,17 +1022,12 @@ ___________
    ->  Broadcast Motion 3:3  (slice1; segments: 3)
          ->  Result
                Filter: (((sum(generate_series)))::double precision > random())
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: generate_series
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: generate_series
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: generate_series
-                                 ->  Result
-                                       One-Time Filter: (gp_execution_segment() = 1)
-                                       ->  Function Scan on generate_series
+                     ->  Result
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
- GP_IGNORE:(14 rows)
+GP_IGNORE:(9 rows)
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
@@ -1211,20 +1202,13 @@ explain select c from rep_tab where c in (select distinct a from dist_tab);
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
                Group Key: dist_tab.a
-               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
                      Sort Key: dist_tab.a
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           Hash Key: dist_tab.a
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 Group Key: dist_tab.a
-                                 ->  Sort  (cost=0.00..431.00 rows=2 width=4)
-                                       Sort Key: dist_tab.a
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                             ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(11 rows)
 
 select c from rep_tab where c in (select distinct a from dist_tab);
  c 
@@ -1250,15 +1234,11 @@ explain select c from rep_tab where c in (select distinct d from rand_tab);
                      Sort Key: rand_tab.d
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            Hash Key: rand_tab.d
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 Group Key: rand_tab.d
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: rand_tab.d
-                                       ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -130,30 +130,26 @@ SELECT DISTINCT p.age FROM person* p ORDER BY age using >;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Finalize Aggregate
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Aggregate
    Output: count()
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count())
-         ->  Partial Aggregate
-               Output: PARTIAL count()
-               ->  GroupAggregate
+         ->  GroupAggregate
+               Group Key: tenk1.two, tenk1.four, tenk1.two
+               ->  Sort
                      Output: two, four
-                     Group Key: tenk1.two, tenk1.four, tenk1.two
-                     ->  Sort
+                     Sort Key: tenk1.two, tenk1.four, tenk1.two
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Output: two, four
-                           Sort Key: tenk1.two, tenk1.four, tenk1.two
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: two, four, two
+                           ->  Streaming HashAggregate
                                  Output: two, four
-                                 Hash Key: two, four, two
-                                 ->  Streaming HashAggregate
+                                 Group Key: tenk1.two, tenk1.four, tenk1.two
+                                 ->  Seq Scan on public.tenk1
                                        Output: two, four
-                                       Group Key: tenk1.two, tenk1.four, tenk1.two
-                                       ->  Seq Scan on public.tenk1
-                                             Output: two, four
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(17 rows)
 
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -276,15 +276,13 @@ explain (costs off)
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: (sp_parallel_restricted(unique1))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: (sp_parallel_restricted(unique1))
-               ->  Streaming Partial HashAggregate
-                     Group Key: sp_parallel_restricted(unique1)
-                     ->  Seq Scan on tenk1
+               ->  Seq Scan on tenk1
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 -- test prepared statement
 prepare tenk1_count(integer) As select  count((unique1)) from tenk1 where hundred > $1;

--- a/src/test/regress/expected/sublink_optimizer.out
+++ b/src/test/regress/expected/sublink_optimizer.out
@@ -60,8 +60,8 @@ select a from group_by_sublink where exists (select avg(a) from group_by_sublink
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on group_by_sublink
    SubPlan 1
-     ->  Materialize
-           ->  Limit
+     ->  Limit
+           ->  Materialize
                  ->  Gather Motion 3:1  (slice2; segments: 3)
                        ->  GroupAggregate
                              Group Key: group_by_sublink_1.a

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -186,23 +186,19 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
-         ->  Finalize HashAggregate  (cost=0.00..1293.02 rows=7 width=20)
+         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.02 rows=7 width=30)
-                     Hash Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                     ->  Partial GroupAggregate  (cost=0.00..1293.02 rows=7 width=30)
-                           Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                           ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
-                                 Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
-                                 ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                                       Sort Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                                       ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
-                                       ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                                   ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+               ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                     Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                           Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                           ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                     ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(15 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -402,25 +398,19 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < '-100'::integer))
-         ->  Finalize GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
+         ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
-                     Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
-                           ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                 Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                 ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                                       Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                             Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                                             ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                       ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
-                                             ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                                   ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=4)
-                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
+               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                     Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                           Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(15 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -663,19 +653,15 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
                ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                            Group Key: csq_pullup_1.v
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                  Sort Key: csq_pullup_1.v
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        Hash Key: csq_pullup_1.v
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                             Group Key: csq_pullup_1.v
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                   Sort Key: csq_pullup_1.v
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(15 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -699,19 +685,15 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=13)
                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
                            Group Key: csq_pullup_1.n
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=13)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=5)
                                  Sort Key: csq_pullup_1.n
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                        Hash Key: csq_pullup_1.n
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                             Group Key: csq_pullup_1.n
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                                   Sort Key: csq_pullup_1.n
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(16 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -729,12 +711,12 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
+                       Filter: ((csq_pullup.n + '1'::numeric) = (csq_pullup_1.n + '1'::numeric))
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
@@ -757,16 +739,16 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
+                       Filter: ((csq_pullup.n + '1'::numeric) = ((csq_pullup_1.i + 1))::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
@@ -968,18 +950,17 @@ select * from subselect_t1 where x in (select y from subselect_t2 union all sele
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-                     Hash Cond: (subselect_t1.x = subselect_t2.y)
-                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(8 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -991,22 +972,21 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-                     Hash Cond: (subselect_t1.x = subselect_t2.y)
-                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=862.00..862.00 rows=1 width=4)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                 Group Key: subselect_t2.y
-                                 ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-                                       Sort Key: subselect_t2.y
-                                       ->  Append  (cost=0.00..862.00 rows=2 width=4)
-                                             ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                     ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                           Group Key: subselect_t2.y
+                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                                 Sort Key: subselect_t2.y
+                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                       ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
@@ -1135,6 +1115,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               Filter: (a = 1)
    SubPlan 1
      ->  Limit  (cost=0.00..431.00 rows=1 width=4)
            ->  Result  (cost=0.00..431.00 rows=1 width=4)
@@ -1152,6 +1133,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               Filter: (a = 1)
    SubPlan 1
      ->  Limit  (cost=0.00..431.00 rows=1 width=4)
            ->  Result  (cost=0.00..431.00 rows=1 width=4)
@@ -1289,20 +1271,16 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                      ->  Dynamic Seq Scan on t_mpp_20470  (cost=0.00..431.00 rows=1 width=8)
                            Number of partitions to scan: 2 (out of 2)
                ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                            Group Key: t_mpp_20470_1.col_name
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                  Sort Key: t_mpp_20470_1.col_name
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                        Hash Key: t_mpp_20470_1.col_name
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                             Group Key: t_mpp_20470_1.col_name
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                                   Sort Key: t_mpp_20470_1.col_name
-                                                   ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
-                                                         Number of partitions to scan: 2 (out of 2)
+                                       ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
+                                             Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(18 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1711,10 +1689,11 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
          ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
                Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
                ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+                     Filter: (NOT (f1 IS NULL))
                ->  Hash  (cost=431.00..431.00 rows=3 width=8)
                      ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(9 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   FROM SUBSELECT_TBL upper
@@ -1768,35 +1747,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Join  (cost=0.00..864.09 rows=34 width=4)
-                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..864.09 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.09 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.09 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.09 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Join  (cost=0.00..864.09 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
+                           ->  Hash  (cost=431.93..431.93 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.93 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(19 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
@@ -1825,35 +1797,28 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Semi Join  (cost=0.00..864.09 rows=34 width=4)
-                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..864.09 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.09 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.09 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.09 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Semi Join  (cost=0.00..864.09 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
+                           ->  Hash  (cost=431.93..431.93 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.93 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(19 rows)
 
 --
 -- Commit 41efb83 remove unused subplans in planner stage, it
@@ -2005,14 +1970,10 @@ select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);
                      Sort Key: ((dedup_tab.a / 10))
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((dedup_tab.a / 10))
-                           ->  GroupAggregate
-                                 Group Key: ((dedup_tab.a / 10))
-                                 ->  Sort
-                                       Sort Key: ((dedup_tab.a / 10))
-                                       ->  Seq Scan on dedup_tab
+                           ->  Seq Scan on dedup_tab
          ->  Hash
                ->  Seq Scan on dedup_reptab
- Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -356,32 +356,23 @@ select * from csq_d1;
 -- outer plan node is coordinator-only and CSQ has distributed relation
 --
 explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
-                                                                                                                     QUERY PLAN                                                                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
-   ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < '-100'::integer))
-         ->  Finalize GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
-               Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=3 width=4)
+   Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < '-100'::integer))
+   ->  GroupAggregate  (cost=0.00..1293.00 rows=3 width=20)
+         Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+         ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=5 width=19)
+               Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=14)
                      Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                           ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                 Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                                 ->  Result  (cost=0.00..1293.00 rows=2 width=19)
-                                       ->  Sort  (cost=0.00..1293.00 rows=2 width=19)
-                                             Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
-                                             ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..1293.00 rows=4 width=19)
-                                                   ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                                                         Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
-                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=14)
-                                                         ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
-                                                               ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                                                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(23 rows)
+                     ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=14)
+               ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                     ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
  x 

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -965,27 +965,26 @@ explain (costs off)
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
   and thousand = 1;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  GroupAggregate
-                     Group Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
-                     ->  Sort
-                           Sort Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
-                           ->  Result
-                                 Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END OR (tenk1_1.ten < 0))
-                                 ->  Hash Right Join
-                                       Hash Cond: (tenk1.unique1 = tenk1_1.unique2)
-                                       ->  Seq Scan on tenk1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                                   Hash Key: tenk1_1.unique2
-                                                   ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
-                                                         Index Cond: (thousand = 1)
+         ->  GroupAggregate
+               Group Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
+               ->  Sort
+                     Sort Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
+                     ->  Result
+                           Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END OR (tenk1_1.ten < 0))
+                           ->  Hash Right Join
+                                 Hash Cond: (tenk1.unique1 = tenk1_1.unique2)
+                                 ->  Seq Scan on tenk1
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Hash Key: tenk1_1.unique2
+                                             ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                                   Index Cond: (thousand = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(17 rows)
 
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
@@ -1016,16 +1015,14 @@ select count(*) from exists_tbl t1
                            ->  Dynamic Seq Scan on exists_tbl
                                  Number of partitions to scan: 2 (out of 2)
                            ->  Hash
-                                 ->  Finalize HashAggregate
+                                 ->  HashAggregate
                                        Group Key: exists_tbl_1.c2
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                              Hash Key: exists_tbl_1.c2
-                                             ->  Streaming Partial HashAggregate
-                                                   Group Key: exists_tbl_1.c2
-                                                   ->  Dynamic Seq Scan on exists_tbl exists_tbl_1
-                                                         Number of partitions to scan: 2 (out of 2)
+                                             ->  Dynamic Seq Scan on exists_tbl exists_tbl_1
+                                                   Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(17 rows)
 
 select count(*) from exists_tbl t1
   where (exists(select 1 from exists_tbl t2 where t1.c1 = t2.c2) or c3 < 0);

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -853,15 +853,11 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                                 ->  Nested Loop
-                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                             ->  Seq Scan on inner_text
-                                       ->  Seq Scan on int8_tbl
+                     ->  Nested Loop
+                           Join Filter: (int8_tbl.q1 = inner_text.c1)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on inner_text
+                           ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -887,15 +883,11 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                                 ->  Nested Loop
-                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                             ->  Seq Scan on inner_text
-                                       ->  Seq Scan on int8_tbl
+                     ->  Nested Loop
+                           Join Filter: (int8_tbl.q1 = inner_text.c1)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on inner_text
+                           ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -921,15 +913,11 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                                 ->  Nested Loop
-                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                             ->  Seq Scan on inner_text
-                                       ->  Seq Scan on int8_tbl
+                     ->  Nested Loop
+                           Join Filter: (int8_tbl.q1 = inner_text.c1)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on inner_text
+                           ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -1080,7 +1068,6 @@ explain (verbose, costs off)
      ->  Result
            Output: 'regression'::name
  Optimizer: Postgres query optimizer
- Settings: optimizer=on
 (9 rows)
 
 explain (verbose, costs off)

--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -241,36 +241,31 @@ union
 explain (SELECT 'test1' as branch, id FROM test1 LIMIT 1)
 union
 (SELECT 'test2' as branch, id FROM test2);
-                                                                     QUERY PLAN                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..984.96 rows=1125 width=12)
-   ->  HashAggregate  (cost=0.00..984.91 rows=375 width=12)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..983.66 rows=1125 width=12)
+   ->  HashAggregate  (cost=0.00..983.61 rows=375 width=12)
          Group Key: ('test1'::text), test1.id
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..984.83 rows=334 width=12)
-               Hash Key: ('test1'::text), test1.id
-               ->  Streaming HashAggregate  (cost=0.00..984.81 rows=334 width=12)
-                     Group Key: ('test1'::text), test1.id
-                     ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..984.73 rows=334 width=12)
-                           ->  Result  (cost=0.00..984.70 rows=1001 width=12)
-                                 ->  Append  (cost=0.00..984.70 rows=1001 width=12)
-                                       ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                             Group Key: ('test1'::text), test1.id
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                                   Sort Key: ('test1'::text), test1.id
-                                                   ->  Limit  (cost=0.00..431.00 rows=1 width=12)
-                                                         ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                                     ->  Seq Scan on test1  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..553.69 rows=1000 width=12)
-                                             ->  HashAggregate  (cost=0.00..553.64 rows=334 width=12)
-                                                   Group Key: ('test2'::text), id
-                                                   ->  Redistribute Motion 3:3  (slice6; segments: 3)  (cost=0.00..553.56 rows=334 width=12)
-                                                         Hash Key: ('test2'::text), id
-                                                         ->  Streaming HashAggregate  (cost=0.00..553.55 rows=334 width=12)
-                                                               Group Key: 'test2'::text, id
-                                                               ->  Result  (cost=0.00..471.53 rows=333334 width=12)
-                                                                     ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..467.53 rows=333334 width=4)
-                                                                           ->  Foreign Scan on test2  (cost=0.00..449.70 rows=1000000 width=4)
+         ->  Append  (cost=0.00..983.53 rows=334 width=12)
+               ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=12)
+                     Hash Key: ('test1'::text), test1.id
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                           Group Key: ('test1'::text), test1.id
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                 Sort Key: ('test1'::text), test1.id
+                                 ->  Limit  (cost=0.00..431.00 rows=1 width=12)
+                                       ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Seq Scan on test1  (cost=0.00..431.00 rows=1 width=4)
+               ->  HashAggregate  (cost=0.00..552.53 rows=334 width=12)
+                     Group Key: ('test2'::text), id
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..552.44 rows=334 width=12)
+                           Hash Key: ('test2'::text), id
+                           ->  Streaming HashAggregate  (cost=0.00..552.43 rows=334 width=12)
+                                 Group Key: 'test2'::text, id
+                                 ->  Result  (cost=0.00..471.53 rows=333334 width=12)
+                                       ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..467.53 rows=333334 width=4)
+                                             ->  Foreign Scan on test2  (cost=0.00..449.70 rows=1000000 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -366,9 +366,7 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Streaming HashAggregate
-                                             Group Key: tenk1_1.fivethous
-                                             ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
@@ -422,9 +420,7 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Streaming HashAggregate
-                                             Group Key: tenk1_1.fivethous
-                                             ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
@@ -767,20 +763,16 @@ explain (costs off)
          Group Key: ((t1.a || t1.b))
          ->  Sort
                Sort Key: ((t1.a || t1.b))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: ((t1.a || t1.b))
-                     ->  GroupAggregate
-                           Group Key: ((t1.a || t1.b))
-                           ->  Sort
-                                 Sort Key: ((t1.a || t1.b))
-                                 ->  Append
-                                       ->  Result
-                                             Filter: (((t1.a || t1.b)) = 'ab'::text)
-                                             ->  Seq Scan on t1
-                                       ->  Index Scan using t2_pkey on t2
-                                             Index Cond: (ab = 'ab'::text)
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((t1.a || t1.b))
+                           ->  Result
+                                 Filter: (((t1.a || t1.b)) = 'ab'::text)
+                                 ->  Seq Scan on t1
+                     ->  Index Scan using t2_pkey on t2
+                           Index Cond: (ab = 'ab'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(14 rows)
 
 --
 -- Test that ORDER BY for UNION ALL can be pushed down to inheritance
@@ -1012,28 +1004,21 @@ where q2 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int8_tbl.q1
+               ->  Append
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       ->  Append
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl.q1
-                                                         ->  Seq Scan on int8_tbl
-                                                               Filter: (q2 = q2)
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl_1.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl_1.q1
-                                                         ->  Seq Scan on int8_tbl int8_tbl_1
-                                                               Filter: (q2 = q2)
+                                 ->  Seq Scan on int8_tbl
+                                       Filter: (q2 = q2)
+                     ->  GroupAggregate
+                           Group Key: int8_tbl_1.q1
+                           ->  Sort
+                                 Sort Key: int8_tbl_1.q1
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: (q2 = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(19 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81
@@ -1059,28 +1044,21 @@ where -q1 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int8_tbl.q1
+               ->  Append
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       ->  Append
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl.q1
-                                                         ->  Seq Scan on int8_tbl
-                                                               Filter: ((- q1) = q2)
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl_1.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl_1.q1
-                                                         ->  Seq Scan on int8_tbl int8_tbl_1
-                                                               Filter: ((- q1) = q2)
+                                 ->  Seq Scan on int8_tbl
+                                       Filter: ((- q1) = q2)
+                     ->  GroupAggregate
+                           Group Key: int8_tbl_1.q1
+                           ->  Sort
+                                 Sort Key: int8_tbl_1.q1
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: ((- q1) = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(19 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -144,10 +144,9 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                            ->  Hash Join
                                                                                  Hash Cond: ((min((keo4.keo_para_budget_date)::text)) = (keo4_1.keo_para_budget_date)::text)
                                                                                  ->  Redistribute Motion 1:3  (slice5; segments: 1)
-                                                                                       ->  Finalize Aggregate
+                                                                                       ->  Aggregate
                                                                                              ->  Gather Motion 3:1  (slice6; segments: 3)
-                                                                                                   ->  Partial Aggregate
-                                                                                                         ->  Seq Scan on keo4
+                                                                                                   ->  Seq Scan on keo4
                                                                                  ->  Hash
                                                                                        ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                                                                              ->  Seq Scan on keo4 keo4_1

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2286,16 +2286,15 @@ SELECT count(a1.i)
                            ->  Hash
                                  ->  Shared Scan (share slice:id 1:1)
                      ->  Redistribute Motion 1:3  (slice2)
-                           ->  Finalize Aggregate
+                           ->  Aggregate
                                  ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Hash Join
-                                                   Hash Cond: (share0_ref3.i = share1_ref3.i)
-                                                   ->  Shared Scan (share slice:id 3:0)
-                                                   ->  Hash
-                                                         ->  Shared Scan (share slice:id 3:1)
+                                       ->  Hash Join
+                                             Hash Cond: (share0_ref3.i = share1_ref3.i)
+                                             ->  Shared Scan (share slice:id 3:0)
+                                             ->  Hash
+                                                   ->  Shared Scan (share slice:id 3:1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(22 rows)
 
 -- Another cross-slice ShareInputScan test. There is one producing slice,
 -- and two consumers in second slice. Make sure the Share Input Scan
@@ -2333,12 +2332,8 @@ UNION ALL
                            Sort Key: ('a'::text), share0_ref2.j
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: ('a'::text), share0_ref2.j
-                                 ->  GroupAggregate
-                                       Group Key: ('a'::text), share0_ref2.j
-                                       ->  Sort
-                                             Sort Key: ('a'::text), share0_ref2.j
-                                             ->  Result
-                                                   ->  Shared Scan (share slice:id 2:0)
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 2:0)
                ->  Hash Join
                      Hash Cond: (share0_ref4.i = share0_ref3.i)
                      ->  Shared Scan (share slice:id 1:0)
@@ -2352,7 +2347,7 @@ UNION ALL
                ->  Result
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(30 rows)
+(26 rows)
 
 WITH cte AS (SELECT * FROM foo)
   (SELECT DISTINCT 'a' as branch, j FROM cte)

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -292,10 +292,11 @@ SELECT count(*) FROM tenk_aocs3;
 SELECT count(*) FROM tenk_aocs4;
 
 -- Issue #15904
+set optimizer = off;
 EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aocs1;
 CREATE TABLE tenk_aorow WITH(appendonly=true, orientation=row) AS SELECT * FROM tenk_heap_for_aocs;
 EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aorow;
-
+reset optimizer;
 -- LIKE
 -- Should not copy storage options if not specified
 CREATE TABLE tenk_like_nocopy_storage (LIKE tenk_aocs1);

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -536,6 +536,7 @@ SELECT count(*) FROM tenk_aocs4;
 (1 row)
 
 -- Issue #15904
+set optimizer = off;
 EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aocs1;
                    QUERY PLAN                    
 -------------------------------------------------
@@ -548,7 +549,8 @@ EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aocs1;
                ->  Seq Scan on public.tenk_aocs1
                      Output: unique1
  Optimizer: Postgres query optimizer
-(9 rows)
+ Settings: optimizer = 'off'
+(10 rows)
 
 CREATE TABLE tenk_aorow WITH(appendonly=true, orientation=row) AS SELECT * FROM tenk_heap_for_aocs;
 EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aorow;
@@ -563,8 +565,10 @@ EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aorow;
                ->  Seq Scan on public.tenk_aorow
                      Output: unique1
  Optimizer: Postgres query optimizer
-(9 rows)
+ Settings: optimizer = 'off'
+(10 rows)
 
+reset optimizer;
 -- LIKE
 -- Should not copy storage options if not specified
 CREATE TABLE tenk_like_nocopy_storage (LIKE tenk_aocs1);


### PR DESCRIPTION
The current cardinality calculation for the local aggregate is significantly deviating from the actual number, 
resulting in a negative impact on the two-stage aggregate. Also observed decline in 
performance for a few queries within the TPC-DS benchmark.
  

RCA:
To evaluate performance, executed TPC-DS benchmark tests on various scenarios:
    Ran TPC-DS on the main with multistage_agg enabled (7X_MulAgg_ON).
    Ran TPC-DS on the main with multistage_agg disabled (7X_MulAgg_OFF).
    Ran TPC-DS on the main with multistage_agg disabled and cardinality estimation tuning (7X_MulAgg_OFF_TC).

Performed a comprehensive performance analysis comparing the following scenarios:
    7X_MulAgg_ON versus 7X_MulAgg_OFF
    7X_MulAgg_ON versus 7X_MulAgg_OFF_TC
    6X_STABLE versus 7X_MulAgg_ON
    6X_STABLE versus 7X_MulAgg_OFF
    6X_STABLE versus 7X_MulAgg_OFF_TC
Overall, we observed that by disabling multistage_agg and fine-tuning cardinality estimation (7X_MulAgg_OFF_TC), we achieved better performance compared to enabling multistage_agg (7X_MulAgg_ON) in comparison to the 6X_STABLE version. This indicates that the performance results of 6X_STABLE versus 7X_MulAgg_OFF_TC are significantly better than those of 6X_STABLE versus 7X_MulAgg_ON.

Resolution:
To address the identified issues, the following fixes were implemented:

1. By default, turned off the multistage_agg  on main(7X).
2. Modified the cardinality estimation of local aggregate.
          Cardinality tuning was introduced to address scenario.'s like when multistage_agg is disabled, we generate both single and multistage plans. However, if the cost estimation for multistage_agg is inaccurate, there is a possibility of choosing a less efficient aggregation method, such as single stage aggregation, which can negatively impact query performance. By adjusting the cardinality estimates for local aggreates, we can ensure that the query execution plan selects the most suitable aggregation method and improve overall query performance.

Currently approach to calculate cardinality for local hash agg:
   rows = (estimated_intput_rows + estimated_output_rows) / 2.0;

New approach to calculate cardinality for local hash aggregate:
   rows = estimated_output_rows * pcmgpdb->UlHosts();

For example, consider the following table and query:
```
foo (a int, b int, c int)
INSERT INTO foo SELECT i, i % 100, i FROM generate_series(1, 1000);
select b, count(*) from foo group by b;
```

Total tuples in the table (tot_tuples): 1000
NDV (Number of Distinct Values) of column b: 100
Number of segments: 3 (assumed)

for the given query input_rows and output_rows for per segment  evaluated as:
estimated input_rows = tot_tuples / number of segments = 1000/3 = 333.3
estimated output_rows = ndv of b / number of segements = 100/3  = 33.3
 
Using the old approach, the cardinality out for segment calculated as:
    rows = (input_rows + output_rows) / 2.0  // (333.3 + 33.3) / 2 = 183.3

     local agg's total cardinality = 183.9 * 3 = 549.9

With the new approach, the cardinality out for segment is calculated as:
    rows = output_rows * num_segments  // 33.3 * 3 = 100

    local agg's total cardinality = 100 *3 = 300

Even though data is distributed evenly, the local agg's total cardinality is at most card(global agg) * num_segments  //100*3 = 300
