### PR TITLE
[7x]: Added --ignore-times and --whole-file option in rsync

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -460,7 +460,9 @@ class GpExpandStatus():
         cpCmd = Rsync('gpexpand copying status file to coordinator mirror',
                     srcFile=self._status_filename,
                     dstFile=self._status_standby_filename,
-                    dstHost=self._coordinator_mirror.getSegmentHostName())
+                    dstHost=self._coordinator_mirror.getSegmentHostName(),
+                    ignore_times=True,
+                    whole_file=True)
         cpCmd.run(validateAfter=True)
 
     def set_status(self, status, status_info=None, force=False):
@@ -530,7 +532,9 @@ class GpExpandStatus():
             cpCmd = Rsync('gpexpand copying segment configuration backup file to coordinator mirror',
                         srcFile=self._gp_segment_configuration_backup,
                         dstFile=self._segment_configuration_standby_filename,
-                        dstHost=self._coordinator_mirror.getSegmentHostName())
+                        dstHost=self._coordinator_mirror.getSegmentHostName(),
+                        ignore_times=True,
+                        whole_file=True)
             cpCmd.run(validateAfter=True)
 
     def get_temp_dir(self):
@@ -775,7 +779,9 @@ class SegmentTemplate:
             cpCmd = Rsync(name='gpexpand distribute tar file to new hosts',
                         srcFile=self.schema_tar_file,
                         dstFile=self.segTarDir,
-                        dstHost=host)
+                        dstHost=host,
+                        ignore_times=True,
+                        whole_file=True)
             self.pool.addCommand(cpCmd)
 
         self.pool.join()
@@ -863,7 +869,7 @@ class SegmentTemplate:
                   % (self.srcSegHostname, self.srcSegDataDir)
         cpCmd = Rsync(name=cmdName, srcFile=self.srcSegDataDir + '/postgresql.conf',
             dstFile=self.tempDir, dstHost=localHostname, ctxt=REMOTE,
-            remoteHost=self.srcSegHostname)
+            remoteHost=self.srcSegHostname, ignore_times=True, whole_file=True)
         cpCmd.run(validateAfter=True)
 
         self.logger.info('Copying pg_hba.conf from existing segment into template')
@@ -871,7 +877,7 @@ class SegmentTemplate:
                   % (self.srcSegHostname, self.srcSegDataDir)
         cpCmd = Rsync(name=cmdName, srcFile=self.srcSegDataDir + '/pg_hba.conf',
                     dstFile=self.tempDir, dstHost=localHostname,ctxt=REMOTE,
-                    remoteHost=self.srcSegHostname)
+                    remoteHost=self.srcSegHostname, ignore_times=True, whole_file=True)
         cpCmd.run(validateAfter=True)
 
     def _tar_template(self):

--- a/gpMgmt/bin/gpmemwatcher
+++ b/gpMgmt/bin/gpmemwatcher
@@ -171,7 +171,7 @@ def stopProcesses(host, workdir):
         return
 
     try:
-        subprocess.check_call('rsync -q %s:%s/%s ./%s.%s' % (host, dest_dir, ps_file, host, ps_file), shell=True)
+        subprocess.check_call('rsync -q -I -W %s:%s/%s ./%s.%s' % (host, dest_dir, ps_file, host, ps_file), shell=True)
     except subprocess.CalledProcessError as e:
         print('Error retrieving data from host: ' + host, file=sys.stderr)
         print(e)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1167,7 +1167,7 @@ def distribute_tarball(queue,list,tarball):
             hostname = db.getSegmentHostName()
             datadir = db.getSegmentDataDirectory()
             (head,tail)=os.path.split(datadir)
