### PR TITLE
Set postmaster status ready after walreceiver up

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -168,7 +168,7 @@ Feature: Tests for gpaddmirrors
         And the user reset the walsender on the primary on content 0
         And the user waits until saved async process is completed
         And recovery_progress.file should not exist in gpAdminLogs in gpAdminLogs
-        And the user waits until mirror on content 0,1,2 is up
+        And verify that mirror on content 0,1,2 is up
 
         And check if mirrors on content 0,1,2 are moved to new location on input file
         And verify there are no recovery backout files
@@ -209,7 +209,7 @@ Feature: Tests for gpaddmirrors
 #        And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
 #        And the user waits until saved async process is completed
 #        And recovery_progress.file should not exist in gpAdminLogs
-#        And the user waits until mirror on content 0,1,2 is up
+#        And verify that mirror on content 0,1,2 is up
 #
 #        And check if mirrors on content 0,1,2 are moved to new location on input file
 #        And verify there are no recovery backout files

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -208,7 +208,7 @@ Feature: Tests for gpmovemirrors
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1 is up
+    And verify that mirror on content 0,1 is up
     And check if mirrors on content 0,1 are moved to new location on input file
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
@@ -232,7 +232,7 @@ Feature: Tests for gpmovemirrors
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And check if mirrors on content 0,1,2 are moved to new location on input file
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
@@ -270,7 +270,6 @@ Feature: Tests for gpmovemirrors
     And verify that mirror on content 0 is down
     And check if mirrors on content 1,2 are moved to new location on input file
     And check if mirrors on content 0 are in their original configuration
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
@@ -294,7 +293,6 @@ Feature: Tests for gpmovemirrors
     And the user asynchronously runs "gprecoverseg -aF" and the process is saved
     And the user just waits until recovery_progress.file is created in gpAdminLogs
     And user waits until gp_stat_replication table has no pg_basebackup entries for content 2
-    And an FTS probe is triggered
     And the user waits until mirror on content 2 is up
     And verify that mirror on content 0,1 is down
     And the gprecoverseg lock directory is removed
@@ -311,7 +309,6 @@ Feature: Tests for gpmovemirrors
     And verify that mirror on content 0,1 is down
     And check if mirrors on content 2 are moved to new location on input file
     And check if mirrors on content 0,1 are in their original configuration
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user reset the walsender on the primary on content 1
     And the user waits until saved async process is completed
@@ -346,7 +343,6 @@ Feature: Tests for gpmovemirrors
     And gprecoverseg should return a return code of 0
     And gpmovemirrors should return a return code of 0
     And check if mirrors on content 0,1,2 are in their original configuration
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user reset the walsender on the primary on content 1
     And the user reset the walsender on the primary on content 2

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -41,7 +41,7 @@ Feature: gprecoverseg tests
           And gprecoverseg should print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
           And gprecoverseg should print "Successfully created replication slot internal_wal_replication_slot" to stdout
           And gprecoverseg should print "Segments successfully recovered" to stdout
-          And the user waits until mirror on content 0,1,2 is up
+          And verify that mirror on content 0,1,2 is up
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the segments are synchronized
           And the cluster is rebalanced
@@ -423,7 +423,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
         And gprecoverseg should print "Segments successfully recovered" to stdout
-        And the user waits until mirror on content 0,1,2 is up
+        And verify that mirror on content 0,1,2 is up
         And verify replication slot internal_wal_replication_slot is available on all the segments
         And all the segments are running
         And the segments are synchronized
@@ -444,7 +444,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Slot internal_wal_replication_slot does not exist" to stdout
         And gprecoverseg should not print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
         And gprecoverseg should print "Segments successfully recovered" to stdout
-        And the user waits until mirror on content 0 is up
+        And verify that mirror on content 0 is up
         And verify replication slot internal_wal_replication_slot is available on all the segments
         And all the segments are running
         And the segments are synchronized
@@ -594,10 +594,9 @@ Feature: gprecoverseg tests
     And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
     When the user asynchronously runs "gprecoverseg -a" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
-    And an FTS probe is triggered
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And a sample recovery_progress.file is created from saved lines
@@ -628,8 +627,7 @@ Feature: gprecoverseg tests
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
@@ -649,7 +647,7 @@ Feature: gprecoverseg tests
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
@@ -668,7 +666,7 @@ Feature: gprecoverseg tests
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in /tmp/custom_logdir
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And user can start transactions
     And all files in "/tmp/custom_logdir" directory are deleted on all hosts in the cluster
 
