### PR TITLE
add view gp_resgroup_status_per_segment to show vmem usage of resource group in each segment

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -16,6 +16,11 @@ select groupname , groupid , cpu_usage , memory_usage from gp_toolkit.gp_resgrou
  default_group | 6437    | 0.00      | 0.00         
 (1 row)
 
+select groupname , groupid , segment_id , vmem_usage from gp_toolkit.gp_resgroup_status_per_segment where groupname='default_group' order by segment_id;
+ groupname | groupid | segment_id | vmem_usage 
+-----------+---------+------------+------------
+(0 rows)
+
 select * from gp_toolkit.gp_resgroup_role where rrrolname='gpadmin';
  rrrolname | rrrsgname   
 -----------+-------------
@@ -47,4 +52,12 @@ select * from gp_toolkit.gp_resgroup_status_per_host;
  6437    | default_group | zero     | 0.00      | 0.00         
  6441    | system_group  | zero     | 0.07      | 55.94        
 (3 rows)
+select * from gp_toolkit.gp_resgroup_status_per_segment;
+ groupid | groupname   | segment_id | vmem_usage 
+---------+-------------+------------+------------
+ 6438    | admin_group | -1         | 11         
+ 6438    | admin_group | 0          | 8          
+ 6438    | admin_group | 1          | 8          
+ 6438    | admin_group | 2          | 8          
+(4 rows)
 -- end_ignore

--- a/src/test/isolation2/sql/resgroup/resgroup_views.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views.sql
@@ -20,6 +20,14 @@ select groupname
     on s.hostname=c.hostname and c.content=-1 and role='p'
  where groupname='default_group';
 
+select groupname
+     , groupid
+     , segment_id
+     , vmem_usage
+  from gp_toolkit.gp_resgroup_status_per_segment
+ where groupname='default_group'
+ order by segment_id;
+
 select *
   from gp_toolkit.gp_resgroup_role
  where rrrolname='gpadmin';
@@ -31,4 +39,5 @@ select *
 select * from gp_toolkit.gp_resgroup_config;
 select * from gp_toolkit.gp_resgroup_status;
 select * from gp_toolkit.gp_resgroup_status_per_host;
+select * from gp_toolkit.gp_resgroup_status_per_segment;
 -- end_ignore


### PR DESCRIPTION
Add view gp_resgroup_status_per_segment to show memory usage calculated by vmem tracker.
The usage of gp_resgroup_status_per_segment is as follows:
create extension gp_toolkit;
postgres=# select * from gp_toolkit.gp_resgroup_status_per_segment ;
 groupid |  groupname  | segment_id | vmem_usage 
---------+-------------+------------+------------
    6438 | admin_group |         -1 |         13
    6438 | admin_group |          0 |          9
    6438 | admin_group |          1 |          9
    6438 | admin_group |          2 |          9
(4 rows)

The view  gp_toolkit.resgroup_session_level_memory_consumption is similar to session_state.session_level_memory_consumption, But session_state.session_level_memory_consumption is in another extension, and we can not create extension nested. So in extension gp_toolkit I create another view based on the same method gp_session_state_memory_entries.