### PR TITLE
[6x]: Fix for gprecoverseg tescase failure (#15979)

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -757,5 +757,7 @@ def impl(context, filename):
 def get_host_address(hostname):
     cmd = Command("get the address of the host", cmdStr="hostname -I", ctxt=REMOTE, remoteHost=hostname)
     cmd.run(validateAfter=True)
-    return cmd.get_stdout().strip()
+    host_address = cmd.get_stdout().strip().split(' ')
+    return host_address[0]
+
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/greenplum-db/gpdb/pull/15979

For ubuntu20.04 gprecoverseg test case fail.

Problem : hostname -I command gives the list of address associated with hostname. so while creating the input config file it taking an extra space and the format of the file becomes incorrect thats throwing error.

Solution: Split hostname -I command output and return the first element. It will make input config file format correct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
