### PR TITLE
Allocate histogram sample array on heap

### DIFF
--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -136,7 +136,7 @@ private:
 	CBucket *operator[](ULONG) const;
 
 	// Populate sample ratio within each bucket
-	void GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE sample_rate[],
+	void GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE *sample_rate,
 					   ULONG index);
 
 	// compute skew estimate


### PR DESCRIPTION
Issue:
Sample array used for skew stats collection caused stack overflow in address sanitizer environment.

Solution:
Allocate the array on heap memory. Also simplified the math in the sample rate populator for better readability.

Fix #16021