### PR TITLE
brin ao/co: Mark dead ranges as empty on VACUUM

### DIFF
--- a/src/backend/access/brin/README
+++ b/src/backend/access/brin/README
@@ -359,3 +359,24 @@ Having a default of 32 will thus be counter-productive - CPU processing cost
 from unwanted tuples will far outweigh any IO cost savings and will dominate the
 total cost of the query (as per planner cost estimation).
 Thus, we use the lowest default possible: a default value of 1.
+
+(5) VACUUM:
+
+For BRIN indexes on AO/CO tables, we exploit a property of exhausted logical
+block ranges (fast sequence numbers used up) belonging to a segment that
+undergoes VACUUM (i.e. a segment awaiting drop). The property is that these
+ranges will never be reused for future inserts.
+
+This is because we don't reset gp_fastsequence when we VACUUM AO/CO tables and
+gp_fastsequence is always increasing.
+
+So, these ranges are effectively dead and can thus be marked as empty. Doing so
+brings about a couple of benefits:
+(1) These dead ranges will never result in false positives when their summaries
+match scan keys - we will not bloat the output tidbitmap unnecessarily.
+(2) Cycles will not be spent trying to summarize them, as empty ranges are not
+summarized. This saves cycles for both the summarization call at the end of
+VACUUM and for all future summarization calls.
+
+We mark these ranges as empty in the brinbulkdelete callback, which is called
+when we are sure that it is safe to recycle a segment awaiting drop.

--- a/src/include/access/brin_tuple.h
+++ b/src/include/access/brin_tuple.h
@@ -89,6 +89,8 @@ extern BrinTuple *brin_form_tuple(BrinDesc *brdesc, BlockNumber blkno,
 								  BrinMemTuple *tuple, Size *size);
 extern BrinTuple *brin_form_placeholder_tuple(BrinDesc *brdesc,
 											  BlockNumber blkno, Size *size);
+extern BrinTuple *brin_form_empty_tuple(BrinDesc *brdesc,
+										BlockNumber blkno, Size *size);
 extern void brin_free_tuple(BrinTuple *tuple);
 extern BrinTuple *brin_copy_tuple(BrinTuple *tuple, Size len,
 								  BrinTuple *dest, Size *destsz);

--- a/src/test/isolation2/input/uao/brin.source
+++ b/src/test/isolation2/input/uao/brin.source
@@ -142,22 +142,16 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid)
 
 VACUUM brin_ao_summarize_@amname@;
 
--- A new INSERT would always map to the last range on the old segment and that
--- range will be updated to hold the new value, as part of INSERT.
-INSERT INTO brin_ao_summarize_@amname@ VALUES(40);
-
 -- All the live tuples will have been moved to a single new logical heap block
--- in seg2 (67108864). The 1 tuple INSERTed after the VACUUM should have gone to
--- the last block in seg1 (33554438).
+-- in seg2 (67108864).
 SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
   FROM brin_ao_summarize_@amname@;
 
 -- Sanity: There should now be 2 revmap pages (1 new one for the new seg). Also,
--- there will be a new index tuple mapping to that new seg and block number.
--- Note: Since VACUUM summarizes all logical heap blocks (invokes summarization
--- with BRIN_ALL_BLOCKRANGES), and doesn't clean up existing summary info, we
--- can expect entries from the 1st seg to be still there (including blank entries
--- added for the 6th and 7th blocks)
+-- there will be a new index tuple mapping to that new seg and block number, as
+-- VACUUM does summarize the entire table (the empty ranges would be no-ops).
+-- Also, VACUUM should have marked all ranges corresponding to the vacuumed seg
+-- as empty (33554432 - 33554438).
 1U: SELECT blkno, brin_page_type(get_raw_page('brin_ao_summarize_@amname@_i_idx', blkno)) FROM
   generate_series(0, nblocks('brin_ao_summarize_@amname@_i_idx') - 1) blkno;
 1U: SELECT * FROM brin_revmap_data(get_raw_page('brin_ao_summarize_@amname@_i_idx', 1))
@@ -167,8 +161,8 @@ SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
 1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2),
   'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
 
--- Sanity: Scan should return only first 3 blocks corresponding to the vacuumed
--- seg, as those ranges are left over from the vacuum.
+-- Sanity: Scan should return 0 blocks as all of the blocks that matches the
+-- scan correspond to the empty ranges in the vacuumed seg.
 SELECT gp_inject_fault_infinite('brin_bitmap_page_added', 'skip', dbid)
   FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 SELECT count(*) FROM brin_ao_summarize_@amname@ WHERE i = 1;