@@ -685,7 +683,7 @@ Feature: gprecoverseg tests
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
@@ -710,7 +708,7 @@ Feature: gprecoverseg tests
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the old data directories are cleaned up for content 0
     And user can start transactions
     And check segment conf: postgresql.conf
@@ -735,7 +733,6 @@ Feature: gprecoverseg tests
     Then recovery_progress.file should not exist in gpAdminLogs
     Then the user reset the walsender on the primary on content 0
     Then the gprecoverseg lock directory is removed
-    And an FTS probe is triggered
     And the user waits until mirror on content 0,1,2 is up
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     And the cluster is rebalanced
@@ -756,7 +753,6 @@ Feature: gprecoverseg tests
     And the user waits until saved async process is completed
     Then recovery_progress.file should not exist in gpAdminLogs
     Then the gprecoverseg lock directory is removed
-    And an FTS probe is triggered
     And the user waits until mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
@@ -806,7 +802,6 @@ Feature: gprecoverseg tests
     When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
     And user waits until gp_stat_replication table has no pg_basebackup entries for content 1
-    And an FTS probe is triggered
     And the user waits until mirror on content 1,2 is up
     And verify that mirror on content 0 is down
     And user can start transactions
@@ -835,11 +830,10 @@ Feature: gprecoverseg tests
     Then gprecoverseg should not print "No basebackup running" to stdout
     And gprecoverseg should return a return code of 0
     And verify that mirror on content 0,1 is up
-    And an FTS probe is triggered
     And gp_stat_replication table has pg_basebackup entry for content 2
     And the user reset the walsender on the primary on content 2
     And the user waits until saved async process is completed
-    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And the cluster is rebalanced
@@ -857,7 +851,6 @@ Feature: gprecoverseg tests
     And the user asynchronously runs "gprecoverseg -aF" and the process is saved
     And the user just waits until recovery_progress.file is created in gpAdminLogs
     And user waits until gp_stat_replication table has no pg_basebackup entries for content 1,2
-    And an FTS probe is triggered
     And the user waits until mirror on content 1,2 is up
     And verify that mirror on content 0 is down
     And the gprecoverseg lock directory is removed
@@ -868,7 +861,6 @@ Feature: gprecoverseg tests
     And gprecoverseg should return a return code of 0
     And verify that mirror on content 1,2 is up
     And verify that mirror on content 0 is down
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
@@ -892,7 +884,6 @@ Feature: gprecoverseg tests
     And the user asynchronously runs "gprecoverseg -aF" and the process is saved
     And the user just waits until recovery_progress.file is created in gpAdminLogs
     And user waits until gp_stat_replication table has no pg_basebackup entries for content 2
-    And an FTS probe is triggered
     And the user waits until mirror on content 2 is up
     And verify that mirror on content 0,1 is down
     And the gprecoverseg lock directory is removed
@@ -903,7 +894,6 @@ Feature: gprecoverseg tests
     And gprecoverseg should return a return code of 0
     And verify that mirror on content 2 is up
     And verify that mirror on content 0,1 is down
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user reset the walsender on the primary on content 1
     And the user waits until saved async process is completed
@@ -935,7 +925,6 @@ Feature: gprecoverseg tests
     And gprecoverseg should print "No segments to recover" to stdout
     And gprecoverseg should return a return code of 0
     And verify that mirror on content 0,1,2 is down
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user reset the walsender on the primary on content 1
     And the user reset the walsender on the primary on content 2
@@ -974,7 +963,6 @@ Feature: gprecoverseg tests
     And gprecoverseg should print "No segments to recover" to stdout
     And gprecoverseg should return a return code of 0
     And verify that mirror on content 0,1,2 is down
-    And an FTS probe is triggered
     And the user reset the walsender on the primary on content 0
     And the user reset the walsender on the primary on content 1
     And the user reset the walsender on the primary on content 2
@@ -1077,8 +1065,7 @@ Feature: gprecoverseg tests
     And verify that mirror on content 2 is down
     And the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @concourse_cluster
@@ -1110,8 +1097,7 @@ Feature: gprecoverseg tests
     And verify that mirror on content 2,3 is down
     And the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2,3 is up
+    And verify that mirror on content 0,1,2,3 is up
     And the cluster is rebalanced
 
   @concourse_cluster
@@ -1140,8 +1126,7 @@ Feature: gprecoverseg tests
     And "SUSPEND_PG_REWIND" environment variable should be restored
     And the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2,3 is up
