### PR TITLE
Fix insert result error to sequence column

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1314,7 +1314,7 @@ init_sequence_internal(Oid _relid, SeqTable *p_elm, Relation *p_rel,
 	 * discard any cached-but-unissued values.  We do not touch the currval()
 	 * state, however.
 	 */
-	if (seqrel->rd_rel->relfilenode != elm->filenode && called_from_dispatcher)
+	if (seqrel->rd_rel->relfilenode != elm->filenode)
 	{
 		elm->filenode = seqrel->rd_rel->relfilenode;
 		elm->cached = elm->last;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3371,6 +3371,7 @@ _outTruncateStmt(StringInfo str, const TruncateStmt *node)
 	WRITE_NODE_TYPE("TRUNCATESTMT");
 
 	WRITE_NODE_FIELD(relations);
+	WRITE_BOOL_FIELD(restart_seqs);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -848,6 +848,7 @@ _readTruncateStmt(void)
 	READ_LOCALS(TruncateStmt);
 
 	READ_NODE_FIELD(relations);
+	READ_BOOL_FIELD(restart_seqs);
 	READ_ENUM_FIELD(behavior,DropBehavior);
 
 	READ_DONE();

--- a/src/test/regress/expected/truncate.out
+++ b/src/test/regress/expected/truncate.out
@@ -339,13 +339,9 @@ DROP TABLE trunc_trigger_test;
 DROP TABLE trunc_trigger_log;
 DROP FUNCTION trunctrigger();
 -- test TRUNCATE ... RESTART IDENTITY
--- the column id should change back to serial when issue #15579 be fixed.
--- details see issue: https://github.com/greenplum-db/gpdb/issues/15579
-CREATE SEQUENCE truncate_a_id CACHE 1;
 CREATE SEQUENCE truncate_a_id1 START WITH 33 CACHE 1;
-CREATE TABLE truncate_a (id integer default nextval('truncate_a_id'),
+CREATE TABLE truncate_a (id serial,
                          id1 integer default nextval('truncate_a_id1'));
-ALTER SEQUENCE truncate_a_id OWNED BY truncate_a.id;
 ALTER SEQUENCE truncate_a_id1 OWNED BY truncate_a.id1;
 INSERT INTO truncate_a DEFAULT VALUES;
 INSERT INTO truncate_a DEFAULT VALUES;
@@ -362,8 +358,8 @@ INSERT INTO truncate_a DEFAULT VALUES;
 SELECT * FROM truncate_a;
  id | id1 
 ----+-----
-  3 |  35
-  4 |  36
+ 21 |  35
+ 22 |  36
 (2 rows)
 
 TRUNCATE truncate_a RESTART IDENTITY;
@@ -424,8 +420,8 @@ SELECT * FROM truncate_a;
 ----+-----
   1 |  33
   2 |  34
-  3 |  35
-  4 |  36
+ 21 |  35
+ 22 |  36
 (4 rows)
 
 DROP TABLE truncate_a;

--- a/src/test/regress/sql/truncate.sql
+++ b/src/test/regress/sql/truncate.sql
@@ -181,13 +181,9 @@ DROP TABLE trunc_trigger_log;
 DROP FUNCTION trunctrigger();
 
 -- test TRUNCATE ... RESTART IDENTITY
--- the column id should change back to serial when issue #15579 be fixed.
--- details see issue: https://github.com/greenplum-db/gpdb/issues/15579
-CREATE SEQUENCE truncate_a_id CACHE 1;
 CREATE SEQUENCE truncate_a_id1 START WITH 33 CACHE 1;
-CREATE TABLE truncate_a (id integer default nextval('truncate_a_id'),
+CREATE TABLE truncate_a (id serial,
                          id1 integer default nextval('truncate_a_id1'));
-ALTER SEQUENCE truncate_a_id OWNED BY truncate_a.id;
 ALTER SEQUENCE truncate_a_id1 OWNED BY truncate_a.id1;
 
 INSERT INTO truncate_a DEFAULT VALUES;


### PR DESCRIPTION
After rollback a transaction which execute restart identity clause in, the insert result to sequence column is incorrect. It's due to the cache value stored in hash table in QE has been out of date but not be cleaned.

If the sequence has been transactionally replaced since we last saw it, should discard any cached-but-unissued values both in QD and QE. Dispatch TruncateStmt with restart_seqs to enable segment to reset a sequence when specify restart identity.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
