### PR TITLE
Disuse physical list for legacy planner Scans

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1002,6 +1002,16 @@ use_physical_tlist(PlannerInfo *root, Path *path, int flags)
 		}
 	}
 
+	/* 
+	 * Greenplum specific code: when generating scan plan in create_scan_plan(),
+	 * the upstream code prefer to generate a tlist containing all Vars in
+	 * order. For the AO-type storage, it would result into unnecessary
+	 * overhead and impact performance, so in this case we let the tlist apply
+	 * to the projection to avoid unnecessory column fetches.
+	 */
+	if (rel->relam == AO_ROW_TABLE_AM_OID || rel->relam == AO_COLUMN_TABLE_AM_OID)
+		return false;
+
 	return true;
 }
 

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -291,6 +291,11 @@ SELECT count(*) FROM tenk_aocs2;
 SELECT count(*) FROM tenk_aocs3;
 SELECT count(*) FROM tenk_aocs4;
 
+-- Issue #15904
+EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aocs1;
+CREATE TABLE tenk_aorow WITH(appendonly=true, orientation=row) AS SELECT * FROM tenk_heap_for_aocs;
+EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aorow;
+
 -- LIKE
 -- Should not copy storage options if not specified
 CREATE TABLE tenk_like_nocopy_storage (LIKE tenk_aocs1);
@@ -515,6 +520,7 @@ DROP TABLE tenk_aocs2;
 DROP TABLE tenk_aocs3;
 DROP TABLE tenk_aocs4;
 DROP TABLE tenk_aocs5;
+DROP TABLE tenk_aorow;
 
 set client_min_messages='WARNING';
 

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -535,6 +535,36 @@ SELECT count(*) FROM tenk_aocs4;
  10000
 (1 row)
 
+-- Issue #15904
+EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aocs1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Finalize Aggregate
+   Output: max(unique1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max(unique1))
+         ->  Partial Aggregate
+               Output: PARTIAL max(unique1)
+               ->  Seq Scan on public.tenk_aocs1
+                     Output: unique1
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+CREATE TABLE tenk_aorow WITH(appendonly=true, orientation=row) AS SELECT * FROM tenk_heap_for_aocs;
+EXPLAIN (verbose, costs off) SELECT max(unique1) FROM tenk_aorow;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Finalize Aggregate
+   Output: max(unique1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max(unique1))
+         ->  Partial Aggregate
+               Output: PARTIAL max(unique1)
+               ->  Seq Scan on public.tenk_aorow
+                     Output: unique1
+ Optimizer: Postgres query optimizer
+(9 rows)
+
 -- LIKE
 -- Should not copy storage options if not specified
 CREATE TABLE tenk_like_nocopy_storage (LIKE tenk_aocs1);
@@ -1044,6 +1074,7 @@ DROP TABLE tenk_aocs2;
 DROP TABLE tenk_aocs3;
 DROP TABLE tenk_aocs4;
 DROP TABLE tenk_aocs5;
+DROP TABLE tenk_aorow;
 set client_min_messages='WARNING';
 -- Test case for MPP-10086, make sure that we handle "else" clauses properly.
 DROP TABLE IF EXISTS aocs_new;


### PR DESCRIPTION
See #15904, when generating scan plan in `create_scan_plan()`, the upstream code prefer to generate a tlist containing all Vars in order. For the row-based storage such as heap, it looks fine, but for column-based storage, it would result into unnecessary overhead and impact performance. 

This commit makes specific optimization for Greenplum, and let the tlist apply to the projection to avoid unnecessory column fetches from the appened-only column storage, to improve the performance.

Applying this patch gains much performance improvement on TPC-DS & TPC-H benchmarks. The reason is for column-based storage, it would avoid loading unnecessary columns into the disk during the Scan.

Upstream discussion: https://www.postgresql.org/message-id/flat/SN6PR05MB51999AC1D043689076188370C400A%40SN6PR05MB5199.namprd05.prod.outlook.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
