### PR TITLE
 change parallel test FIXME to FEATURE NOT SUPPORTED 

### DIFF
--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -1,7 +1,7 @@
 --
 -- PARALLEL
 --
--- GPDB_96_MERGE_FIXME: We don't support parallel query. These tests won't actually
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We don't support parallel query. These tests won't actually
 -- generate any parallel plans. Should we pay attention to the parallel restrictions
 -- when creating MPP plans? For example, should we force parallel restricted functions
 -- to run in the QD?

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -1,7 +1,7 @@
 --
 -- PARALLEL
 --
--- GPDB_96_MERGE_FIXME: We don't support parallel query. These tests won't actually
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We don't support parallel query. These tests won't actually
 -- generate any parallel plans. Should we pay attention to the parallel restrictions
 -- when creating MPP plans? For example, should we force parallel restricted functions
 -- to run in the QD?

--- a/src/test/regress/expected/write_parallel.out
+++ b/src/test/regress/expected/write_parallel.out
@@ -1,7 +1,7 @@
 --
 -- PARALLEL
 --
--- GPDB_96_MERGE_FIXME: We don't support parallel query. These tests won't actually
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We don't support parallel query. These tests won't actually
 -- generate any parallel plans. Same as in 'select_parallel' test.
 -- Serializable isolation would disable parallel query, so explicitly use an
 -- arbitrary other level.

--- a/src/test/regress/sql/select_parallel.sql
+++ b/src/test/regress/sql/select_parallel.sql
@@ -2,7 +2,7 @@
 -- PARALLEL
 --
 
--- GPDB_96_MERGE_FIXME: We don't support parallel query. These tests won't actually
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We don't support parallel query. These tests won't actually
 -- generate any parallel plans. Should we pay attention to the parallel restrictions
 -- when creating MPP plans? For example, should we force parallel restricted functions
 -- to run in the QD?

--- a/src/test/regress/sql/write_parallel.sql
+++ b/src/test/regress/sql/write_parallel.sql
@@ -2,7 +2,7 @@
 -- PARALLEL
 --
 
--- GPDB_96_MERGE_FIXME: We don't support parallel query. These tests won't actually
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We don't support parallel query. These tests won't actually
 -- generate any parallel plans. Same as in 'select_parallel' test.
 
 -- Serializable isolation would disable parallel query, so explicitly use an


### PR DESCRIPTION
Since Greenplum doesn't support parallel scan, so change the FIXME to
FEATURE NOT SUPPORTED. But this is the feature of version 9.6, and we do
not want to create another new FLAG, so change it to the value of
`GPDB_12_MERGE_FEATURE_NOT_SUPPORTED`
