### PR TITLE
Fix flaky test for crash_recovery_dtm

### DIFF
--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -349,15 +349,15 @@ server closed the connection unexpectedly
 --------------------------
  Success:                 
 (1 row)
-19: SELECT gp_inject_fault_infinite('after_orphaned_check', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
 19: SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
+(1 row)
+19: SELECT gp_inject_fault_infinite('after_orphaned_check', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
 (1 row)
 
 -- let prepare finish else dtx recovery can not abort the prepared transaction.

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -171,9 +171,9 @@ FROM gp_segment_configuration g1 where role = 'p';
 -- coordinator suspends before running periodical checking of orphaned prepared transactions.
 19: SELECT gp_inject_fault_infinite('before_orphaned_check', 'suspend', dbid)
    from gp_segment_configuration where role = 'p' and content = -1;
-19: SELECT gp_inject_fault_infinite('after_orphaned_check', 'suspend', dbid)
-   from gp_segment_configuration where role = 'p' and content = -1;
 19: SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+19: SELECT gp_inject_fault_infinite('after_orphaned_check', 'suspend', dbid)
    from gp_segment_configuration where role = 'p' and content = -1;
 
 -- let prepare finish else dtx recovery can not abort the prepared transaction.


### PR DESCRIPTION
We might be hitting a race condition where we are suspending `after_orphaned_check` on before suspending on `before_orphaned_check`, which may cause the `gp_inject_fault_infinite` of
`before_orphaned_check` to never get triggered.

Reorder the fault injection to fix the issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
