### PR TITLE
brin: Adjust the default value of pages_per_range

### DIFF
--- a/src/backend/access/brin/README
+++ b/src/backend/access/brin/README
@@ -347,3 +347,15 @@ insert. So, we can safely position the revmap iterator at the end of the chain
 (instead of traversing the chain unnecessarily from the front).
 
 Note: Multiple revmap pages across chains can map to the same data page.
+
+(4) Default pages_per_range:
+For heap tables, we have decided to scale back the default to 32, since in GPDB
+one heap block is 4x the default size in PG.
+
+For AO/CO tables, since many more tuples fit in 1 logical heap block as opposed
+to heap (for e.g. the tpch lineitem table will have at most 248 tuples/block,
+whereas an AO/CO table is bound to have 32768 tuples/block).
+Having a default of 32 will thus be counter-productive - CPU processing cost
+from unwanted tuples will far outweigh any IO cost savings and will dominate the
+total cost of the query (as per planner cost estimation).
+Thus, we use the lowest default possible: a default value of 1.

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -17,6 +17,7 @@
 
 #include <float.h>
 
+#include "access/brin.h"
 #include "access/gist_private.h"
 #include "access/hash.h"
 #include "access/htup_details.h"
@@ -320,11 +321,17 @@ static relopt_int intRelOpts[] =
 	},
 	{
 		{
+			/*
+			 * GPDB: We use a sentinel value of BRIN_UNDEFINED_PAGES_PER_RANGE
+			 * to indicate that the default assigned in the relcache is AM
+			 * agnostic. The actual default will be determined later in
+			 * BrinGetPagesPerRange().
+			 */
 			"pages_per_range",
 			"Number of pages that each page range covers in a BRIN index",
 			RELOPT_KIND_BRIN,
 			AccessExclusiveLock
-		}, 128, 1, 131072
+		}, BRIN_UNDEFINED_PAGES_PER_RANGE, BRIN_UNDEFINED_PAGES_PER_RANGE, 131072
 	},
 	{
 		{

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -4277,3 +4277,22 @@ RestoreReindexState(void *reindexstate)
 	/* Note the worker has its own transaction nesting level */
 	reindexingNestLevel = GetCurrentTransactionNestLevel();
 }
+
+/*
+ * Is this index on an append-optimized table?
+ */
+bool
+IsIndexOnAORel(Relation idx)
+{
+	Oid relid;
+	Oid relam;
+
+	Assert(idx->rd_index);
+
+	relid = idx->rd_index->indrelid;
+	relam = get_rel_am(relid);
+
+	Assert(OidIsValid(relam));
+
+	return (relam == AO_ROW_TABLE_AM_OID || relam == AO_COLUMN_TABLE_AM_OID);
+}

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -7446,8 +7446,10 @@ brincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		 * Assume default number of pages per range, and estimate the number
 		 * of ranges based on that.
 		 */
+		bool isAO = (baserel->relam == AO_ROW_TABLE_AM_OID ||
+						baserel->relam == AO_COLUMN_TABLE_AM_OID);
 		indexRanges = Max(ceil((double) baserel->pages /
-							   BRIN_DEFAULT_PAGES_PER_RANGE), 1.0);
+								BrinDefaultPagesPerRange(isAO)), 1.0);
 
 		statsData.pagesPerRange = BRIN_DEFAULT_PAGES_PER_RANGE;
 		statsData.revmapNumPages = (indexRanges / REVMAP_PAGE_MAXITEMS) + 1;

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -2322,6 +2322,32 @@ get_relnatts(Oid relid)
 #endif
 
 /*
+ * get_rel_am
+ *		Returns the access method of a given relation.
+ *
+ * Returns InvalidOid if there is no such relation or if the relation is not an
+ * index or a table.
+ */
+Oid
+get_rel_am(Oid relid)
+{
+	HeapTuple       tp;
+
+	tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	if (HeapTupleIsValid(tp))
+	{
+		Form_pg_class reltup = (Form_pg_class) GETSTRUCT(tp);
+		Oid       result;
+
+		result = reltup->relam;
+		ReleaseSysCache(tp);
+		return result;
+	}
+
+	return InvalidOid;
+}
+
+/*
  * get_rel_name
  *		Returns the name of a given relation.
  *

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -341,5 +341,4 @@ extern List *updateEncodingList(List *current_encodings,
 extern List *form_default_storage_directive(List *enc);
 extern bool is_storage_encoding_directive(char *name);
 extern void free_options_deep(relopt_value *options, int num_options);
-
 #endif							/* RELOPTIONS_H */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302307131
+#define CATALOG_VERSION_NO	302307241
 
 #endif

--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -164,6 +164,7 @@ extern void SerializeReindexState(Size maxsize, char *start_address);
 extern void RestoreReindexState(void *reindexstate);
 
 extern void IndexSetParentIndex(Relation idx, Oid parentOid);
