### PR TITLE
Fix threading.Thread.getName() is deprecated

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -832,8 +832,8 @@ class CatThread(threading.Thread):
         except Exception as e:
             # close fd so that not block the worker thread because of stdout/stderr pipe not finish/closed.
             self.fd.close()
-            sys.stderr.write("\n\nWarning: gpfdist log halt because Log Thread '%s' got an exception: %s \n" % (self.getName(), str(e)))
-            self.gpload.log(self.gpload.WARN, "gpfdist log halt because Log Thread '%s' got an exception: %s" % (self.getName(), str(e)))
+            sys.stderr.write("\n\nWarning: gpfdist log halt because Log Thread '%s' got an exception: %s \n" % (self.name, str(e)))
+            self.gpload.log(self.gpload.WARN, "gpfdist log halt because Log Thread '%s' got an exception: %s" % (self.name, str(e)))
             raise
 
 def cli_help():


### PR DESCRIPTION

Long log:

threading.Thread.getName() is deprecated since python 3.10.
Deprecated getter/setter API for [name](https://docs.python.org/3/library/threading.html#threading.Thread.name); use it directly as a property instead.

Take a simple example in python 3.10:
```
import threading
import time

def run(n):
    print("task", n)
    time.sleep(1)
    print('1s')
    time.sleep(1)
    print('0s')
    time.sleep(1)

if __name__ == '__main__':
    t1 = threading.Thread(target=run, args=("t1",))
    t1.start()
    print(t1.getName())
    print(t1.name)
```

The result is shown as below:
```
$ python main.py
task t1
/hoem/gpadmin/main.py:15: DeprecationWarning: getName() is deprecated, get the name attribute instead
  print(t1.getName())
Thread-1 (run)
Thread-1 (run)
1s
0s
```

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>