### PR TITLE
[7x] Move single row expression handler list-concat logic to parser.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1004,16 +1004,6 @@ DoCopy(ParseState *pstate, const CopyStmt *stmt,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("COPY single row error handling only available using COPY FROM")));
 
-/* GPDB_91_MERGE_FIXME: this should probably be done earlier, e.g. in parser */
-	/* Transfer any SREH options to the options list, so that BeginCopy can see them. */
-	if (stmt->sreh)
-	{
-		SingleRowErrorDesc *sreh = (SingleRowErrorDesc *) stmt->sreh;
-
-		options = list_copy(options);
-		options = lappend(options, makeDefElem("sreh", (Node *) sreh, -1));
-	}
-
 	/*
 	 * Disallow COPY to/from file or program except to users with the
 	 * appropriate role.

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -6492,7 +6492,7 @@ OptSingleRowErrorHandling:
 					   (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("invalid (ROWS) reject limit. Should be 2 or larger")));
 
-			$$ = lappend(NULL, makeDefElem("sreh", (Node *) n));
+			$$ = lappend(NULL, makeDefElem("sreh", (Node *) n, @1));
 		}
 		| /*EMPTY*/		{ $$ = NULL; }
 		;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -304,7 +304,9 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 		CreateExternalStmt
 		CreateQueueStmt CreateResourceGroupStmt
 		DropQueueStmt DropResourceGroupStmt
-		ExtTypedesc OptSingleRowErrorHandling ExtSingleRowErrorHandling
+		ExtTypedesc ExtSingleRowErrorHandling
+
+%type<list> 	OptSingleRowErrorHandling
 
 %type <node>    deny_login_role deny_interval deny_point deny_day_specifier
 
@@ -4334,6 +4336,9 @@ CopyStmt:	COPY opt_binary qualified_name opt_column_list
 						n->options = lappend(n->options, $8);
 					if ($10)
 						n->options = list_concat(n->options, $10);
+					if ($12)
+						n->options = list_concat(n->options, $12);
+
 					$$ = (Node *)n;
 				}
 			| COPY '(' PreparableStmt ')' TO opt_program copy_file_name opt_with copy_options
@@ -6487,7 +6492,7 @@ OptSingleRowErrorHandling:
 					   (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("invalid (ROWS) reject limit. Should be 2 or larger")));
 
-			$$ = (Node *)n;
+			$$ = lappend(NULL, makeDefElem("sreh", (Node *) n));
 		}
 		| /*EMPTY*/		{ $$ = NULL; }
 		;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2276,7 +2276,7 @@ typedef struct CopyStmt
 	List	   *options;		/* List of DefElem nodes */
 	Node	   *whereClause;	/* WHERE condition (or NULL) */
 
-	Node	   *sreh;			/* Single row error handling info */
+	List	   *sreh;			/* Single row error handling info */
 } CopyStmt;
 
 /* ----------------------


### PR DESCRIPTION
This is the same pr as https://github.com/greenplum-db/gpdb/pull/14840 but cherry-picked to master branch 



This resolves GPDB_91_MERGE_FIXME in copy.c
Yacc parser rules modified so that SREH clause now return a list of options, which is later concatenated with other copy stmt options.

Removed plain C code from copy.c which does exatly the same.

Change sreh type to List in CopyStmt struct.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
