### PR TITLE
[7X] Remove assertion to allow per-phase progress reporting on VACUUM AO/CO.

### DIFF
--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -242,6 +242,212 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
  50000      | 0          | t               | 2            
 (1 row)
 
+1q: ... <quitting>
+-- Test vacuum worker process is changed at post-cleanup phase due to mirror down.
+-- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
+-- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
+-- in which vacuum worker isn't changed.
+ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
+ALTER SYSTEM
+ALTER SYSTEM SET gp_fts_probe_interval to 10;
+ALTER SYSTEM
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+ 2             | t              
+ 1             | t              
+ 0             | t              
+ -1            | t              
+(4 rows)
+
+DROP TABLE IF EXISTS vacuum_progress_ao_column;
+DROP TABLE
+CREATE TABLE vacuum_progress_ao_column(i int, j int);
+CREATE TABLE
+CREATE INDEX on vacuum_progress_ao_column(i);
+CREATE INDEX
+CREATE INDEX on vacuum_progress_ao_column(j);
+CREATE INDEX
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: COMMIT;
+COMMIT
+2: BEGIN;
+BEGIN
+2: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: ABORT;
+ROLLBACK
+2q: ... <quitting>
+1: ABORT;
+ROLLBACK
+DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
+DELETE 50000
+
+-- Suspend execution at the end of compact phase.
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+1: set debug_appendonly_print_compaction to on;
+SET
+1&: vacuum vacuum_progress_ao_column;  <waiting ...>
+
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- Non-zero progressing data num_dead_tuples is showed up.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+ gp_segment_id | relname                   | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------+---------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ 1             | vacuum_progress_ao_column | append-optimized compact | 25              | 9                 | 17                 | 0                  | 33327           | 16621           
+ 0             | vacuum_progress_ao_column | append-optimized compact | 25              | 9                 | 17                 | 0                  | 33462           | 16726           
+ 2             | vacuum_progress_ao_column | append-optimized compact | 25              | 9                 | 17                 | 0                  | 33211           | 16653           
+(3 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                   | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_column | append-optimized compact | 75              | 27                | 51                 | 0                  | 100000          | 50000           
+(1 row)
+
+-- Resume execution of compact phase and block at syncrep on one segment.
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- stop the mirror should turn off syncrep
+2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content = 1 AND role = 'm';
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Resume walsender to detect mirror down and suspend at the beginning
+-- of post-cleanup taken over by a new vacuum worker.
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- resume walsender and let it exit so that mirror stop can be detected
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Ensure we enter into the target logic which stops cumulative data but
+-- initializes a new vacrelstats at the beginning of post-cleanup phase.
+-- Also all segments should reach to the same "vacuum_worker_changed" point
+-- due to FTS version being changed.
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+-- now seg1's mirror is marked as down
+2: SELECT content, role, preferred_role, mode, status FROM gp_segment_configuration WHERE content > -1;
+ content | role | preferred_role | mode | status 
+---------+------+----------------+------+--------
+ 2       | p    | p              | s    | u      
+ 2       | m    | m              | s    | u      
+ 0       | p    | p              | s    | u      
+ 0       | m    | m              | s    | u      
+ 1       | p    | p              | n    | u      
+ 1       | m    | m              | n    | d      
+(6 rows)
+
+-- Resume execution and entering post_cleaup phase, suspend at the end of it.
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- The previous collected num_dead_tuples in compact phase is zero.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+ gp_segment_id | relname                   | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------+---------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ 2             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 0             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 1             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+(3 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                   | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+(1 row)
+
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+1<:  <... completed>
+VACUUM
+
+-- restore environment
+1: reset debug_appendonly_print_compaction;
+RESET
+
+2: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 1;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+2: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
  gp_inject_fault_infinite 
@@ -259,3 +465,15 @@ reset Debug_appendonly_print_compaction;
 RESET
 reset default_table_access_method;
 RESET
+ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER SYSTEM
+ALTER SYSTEM RESET gp_fts_probe_interval;
+ALTER SYSTEM
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+ 2             | t              
+ 1             | t              
+ 0             | t              
+ -1            | t              
+(4 rows)

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -291,6 +291,212 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
  50000      | 0          | t               | 2            
 (1 row)
 
+1q: ... <quitting>
+-- Test vacuum worker process is changed at post-cleanup phase due to mirror down.
+-- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
+-- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
+-- in which vacuum worker isn't changed.
+ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
+ALTER SYSTEM
+ALTER SYSTEM SET gp_fts_probe_interval to 10;
+ALTER SYSTEM
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+ 2             | t              
+ 1             | t              
+ 0             | t              
+ -1            | t              
+(4 rows)
+
+DROP TABLE IF EXISTS vacuum_progress_ao_row;
+DROP TABLE
+CREATE TABLE vacuum_progress_ao_row(i int, j int);
+CREATE TABLE
+CREATE INDEX on vacuum_progress_ao_row(i);
+CREATE INDEX
+CREATE INDEX on vacuum_progress_ao_row(j);
+CREATE INDEX
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: COMMIT;
+COMMIT
+2: BEGIN;
+BEGIN
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 0 100000
+2: ABORT;
+ROLLBACK
+2q: ... <quitting>
+1: ABORT;
+ROLLBACK
+DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
+DELETE 50000
+
+-- Suspend execution at the end of compact phase.
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+1: set debug_appendonly_print_compaction to on;
+SET
+1&: vacuum vacuum_progress_ao_row;  <waiting ...>
+
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- Non-zero progressing data num_dead_tuples is showed up.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+ gp_segment_id | relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------+------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ 1             | vacuum_progress_ao_row | append-optimized compact | 55              | 19                | 37                 | 0                  | 33327           | 16622           
+ 2             | vacuum_progress_ao_row | append-optimized compact | 55              | 19                | 37                 | 0                  | 33211           | 16653           
+ 0             | vacuum_progress_ao_row | append-optimized compact | 56              | 19                | 37                 | 0                  | 33462           | 16725           
+(3 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized compact | 166             | 57                | 111                | 0                  | 100000          | 50000           
+(1 row)
+
+-- Resume execution of compact phase and block at syncrep.
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- stop the mirror should turn off syncrep
+2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=1 AND role = 'm';
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Resume walsender to detect mirror down and suspend at the beginning
+-- of post-cleanup taken over by a new vacuum worker.
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- resume walsender and let it exit so that mirror stop can be detected
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Ensure we enter into the target logic which stops cumulative data but
+-- initializes a new vacrelstats at the beginning of post-cleanup phase.
+-- Also all segments should reach to the same "vacuum_worker_changed" point
+-- due to FTS version being changed.
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+-- now seg1's mirror is marked as down
+2: SELECT content, role, preferred_role, mode, status FROM gp_segment_configuration WHERE content > -1;
+ content | role | preferred_role | mode | status 
+---------+------+----------------+------+--------
+ 2       | p    | p              | s    | u      
+ 2       | m    | m              | s    | u      
+ 0       | p    | p              | s    | u      
+ 0       | m    | m              | s    | u      
+ 1       | p    | p              | n    | u      
+ 1       | m    | m              | n    | d      
+(6 rows)
+
+-- Resume execution and entering post_cleaup phase, suspend at the end of it.
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- The previous collected num_dead_tuples in compact phase is zero.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+ gp_segment_id | relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------------+------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ 0             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 2             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 1             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+(3 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+(1 row)
+
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+1<:  <... completed>
+VACUUM
+
+-- restore environment
+1: reset debug_appendonly_print_compaction;
+RESET
+
+2: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 1;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+2: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
  gp_inject_fault_infinite 
@@ -308,3 +514,15 @@ reset Debug_appendonly_print_compaction;
 RESET
 reset default_table_access_method;
 RESET
+ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER SYSTEM
+ALTER SYSTEM RESET gp_fts_probe_interval;
+ALTER SYSTEM
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+ gp_segment_id | pg_reload_conf 
+---------------+----------------
+ 2             | t              
+ 1             | t              
+ 0             | t              
+ -1            | t              
+(4 rows)

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -97,7 +97,85 @@ SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) 
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_column' and gp_segment_id = 1;
 
+1q:
+-- Test vacuum worker process is changed at post-cleanup phase due to mirror down.
+-- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
+-- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
+-- in which vacuum worker isn't changed.
+ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
+ALTER SYSTEM SET gp_fts_probe_interval to 10;
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+
+DROP TABLE IF EXISTS vacuum_progress_ao_column;
+CREATE TABLE vacuum_progress_ao_column(i int, j int);
+CREATE INDEX on vacuum_progress_ao_column(i);
+CREATE INDEX on vacuum_progress_ao_column(j);
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+2: COMMIT;
+2: BEGIN;
+2: INSERT INTO vacuum_progress_ao_column SELECT i, i FROM generate_series(1, 100000) i;
+2: ABORT;
+2q:
+1: ABORT;
+DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
+
+-- Suspend execution at the end of compact phase.
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+1: set debug_appendonly_print_compaction to on;
+1&: vacuum vacuum_progress_ao_column;
+
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- Non-zero progressing data num_dead_tuples is showed up.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+
+-- Resume execution of compact phase and block at syncrep on one segment.
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- stop the mirror should turn off syncrep
+2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content = 1 AND role = 'm';
+
+-- Resume walsender to detect mirror down and suspend at the beginning
+-- of post-cleanup taken over by a new vacuum worker.
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- resume walsender and let it exit so that mirror stop can be detected
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- Ensure we enter into the target logic which stops cumulative data but
+-- initializes a new vacrelstats at the beginning of post-cleanup phase.
+-- Also all segments should reach to the same "vacuum_worker_changed" point
+-- due to FTS version being changed.
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- now seg1's mirror is marked as down
+2: SELECT content, role, preferred_role, mode, status FROM gp_segment_configuration WHERE content > -1;
+
+-- Resume execution and entering post_cleaup phase, suspend at the end of it.
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- The previous collected num_dead_tuples in compact phase is zero.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+1<:
+
+-- restore environment
+1: reset debug_appendonly_print_compaction;
+
+2: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 1;
+2: SELECT wait_until_all_segments_synchronized();
+
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
 reset Debug_appendonly_print_compaction;
 reset default_table_access_method;
+ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER SYSTEM RESET gp_fts_probe_interval;
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -101,7 +101,85 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
 
+1q:
+-- Test vacuum worker process is changed at post-cleanup phase due to mirror down.
+-- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
+-- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
+-- in which vacuum worker isn't changed.
+ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
+ALTER SYSTEM SET gp_fts_probe_interval to 10;
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
+
+DROP TABLE IF EXISTS vacuum_progress_ao_row;
+CREATE TABLE vacuum_progress_ao_row(i int, j int);
+CREATE INDEX on vacuum_progress_ao_row(i);
+CREATE INDEX on vacuum_progress_ao_row(j);
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+2: COMMIT;
+2: BEGIN;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+2: ABORT;
+2q:
+1: ABORT;
+DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
+
+-- Suspend execution at the end of compact phase.
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+1: set debug_appendonly_print_compaction to on;
+1&: vacuum vacuum_progress_ao_row;
+
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- Non-zero progressing data num_dead_tuples is showed up.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+
+-- Resume execution of compact phase and block at syncrep.
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- stop the mirror should turn off syncrep
+2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=1 AND role = 'm';
+
+-- Resume walsender to detect mirror down and suspend at the beginning
+-- of post-cleanup taken over by a new vacuum worker.
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- resume walsender and let it exit so that mirror stop can be detected
+2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- Ensure we enter into the target logic which stops cumulative data but
+-- initializes a new vacrelstats at the beginning of post-cleanup phase.
+-- Also all segments should reach to the same "vacuum_worker_changed" point
+-- due to FTS version being changed.
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+-- now seg1's mirror is marked as down
+2: SELECT content, role, preferred_role, mode, status FROM gp_segment_configuration WHERE content > -1;
+
+-- Resume execution and entering post_cleaup phase, suspend at the end of it.
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_inject_fault('vacuum_worker_changed', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- The previous collected num_dead_tuples in compact phase is zero.
+select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+
+2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+1<:
+
+-- restore environment
+1: reset debug_appendonly_print_compaction;
+
+2: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 1;
+2: SELECT wait_until_all_segments_synchronized();
+
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
 reset Debug_appendonly_print_compaction;
 reset default_table_access_method;
+ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
+ALTER SYSTEM RESET gp_fts_probe_interval;
+SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');


### PR DESCRIPTION
VACUUM Append-Optimized is a multi-phases process, coordinator performs disptching vacuum for doing each phase job respectively, progress reporting accumulates each phase data as long as running vacuum on the same backend of each segment.

However, multiple dispatches job could be handled on different backends when there is an update of cluster configuration such like mirror down or node expansion. If this event happens in between phases of VACUUM, the vacuum backend may be changed resulting in accumulated progressing data in former phases being reset in the new worker.

This patch allows vacuum reporting per-phase progress instead of failing assertion like issue https://github.com/greenplum-db/gpdb/issues/15916 when vacuum backend is changed in between phases.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/hw-7X_vac_assert_fail

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