@@ -188,6 +182,13 @@ SELECT brin_summarize_new_values('brin_ao_summarize_@amname@_i_idx');
   WHERE pages != '(0,0)' order by 1;
 1U: SELECT * FROM brin_revmap_data(get_raw_page('brin_ao_summarize_@amname@_i_idx', 3))
   WHERE pages != '(0,0)' order by 1;
+1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2),
+  'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
+
+-- The next insert would map to seg1 and will map to the last partial range
+-- 33554438 in seg1.
+INSERT INTO brin_ao_summarize_@amname@ VALUES(40);
+-- Summary info for 33554438 should have been updated.
 1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2),
   'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
 

--- a/src/test/isolation2/output/uao/brin.source
+++ b/src/test/isolation2/output/uao/brin.source
@@ -332,27 +332,19 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid) FROM gp_segment_
 VACUUM brin_ao_summarize_@amname@;
 VACUUM
 
--- A new INSERT would always map to the last range on the old segment and that
--- range will be updated to hold the new value, as part of INSERT.
-INSERT INTO brin_ao_summarize_@amname@ VALUES(40);
-INSERT 0 1
-
 -- All the live tuples will have been moved to a single new logical heap block
--- in seg2 (67108864). The 1 tuple INSERTed after the VACUUM should have gone to
--- the last block in seg1 (33554438).
+-- in seg2 (67108864).
 SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum FROM brin_ao_summarize_@amname@;
  blknum   
 ----------
- 33554438 
  67108864 
-(2 rows)
+(1 row)
 
 -- Sanity: There should now be 2 revmap pages (1 new one for the new seg). Also,
--- there will be a new index tuple mapping to that new seg and block number.
--- Note: Since VACUUM summarizes all logical heap blocks (invokes summarization
--- with BRIN_ALL_BLOCKRANGES), and doesn't clean up existing summary info, we
--- can expect entries from the 1st seg to be still there (including blank entries
--- added for the 6th and 7th blocks)
+-- there will be a new index tuple mapping to that new seg and block number, as
+-- VACUUM does summarize the entire table (the empty ranges would be no-ops).
+-- Also, VACUUM should have marked all ranges corresponding to the vacuumed seg
+-- as empty (33554432 - 33554438).
 1U: SELECT blkno, brin_page_type(get_raw_page('brin_ao_summarize_@amname@_i_idx', blkno)) FROM generate_series(0, nblocks('brin_ao_summarize_@amname@_i_idx') - 1) blkno;
  blkno | brin_page_type 
 -------+----------------
@@ -380,18 +372,18 @@ SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum FROM brin_a
 1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2), 'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
  itemoffset | blknum   | attnum | allnulls | hasnulls | placeholder | empty | value      
 ------------+----------+--------+----------+----------+-------------+-------+------------
- 1          | 33554432 | 1      | f        | f        | f           | f     | {1 .. 1}   
- 2          | 33554433 | 1      | f        | f        | f           | f     | {1 .. 1}   
- 3          | 33554434 | 1      | f        | f        | f           | f     | {1 .. 20}  
- 4          | 33554435 | 1      | f        | f        | f           | f     | {20 .. 20} 
- 5          | 33554436 | 1      | f        | f        | f           | f     | {20 .. 30} 
+ 1          | 33554432 | 1      | t        | f        | f           | t     |            
+ 2          | 33554433 | 1      | t        | f        | f           | t     |            
+ 3          | 33554434 | 1      | t        | f        | f           | t     |            
+ 4          | 33554435 | 1      | t        | f        | f           | t     |            
+ 5          | 33554436 | 1      | t        | f        | f           | t     |            
  6          | 33554437 | 1      | t        | f        | f           | t     |            
- 7          | 33554438 | 1      | f        | f        | f           | f     | {40 .. 40} 
+ 7          | 33554438 | 1      | t        | f        | f           | t     |            
  8          | 67108864 | 1      | f        | f        | f           | f     | {20 .. 30} 
 (8 rows)
 
