### PR TITLE
Fix ABI broken of 6X introduced by e0cca54551.

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1142,6 +1142,7 @@ typedef struct SubPlanState
 	FmgrInfo   *cur_eq_funcs;	/* equality functions for LHS vs. table */
 	void	   *ts_pos;
 	GenericTupStore *ts_state;
+	bool        prefetch_subplan_done; /* Greenplum specific */
 } SubPlanState;
 
 /* ----------------
@@ -1432,8 +1433,6 @@ typedef struct PlanState
 
 	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
 	MemoryAccountIdType memoryAccountId;
-
-	bool		prefetch_subplans_done;
 } PlanState;
 
 /* Gpperfmon helper functions defined in execGpmon.c */


### PR DESCRIPTION
Commit e0cca54551 add a new field at the end of struct PlanState, however PlanState is many other execute Nodes' base. So the previous commit breaks ABI of stable version. This commit fixes it by adding the field in SubPlanState, which is a leaf struct in GPDB 6 (no other struct include it as base).