-            rsync_cmd=Rsync(name="copy coordinator",srcFile=tarball,dstHost=hostname,dstFile=head)
+            rsync_cmd=Rsync(name="copy coordinator",srcFile=tarball,dstHost=hostname,dstFile=head, ignore_times=True, whole_file=True)
             queue.addCommand(rsync_cmd)
         queue.join()
         queue.check_results()

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -447,7 +447,7 @@ class Rsync(Command):
     def __init__(self, name, srcFile, dstFile, srcHost=None, dstHost=None, recursive=False,
                  verbose=True, archive_mode=True, checksum=False, delete=False, progress=False,
                  stats=False, dry_run=False, bwlimit=None, exclude_list=[], ctxt=LOCAL,
-                 remoteHost=None, compress=False, progress_file=None):
+                 remoteHost=None, compress=False, progress_file=None, ignore_times=False, whole_file=False):
 
         """
             rsync options:
@@ -465,6 +465,8 @@ class Rsync(Command):
                 dry_run: perform a trial run with no changes made
                 compress: compress file data during the transfer
                 progress: to show the progress of rsync execution, like % transferred
+                ignore_times: Not skip files that match modification time and size
+                whole_file: Copy file without rsync's delta-transfer algorithm
         """
 
         cmd_tokens = [findCmdInPath('rsync')]
@@ -481,6 +483,14 @@ class Rsync(Command):
         # To skip the files based on checksum, not modification time and size
         if checksum:
             cmd_tokens.append('-c')
+
+        # To not skip files that match modification time and size
+        if ignore_times:
+            cmd_tokens.append('--ignore-times')
+
+        # Copy file without rsync's delta-transfer algorithm
+        if whole_file:
+            cmd_tokens.append('--whole-file')
 
         if progress:
             cmd_tokens.append('--progress')

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -121,7 +121,7 @@ class SyncPackages(Operation):
                 Rsync(name='Syncing {} to localhost'.format(package),
                       srcFile=remote_package_metadata,
                       dstFile=remove_package_metadata,
-                      srcHost=self.host).run(validateAfter=True)
+                      srcHost=self.host, ignore_times=True, whole_file=True).run(validateAfter=True)
                 remove_list = get_package_file_list(package)
                 for file_ in remove_list:
                     RemoveRemoteFile(os.path.join(GPHOME, file_), self.host).run()

--- a/gpMgmt/bin/gpssh-exkeys
+++ b/gpMgmt/bin/gpssh-exkeys
@@ -751,7 +751,7 @@ try:
 
 
         for h in GV.newHosts:
-            cmd = ('rsync -q -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
+            cmd = ('rsync -q -I -W -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
                    '%s %s %s %s %s:.ssh/ 2>&1'
                    % (GV.authorized_keys_fname,
                       GV.known_hosts_fname,
@@ -792,7 +792,7 @@ try:
                     remoteIdentity = GV.id_rsa_fname
                     remoteIdentityPub = GV.id_rsa_pub_fname
 
-                cmd = ('rsync -q -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
+                cmd = ('rsync -q -I -W -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
                        '%s %s %s %s %s:.ssh/ 2>&1'
                        % (remoteAuthKeysFile,
                           remoteKnownHostsFile,


### PR DESCRIPTION
Fixes https://github.com/greenplum-db/gpdb/issues/14744

Problem :
rsync skips file if it has identical sizes and modification times on the source and destination hosts, this makes gpsync behave different than gpscp. gpscp was replaced with gpsync (which uses rsync to copy files) but we don't want to change the behaviour.

Solution :
To make gpsync behave the same as gpscp, -I or --ignore-times and -W or --whole-file option can be used with rsync. It will copy the files that have identical size and modification time on the source and destination hosts. -I or --ignore-times is used to make sure files that match in size and mod-time are not skipped. -W or --whole-file flag used to copy files completely without using delta-transfer algorithm.

Implementation :
Added the -I or --ignore-times and -W or --whole-file option with rsync command everywhere in cluster management utility codebase(wherever scp was used to copy files) to make sure rsync behaves exactly same as scp.
Note: gpsync utility taken care as a part of separate PR

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
