### PR TITLE
Replace pygresql with psycopg2 for gpload.

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -295,7 +295,7 @@ def drop_tables():
                           host='localhost',
                           port=int(PGPORT)) as conn:
         with conn.cursor() as cur:
-            for i in list:
+            for i in table_list:
                 name = i[0]
                 match = re.search('ext_gpload',name)
                 if match:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -231,7 +231,6 @@ def gpdbAnsFile(fname):
     return os.path.splitext(fname)[0] + ext
 
 def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
-
     LMYD = os.path.abspath(os.path.dirname(__file__))
     if not os.access( f1, os.R_OK ):
         raise Exception( 'Error: cannot find file %s' % f1 )
@@ -239,23 +238,23 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
         raise Exception( 'Error: cannot find file %s' % f2 )
     dfile = diffFile( f1, outputPath = outputPath )
     # Gets the suitePath name to add init_file
-    suitePath = f1[0:f1.rindex( os.sep )]
-    global_init_file = os.path.join(LMYD, "global_init_file")
-    init_file = os.path.join(suitePath, "init_file")
-    if os.path.exists(os.path.join(suitePath, "init_file")):
-        (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
-                              ' --gp_init_file=%s --gp_init_file=%s '
-                              '%s %s > %s 2>&1' % (global_init_file, init_file, f1, f2, dfile))
+    suitePath = f1[0:f1.rindex( "/" )]
+
+    gphome = os.environ['GPHOME']
+    if os.path.exists(suitePath + "/init_file"):
+        (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
+                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
+                              '%s %s > %s 2>&1' % (LMYD, suitePath, f1, f2, dfile))
 
     else:
         if os.path.exists(myinitfile):
-            (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
-                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s --gp_init_file=%s '
-                                  '%s %s > %s 2>&1' % (global_init_file, myinitfile, f1, f2, dfile))
+            (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
+                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s '
+                                  '%s %s > %s 2>&1' % (LMYD, myinitfile, f1, f2, dfile))
         else:
-            (ok, out) = run( 'gpdiff.pl -w ' + optionalFlags + \
-                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s '
-                              '%s %s > %s 2>&1' % ( global_init_file, f1, f2, dfile ) )
+            (ok, out) = run( gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
+                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file '
+                              '%s %s > %s 2>&1' % ( LMYD, f1, f2, dfile ) )
 
 
     if ok:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -231,6 +231,7 @@ def gpdbAnsFile(fname):
     return os.path.splitext(fname)[0] + ext
 
 def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
+
     LMYD = os.path.abspath(os.path.dirname(__file__))
     if not os.access( f1, os.R_OK ):
         raise Exception( 'Error: cannot find file %s' % f1 )
@@ -238,23 +239,23 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
         raise Exception( 'Error: cannot find file %s' % f2 )
     dfile = diffFile( f1, outputPath = outputPath )
     # Gets the suitePath name to add init_file
-    suitePath = f1[0:f1.rindex( "/" )]
-
-    gphome = os.environ['GPHOME']
-    if os.path.exists(suitePath + "/init_file"):
-        (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s/init_file '
-                              '%s %s > %s 2>&1' % (LMYD, suitePath, f1, f2, dfile))
+    suitePath = f1[0:f1.rindex( os.sep )]
+    global_init_file = os.path.join(LMYD, "global_init_file")
+    init_file = os.path.join(suitePath, "init_file")
+    if os.path.exists(os.path.join(suitePath, "init_file")):
+        (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+                              ' --gp_init_file=%s --gp_init_file=%s '
+                              '%s %s > %s 2>&1' % (global_init_file, init_file, f1, f2, dfile))
 
     else:
         if os.path.exists(myinitfile):
-            (ok, out) = run(gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file --gp_init_file=%s '
-                                  '%s %s > %s 2>&1' % (LMYD, myinitfile, f1, f2, dfile))
+            (ok, out) = run('gpdiff.pl -w ' + optionalFlags + \
+                                  ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s --gp_init_file=%s '
+                                  '%s %s > %s 2>&1' % (global_init_file, myinitfile, f1, f2, dfile))
         else:
-            (ok, out) = run( gphome+'/lib/postgresql/pgxs/src/test/regress/gpdiff.pl -w ' + optionalFlags + \
-                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: -I DROP --gp_init_file=%s/global_init_file '
-                              '%s %s > %s 2>&1' % ( LMYD, f1, f2, dfile ) )
+            (ok, out) = run( 'gpdiff.pl -w ' + optionalFlags + \
+                              ' -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE: --gp_init_file=%s '
+                              '%s %s > %s 2>&1' % ( global_init_file, f1, f2, dfile ) )
 
 
     if ok:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_REMOTE.py
@@ -11,7 +11,7 @@ import platform
 import re
 import subprocess
 from shutil import copyfile
