### PR TITLE
[6X] Fix incorrect cost estimation for two-stage deduplication

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2949,7 +2949,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				base_cost = motion_cost_per_row * result_plan->plan_rows;
 				alt_cost = motion_cost_per_row * numDistinct;
 				cost_sort(&sort_path, root, NIL, alt_cost,
-						  numDistinct, result_plan->plan_rows,
+						  numDistinct, result_plan->plan_width,
 						  0, work_mem, -1.0);
 				alt_cost += sort_path.startup_cost;
 				alt_cost += cpu_operator_cost * numDistinct


### PR DESCRIPTION
We used to pass in wrong parameter for `cost_sort()` when estimate the cost of two-stage deduplication. The sixth parameter should be `width` instead of the `rows`, which leads to the overrestimation of the cost of pre-unique when `result_plan->plan_rows` is greater than `result->plan->width`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