+extern bool IsIndexOnAORel(Relation idx);
 
 
 /*

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -159,6 +159,7 @@ extern bool is_agg_repsafe(Oid aggid);
 extern bool is_agg_partial_capable(Oid aggid);
 extern RegProcedure get_func_support(Oid funcid);
 extern Oid	get_relname_relid(const char *relname, Oid relnamespace);
+extern Oid get_rel_am(Oid relid);
 extern char *get_rel_name(Oid relid);
 extern Oid	get_rel_namespace(Oid relid);
 extern Oid	get_rel_type_id(Oid relid);

--- a/src/test/regress/expected/brin_interface.out
+++ b/src/test/regress/expected/brin_interface.out
@@ -154,5 +154,189 @@ ALTER INDEX brin_interface_idx SET (autosummarize=false);
 -- Altering it to true should result in an error.
 ALTER INDEX brin_interface_idx SET (autosummarize=true);
 ERROR:  autosummarize is not supported
+-- Test BRIN pages_per_range defaults
+CREATE TABLE brin_ppr_heap1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_heap1 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_heap1_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+CREATE UNLOGGED TABLE brin_ppr_heap2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_heap2 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_heap2_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+CREATE TABLE brin_ppr_heap3(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_heap3 USING brin(i) WITH (autosummarize=false);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_heap3_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+CREATE TABLE brin_ppr_ao_row1(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_row1 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_row1_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+CREATE UNLOGGED TABLE brin_ppr_ao_row2(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_row2 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_row2_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+CREATE TABLE brin_ppr_ao_row3(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_row3 USING brin(i) WITH (autosummarize=false);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_row3_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+CREATE TABLE brin_ppr_ao_column1(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_column1 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_column1_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+CREATE UNLOGGED TABLE brin_ppr_ao_column2(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_column2 USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_column2_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+CREATE TABLE brin_ppr_ao_column3(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_ao_column3 USING brin(i) WITH (autosummarize=false);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_column3_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+-- Test ALTERing pages_per_range
+-- Use REINDEX too as pages_per_range change won't go into effect until next reindex
+ALTER INDEX brin_ppr_heap1_i_idx SET (pages_per_range=16);
+REINDEX INDEX brin_ppr_heap1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_heap1_i_idx', 0));
+ pagesperrange 
+---------------
+            16
+(1 row)
+
+ALTER INDEX brin_ppr_heap1_i_idx RESET (pages_per_range);
+REINDEX INDEX brin_ppr_heap1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_heap1_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+ALTER INDEX brin_ppr_ao_row1_i_idx SET (pages_per_range=16);
+REINDEX INDEX brin_ppr_ao_row1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_row1_i_idx', 0));
+ pagesperrange 
+---------------
+            16
+(1 row)
+
+ALTER INDEX brin_ppr_ao_row1_i_idx RESET (pages_per_range);
+REINDEX INDEX brin_ppr_ao_row1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_row1_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+ALTER INDEX brin_ppr_ao_column1_i_idx SET (pages_per_range=16);
+REINDEX INDEX brin_ppr_ao_column1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_column1_i_idx', 0));
+ pagesperrange 
+---------------
+            16
+(1 row)
+
+ALTER INDEX brin_ppr_ao_column1_i_idx RESET (pages_per_range);
+REINDEX INDEX brin_ppr_ao_column1_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_ao_column1_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+-- ALTERIng the ACCESS METHOD of the table should gracefully set the default
+-- pages_per_range for the associated BRIN index.
+CREATE TABLE brin_ppr_atsetam(i int) USING heap;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ppr_atsetam USING brin(i);
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+ALTER TABLE brin_ppr_atsetam SET ACCESS METHOD ao_row;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
+ pagesperrange 
+---------------
+             1
+(1 row)
+
+ALTER TABLE brin_ppr_atsetam SET ACCESS METHOD heap;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
+ pagesperrange 
+---------------
+            32
+(1 row)
+
+-- ALTERing the ACCESS METHOD of the table should NOT set the default
+-- pages_per_range if the index had a pages_per_range set.
+ALTER INDEX brin_ppr_atsetam_i_idx SET (pages_per_range=8);
+REINDEX INDEX brin_ppr_atsetam_i_idx;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
+ pagesperrange 
+---------------
+             8
+(1 row)
+
+ALTER TABLE brin_ppr_atsetam SET ACCESS METHOD ao_row;
+SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
+ pagesperrange 
+---------------
+             8
+(1 row)
+
 DROP EXTENSION pageinspect CASCADE;
 NOTICE:  drop cascades to view revmap_page1


### PR DESCRIPTION
For heap tables, we have decided to scale back the default to 32, since in GPDB
one heap block is 4x the default size in PG.

For AO/CO tables, since many more tuples fit in 1 logical heap block as
opposed to heap (for e.g. the tpch lineitem table will have at most 248
tuples/block, whereas an AO/CO table is bound to have 32768
tuples/block).
Having a default of 32 will thus be counter-productive - CPU processing
cost from unwanted tuples will far outweigh any IO cost savings and will
dominate the total cost of the query (as per planner cost estimation).
Thus, we use the lowest default possible: a default value of 1.

Implementation:

Without access to the base table type inside brinoptions(), we are left
with no choice but to introduce a thin layer over the default value. We
define BRIN_UNDEFINED_PAGES_PER_RANGE, which conveys an AM agnostic
placeholder default for the relcache. The real default value is set when
BrinGetPagesPerRange() is used.

We do a catalog bump since the default value of pages_per_range is never
dumped by pg_dump, if it is unspecified in pg_class.reloptions.

Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/Hz100_bPkR4/m/o84SdziZAwAJ

Co-authored-by: Huansong Fu <fuhuansong@gmail.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/brin_ppr