-import pg
+import psycopg2
 
 """
 Global Values
@@ -275,44 +275,34 @@ def copy_data(source='',target=''):
     copyfile(os.path.join('data', source), target)
 
 def get_table_name():
-    try:
-        db = pg.DB(dbname='reuse_gptest'
-                  ,host='localhost'
-                  ,port=int(PGPORT)
-                  )
-    except Exception as e:
-        errorMessage = str(e)
-        print(('could not connect to database: ' + errorMessage))
-    queryString = """SELECT relname
-                     from pg_class
-                     WHERE relname
-                     like 'ext_gpload_reusable%'
-                     OR relname
-                     like 'staging_gpload_reusable%';"""
-    resultList = db.query(queryString.encode('utf-8')).getresult()
-    return resultList
+    with psycopg2.connect(dbname='reuse_gptest',
+                          host='localhost',
+                          port=int(PGPORT)) as conn:
+        with conn.cursor() as cur:
+            queryString = """SELECT relname
+            from pg_class
+            WHERE relname
+            like 'ext_gpload_reusable%'
+            OR relname
+            like 'staging_gpload_reusable%';"""
+            cur.execute(queryString)
+            resultList = cur.fetchall()
+            return resultList
 
 def drop_tables():
-    try:
-        db = pg.DB(dbname='reuse_gptest'
-                  ,host='localhost'
-                  ,port=int(PGPORT)
-                  )
-    except Exception as e:
-        errorMessage = str(e)
-        print(('could not connect to database: ' + errorMessage))
-
-    list = get_table_name()
-    for i in list:
-        name = i[0]
-        match = re.search('ext_gpload',name)
-        if match:
-            queryString = "DROP EXTERNAL TABLE %s" % name
-            db.query(queryString.encode('utf-8'))
-
-        else:
-            queryString = "DROP TABLE %s" % name
-            db.query(queryString.encode('utf-8'))
+    table_list = get_table_name()
+    with psycopg2.connect(dbname='reuse_gptest',
+                          host='localhost',
+                          port=int(PGPORT)) as conn:
+        with conn.cursor() as cur:
+            for i in list:
+                name = i[0]
+                match = re.search('ext_gpload',name)
+                if match:
+                    queryString = "DROP EXTERNAL TABLE %s" % name
+                else:
+                    queryString = "DROP TABLE %s" % name
+                cur.execute(queryString)
 
 class PSQLError(Exception):
     '''

--- a/gpMgmt/bin/gpload_test/gpload2/query205.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query205.ans
@@ -2,7 +2,7 @@
 2021-11-29 11:56:45|INFO|setting schema 'public' for table 'texttable2'
 2021-11-29 11:56:45|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:56:45|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5e8c16ac_50c8_11ec_a3c6_0050569e2380
-2021-11-29 11:56:45|ERROR|could not run SQL "create external table ext_gpload_reusable_5e8c16ac_50c8_11ec_a3c6_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  COPY delimiter must be a single one-byte character, or 'off'
+2021-11-29 11:56:45|ERROR|could not run SQL "create external table ext_gpload_reusable_5e8c16ac_50c8_11ec_a3c6_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '' null '\N' escape '\' ) encoding'UTF8' ": COPY delimiter must be a single one-byte character, or 'off'
 
 2021-11-29 11:56:45|INFO|rows Inserted          = 0
 2021-11-29 11:56:45|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query207.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query207.ans
@@ -2,7 +2,7 @@
 2020-12-17 15:38:22|INFO|setting schema 'public' for table 'texttable2'
 2020-12-17 15:38:22|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2020-12-17 15:38:22|INFO|reusing external table ext_gpload_reusable_6f2dfb50_4035_11eb_b7f6_00505698d059
-2020-12-17 15:38:22|ERROR|ERROR:  missing data for column "s2"  (seg0 slice1 10.152.8.113:7002 pid=6654)
+2020-12-17 15:38:22|ERROR|missing data for column "s2"  (seg0 slice1 10.152.8.113:7002 pid=6654)
 CONTEXT:  External table ext_gpload_reusable_6f2dfb50_4035_11eb_b7f6_00505698d059, line 1 of gpfdist://*:pathto/data_file.txt: "123456789	abcd"
  encountered while running INSERT INTO public."texttable2" ("s1","s2") SELECT "s1","s2" FROM ext_gpload_reusable_6f2dfb50_4035_11eb_b7f6_00505698d059
 2020-12-17 15:38:22|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query211.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query211.ans
@@ -2,7 +2,7 @@
 2020-12-18 16:59:08|INFO|setting schema 'public' for table 'texttable2'
 2020-12-18 16:59:08|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2020-12-18 16:59:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_49ed34de_410f_11eb_bbac_00505698d059
-2020-12-18 16:59:08|ERROR|ERROR:  extra data after last expected column  (seg2 slice1 10.152.8.113:7004 pid=2301)
+2020-12-18 16:59:08|ERROR|extra data after last expected column  (seg2 slice1 10.152.8.113:7004 pid=2301)
 CONTEXT:  External table ext_gpload_reusable_49ed34de_410f_11eb_bbac_00505698d059, line 1 of gpfdist://*:pathto/data_file.txt: "a|||b"
  encountered while running INSERT INTO public."texttable2" ("s1","s2") SELECT "s1","s2" FROM ext_gpload_reusable_49ed34de_410f_11eb_bbac_00505698d059
 2020-12-18 16:59:08|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query220.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query220.ans
@@ -2,7 +2,7 @@
 2020-12-21 10:55:38|INFO|setting schema 'public' for table 'texttable1'
 2020-12-21 10:55:38|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2020-12-21 10:55:38|INFO|did not find an external table to reuse. creating ext_gpload_reusable_015f190a_4338_11eb_b807_00505698d059
-2020-12-21 10:55:38|ERROR|ERROR:  missing data for column "n8"  (seg0 slice1 10.152.8.113:7002 pid=3859)
+2020-12-21 10:55:38|ERROR|missing data for column "n8"  (seg0 slice1 10.152.8.113:7002 pid=3859)
 CONTEXT:  External table ext_gpload_reusable_015f190a_4338_11eb_b807_00505698d059, line 1 of gpfdist://*:pathto/data_file.txt: "aaa|qwer|shjhjg|2012-06-01 15:30:30|1|111|834567|45.67|789.123|7.12345|123.456789"
  encountered while running INSERT INTO public."texttable1" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_015f190a_4338_11eb_b807_00505698d059
 2020-12-21 10:55:38|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query233.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query233.ans
@@ -2,7 +2,7 @@
 2021-11-29 11:56:55|INFO|setting schema 'public' for table 'texttable2'
 2021-11-29 11:56:55|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:56:55|INFO|did not find an external table to reuse. creating ext_gpload_reusable_64b5f930_50c8_11ec_ad50_0050569e2380
-2021-11-29 11:56:55|ERROR|could not run SQL "create external table ext_gpload_reusable_64b5f930_50c8_11ec_ad50_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null 'E''\x08E'\'' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "\"
+2021-11-29 11:56:55|ERROR|could not run SQL "create external table ext_gpload_reusable_64b5f930_50c8_11ec_ad50_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null 'E''\x08E'\'' escape '\' ) encoding'UTF8' ": syntax error at or near "\"
 LINE 1: ....txt') format'text' (delimiter '|' null 'E''\x08E'\'' escape...
                                                              ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query241.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query241.ans
@@ -2,7 +2,7 @@
 2021-01-04 16:30:12|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 16:30:12|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2021-01-04 16:30:12|INFO|did not find an external table to reuse. creating ext_gpload_reusable_0ff6e3e6_4e67_11eb_9d70_00505698d059
-2021-01-04 16:30:12|ERROR|ERROR:  character with byte sequence 0xad 0xe5 in encoding "GBK" has no equivalent in encoding "UTF8"  (seg1 slice1 10.152.8.113:7003 pid=20453)
+2021-01-04 16:30:12|ERROR|character with byte sequence 0xad 0xe5 in encoding "GBK" has no equivalent in encoding "UTF8"  (seg1 slice1 10.152.8.113:7003 pid=20453)
 CONTEXT:  External table ext_gpload_reusable_0ff6e3e6_4e67_11eb_9d70_00505698d059, line 1 of file gpfdist://*:pathto/data_file.txt
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_reusable_0ff6e3e6_4e67_11eb_9d70_00505698d059
 2021-01-04 16:30:12|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query244.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query244.ans
@@ -2,7 +2,7 @@
 2021-01-04 16:35:29|INFO|setting schema 'public' for table 'texttable2'
 2021-01-04 16:35:29|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2021-01-04 16:35:29|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ccfc0c6e_4e67_11eb_bac2_00505698d059
-2021-01-04 16:35:29|ERROR|ERROR:  invalid byte sequence for encoding "UTF8": 0xd6 0xd0  (seg0 slice1 10.152.8.113:7002 pid=21163)
+2021-01-04 16:35:29|ERROR|invalid byte sequence for encoding "UTF8": 0xd6 0xd0  (seg0 slice1 10.152.8.113:7002 pid=21163)
 CONTEXT:  External table ext_gpload_reusable_ccfc0c6e_4e67_11eb_bac2_00505698d059, line 1 of file gpfdist://*:pathto/data_file.txt
  encountered while running INSERT INTO public."texttable2" ("s1","s2") SELECT "s1","s2" FROM ext_gpload_reusable_ccfc0c6e_4e67_11eb_bac2_00505698d059
 2021-01-04 16:35:29|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query259.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query259.ans
@@ -2,7 +2,7 @@
 2021-11-29 11:57:05|INFO|setting schema 'public' for table 'texttable2'
 2021-11-29 11:57:05|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:57:05|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6adbab20_50c8_11ec_94a0_0050569e2380
-2021-11-29 11:57:05|ERROR|could not run SQL "create external table ext_gpload_reusable_6adbab20_50c8_11ec_94a0_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
+2021-11-29 11:57:05|ERROR|could not run SQL "create external table ext_gpload_reusable_6adbab20_50c8_11ec_94a0_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' newline 'LFCR' ) encoding'UTF8' ": invalid value for NEWLINE "LFCR"
 HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
 
 2021-11-29 11:57:05|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query260.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query260.ans
@@ -2,7 +2,7 @@
 2021-11-30 15:00:23|INFO|setting schema 'public' for table 'texttable2'
 2021-11-30 15:00:23|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
 2021-11-30 15:00:23|INFO|did not find an external table to reuse. creating ext_gpload_reusable_30a0dcd0_51ab_11ec_839b_0050569e2380
-2021-11-30 15:00:23|ERROR|could not run SQL "create external table ext_gpload_reusable_30a0dcd0_51ab_11ec_839b_0050569e2380("s1" text,"s2" text)location('gpfdist://*:pathto/data_file.csv') format'csv' (delimiter ',' null '' escape '"' quote '"' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
+2021-11-30 15:00:23|ERROR|could not run SQL "create external table ext_gpload_reusable_30a0dcd0_51ab_11ec_839b_0050569e2380("s1" text,"s2" text)location('gpfdist://*:pathto/data_file.csv') format'csv' (delimiter ',' null '' escape '"' quote '"' newline 'LFCR' ) encoding'UTF8' ": invalid value for NEWLINE "LFCR"
 HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
 
 2021-11-30 15:00:23|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query31.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query31.ans
@@ -3,7 +3,7 @@
 2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
 2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
-2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
+2018-07-20 09:06:30|ERROR|column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
  encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
@@ -16,7 +16,7 @@ LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
 2018-07-20 09:06:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2018-07-20 09:06:30|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0
 2018-07-20 09:06:30|INFO|reusing external table ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002
-2018-07-20 09:06:30|ERROR|ERROR:  column "n8" does not exist
+2018-07-20 09:06:30|ERROR|column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
  encountered while running INSERT INTO staging_gpload_reusable_9faa546d615fa55cc3e9e2cee6f130b0 ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ext_gpload_reusable_30024be2_8bfc_11e8_83d4_0242ac110002

--- a/gpMgmt/bin/gpload_test/gpload2/query312.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query312.ans
@@ -2,7 +2,7 @@
 2020-12-17 15:57:28|INFO|setting schema 'public' for table 'texttable'
 2020-12-17 15:57:28|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2020-12-17 15:57:28|INFO|did not find an external table to reuse. creating ext_gpload_reusable_823e0c46_403d_11eb_ba00_000c299afcc5
-2020-12-17 15:57:29|ERROR|ERROR:  segment reject limit reached, aborting operation  (seg0 slice1 127.0.0.1:6000 pid=3953)
+2020-12-17 15:57:29|ERROR|segment reject limit reached, aborting operation  (seg0 slice1 127.0.0.1:6000 pid=3953)
 DETAIL:  Last error was: invalid input syntax for type smallint: "invalid string", column n1
 CONTEXT:  External table ext_gpload_reusable_823e0c46_403d_11eb_ba00_000c299afcc5, line 4 of gpfdist://*:pathto/data_file.txt, column n1
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_reusable_823e0c46_403d_11eb_ba00_000c299afcc5

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-11-29 11:57:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:57:32|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
 2021-11-29 11:57:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7ac93e9e_50c8_11ec_821e_0050569e2380
-2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ac93e9e_50c8_11ec_821e_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ac93e9e_50c8_11ec_821e_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": xxxx is not a valid encoding name
 
 2021-11-29 11:57:32|INFO|rows Inserted          = 0
 2021-11-29 11:57:32|INFO|rows Updated           = 0
@@ -18,7 +18,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-11-29 11:57:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:57:32|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
 2021-11-29 11:57:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7ae5d7e8_50c8_11ec_9979_0050569e2380
-2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ae5d7e8_50c8_11ec_9979_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ae5d7e8_50c8_11ec_9979_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": xxxx is not a valid encoding name
 
 2021-11-29 11:57:32|INFO|rows Inserted          = 0
 2021-11-29 11:57:32|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query402.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query402.ans
@@ -2,7 +2,7 @@
 2021-11-30 15:17:58|INFO|setting schema 'public' for table 'texttable'
 2021-11-30 15:17:58|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2021-11-30 15:17:58|INFO|did not find an external table to reuse. creating non_ext_schema_test.ext_gpload_reusable_a53b654a_51ad_11ec_b1b3_0050569e2380
-2021-11-30 15:17:58|ERROR|could not run SQL "create external table non_ext_schema_test.ext_gpload_reusable_a53b654a_51ad_11ec_b1b3_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  schema "non_ext_schema_test" does not exist
+2021-11-30 15:17:58|ERROR|could not run SQL "create external table non_ext_schema_test.ext_gpload_reusable_a53b654a_51ad_11ec_b1b3_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'UTF8' ": schema "non_ext_schema_test" does not exist
 
 2021-11-30 15:17:58|INFO|rows Inserted          = 0
 2021-11-30 15:17:58|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query497.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query497.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 16:55:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
 2021-01-04 16:55:52|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 16:55:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a651e6f8_4e6a_11eb_b8a4_7085c2381836
-2021-01-04 16:55:52|ERROR|ERROR:  column "non_col" does not exist
+2021-01-04 16:55:52|ERROR|column "non_col" does not exist
 LINE 1: ...ble."s1" and into_table."s2"=from_table."s2" and  non_col = ...
                                                              ^
  encountered while running update public."texttable" into_table set "n2"=from_table."n2" from staging_gpload_reusable_4b4814f7db18b678f1605a0caec3c1fe from_table where into_table."n1"=from_table."n1" and into_table."s1"=from_table."s1" and into_table."s2"=from_table."s2" and  non_col = 5

--- a/gpMgmt/bin/gpload_test/gpload2/query522.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query522.ans
@@ -7,7 +7,7 @@ CREATE TABLE
 2021-01-07 16:25:52|INFO|setting schema 'public' for table 'mapping_test'
 2021-01-07 16:25:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
 2021-01-07 16:25:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f42535ca_50c1_11eb_a32e_7085c2381836
-2021-01-07 16:25:52|ERROR|ERROR:  column "n3" does not exist
+2021-01-07 16:25:52|ERROR|column "n3" does not exist
 LINE 1: ...blic."mapping_test" ("s1","s2","s3") SELECT c1,c2,n3 FROM ex...
                                                              ^
 HINT:  Perhaps you meant to reference the column "ext_gpload_reusable_f42535ca_50c1_11eb_a32e_7085c2381836.c3" or the column "mapping_test.s3".

--- a/gpMgmt/bin/gpload_test/gpload2/query523.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query523.ans
@@ -7,7 +7,7 @@ CREATE TABLE
 2021-01-07 16:26:05|INFO|setting schema 'public' for table 'mapping_test'
 2021-01-07 16:26:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
 2021-01-07 16:26:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_fc7440a4_50c1_11eb_a0a7_7085c2381836
-2021-01-07 16:26:06|ERROR|ERROR:  column "s4" is of type integer but expression is of type text
+2021-01-07 16:26:06|ERROR|column "s4" is of type integer but expression is of type text
 LINE 1: ...blic."mapping_test" ("s2","s3","s4") SELECT c2,c3,c1 FROM ex...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.

--- a/gpMgmt/bin/gpload_test/gpload2/query529.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query529.ans
@@ -7,7 +7,7 @@ CREATE TABLE
 2021-01-07 16:37:32|INFO|setting schema 'public' for table 'mapping_test'
 2021-01-07 16:37:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
 2021-01-07 16:37:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_959774bc_50c3_11eb_b301_7085c2381836
-2021-01-07 16:37:32|ERROR|ERROR:  function rocket_bites(unknown) does not exist
+2021-01-07 16:37:32|ERROR|function rocket_bites(unknown) does not exist
 LINE 1: INSERT INTO public."mapping_test" ("s1") SELECT rocket_bites...
                                                         ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/gpMgmt/bin/gpload_test/gpload2/query532.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query532.ans
@@ -12,7 +12,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-07 17:38:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
 2021-01-07 17:38:14|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b
 2021-01-07 17:38:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_102fae3a_50cc_11eb_b6c8_7085c2381836
-2021-01-07 17:38:14|ERROR|ERROR:  column "s4" is of type integer but expression is of type text
+2021-01-07 17:38:14|ERROR|column "s4" is of type integer but expression is of type text
 LINE 1: ...5c64da950cfbc41ff55 ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.

--- a/gpMgmt/bin/gpload_test/gpload2/query533.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query533.ans
@@ -12,7 +12,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-07 17:38:26|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
 2021-01-07 17:38:26|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b
 2021-01-07 17:38:26|INFO|did not find an external table to reuse. creating ext_gpload_reusable_1777c5e2_50cc_11eb_bb05_7085c2381836
-2021-01-07 17:38:26|ERROR|ERROR:  column "s4" is of type integer but expression is of type text
+2021-01-07 17:38:26|ERROR|column "s4" is of type integer but expression is of type text
 LINE 1: ...5c64da950cfbc41ff55 ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.

--- a/gpMgmt/bin/gpload_test/gpload2/query60.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query60.ans
@@ -20,7 +20,7 @@
 2020-12-07 09:57:17|INFO|setting schema 'public' for table 'texttable'
 2020-12-07 09:57:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2020-12-07 09:57:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_89036be0_382f_11eb_95c3_00505698707d
-2020-12-07 09:57:18|ERROR|ERROR:  connection with gpfdist failed for "gpfdist://*:pathto/data_file.txt", effective url: "http://*:pathto/data_file.txt": error code = 111 (Connection refused);  (seg1 slice1 10.152.8.160:7003 pid=4267)
+2020-12-07 09:57:18|ERROR|connection with gpfdist failed for "gpfdist://*:pathto/data_file.txt", effective url: "http://*:pathto/data_file.txt": error code = 111 (Connection refused);  (seg1 slice1 10.152.8.160:7003 pid=4267)
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_reusable_89036be0_382f_11eb_95c3_00505698707d
 2020-12-07 09:57:18|INFO|rows Inserted          = 0
 2020-12-07 09:57:18|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query604.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query604.ans
@@ -2,7 +2,7 @@
 2021-01-17 20:28:18|INFO|setting schema 'public' for table 'texttable'
 2021-01-17 20:28:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/temp/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-01-17 20:28:18|INFO|reusing external staging table "STAGING_test"
-2021-01-17 20:28:18|ERROR|ERROR:  column "n8" does not exist
+2021-01-17 20:28:18|ERROR|column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
 HINT:  There is a column named "n8" in table "texttable", but it cannot be referenced from this part of the query.

--- a/gpMgmt/bin/gpload_test/gpload2/query65.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query65.ans
@@ -2,7 +2,7 @@
 2021-01-08 16:05:19|INFO|setting schema 'public' for table 'texttable'
 2021-01-08 16:05:19|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt pathto/data_file1.txt pathto/data_file99.txt" -t 30
 2021-01-08 16:05:19|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3fe4da80_5188_11eb_bc9e_00505698707d
-2021-01-08 16:05:20|ERROR|ERROR:  http response code 404 from gpfdist (gpfdist://*:pathto/data_file.txt%pathto/data_file1.txt%pathto/data_file99.txt): HTTP/1.0 404 file not found  (seg0 slice1 10.152.8.160:7002 pid=18998)
+2021-01-08 16:05:20|ERROR|http response code 404 from gpfdist (gpfdist://*:pathto/data_file.txt%pathto/data_file1.txt%pathto/data_file99.txt): HTTP/1.0 404 file not found  (seg0 slice1 10.152.8.160:7002 pid=18998)
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_reusable_3fe4da80_5188_11eb_bc9e_00505698707d
 2021-01-08 16:05:20|INFO|rows Inserted          = 0
 2021-01-08 16:05:20|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query652.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query652.ans
@@ -1,7 +1,7 @@
 2021-01-04 19:52:14|INFO|gpload session started 2021-01-04 19:52:14
 2021-01-04 19:52:14|INFO|setting schema 'public' for table 'texttable_652'
 2021-01-04 19:52:14|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-04 19:52:14|ERROR|could not execute SQL in sql:before "INSERT INTO test_652 VALUES(1)": ERROR:  relation "test_652" does not exist
+2021-01-04 19:52:14|ERROR|could not execute SQL in sql:before "INSERT INTO test_652 VALUES(1)": relation "test_652" does not exist
 LINE 1: INSERT INTO test_652 VALUES(1)
                     ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query662.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query662.ans
@@ -2,7 +2,7 @@
 2021-01-11 18:03:26|INFO|setting schema 'public' for table 'texttable_662'
 2021-01-11 18:03:26|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
 2021-01-11 18:03:26|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3f87f84c_53f4_11eb_8b61_005056983e1a
-2021-01-11 18:03:26|ERROR|could not execute SQL in sql:after "INSERT INTO test_662 VALUES(1)": ERROR:  relation "test_662" does not exist
+2021-01-11 18:03:26|ERROR|could not execute SQL in sql:after "INSERT INTO test_662 VALUES(1)": relation "test_662" does not exist
 LINE 1: INSERT INTO test_662 VALUES(1)
                     ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query664.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query664.ans
@@ -1,7 +1,7 @@
 2021-01-11 18:56:05|INFO|gpload session started 2021-01-11 18:56:05
 2021-01-11 18:56:05|INFO|setting schema 'public' for table 'texttable_664'
 2021-01-11 18:56:05|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-11 18:56:05|ERROR|could not execute SQL in sql:before "INSERT INTO test_664_before VALUES('a')": ERROR:  invalid input syntax for type integer: "a"
+2021-01-11 18:56:05|ERROR|could not execute SQL in sql:before "INSERT INTO test_664_before VALUES('a')": invalid input syntax for type integer: "a"
 LINE 1: INSERT INTO test_664_before VALUES('a')
                                            ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query665.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query665.ans
@@ -2,7 +2,7 @@
 2021-01-11 18:56:59|INFO|setting schema 'public' for table 'texttable_665'
 2021-01-11 18:56:59|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
 2021-01-11 18:56:59|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ba362bb6_53fb_11eb_a8b6_005056983e1a
-2021-01-11 18:56:59|ERROR|could not execute SQL in sql:after "INSERT INTO test_665_after VALUES('a')": ERROR:  invalid input syntax for type integer: "a"
+2021-01-11 18:56:59|ERROR|could not execute SQL in sql:after "INSERT INTO test_665_after VALUES('a')": invalid input syntax for type integer: "a"
 LINE 1: INSERT INTO test_665_after VALUES('a')
                                           ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query666.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query666.ans
@@ -1,7 +1,7 @@
 2021-01-11 19:18:24|INFO|gpload session started 2021-01-11 19:18:24
 2021-01-11 19:18:24|INFO|setting schema 'public' for table 'texttable_666'
 2021-01-11 19:18:24|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-11 19:18:24|ERROR|could not execute SQL in sql:before "INSERT INTO test_666_before VALUES('a')": ERROR:  invalid input syntax for type integer: "a"
+2021-01-11 19:18:24|ERROR|could not execute SQL in sql:before "INSERT INTO test_666_before VALUES('a')": invalid input syntax for type integer: "a"
 LINE 1: INSERT INTO test_666_before VALUES('a')
                                            ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query667.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query667.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-11 19:20:03|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
 2021-01-11 19:20:03|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_08aff1d5e0be087569323178726e90f6
 2021-01-11 19:20:03|INFO|did not find an external table to reuse. creating ext_gpload_reusable_f39a934e_53fe_11eb_898a_005056983e1a
-2021-01-11 19:20:04|ERROR|could not execute SQL in sql:after "INSERT INTO test_667_after VALUES('a')": ERROR:  invalid input syntax for type integer: "a"
+2021-01-11 19:20:04|ERROR|could not execute SQL in sql:after "INSERT INTO test_667_after VALUES('a')": invalid input syntax for type integer: "a"
 LINE 1: INSERT INTO test_667_after VALUES('a')
                                           ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query68.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query68.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-08 16:05:22|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
 2021-01-08 16:05:22|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
 2021-01-08 16:05:22|INFO|did not find an external table to reuse. creating ext_gpload_reusable_418b1b42_5188_11eb_93db_00505698707d
-2021-01-08 16:05:22|ERROR|ERROR:  column "Field1" is of type bigint but expression is of type text
+2021-01-08 16:05:22|ERROR|column "Field1" is of type bigint but expression is of type text
 LINE 1: ...bb31496d7e9a13bd29b90 ("Field1","Field#2") SELECT "Field1","...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.

--- a/gpMgmt/bin/gpload_test/gpload2/query69.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query69.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-08 16:28:20|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
 2021-01-08 16:28:20|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
 2021-01-08 16:28:20|INFO|did not find an external table to reuse. creating ext_gpload_reusable_770f4452_518b_11eb_98a2_00505698707d
-2021-01-08 16:28:20|ERROR|ERROR:  column "Field1" is of type bigint but expression is of type text
+2021-01-08 16:28:20|ERROR|column "Field1" is of type bigint but expression is of type text
 LINE 1: ...bb31496d7e9a13bd29b90 ("Field1","Field#2") SELECT "Field1","...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.

--- a/gpMgmt/bin/gpload_test/gpload2/query75.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query75.ans
@@ -14,7 +14,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-08-10 14:56:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-08-10 14:56:46|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
 2021-08-10 14:56:46|INFO|reusing external table ext_gpload_reusable_2092c476_f9a8_11eb_b503_0050569e2380
-2021-08-10 14:56:46|ERROR|ERROR:  column "列" does not exist
+2021-08-10 14:56:46|ERROR|column "列" does not exist
 LINE 1: ..." FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS g...
                                                              ^
 HINT:  Perhaps you meant to reference the column "staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7.列1" or the column "chinese表.列1".
@@ -37,7 +37,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-08-10 14:56:46|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-08-10 14:56:46|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
 2021-08-10 14:56:46|INFO|reusing external table ext_gpload_reusable_2092c476_f9a8_11eb_b503_0050569e2380
-2021-08-10 14:56:46|ERROR|ERROR:  column "列" does not exist
+2021-08-10 14:56:46|ERROR|column "列" does not exist
 LINE 1: ..." FROM (SELECT *, row_number() OVER (PARTITION BY 列#2) AS g...
                                                              ^
 HINT:  Perhaps you meant to reference the column "staging_gpload_reusable_77874e55aae34d59751eb574ff0f5cf7.列1" or the column "chinese表.列1".

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -3,18 +3,12 @@ LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
 WARNING:  nonstandard use of escape in a string literal
-LINE 1: ...pathto/data_file.txt') format'text' (delimiter ';' null '\N' escap...
-                                                             ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
 WARNING:  nonstandard use of \' in a string literal
-LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
-                                                             ^
-HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
 2021-11-29 15:29:03|INFO|gpload session started 2021-11-29 15:29:03
 2021-11-29 15:29:03|INFO|setting schema 'public' for table 'chinese表'
 2021-11-29 15:29:03|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2021-11-29 15:29:03|INFO|did not find an external table to reuse. creating ext_gpload_reusable_075bc846_50e6_11ec_8cb7_0050569e2380
-2021-11-29 15:29:03|ERROR|could not run SQL "create external table ext_gpload_reusable_075bc846_50e6_11ec_8cb7_0050569e2380("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-11-29 15:29:03|ERROR|could not run SQL "create external table ext_gpload_reusable_075bc846_50e6_11ec_8cb7_0050569e2380("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": syntax error at or near "UTF8"
 LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
                                                                  ^
 
@@ -41,7 +35,7 @@ HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
 2021-11-29 15:29:04|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
 2021-11-29 15:29:04|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
 2021-11-29 15:29:04|INFO|did not find an external table to reuse. creating ext_gpload_reusable_07a3c70e_50e6_11ec_9873_0050569e2380
-2021-11-29 15:29:04|ERROR|could not run SQL "create external table ext_gpload_reusable_07a3c70e_50e6_11ec_9873_0050569e2380(列1 text,列#2 int,lie3 timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "#"
+2021-11-29 15:29:04|ERROR|could not run SQL "create external table ext_gpload_reusable_07a3c70e_50e6_11ec_9873_0050569e2380(列1 text,列#2 int,lie3 timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": syntax error at or near "#"
 LINE 1: ...(列1 text,列#2 int,lie...
                                                              ^
 

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -3,18 +3,12 @@ LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
 WARNING:  nonstandard use of escape in a string literal
-LINE 1: .../data_file.txt') format'text' (delimiter ';' null '\N' escap...
-                                                             ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
 WARNING:  nonstandard use of \' in a string literal
-LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
-                                                             ^
-HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
 2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
 2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
 2021-11-29 11:57:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:57:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6f40f210_50c8_11ec_89e8_0050569e2380
-2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f40f210_50c8_11ec_89e8_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f40f210_50c8_11ec_89e8_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": syntax error at or near "UTF8"
 LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
                                                                  ^
 
@@ -22,26 +16,18 @@ LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8'
 2021-11-29 11:57:13|INFO|rows Updated           = 0
 2021-11-29 11:57:13|INFO|data formatting errors = 0
 2021-11-29 11:57:13|INFO|gpload failed
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'Field1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  nonstandard use of \\ in a string literal
 LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
 WARNING:  nonstandard use of escape in a string literal
-LINE 1: .../data_file.txt') format'text' (delimiter ';' null '\N' escap...
-                                                             ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
 WARNING:  nonstandard use of \' in a string literal
-LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
-                                                             ^
-HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
 2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
 2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
 2021-11-29 11:57:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-11-29 11:57:13|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
 2021-11-29 11:57:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6f5c6568_50c8_11ec_ae2f_0050569e2380
-2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f5c6568_50c8_11ec_ae2f_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f5c6568_50c8_11ec_ae2f_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": syntax error at or near "UTF8"
 LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
                                                                  ^
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -33,8 +33,11 @@ class GpLoadTestCase(unittest.TestCase):
         print(gpload_param)
         gploader = gpload(gpload_param)
         gploader.read_config()
-        gploader.db = self
-        gploader.db.query = Mock(side_effect=self.mockQuery)
+        gploader.conn = Mock()
+        gploader.conn.cursor.return_value = Mock()
+        gploader.conn.cursor.return_value.__enter__ = Mock(return_value=Mock(spec=['fetchall', 'execute']))
+        gploader.conn.cursor.return_value.__exit__ = Mock(return_value=False)
+        gploader.conn.cursor.return_value.__enter__.return_value.execute = Mock(side_effect=self.mockQuery)
         gploader.do_method_merge = Mock(side_effect=self.mockDoNothing)
         gploader.do_method_update = Mock(side_effect=self.mockDoNothing)
         gploader.do_method_insert = Mock(side_effect=self.mockDoNothing)


### PR DESCRIPTION
This is the last patch for replacing pygresql with psycopg2 in Greenplum. This patch mainly targets the gpload.

Benefits for replacing pygresql with psycopg2.
- Psycopg2 is maintained actively we have encountered bugs that haven't been fixed by the upstream yet, e.g., https://github.com/greenplum-db/gpdb/pull/13953.
- Psycopg2 is provided by Rocky Linux and Ubuntu. That is to say, we don't need to vendor it ourselves.
- Possibly remove the `PYTHONPATH` from `greenplum_path.sh`, which is good for users that they don't need to worry about their Python environment being overwritten by Greenplum.

Most of the change can be summarized as follows.

When using pygresql, we're utilizing the following APIs.

```python
result = conn.query(sql).getresult() ## The return value is a list of tuples.
result = conn.query(sql).dictresult() ## The return value is a list of dict(), where the key of the dict is the column name.
```

With psycopg2, we need to replace them with the following APIs.

```python
with conn.cursor() as cur:
    cur.execute(sql)
    result = cur.fetchall() ## The return value is a list of tuples.

with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
    cur.execute(sql)
    result = cur.fetchall() ## The return value is a list of dict().
```

Co-authored-by: Chen Mulong <chenmulong@gmail.com>
Co-authored-by: Xiaoxiao He <hxiaoxiao@vmware.com>