### PR TITLE
Rename database name in test_dbconn.py to avoid mismatching

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1323,13 +1323,13 @@ ABORT;
 -- Perform these tests in a funnily named database, to test
 -- escaping
 set client_min_messages='warning';
-DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+DROP DATABASE IF EXISTS "funny_copy""db'with\\quotes";
 reset client_min_messages;
-CREATE DATABASE "funny copy""db'with\\quotes";
+CREATE DATABASE "funny_copy""db'with\\quotes";
 
 \! python3 test_dbconn.py 1
 
-\c "funny copy""db'with\\quotes"
+\c "funny_copy""db'with\\quotes"
 -- echo will behave differently on different platforms, force to use bash with -E option
 COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; /usr/bin/env bash -c ''echo -E database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest '' ' ESCAPE 'OFF';
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1647,11 +1647,11 @@ ABORT;
 -- Perform these tests in a funnily named database, to test
 -- escaping
 set client_min_messages='warning';
-DROP DATABASE IF EXISTS "funny copy""db'with\\quotes";
+DROP DATABASE IF EXISTS "funny_copy""db'with\\quotes";
 reset client_min_messages;
-CREATE DATABASE "funny copy""db'with\\quotes";
+CREATE DATABASE "funny_copy""db'with\\quotes";
 \! python3 test_dbconn.py 1
-\c "funny copy""db'with\\quotes"
+\c "funny_copy""db'with\\quotes"
 -- echo will behave differently on different platforms, force to use bash with -E option
 COPY (SELECT 'data1') TO PROGRAM 'cat > /tmp/gpcopyenvtest; /usr/bin/env bash -c ''echo -E database in COPY TO: $GP_DATABASE >> /tmp/gpcopyenvtest '' ' ESCAPE 'OFF';
 CREATE TABLE foo (t text);
@@ -1661,8 +1661,8 @@ select * from foo;
                          t                         
 ---------------------------------------------------
  data1
- database in COPY FROM: funny copy"db'with\\quotes
- database in COPY TO: funny copy"db'with\\quotes
+ database in COPY FROM: funny_copy"db'with\\quotes
+ database in COPY TO: funny_copy"db'with\\quotes
 (3 rows)
 
 --

--- a/src/test/regress/test_dbconn.py
+++ b/src/test/regress/test_dbconn.py
@@ -14,7 +14,7 @@ import sys
 from gppylib.db import dbconn
 
 dbnames = ['funny\"db\'with\\\\quotes',    # from regress/dispatch
-           'funny copy\"db\'with\\\\quotes'# from regress/gpcopy
+           'funny_copy\"db\'with\\\\quotes'# from regress/gpcopy
 ]
 
 def test_connect_special_dbname(dbname):


### PR DESCRIPTION
See https://github.com/greenplum-db/gpdb/issues/15542#issuecomment-1641058351

Remove white space in database name in case that pygresql couldn't recognize the db url with white space.
This may fix issue https://github.com/greenplum-db/gpdb/issues/15542

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