--- Sanity: Scan should return only first 3 blocks corresponding to the vacuumed
--- seg, as those ranges are left over from the vacuum.
+-- Sanity: Scan should return 0 blocks as all of the blocks that matches the
+-- scan correspond to the empty ranges in the vacuumed seg.
 SELECT gp_inject_fault_infinite('brin_bitmap_page_added', 'skip', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault_infinite 
 --------------------------
@@ -403,9 +395,9 @@ SELECT count(*) FROM brin_ao_summarize_@amname@ WHERE i = 1;
  0     
 (1 row)
 SELECT gp_inject_fault('brin_bitmap_page_added', 'status', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault                                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'brin_bitmap_page_added' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
+ gp_inject_fault                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'brin_bitmap_page_added' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
  
 (1 row)
 SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
@@ -450,11 +442,29 @@ SELECT brin_summarize_new_values('brin_ao_summarize_@amname@_i_idx');
 1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2), 'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
  itemoffset | blknum   | attnum | allnulls | hasnulls | placeholder | empty | value      
 ------------+----------+--------+----------+----------+-------------+-------+------------
- 1          | 33554432 | 1      | f        | f        | f           | f     | {1 .. 1}   
- 2          | 33554433 | 1      | f        | f        | f           | f     | {1 .. 1}   
- 3          | 33554434 | 1      | f        | f        | f           | f     | {1 .. 20}  
- 4          | 33554435 | 1      | f        | f        | f           | f     | {20 .. 20} 
- 5          | 33554436 | 1      | f        | f        | f           | f     | {20 .. 30} 
+ 1          | 33554432 | 1      | t        | f        | f           | t     |            
+ 2          | 33554433 | 1      | t        | f        | f           | t     |            
+ 3          | 33554434 | 1      | t        | f        | f           | t     |            
+ 4          | 33554435 | 1      | t        | f        | f           | t     |            
+ 5          | 33554436 | 1      | t        | f        | f           | t     |            
+ 6          | 33554437 | 1      | t        | f        | f           | t     |            
+ 7          | 33554438 | 1      | t        | f        | f           | t     |            
+ 8          | 67108864 | 1      | f        | f        | f           | f     | {20 .. 30} 
+(8 rows)
+
+-- The next insert would map to seg1 and will map to the last partial range
+-- 33554438 in seg1.
+INSERT INTO brin_ao_summarize_@amname@ VALUES(40);
+INSERT 0 1
+-- Summary info for 33554438 should have been updated.
+1U: SELECT * FROM brin_page_items(get_raw_page('brin_ao_summarize_@amname@_i_idx', 2), 'brin_ao_summarize_@amname@_i_idx') ORDER BY blknum, attnum;
+ itemoffset | blknum   | attnum | allnulls | hasnulls | placeholder | empty | value      
+------------+----------+--------+----------+----------+-------------+-------+------------
+ 1          | 33554432 | 1      | t        | f        | f           | t     |            
+ 2          | 33554433 | 1      | t        | f        | f           | t     |            
+ 3          | 33554434 | 1      | t        | f        | f           | t     |            
+ 4          | 33554435 | 1      | t        | f        | f           | t     |            
+ 5          | 33554436 | 1      | t        | f        | f           | t     |            
  6          | 33554437 | 1      | t        | f        | f           | t     |            
  7          | 33554438 | 1      | f        | f        | f           | f     | {40 .. 40} 
  8          | 67108864 | 1      | f        | f        | f           | f     | {20 .. 30} 


### PR DESCRIPTION
For BRIN indexes on AO/CO tables, we can exploit a property of exhausted
logical block ranges (fast sequence numbers used up) belonging to a
segment that undergoes VACUUM (i.e. a segment awaiting drop). The
property is that these ranges will never be reused for future inserts.

This is because we don't reset gp_fastsequence when we VACUUM AO/CO
tables and gp_fastsequence is always increasing.

So, these ranges are effectively dead and can thus be marked as empty.
Doing so brings about a couple of benefits:

(1) These dead ranges will never result in false positives during scans
which match the ranges' summary info.

(2) Cycles will not be spent trying to summarize them, as empty ranges
are not summarized. This saves cycles for both the summarization call at
the end of VACUUM and for all future summarization calls.

We mark these ranges as empty in the brinbulkdelete callback, which is
called when we are sure that it is safe to recycle a segment awaiting
drop.

We loop through the dead segs passed into the brinbulkdelete callback,
and then loop through each of their logical block ranges. For each
range, we replace its data tuple with an empty tuple (with the
appropriate flag set).

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/brin_vac_take2