+    And verify that mirror on content 0,1,2,3 is up
     And the cluster is rebalanced
 
   @concourse_cluster
@@ -1179,8 +1164,7 @@ Feature: gprecoverseg tests
     And verify that mirror on content 0,1 is down
     And the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @concourse_cluster
@@ -1215,8 +1199,7 @@ Feature: gprecoverseg tests
     Then "SUSPEND_PG_REWIND" environment variable should be restored
     And the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
-    And an FTS probe is triggered
-    And the user waits until mirror on content 0,1,2,3 is up
+    And verify that mirror on content 0,1,2,3 is up
     And the cluster is rebalanced
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
@@ -1366,13 +1349,13 @@ Feature: gprecoverseg tests
     And the user runs sql "select pg_start_backup('test')" in "postgres" on primary segment with content 0
     When the user runs "gprecoverseg -a --differential"
     Then gprecoverseg should return a return code of 0
-    And the user waits until mirror on content 1,2 is up
+    And verify that mirror on content 1,2 is up
     And verify that mirror on content 0 is down
     Then gprecoverseg should print "Found differential recovery running for segments with contentIds [0], skipping recovery of these segments" to logfile
     And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0
     When the user runs "gprecoverseg -av --differential"
     Then gprecoverseg should return a return code of 0
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @demo_cluster
@@ -1387,13 +1370,13 @@ Feature: gprecoverseg tests
     And the user runs sql "select pg_start_backup('test')" in "postgres" on primary segment with content 0,1
     When the user runs "gprecoverseg -a --differential"
     Then gprecoverseg should return a return code of 0
-    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 2 is up
     And verify that mirror on content 0,1 is down
     Then gprecoverseg should print "Found differential recovery running for segments with contentIds [0, 1], skipping recovery of these segments" to logfile
     And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0,1
     When the user runs "gprecoverseg -av --differential"
     Then gprecoverseg should return a return code of 0
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @demo_cluster
@@ -1413,7 +1396,7 @@ Feature: gprecoverseg tests
     And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0,1,2
     When the user runs "gprecoverseg -av --differential"
     Then gprecoverseg should return a return code of 0
-    And the user waits until mirror on content 0,1,2 is up
+    And verify that mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @concourse_cluster

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5828,6 +5828,9 @@ sigusr1_handler(SIGNAL_ARGS)
 		MaybeStartWalReceiver();
 	}
 
