### PR TITLE
[6X] Consider bitmap alternative only for ANY ScalarArray

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1923,6 +1923,8 @@ CPredicateUtils::PexprIndexLookup(CMemoryPool *mp, CMDAccessor *md_accessor,
 		cmptype = CScalarCmp::PopConvert(pexprScalar->Pop())->ParseCmpType();
 	}
 	else if (CUtils::FScalarArrayCmp(pexprScalar) &&
+			 CScalarArrayCmp::EarrcmpAny ==
+				 CScalarArrayCmp::PopConvert(pexprScalar->Pop())->Earrcmpt() &&
 			 (IMDIndex::EmdindBitmap == pmdindex->IndexType() ||
 			  (allowArrayCmpForBTreeIndexes &&
 			   IMDIndex::EmdindBtree == pmdindex->IndexType())))

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -771,6 +771,88 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+--
+-- Test ORCA generates BitmapIndexScan alternative for ScalarArrayOpExpr ANY only
+--
+CREATE TABLE bitmap_alt (id int, bitmap_idx_col int, btree_idx_col int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX bitmap_alt_idx1 on bitmap_alt using bitmap(bitmap_idx_col);
+CREATE INDEX bitmap_alt_idx2 on bitmap_alt using btree(btree_idx_col);
+INSERT INTO bitmap_alt SELECT i, i, i from generate_series(1,10)i;
+ANALYZE bitmap_alt;
+-- ORCA should generate bitmap index scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on bitmap_alt
+         Recheck Cond: (bitmap_idx_col = ANY ('{3,5}'::integer[]))
+         ->  Bitmap Index Scan on bitmap_alt_idx1
+               Index Cond: (bitmap_idx_col = ANY ('{3,5}'::integer[]))
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  3 |              3 |             3
+  5 |              5 |             5
+(2 rows)
+
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on bitmap_alt
+         Recheck Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
+         ->  Bitmap Index Scan on bitmap_alt_idx2
+               Index Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  5 |              5 |             5
+  3 |              3 |             3
+(2 rows)
+
+-- ORCA should generate seq scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bitmap_alt
+         Filter: (bitmap_idx_col = ALL ('{3}'::integer[]))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  3 |              3 |             3
+(1 row)
+
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bitmap_alt
+         Filter: (btree_idx_col = ALL ('{3}'::integer[]))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  3 |              3 |             3
+(1 row)
+
 -- The following tests are to verify a fix that allows ORCA to
 -- choose the bitmap index scan alternative when the predicate
 -- is in the form of `value operator cast(column)`. The fix

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -758,6 +758,88 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+--
+-- Test ORCA generates BitmapIndexScan alternative for ScalarArrayOpExpr ANY only
+--
+CREATE TABLE bitmap_alt (id int, bitmap_idx_col int, btree_idx_col int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX bitmap_alt_idx1 on bitmap_alt using bitmap(bitmap_idx_col);
+CREATE INDEX bitmap_alt_idx2 on bitmap_alt using btree(btree_idx_col);
+INSERT INTO bitmap_alt SELECT i, i, i from generate_series(1,10)i;
+ANALYZE bitmap_alt;
+-- ORCA should generate bitmap index scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on bitmap_alt
+         Recheck Cond: (bitmap_idx_col = ANY ('{3,5}'::integer[]))
+         ->  Bitmap Index Scan on bitmap_alt_idx1
+               Index Cond: (bitmap_idx_col = ANY ('{3,5}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  5 |              5 |             5
+  3 |              3 |             3
+(2 rows)
+
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on bitmap_alt
+         Recheck Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
+         ->  Bitmap Index Scan on bitmap_alt_idx2
+               Index Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  5 |              5 |             5
+  3 |              3 |             3
+(2 rows)
+
+-- ORCA should generate seq scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bitmap_alt
+         Filter: (bitmap_idx_col = ALL ('{3}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  3 |              3 |             3
+(1 row)
+
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bitmap_alt
+         Filter: (btree_idx_col = ALL ('{3}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+ id | bitmap_idx_col | btree_idx_col 
+----+----------------+---------------
+  3 |              3 |             3
+(1 row)
+
 -- The following tests are to verify a fix that allows ORCA to
 -- choose the bitmap index scan alternative when the predicate
 -- is in the form of `value operator cast(column)`. The fix

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -354,6 +354,32 @@ RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
 
+--
+-- Test ORCA generates BitmapIndexScan alternative for ScalarArrayOpExpr ANY only
+--
+
+CREATE TABLE bitmap_alt (id int, bitmap_idx_col int, btree_idx_col int);
+CREATE INDEX bitmap_alt_idx1 on bitmap_alt using bitmap(bitmap_idx_col);
+CREATE INDEX bitmap_alt_idx2 on bitmap_alt using btree(btree_idx_col);
+INSERT INTO bitmap_alt SELECT i, i, i from generate_series(1,10)i;
+ANALYZE bitmap_alt;
+
+-- ORCA should generate bitmap index scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
+
+-- ORCA should generate seq scan plans for the following
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+SELECT * FROM bitmap_alt WHERE bitmap_idx_col=ALL(ARRAY[3]);
+EXPLAIN (COSTS OFF)
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
+
 -- The following tests are to verify a fix that allows ORCA to
 -- choose the bitmap index scan alternative when the predicate
 -- is in the form of `value operator cast(column)`. The fix


### PR DESCRIPTION
This is a partial backport of PR: https://github.com/greenplum-db/gpdb/pull/15898
(changes for hash index not ported)

Partial cherry-pick of commit 8bbadb87007502365b244f46d654d6ec3684ced3

Updated test for ALL to have single element in array so that ORCA goes through the codepath that has been fixed as part of this commit. In GP6, ORCA optimizes ALL with multiple array elements to a one-time false filter.

Original commit messgae:

Commit 290166f introduced ScalarArrayOpExpr as an indexable qual for ANY operator only as it is translated into an OR combination of indexscan on the array elements.  Prior to this commit ORCA considered Bitmap alternatives for equality on ScalarArrayCmp (both ANY and ALL) whereas similar to planner, ORCA should also only consider it for equality on ANY op. This commit fixes that issue and adds tests for the same.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
