### PR TITLE
Fix gsutil command failed due to wrong dependency location

### DIFF
--- a/concourse/scripts/gsutil_sync
+++ b/concourse/scripts/gsutil_sync
@@ -46,6 +46,7 @@ export BOTO_CONFIG=$(pwd)/boto.cfg
 # Set PIP Download cache directory
 export PIP_CACHE_DIR="${PWD}/pip-cache-dir"
 
+pip3 uninstall -y urllib3
 pip3 --retries 10 install -r ./gpdb_src/gpMgmt/requirements-dev.txt
 
 # Trim a trailing slash from the source directory if it has one

--- a/gpMgmt/requirements-dev.txt
+++ b/gpMgmt/requirements-dev.txt
@@ -1,4 +1,5 @@
-gsutil
+gsutil<=5.25
 behave~=1.2.6
 coverage~=4.5
 mock<=5.0.0
+urllib3>=1.21.1,<1.25


### PR DESCRIPTION
After switched python3.9 to python3.6, `gsutil` command cannot work on RHEL8 image, it will have the following error:

```
  File "/usr/lib/python3.6/site-packages/urllib3/exceptions.py", line 2, in <module>
    from .packages.six.moves.http_client import (
ModuleNotFoundError: No module named 'urllib3.packages.six'
```
By default the RHEL8 system has the package `urllib3` installed under `/usr/lib/python3.6`, when installing `gsutil`,the dependencies are installed under `/usr/local/lib/python3.6`, so `gsutil` cannot find dependencies when calling `urllib3`. In order to fix the above error, need to uninstall and reinstall urllib3.

Authored-by: Ning Wu <ningw@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
