### PR TITLE
[6x] gpcheckcat: Add new option -x to set session level GUCs

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -16,6 +16,7 @@ Usage: gpcheckcat [<option>] [dbname]
     -R test | 'test1, test2' : run this particular test(s) (quoted, comma seperated list for multiple tests)
     -s test | 'test1, test2' : skip this particular test(s) (quoted, comma seperated list for multiple tests)
     -C catname               : run cross consistency, FK and ACL tests for this catalog table
+    -x                       : set session level GUCs
 
     Test subset options are mutually exclusive, use only one of '-R', '-s', or '-C'.
 
@@ -126,6 +127,7 @@ class Global():
         self.opt['-l'] = False
 
         self.opt['-E'] = False
+        self.opt['-x'] = []
 
         self.master_dbid = None
         self.cfg = None
@@ -229,7 +231,7 @@ def getalldbs():
 def parseCommandLine():
     try:
         # A colon following the flag indicates an argument is expected
-        (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:s:C:lE', 'help')
+        (options, args) = getopt.getopt(sys.argv[1:], '?x:p:P:U:B:vg:t:AOS:R:s:C:lE', 'help')
     except Exception as e:
         usage('Error: ' + str(e))
 
@@ -240,6 +242,8 @@ def parseCommandLine():
             GV.opt[switch] = val
         elif switch[1] in 'vtAOlE':
             GV.opt[switch] = True
+        elif switch[1] in 'x':
+            GV.opt[switch].append(val)
 
     def setdef(x, v):
         if not GV.opt[x]:
@@ -323,6 +327,8 @@ def connect(user=None, password=None, host=None, port=None,
     options = '-c search_path='
     if utilityMode:
         options += ' -c gp_session_role=utility'
+    for val in GV.opt['-x']:
+        options += ' -c {}'.format(val)
 
     if not user: user = GV.opt['-U']
     if not password: password = GV.opt['-P']

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -609,3 +609,35 @@ Feature: gpcheckcat tests
         Examples:
             | attrname   | tablename     |
             | conrelid   | pg_constraint |
+
+
+    Scenario: set multiple GUC at session level in gpcheckcat
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -x disable_cost=3e15 -x log_min_messages=debug5 -R foreign_key"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should print "foreign_key" to stdout
+        And the user runs "dropdb all_good"
+
+
+    Scenario: set GUC with invalid value at session level in gpcheckcat
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -x disable_cost=invalid -R foreign_key"
+        Then gpcheckcat should return a return code of 1
+        And gpcheckcat should print ".* parameter "disable_cost" requires a numeric value"" to stdout
+        And the user runs "dropdb all_good"
+
+
+    Scenario: validate session GUC passed with -x is set
+        Given the database is not running
+          And the user runs "gpstart -ma"
+          And "gpstart -ma" should return a return code of 0
+         Then the user runs "gpcheckcat -R foreign_key"
+         Then gpcheckcat should return a return code of 1
+          And gpcheckcat should print ".* System was started in master-only utility mode - only utility mode connections are allowed" to stdout
+         Then the user runs "gpcheckcat -x gp_session_role=utility -R foreign_key"
+         Then gpcheckcat should return a return code of 0
+          And the user runs "gpstop -ma"
+          And "gpstop -m" should return a return code of 0
+          And the user runs "gpstart -a"
+
+


### PR DESCRIPTION
This is a cherry pick of https://github.com/greenplum-db/gpdb/pull/15962

Problem : Running gpcheckcat FK check taking a lot of time to complete, One of the workarounds to fix this is to Pull the FK query and run it separately in psql using the GUC disable_cost='1e20' at session level. It help in making the query run faster but its not acceptable solution.So need to set the GUC at session level.

Solution : Added a new option [-x] in gpcheckcat that will provide support for PGOPTIONS to pass multiple session GUCs [such as disable_costs, gp_role] to set the parameter.

Implementation : Added a new option -x which is used to pass the multiple session GUCs to set the parameter. This is helpful when wanting to run certain tests in gpcheckcat with session level parameters. User can use the -x option multiple times to specify multiple GUC.

User can pass the GUC like : `gpcheckcat -x "disable_cost=3e15" -x "log_min_messages=debug5" -R foreign_key`
Note : GUCs with spaces are not allowed because PGOPTIONS currently don't support GUCs with spaces.

Added behave test case for the same

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
