### PR TITLE
Fix error of unique index key order

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -426,6 +426,9 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 	 * If it is to add a part to a partition table, the new partition must
 	 * has exact same distribution keys to root partition. So the transformation
 	 * is unnecessary.
+	 * Note: when we perform "split partition", we actually perform "add
+	 * partition" multiple times to create new partitions, and is_split_part
+	 * is never set. So we don't need to care about is_split_part here.
 	 */
 	if (stmt->relKind == RELKIND_RELATION && !stmt->is_add_part)
 	{

--- a/src/test/regress/expected/gp_index.out
+++ b/src/test/regress/expected/gp_index.out
@@ -155,6 +155,42 @@ Check constraints:
 Inherits: foo1
 Distributed by: (a, b, c)
 
+-- alter table by split partition
+alter table public.foo1 split partition p1 at(500) into (partition p1_0, partition p1_1);
+NOTICE:  exchanged partition "p1" of relation "foo1" with relation "pg_temp_17592"
+NOTICE:  dropped partition "p1" for relation "foo1"
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p1_0" for table "foo1"
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p1_1" for table "foo1"
+-- check the status of the split partitions: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p1_0
+                   Table "public.foo1_1_prt_p1_0"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ a      | integer |           | plain   |              | 
+ b      | integer |           | plain   |              | 
+ c      | integer |           | plain   |              | 
+Indexes:
+    "foo1_1_prt_p1_0_a_c_b_idx" UNIQUE, btree (a, c, b)
+Check constraints:
+    "foo1_1_prt_p1_0_check" CHECK (a >= 1 AND a < 500)
+Inherits: foo1
+Distributed by: (a, b, c)
+
+\d+ foo1_1_prt_p1_1
+                   Table "public.foo1_1_prt_p1_1"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ a      | integer |           | plain   |              | 
+ b      | integer |           | plain   |              | 
+ c      | integer |           | plain   |              | 
+Indexes:
+    "foo1_1_prt_p1_1_a_c_b_idx" UNIQUE, btree (a, c, b)
+Check constraints:
+    "foo1_1_prt_p1_1_check" CHECK (a >= 500 AND a <= 10000)
+Inherits: foo1
+Distributed by: (a, b, c)
+
 DROP TABLE foo1;
 -- before dispatch stmt to QEs, switching user to login user,
 -- so that the connection to QEs use the same user as the connection to QD.

--- a/src/test/regress/expected/gp_index.out
+++ b/src/test/regress/expected/gp_index.out
@@ -126,6 +126,36 @@ Indexes:
 Distributed by: (k)
 
 DROP TABLE tbl_create_index;
+-- create partition table with dist keys (a,b,c)
+CREATE TABLE foo1 (a int, b int, c int)  DISTRIBUTED BY (a,b,c) PARTITION BY RANGE(a)
+(PARTITION p1 START (1) END (10000) INCLUSIVE,
+PARTITION p2 START (10001) END (100000) INCLUSIVE,
+PARTITION p3 START (100001) END (1000000) INCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p1" for table "foo1"
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p2" for table "foo1"
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p3" for table "foo1"
+-- create unique index with same keys but different order (a,c,b)
+create unique index acb_idx on public.foo1 using btree(a,c,b);
+-- alter table by add partition
+alter table public.foo1 add partition p4 START (1000001) END (2000000) INCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "foo1_1_prt_p4" for table "foo1"
+-- check the status of the new partition: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p4
+                    Table "public.foo1_1_prt_p4"
+ Column |  Type   | Modifiers | Storage | Stats target | Description 
+--------+---------+-----------+---------+--------------+-------------
+ a      | integer |           | plain   |              | 
+ b      | integer |           | plain   |              | 
+ c      | integer |           | plain   |              | 
+Indexes:
+    "foo1_1_prt_p4_a_c_b_idx" UNIQUE, btree (a, c, b)
+Check constraints:
+    "foo1_1_prt_p4_check" CHECK (a >= 1000001 AND a <= 2000000)
+Inherits: foo1
+Distributed by: (a, b, c)
+
+DROP TABLE foo1;
 -- before dispatch stmt to QEs, switching user to login user,
 -- so that the connection to QEs use the same user as the connection to QD.
 -- pass the permission check of schema on QEs.

--- a/src/test/regress/sql/gp_index.sql
+++ b/src/test/regress/sql/gp_index.sql
@@ -62,6 +62,24 @@ ALTER TABLE tbl_create_index ADD CONSTRAINT PKEY PRIMARY KEY(i, k);
 
 DROP TABLE tbl_create_index;
 
+-- create partition table with dist keys (a,b,c)
+CREATE TABLE foo1 (a int, b int, c int)  DISTRIBUTED BY (a,b,c) PARTITION BY RANGE(a)
+(PARTITION p1 START (1) END (10000) INCLUSIVE,
+PARTITION p2 START (10001) END (100000) INCLUSIVE,
+PARTITION p3 START (100001) END (1000000) INCLUSIVE);
+
+-- create unique index with same keys but different order (a,c,b)
+create unique index acb_idx on public.foo1 using btree(a,c,b);
+
+-- alter table by add partition
+alter table public.foo1 add partition p4 START (1000001) END (2000000) INCLUSIVE;
+
+-- check the status of the new partition: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p4
+
+DROP TABLE foo1;
+
 -- before dispatch stmt to QEs, switching user to login user,
 -- so that the connection to QEs use the same user as the connection to QD.
 -- pass the permission check of schema on QEs.

--- a/src/test/regress/sql/gp_index.sql
+++ b/src/test/regress/sql/gp_index.sql
@@ -78,6 +78,14 @@ alter table public.foo1 add partition p4 START (1000001) END (2000000) INCLUSIVE
 -- to the parent table
 \d+ foo1_1_prt_p4
 
+-- alter table by split partition
+alter table public.foo1 split partition p1 at(500) into (partition p1_0, partition p1_1);
+
+-- check the status of the split partitions: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p1_0
+\d+ foo1_1_prt_p1_1
+
 DROP TABLE foo1;
 
 -- before dispatch stmt to QEs, switching user to login user,


### PR DESCRIPTION
Co-authored-by: Xing Guo <admin@higuoxing.com>

### Issue

The unique index key order will affect the distribution key order of child partitions. For example we create a partitioned table with distribution key(a, b, c). After that, an unique index created on (a, c, b):
```
CREATE TABLE foo1 (a int, b int, c int)  DISTRIBUTED BY (a,b,c) PARTITION BY RANGE(a) 
(PARTITION p1 START (1) END (10000) INCLUSIVE,
PARTITION p2 START (10001) END (100000) INCLUSIVE,
PARTITION p3 START (100001) END (1000000) INCLUSIVE);
create unique index acb_idx on public.foo1 using btree(a,c,b);
```
When adding a new partition p4, we found the p4 distribution key has been changed to (a ,c ,b) which is different from other partitions:
```
alter table public.foo1 add partition p4 START (1000001) END (2000000) INCLUSIVE;
\d+ foo1_1_prt_p4
                   Table "public.foo1_1_prt_p4"
 Column |  Type   | Modifiers | Storage | Stats target | Description 
--------+---------+-----------+---------+--------------+-------------
 a      | integer |           | plain   |              | 
 b      | integer |           | plain   |              | 
 c      | integer |           | plain   |              | 
Indexes:
    "foo1_1_prt_p4_a_c_b_idx" UNIQUE, btree (a, c, b)
Check constraints:
    "foo1_1_prt_p4_check" CHECK (a >= 1000001 AND a <= 2000000)
Inherits: foo1
Distributed by: (a, c, b)
```
This causes an inconsistency issue in gpcheckcat:
```
Performing test 'part_integrity'
[ERROR]: child partition(s) are distributed differently from the root partition, and must be manually redistributed, for some tables. Check the gpcheckcat log for details.
```
### Root cause
The issue was imported by https://github.com/greenplum-db/gpdb/pull/10969. The design is to use the most common columns in all unique indexes as the distribution keys, and the set of the distribution keys must be a subset of the set of columns on the unique constraint. See the code in `transformDistributedBy()`:
```
			foreach(cell, index_stmt->indexParams)
			{
				IndexElem *iparam = lfirst(cell);
				ListCell *dkcell;

				/*
				 * The index element could be either a column name or an expression.
				 * If the index element is not a column name, it should be skipped
				 * to compute the most common columns. For example,
				 *
				 *   create table t(i int, j int, k int) distributed by (i,j);
				 *   create unique index on t(i, func1(j));
				 *
				 * The first index element is a name, the second index element
				 * is an expression. The set of distribution keys is not a subset
				 * of the column names in the index, so it violates the
				 * compatibility and finally it fails.
				 * But `create unique index on t(i, j);` will success.
				 */
				if (!iparam || !iparam->name)
					continue;
				foreach(dkcell, distrkeys)
				{
					IndexElem  *dk = (IndexElem *) lfirst(dkcell);
					if (strcmp(dk->name, iparam->name) == 0)
					{
						new_distrkeys = lappend(new_distrkeys, dk);
						break;
					}
				}
			}
```
However, it didn't consider the order of new dist keys, and the order of unique indexes is always used for new dist keys.

### Solution
We can go through dist keys in outer loop and unique indexes in inner loop. Since the target is to get the common subset of them, it can guarantee to get the correct subset with order of dist keys.