+	if (CheckPostmasterSignal(PMSIGNAL_WALRCV_STREAMING) && WalReceiverPID != 0)
+		AddToDataDirLockFile(LOCK_FILE_LINE_PM_STATUS, PM_STATUS_WALRECV_STARTED_STREAMING);
+
 	if (CheckPostmasterSignal(PMSIGNAL_WAKEN_FTS) && FtsProbePID() != 0)
 	{
 		signal_child(FtsProbePID(), SIGINT);

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -372,10 +372,14 @@ WalReceiverMain(void)
 		if (walrcv_startstreaming(wrconn, &options))
 		{
 			if (first_stream)
+			{
 				ereport(LOG,
 						(errmsg("started streaming WAL from primary at %X/%X on timeline %u",
 								(uint32) (startpoint >> 32), (uint32) startpoint,
 								startpointTLI)));
+				/* indicate the postmaster that walreceiver has started streaming */
+				SendPostmasterSignal(PMSIGNAL_WALRCV_STREAMING);
+			}
 			else
 				ereport(LOG,
 						(errmsg("restarted WAL streaming at %X/%X on timeline %u",

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -40,6 +40,7 @@ typedef enum
 	PMSIGNAL_START_AUTOVAC_WORKER,	/* start an autovacuum worker */
 	PMSIGNAL_BACKGROUND_WORKER_CHANGE,	/* background worker state change */
 	PMSIGNAL_START_WALRECEIVER, /* start a walreceiver */
+	PMSIGNAL_WALRCV_STREAMING,    /* walreceiver started streaming */
 	PMSIGNAL_ADVANCE_STATE_MACHINE, /* advance postmaster's state machine */
 
 	PMSIGNAL_WAKEN_FTS,         /* wake up FTS to probe segments */

--- a/src/include/utils/pidfile.h
+++ b/src/include/utils/pidfile.h
@@ -51,6 +51,7 @@
 #define PM_STATUS_STOPPING		"stopping"	/* in shutdown sequence */
 #define PM_STATUS_READY			"ready   "	/* ready for connections */
 #define PM_STATUS_STANDBY		"standby "	/* up, won't accept connections */
-#define PM_STATUS_DTM_RECOVERED "dtmready"  /* ready for distributed connections */
+#define PM_STATUS_DTM_RECOVERED "dtmready" /* ready for distributed connections */
+#define PM_STATUS_WALRECV_STARTED_STREAMING "wrecvstreaming" /* ready for receiving WAL */
 
 #endif							/* UTILS_PIDFILE_H */

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -147,12 +147,12 @@ select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid) from g
  Success:                 
 (1 row)
 
--- bring the mirror back up and see primary s/u and mirror s/u
--1U: select pg_ctl_start((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'));
- pg_ctl_start                                     
---------------------------------------------------
- waiting for server to start done
-server started
+-- try to start the mirror, we don't wait for pg_ctl start to complete
+-- since the walreceiver won't start streaming
+-1U: select pg_ctl_start((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), false);
+ pg_ctl_start     
+------------------
+ server starting
  
 (1 row)
 select gp_wait_until_triggered_fault('initialize_wal_sender', 1, dbid) from gp_segment_configuration where role='p' and content=2;

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -52,7 +52,7 @@ CREATE FUNCTION
 --   datadir: data directory of process to target with `pg_ctl`
 --   port: which port the server should start on
 --
-create or replace function pg_ctl_start(datadir text, port int) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir opts = '-p %d' % (port) opts = opts + ' -c gp_role=execute' cmd = cmd + '-o "%s" start' % opts return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).decode().replace('.', '') $$ language plpython3u;
+create or replace function pg_ctl_start(datadir text, port int, should_wait bool default true) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir if not should_wait: cmd = cmd + ' -W ' opts = '-p %d' % (port) opts = opts + ' -c gp_role=execute' cmd = cmd + '-o "%s" start' % opts return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).decode().replace('.', '') $$ language plpython3u;
 CREATE FUNCTION
 
 --

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -63,8 +63,9 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 select gp_inject_fault_infinite('initialize_wal_sender', 'suspend', dbid)
 from gp_segment_configuration where role='p' and content=2;
 
--- bring the mirror back up and see primary s/u and mirror s/u
--1U: select pg_ctl_start((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'));
+-- try to start the mirror, we don't wait for pg_ctl start to complete
+-- since the walreceiver won't start streaming
+-1U: select pg_ctl_start((select datadir from gp_segment_configuration c where c.role='m' and c.content=2), (select port from gp_segment_configuration where content = 2 and preferred_role = 'm'), false);
 select gp_wait_until_triggered_fault('initialize_wal_sender', 1, dbid)
 from gp_segment_configuration where role='p' and content=2;
 -- make sure the walsender on primary is in startup

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -160,10 +160,12 @@ $$ language plpython3u;
 --   datadir: data directory of process to target with `pg_ctl`
 --   port: which port the server should start on
 --
-create or replace function pg_ctl_start(datadir text, port int)
+create or replace function pg_ctl_start(datadir text, port int, should_wait bool default true)
 returns text as $$
     import subprocess
     cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
+    if not should_wait:
+        cmd = cmd + ' -W '
     opts = '-p %d' % (port)
     opts = opts + ' -c gp_role=execute'
     cmd = cmd + '-o "%s" start' % opts


### PR DESCRIPTION
pg_ctl start -w waits until the postmaster state PM_STATUS_STANDBY
on the mirror for it to return. On postmaster startup, we begin starting
the walreceiver after we have already reached this state. We require the
walreceiver to be up to mark the mirror as up in
gp_segment_configuration. This results in utilities such as gprecoverseg
to complete before the walreceiver is up, while they are still starting.

This commit adds a new postmaster signal PMSIGNAL_WALRCV_STREAMING
which is sent by the walreceiver when it first starts streaming. We
also add a new postmaster state PM_STATUS_WALRECV_STARTED_STREAMING
which is set when the postmaster receives the signal from walreceiver
when it has started streaming.
For mirrors, pg_ctl start -w  will now
wait until this state is reached, to ensure the walreceiver is up and
streaming already. This will ensure that the mirror can be immediately
marked as up when pg_ctl returns.

Change behave tests to not wait for mirrors to be up after gprecoverseg,
but instead only verify that they are up

Co-authored-by: Huansong Fu <fuhuansong@gmail.com>

This solves the github issue: https://github.com/greenplum-db/gpdb/issues/12363
Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-pm_walrecv_status_update-rocky8?group=all
