### PR TITLE
Compress motion data packets. 

### DIFF
--- a/src/backend/cdb/motion/README.ic-proxy.md
+++ b/src/backend/cdb/motion/README.ic-proxy.md
@@ -204,6 +204,8 @@ TODO: in fact as long as the header is completely received we could begin
 routing the data to the target backend, this could save some memory copying, as
 well as reduce the latency.
 
+XXX: when packet compression is used, data stream compression methods should be used.
+
 ### Control message
 
 Besides the data there are also control messages:

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -525,8 +525,6 @@ get_eos_tuplechunklist(void)
 }
 
 
-bool spin = true;
-
 /*
  * Sends a token to all peer Motion Nodes, indicating that this motion
  * node has no more tuples to send out.
@@ -537,13 +535,6 @@ SendEndOfStream(MotionLayerState *mlStates,
 				int motNodeID)
 {
 	MotionNodeEntry *pMNEntry;
-
-
-	// while (spin)
-	// {
-	// 	pg_usleep(1000000L);
-	// }
-	
 
 	/*
 	 * Pull up the motion node entry with the node's details.  This includes

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -524,6 +524,9 @@ get_eos_tuplechunklist(void)
 	return s_eos_chunk_data;
 }
 
+
+bool spin = true;
+
 /*
  * Sends a token to all peer Motion Nodes, indicating that this motion
  * node has no more tuples to send out.
@@ -534,6 +537,13 @@ SendEndOfStream(MotionLayerState *mlStates,
 				int motNodeID)
 {
 	MotionNodeEntry *pMNEntry;
+
+
+	// while (spin)
+	// {
+	// 	pg_usleep(1000000L);
+	// }
+	
 
 	/*
 	 * Pull up the motion node entry with the node's details.  This includes

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -28,6 +28,7 @@
 #include "cdb/ml_ipc.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp.h"
+#include "cdb/cdbsrlz.h"
 
 #ifdef ENABLE_IC_PROXY
 #include "ic_proxy_backend.h"
@@ -321,9 +322,9 @@ readPacket(MotionConn *conn, ChunkTransportState *transportStates)
 	/* do we have a complete message waiting to be processed ? */
 	if (conn->recvBytes >= PACKET_HEADER_SIZE)
 	{
-		memcpy(&conn->msgSize, conn->msgPos, sizeof(uint32));
+		memcpy(&conn->rawMsgSize, conn->rawMsgPos, sizeof(uint32));
 		gotHeader = true;
-		if (conn->recvBytes >= conn->msgSize)
+		if (conn->recvBytes >= conn->rawMsgSize)
 		{
 #ifdef AMS_VERBOSE_LOGGING
 			elog(DEBUG5, "readpacket: returning previously read data (%d)", conn->recvBytes);
@@ -338,9 +339,9 @@ readPacket(MotionConn *conn, ChunkTransportState *transportStates)
 	 * buffer
 	 */
 	if (conn->recvBytes != 0)
-		memmove(conn->pBuff, conn->msgPos, conn->recvBytes);
+		memmove(conn->pBuff, conn->rawMsgPos, conn->recvBytes);
 
-	conn->msgPos = conn->pBuff;
+	conn->rawMsgPos = conn->pBuff;
 
 #ifdef AMS_VERBOSE_LOGGING
 	elog(DEBUG5, "readpacket: %s on previous call msgSize %d", gotHeader ? "got header" : "no header", conn->msgSize);
@@ -430,12 +431,12 @@ readPacket(MotionConn *conn, ChunkTransportState *transportStates)
 			if (!gotHeader && bytesRead >= PACKET_HEADER_SIZE)
 			{
 				/* got the header */
-				memcpy(&conn->msgSize, conn->msgPos, sizeof(uint32));
+				memcpy(&conn->rawMsgSize, conn->rawMsgPos, sizeof(uint32));
 				gotHeader = true;
 			}
 			conn->recvBytes = bytesRead;
 
-			if (gotHeader && bytesRead >= conn->msgSize)
+			if (gotHeader && bytesRead >= conn->rawMsgSize)
 				gotPacket = true;
 		}
 	}
@@ -2736,8 +2737,18 @@ SendEosTCP(ChunkTransportState *transportStates,
 	{
 		conn = pEntry->conns + i;
 
-		if (conn->sockfd >= 0 && conn->state == mcsStarted)
+		if (conn->sockfd >= 0 && conn->state == mcsStarted) {
+			/* TBD: GUC */
+
+			if (/* compress? */ true) {
+				conn->rawMsgPos = compress_string(conn->pBuff + PACKET_HEADER_SIZE, conn->msgSize - PACKET_HEADER_SIZE, &conn->rawMsgSize, true);
+			} else {
+				conn->rawMsgPos = conn->pBuff;
+				conn->rawMsgSize = conn->msgSize;
+			}
+
 			flushBuffer(transportStates, pEntry, conn, motNodeID);
+		}
 
 #ifdef AMS_VERBOSE_LOGGING
 		elog(DEBUG5, "SendEosTCP() Leaving");
@@ -2768,10 +2779,10 @@ flushBuffer(ChunkTransportState *transportStates,
 #endif
 
 	/* first set header length */
-	*(uint32 *) conn->pBuff = conn->msgSize;
+	*(uint32 *) conn->rawMsgPos = conn->rawMsgSize;
 
 	/* now send message */
-	sendptr = (char *) conn->pBuff;
+	sendptr = (char *) conn->rawMsgPos;
 	sent = 0;
 	do
 	{
@@ -2799,7 +2810,7 @@ flushBuffer(ChunkTransportState *transportStates,
 			return false;
 		}
 
-		if ((n = send(conn->sockfd, sendptr + sent, conn->msgSize - sent, 0)) < 0)
+		if ((n = send(conn->sockfd, sendptr + sent, conn->rawMsgSize - sent, 0)) < 0)
 		{
 			int	send_errno = errno;
 			ML_CHECK_FOR_INTERRUPTS(transportStates->teardownActive);
@@ -2908,9 +2919,10 @@ flushBuffer(ChunkTransportState *transportStates,
 		{
 			sent += n;
 		}
-	} while (sent < conn->msgSize);
+	} while (sent < conn->rawMsgSize);
 
 	conn->tupleCount = 0;
+	conn->rawMsgSize = PACKET_HEADER_SIZE;
 	conn->msgSize = PACKET_HEADER_SIZE;
 
 	return true;
@@ -2938,6 +2950,15 @@ SendChunkTCP(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEn
 
 	if (conn->msgSize + length > Gp_max_packet_size)
 	{
+		/* TBD: GUC */
+
+		if (/* compress? */ true) {
+			conn->rawMsgPos = compress_string(conn->pBuff + PACKET_HEADER_SIZE, conn->msgSize - PACKET_HEADER_SIZE, &conn->rawMsgSize, true);
+		} else {
+			conn->rawMsgPos = conn->pBuff;
+			conn->rawMsgSize = conn->msgSize;
+		}
+
 		if (!flushBuffer(transportStates, pEntry, conn, motionId))
 			return false;
 	}

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -50,6 +50,7 @@
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbicudpfaultinjection.h"
+#include "cdb/cdbsrlz.h"
 
 #include <fcntl.h>
 #include <limits.h>
@@ -4534,6 +4535,7 @@ prepareXmit(MotionConn *conn)
 
 	conn->conn_info.len = conn->msgSize;
 	conn->conn_info.crc = 0;
+	/* compress ? */
 
 	memcpy(conn->pBuff, &conn->conn_info, sizeof(conn->conn_info));
 

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -236,6 +236,12 @@ struct MotionConn
 	/* position of message inside of buffer, "cursor" pointer */
 	uint8	   *msgPos;
 
+	/* size of the message in the buffer, if any. */
+	int32		rawMsgSize;
+
+	/* position of message inside of buffer, "cursor" pointer */
+	uint8	   *rawMsgPos;
+
 	/*
 	 * recv bytes: we can have more than one message/message fragment in recv
 	 * queue at once

--- a/src/include/cdb/cdbsrlz.h
+++ b/src/include/cdb/cdbsrlz.h
@@ -22,5 +22,7 @@
 
 extern char *serializeNode(Node *node, int *size, int *uncompressed_size);
 extern Node *deserializeNode(const char *strNode, int size);
+extern char *compress_string(const char *src, int uncompressed_size, int *size, bool pack);
+extern char *uncompress_string(const char *src, int size, int *uncompressed_size_p);
 
 #endif   /* CDBSRLZ_H */


### PR DESCRIPTION
Hi gpdb, im currently hacking on compressing (broadcast, redistribute, gather) motion data packets. Data compression may save network in case of heavy-loaded bandwidth-bounded setups, but costs additional cpu computations. Proposed changes is to create some GUC to set GreenPlum interconnect compress behavior.

Currently this patch is proof-of-concept and works only for `TCP` and `PROXY` GreenPlum interconnect types. UPD interconnect is a but tricky for me, as i dont fully understand how it works yet. 

PR is created to receive your though on subject. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
