### PR TITLE
Docs gpv reference

### DIFF
--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -473,11 +473,12 @@ The XFS options can also be set in the `/etc/fstab` file. This example entry fro
 
 The maximum transmission unit (MTU) of a network specifies the size (in bytes) of the largest data packet/frame accepted by a network-connected device. A jumbo frame is a frame that contains more than the standard MTU of 1500 bytes.
 
-Greenplum Database utilizes 3 distinct MTU settings:
+You may control the value of the MTU at various locations:
 
 - The Greenplum Database [gp_max_packet_size](../ref_guide/config_params/guc-list.html#gp_max_packet_size) server configuration parameter. The default max packet size is 8192. This default assumes a jumbo frame MTU.
-- The operating system MTU setting.
-- The rack switch MTU setting.
+- The operating system MTU settings for network interfaces.
+- The physical switch MTU settings.
+- The virtual switch MTU setting when using vSphere.
 
 These settings are connected, in that they should always be either the same, or close to the same, value, or otherwise in the order of Greenplum < OS < switch for MTU size.
 

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -480,7 +480,7 @@ You may control the value of the MTU at various locations:
 - The physical switch MTU settings.
 - The virtual switch MTU setting when using vSphere.
 
-These settings are connected, in that they should always be either the same, or close to the same, value, or otherwise in the order of Greenplum < OS < switch for MTU size.
+These settings are connected, in that they should always be either the same, or close to the same, value, or otherwise in the order of Greenplum < Operating System < Virtual or Physical switch for MTU size.
 
 9000 is a common supported setting for switches, and is the recommended OS and rack switch MTU setting for your Greenplum Database hosts.
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
@@ -1,7 +1,6 @@
 # gpv base
 
-Manages the base virtual machine for a deployment.
-The `gpv base` command group allows you to import and deploy the base virtual machine.
+Manage the base virtual machine for a deployment of Greenplum Database on vSphere. The `gpv base` command group allows you to import and deploy the base virtual machine.
 
 ## <a id="section2"></a>Usage
 
@@ -11,34 +10,36 @@ gpv base <command>
 
 ## <a id="opts"></a>Commands
 
-### <a id="deploy"></a>Deploy
+The available commands for `gpv base` are `deploy` and `import`.
 
-Configure the imported base VM for Greenplum deployment. The `gpv base deploy` command performs the following operations in the base vm:
+### <a id="deploy"></a>deploy
 
-- Copy and install Greenplum and Greenplum Virtual Service packages.
-- Configure the OS using the Greenplum Virtual Service.
-- Change secrets for `root` and `gpadmin` roles.
-- Validate that the base virtual machine is properly configured.
+Configure the imported base virtual machine for Greenplum deployment. The `gpv base deploy` command performs the following operations in the base virtual machine:
 
-### <a id="import"></a>Import
+- Copies and installs Greenplum and Greenplum Virtual Service packages.
+- Configures the OS using the Greenplum Virtual Service.
+- Changes secrets for the `root` and `gpadmin` roles.
+- Validates that the base virtual machine is configured correctly.
 
-Import an existing VM template or an OVA file as a new base VM. The `gpv base import` command creates a new base virtual machine. This virtual machine can be created from an existing virtual machine template provided by the user, usually already certified to follow all the existing policies. It may also be created from an OVA file. For example, the VMWare provided OVA with all the dependencies required for Greenplum deployment in an air-gaped environment.
+### <a id="import"></a>import
+
+Import an existing virtual machine template or an OVA file as a new base virtual machine. The `gpv base import` command creates a new base virtual machine from your own virtual machine template (certified to follow all the existing policies), or from an OVA file, such as the Greenplum Virtual Machine base template available on [VMware Tanzu Network](https://network.tanzu.vmware.com/products/vmware-greenplum).
 
 Options:
 
 -f, --ova=file_name
-:   Specify a local OVA file name to be uploaded to the target vSphere cluster.
+:   Specify a local OVA file name.
 
 -t, --template=template_name
-:   Specify an existing virtual machine template `template_name` to be cloned.
+:   Specify an existing virtual machine template `template_name`.
 
 
-## <a id="examples"></a>Examples
+#### <a id="examples"></a>Examples
 
-Import an existing VM template:
+Import an existing virtual machine template:
 
 ```
-gpv base import -t customer-provided-template
+gpv base import -t my-company-template
 ```
 
 Import a local OVA:

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
@@ -1,17 +1,21 @@
 # gpv base
 
-Manage the base virtual machine for a deployment of Greenplum Database on vSphere. The `gpv base` command group allows you to import and deploy the base virtual machine.
+Manage the base virtual machine for a deployment of Greenplum Database on vSphere. 
 
-## <a id="section2"></a>Usage
+## <a id="section2"></a>Synopsis
 
 ```
 gpv base deploy
 gpv base import [ -f <file_name> | --ova=<file_name> ] [ -t <template_name> | --template=<template_name> ]
 ```
 
-## <a id="opts"></a>Commands
+## <a id="section3"></a>Description
 
-The available commands for `gpv base` are `deploy` and `import`.
+The `gpv base` command allows you to import and deploy the base virtual machine for your Greenplum Database cluster on VMware vSphere.
+
+## <a id="opts"></a>Sub-commands
+
+The available sub-commands for `gpv base` are `deploy` and `import`.
 
 ### <a id="deploy"></a>deploy
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
@@ -1,0 +1,50 @@
+# gpv base
+
+Manages the base virtual machine for a deployment.
+The `gpv base` command group allows you to import and deploy the base virtual machine.
+
+## <a id="section2"></a>Usage
+
+```
+gpv base <command>
+```
+
+## <a id="opts"></a>Commands
+
+### <a id="deploy"></a>Deploy
+
+Configure the imported base VM for Greenplum deployment. The `gpv base deploy` command performs the following operations in the base vm:
+
+- Copy and install Greenplum and Greenplum Virtual Service packages.
+- Configure the OS using the Greenplum Virtual Service.
+- Change secrets for `root` and `gpadmin` roles.
+- Validate that the base virtual machine is properly configured.
+
+### <a id="import"></a>Import
+
+Import an existing VM template or an OVA file as a new base VM. The `gpv base import` command creates a new base virtual machine. This virtual machine can be created from an existing virtual machine template provided by the user, usually already certified to follow all the existing policies. It may also be created from an OVA file. For example, the VMWare provided OVA with all the dependencies required for Greenplum deployment in an air-gaped environment.
+
+Options:
+
+-f, --ova=file_name
+:   Specify a local OVA file name to be uploaded to the target vSphere cluster.
+
+-t, --template=template_name
+:   Specify an existing virtual machine template `template_name` to be cloned.
+
+
+## <a id="examples"></a>Examples
+
+Import an existing VM template:
+
+```
+gpv base import -t customer-provided-template
+```
+
+Import a local OVA:
+
+```
+gpv base import -f /path/to/pre-built.ova
+```
+
+

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-base.html.md
@@ -5,7 +5,8 @@ Manage the base virtual machine for a deployment of Greenplum Database on vSpher
 ## <a id="section2"></a>Usage
 
 ```
-gpv base <command>
+gpv base deploy
+gpv base import [ -f <file_name> | --ova=<file_name> ] [ -t <template_name> | --template=<template_name> ]
 ```
 
 ## <a id="opts"></a>Commands

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -74,18 +74,18 @@ gpv config set network <setting>
 
 Where `setting` can be one of the following:
 
-base-vm <sub-setting>
+base-vm <sub_setting>
 :   Configure the network settings for the base virtual machine. The possible sub-settings are:
     - `gateway-ip <IP>`: Set the gateway IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
     - `ip <IP>`: Set the static IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
     - `netmask <NETMASK>`: Set the netmask for the base virtual machine when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
     - `network-type <TYPE>`: Set the network type for base virtual machine. The possible values are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
 
-gp-virtual-etl-bar <sub-subsetting>
+gp-virtual-etl-bar <sub_subsetting>
 :   Configure the network settings for ETL, backup and restore traffic. The possible sub-settings are:
     - `cidr <CIDR>`: Set the Classless Inter-Domain Routing (CIDR) for the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
 
-gp-virtual-external <sub-subsetting>
+gp-virtual-external <sub_subsetting>
 :   Configure the network settings of the routable network for Greenplum clients. The possible sub-settings are:
     - `cidr <CIDR>`: Set the CIDR for the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
     - `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
@@ -93,7 +93,7 @@ gp-virtual-external <sub-subsetting>
     - `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, you only need one IP address. If the Greenplum deployment type is `mirrored`, you need two IP addresses. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
     - `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
 
-gp-virtual-internal <sub-setting>
+gp-virtual-internal <sub_setting>
 :   Configure the network settings of the internal communications network among Greenplum virtual machines. The possible sub-settings are:
     - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
 
@@ -107,13 +107,13 @@ gpv config set vm <setting>
 
 Where `setting` can be one of the following:
 
-base-name <base-VM-name>
+base-name <base_VM_name>
 :    Set the name of the base virtual machine to use during configuring and deploying Greenplum on vSphere.
 
 gpadmin-password
 :    Set the guest operating system password for `gpadmin` user. The utility prompts you to enter a password when you enter this command.
 
-primary-segment-vm-count <number-of-segment-vms>
+primary-segment-vm-count <number_of_segment_vms>
 :    Set the number of virtual machines to house primary segments. For example: `gpv config set vm primary-segment-vm-count 64`. 
 
 root-password
@@ -132,26 +132,26 @@ Where `setting` can be one of the following:
 admin-password
 :    Set the password for the vCenter administrator. The utility prompts you to enter a password when you enter this command.
 
-admin-username <user-name>
+admin-username <user_name>
 :    Set the username of the vCenter administrator.
 
-compute-cluster-name <compute-cluster-name>
+compute-cluster-name <compute_cluster_name>
 :    Set the name of the compute cluster to use.
 
-datacenter-name <datacenter-name>
+datacenter-name <datacenter_name>
 :    Set the name of the datacenter to use.
 
-storage-name <storage-name>
+storage-name <storage_name>
 :    Set the name of the vSphere datastore or datastore cluster. Specify the name of the storage layer to use within vCenter. For vSAN, specify the datastore name; for Dell PowerFlex, specify the datastore cluster name.
 
-storage-policy <storage-policy>
+storage-policy <storage_policy>
 :    Set the virtual machine storage policy for the storage layer, if applicable. This setting is required for vSAN only. When specifying the policy, ensure that it is surrounded by quotation marks if the policy's name contains whitespace. For example: `gpv config set vsphere storage-policy "this policy contains spaces"`.
 
-storage-type <storage-type>
+storage-type <storage_type>
 :    Set the type of storage layer to use. Possible values are `powerflex` and `vsan`.
 
-vcenter-address <vcenter-address>
+vcenter-address <vcenter_address>
 :    Set the address of the target vCenter. Do not include the protocol prefix in the address (http://, https://). For example: `gpv config set vsphere vcenter-address gp.vcenter.example.com`.
 
-vsphere-distributed-switch-mtu <mtu>
+vsphere-distributed-switch-mtu <mtu_size>
 :    Specify the Maximum Transfer Unit (MTU) for the vSphere distributed switch, in bytes. Valid values range from 1500 to 9000.

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -56,7 +56,7 @@ Configure the settings for the Greenplum Database.
 gpv config set database <setting>
 ```
 
-Settings:
+Where `setting` can be one of the following:
 
 deployment-type <type_name>
 :   Specifies whether the Greenplum deployment uses mirror segments or not. Valid values of `<type_name>` include `mirrored` and `mirrorless`. For example: `gpv config set database deployment-type mirrored`. 
@@ -72,15 +72,16 @@ Configure the network settings for the Greenplum cluster.
 gpv config set network <setting>
 ```
 
-Settings:
+Where `setting` can be one of the following:
 
 base-vm <subsetting>
 :   Configure the network settings for the base virtual machine. The possible sub-settings are:
 
-        - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
-        - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
-        - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
-        - `network-type <TYPE>`: Set the network type tp be used by the base VM. Specifies how the IP addresses are assigned to the base VM. Valid values for `<TYPE>` are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
+The possible <subsettings> can be: 
+    - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
+    - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
+    - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
+    - `network-type <TYPE>`: Set the network type tp be used by the base VM. Specifies how the IP addresses are assigned to the base VM. Valid values for `<TYPE>` are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
 
 gp-virtual-etl-bar <subsetting>
 :   Configure the network settings for ETL, backup and restore traffic. The possible sub-settings are:

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -49,16 +49,16 @@ List the current configuration settings. The `gpv config list` command displays 
 Set an individual configuration setting. 
 
 ```
-gpv config set database
-gpv config set network base-vm
-gpv config set network gp-virtual-etl-bar
-gpv config set network gp-virtual-external
-gpv config set network gp-virtual-internal
-gpv config set vm
-gpv config set vsphere
+gpv config set database <setting>
+gpv config set network base-vm <setting>
+gpv config set network gp-virtual-etl-bar <setting>
+gpv config set network gp-virtual-external <setting>
+gpv config set network gp-virtual-internal <setting>
+gpv config set vm <setting>
+gpv config set vsphere <setting>
 ```
 
-Below are the available options for the `gpv config` subcommand:
+The available options for `gpv config set` are:
 
 #### <a id="database"></a>database
 
@@ -74,7 +74,7 @@ deployment-type <type_name>
 :   Specifies whether the Greenplum deployment uses mirror segments or not. Valid values of `<type_name>` include `mirrored` and `mirrorless`. For example: `gpv config set database deployment-type mirrored`. 
 
 prefix <prefix_name>
-:   Specifies a label which serves as a prefix for the names of the resource pool and the virtual machines in the Greenplum cluster. 
+:   Specifies a label which serves as a prefix for the names of the resource pool and the virtual machines in the Greenplum cluster. For example, `gpv config set database prefix gpdb` prepends `gpdb` to virtual machines and resource pool names.
 
 #### <a id="network-base"></a>network base-vm
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -5,7 +5,7 @@ Manage the configuration of a Greenplum Database on vSphere cluster.
 ## <a id="section2"></a>Synopsis
 
 ```
-gpv config init <file_name>
+gpv config init [<file_name>]
 gpv config list
 gpv config set <options>
 ```
@@ -50,13 +50,15 @@ Set an individual configuration setting.
 
 ```
 gpv config set database
-gpv config set vm
-gpv config set vsphere
 gpv config set network base-vm
 gpv config set network gp-virtual-etl-bar
 gpv config set network gp-virtual-external
 gpv config set network gp-virtual-internal
+gpv config set vm
+gpv config set vsphere
 ```
+
+Below are the available options for the `gpv config` subcommand:
 
 #### <a id="database"></a>database
 
@@ -74,38 +76,53 @@ deployment-type <type_name>
 prefix <prefix_name>
 :   Specifies a label which serves as a prefix for the names of the resource pool and the virtual machines in the Greenplum cluster. 
 
-#### <a id="network"></a>network
+#### <a id="network-base"></a>network base-vm
 
-Configure the network settings for the Greenplum cluster.
+Configure the network settings for the base virtual machine
 
 ```
-gpv config set network <setting>
+gpv config set network base-vm <setting>
 ```
 
 Where `setting` can be one of the following:
+- `gateway-ip <IP>`: Set the gateway IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
+- `ip <IP>`: Set the static IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
+- `netmask <NETMASK>`: Set the netmask for the base virtual machine when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
+- `network-type <TYPE>`: Set the network type for base virtual machine. The possible values are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
 
-base-vm <sub_setting>
-:   Configure the network settings for the base virtual machine. The possible sub-settings are:
-    - `gateway-ip <IP>`: Set the gateway IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
-    - `ip <IP>`: Set the static IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
-    - `netmask <NETMASK>`: Set the netmask for the base virtual machine when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
-    - `network-type <TYPE>`: Set the network type for base virtual machine. The possible values are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
+#### <a id="network-etl"></a>network gp-virtual-etl-bar
 
-gp-virtual-etl-bar <sub_subsetting>
-:   Configure the network settings for ETL, backup and restore traffic. The possible sub-settings are:
-    - `cidr <CIDR>`: Set the Classless Inter-Domain Routing (CIDR) for the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
+Configure the network settings for the ETL, backup and restore traffic.
 
-gp-virtual-external <sub_subsetting>
-:   Configure the network settings of the routable network for Greenplum clients. The possible sub-settings are:
-    - `cidr <CIDR>`: Set the CIDR for the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
-    - `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
-    - `gateway-ip <IP>`: Set the gateway IP of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external gateway-ip 10.0.1.1`.
-    - `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, you only need one IP address. If the Greenplum deployment type is `mirrored`, you need two IP addresses. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
-    - `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
+```
+gpv config set network gp-virtual-etl-bar cidr <CIDR>
+```
 
-gp-virtual-internal <sub_setting>
-:   Configure the network settings of the internal communications network among Greenplum virtual machines. The possible sub-settings are:
-    - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
+Set the Classless Inter-Domain Routing (CIDR) for the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
+
+#### <a id="network-external"></a>network gp-virtual-external
+
+Configure the network settings for the routable network for Greenplum clients.
+
+```
+gpv config set network gp-virtual-external <setting>
+```
+
+Where `setting` can be one of the following:
+- `cidr <CIDR>`: Set the CIDR for the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
+- `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
+- `gateway-ip <IP>`: Set the gateway IP of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external gateway-ip 10.0.1.1`.
+- `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, you only need one IP address. If the Greenplum deployment type is `mirrored`, you need two IP addresses. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
+- `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
+
+#### <a id="network-internal"></a>network gp-virtual-internal
+
+Configure the network settings for the internal communications network among Greenplum virtual machines.
+
+```
+gpv config set network gp-virtual-internal cidr <CIDR>
+```
+Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
 
 #### <a id="vm"></a>vm
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -14,6 +14,48 @@ gpv config set <options>
 
 The `gpv config` command allows you to configure a Greenplum cluster on VMware vSphere, import an external configuration, and list the current configuration.
 
+## <a id="info"></a>Required Inputs
+
+The following table lists all the information you require in order to configure the a base virtual machine template using the `gpv` utility. Be sure you have this information available before you start with the configuration.
+
+|Configuration|Description|
+|-|-| 
+|**vSphere**|**Configuration parameters for vSphere**|
+|vSphere admin username|An administrator account with enough permissions to deploy the Greenplum cluster|
+|vSphere admin password|The password for the administrator account| 
+|vCenter address|The FQDN or IP address of the vCenter (do not include `https://`)|
+|Datacenter name|The virtual data center name|
+|Compute cluster name|The virtual compute cluster name|
+|Storage type |The storage provider type (`powerflex` or `vsan`)|
+|Storage name|The datastore name for this deployment|
+|Storage policy|The storage policy name|
+|vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch*|
+|**Database**|**Configuration parameters for Greenplum Database**|
+|Deployment type|Greenplum deployment type (`mirrored` or `mirrorless`)|
+|Greenplum database cluster prefix |Prefix to prepend to the resource pool and virtual machine names. Default is `gpv`|
+|**Base-vm**|**Configuration parameters for the base virtual machine**|
+|Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask|
+|Base VM IP| The IP to use if the network type is `static`|
+|Base VM gateway IP|The gateway to use if the network type is `static`|
+|Base VM netmask|The Netmask to use if the network type is `static`|
+|**gp-virtual-external**|**Configuration parameters for the routable network**|
+|gp-virtual-external CIDR|The Classless Inter-Domain Routing (CIDR) of the routable network connected to the `mdw` and `smdw` virtual machines to provide the Greenplum database service to the user clients|
+|gp-virtual-external available IPs|The space separated IP addresses used for `mdw` and `smdw`. The second IP (for `smdw`) is only required for `mirrored` deployment.|
+|gp-virtual-external DNS servers|Space separated IP addresses of the DNS servers on the routable network|
+|gp-virtual-external NTP servers|Space separated addresses of the NTP servers|
+|gp-virtual-external gateway IP|The gateway IP address|
+|**gp-virtual-internal**|**Configuration parameters for the Greenplum internal network**|
+|gp-virtual-internal CIDR|The internal network The Classless Inter-Domain Routing (CIDR) for the interconnect communications between Greenplum virtual machines|
+|**gp-virtual-etl-bar**|**Configuration parameters for the ETL-BAR network**|
+|gp-virtual-etl-bar CIDR|The network The Classless Inter-Domain Routing (CIDR) for Extraction Transformation Load (`etl`) and/or Backup and Restore (`bar`) network. Usually this network is not routable to the database user clients, but routable to the backup or staging servers. This network allows access to all segments within the Greenplum cluster to ensure maximum throughput for heavy data movement workloads.|
+|**Virtual machine options**|**Configuration parameters for the virtual machines**|
+|base-VM-name|The name of the base virtual machine, provisioned in the next section|
+|boot password for the root user|The password for the `root` user on the base virtual machine|
+|boot password for the gpadmin user|The password for the `gpadmin` user on the base virtual machine. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
+|Number of primary segment VMs|The number of virtual machines for the primary segments. For `mirrored`, use `number of primary segments * 2 + 2`. For `mirrorless`, use `number of primary segments + 1`.|
+
+*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the vSphere distributed switch supports it. If it is less than 9000, you must adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually. See [Configuring Your Systems](../../install_guide/prep_os.html#networking) for more information about MTU.
+
 ## <a id="opts"></a>Sub-commands
 
 The available sub-commands for `gpv config` are `init`, `list`, and `set`.

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -1,0 +1,147 @@
+# gpv config
+
+Manage the configuration of a Greenplum cluster. The `gpv config` command group allows a user to configure a Greenplum cluster, import an external configuration, and list the configuration.
+
+## <a id="section2"></a>Usage
+
+```
+gpv config <command>
+```
+
+## <a id="opts"></a>Commands
+
+### <a id="init"></a>Init
+
+Initialize a configuration interactively or import an external configuration. The `gpv config init` command creates a configuration for deploying Greenplum. This configuration may be specified via the user entering each value interactively. It may also be created from an existing configuration yaml file, `file_name`.
+
+```
+gpv config init [<file_name>]
+```
+
+For example, start a new configuration from scratch: gpv config init
+Import an existing configuration: gpv config init /path/to/config.yaml.
+
+### <a id="list"></a>List
+
+List the current configuration GPV settings. The `gpv config list` command displays the current configuration for deploying Greenplum.
+
+### <a id="set"></a>Set
+
+Set a single configuration setting. Set an individual setting for GPV deployments related to: database, vSphere, VM, and network.
+
+```
+gpv config set <area>
+```
+
+Where `area` can be one of the following:
+
+#### <a id="database"></a>Database
+
+Configure the settings for the Greenplum Database.
+
+```
+gpv config set database <setting>
+```
+
+Settings:
+
+deployment-type <type_name>
+:   Specifies a `mirrored` or `mirrorless` deployment. The setting specifies whether the Greenplum deployment will use mirrors or not.  Valid values of TYPE include mirrored and mirrorless. For example: `gpv config set database deployment-type mirrored`. 
+
+prefix <prefix_name>
+:   Specifies a prefix to be prepended to the resource pool and VM names. The gpv config set database prefix specifies a label which will serve as a prefix for the names of the resource pool and the VMs in the deployed GPV cluster. The resource pool name will be <PREFIX>-greenplum and the VM names will be like <PREFIX>-mdw, <PREFIX-smdw>, and PREFIX-sdw-001, etc.
+
+#### <a id="network"></a>Network
+
+Configure the network settings for Greenplum to interact with itself and the outside world. gpv config set network - Configure network-related settings.
+
+```
+gpv config set network <setting>
+```
+
+Settings:
+
+base-vm <subsetting>
+:   Configure the network settings for the base virtual machine. The possible sub-settings are:
+        - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
+        - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
+        - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
+        - `network-type <TYPE>`: Set the network type tp be used by the base VM. Specifies how the IP addresses are assigned to the base VM. Valid values for `<TYPE>` are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
+
+gp-virtual-etl-bar <subsetting>
+:   Configure the network settings for ETL, backup and restore traffic. The possible sub-settings are:
+        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
+
+gp-virtual-external
+:   Configure the network settings of the routable network for Greenplum clients. The possible sub-settings are:
+        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
+        - `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
+        - `gateway-ip <IP>`: Set the gateway IP of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external gateway-ip 10.0.1.1`.
+        - `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, only one IP address is needed. If the Greenplum deployment type is `mirrored`, two IP addresses are needed. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
+        - `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
+
+gp-virtual-internal
+:   Configure the network settings of the internal communications network among Greenplum virtual machines.
+        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
+
+#### <a id="vm"></a>VM
+
+Configure individual settings which will appear on all VMs in the cluster. 
+
+```
+gpv config set vm <setting>
+```
+
+Settings:
+
+base-name <NAME>
+:    Set the name of the base VM, which is used during configuring and deploying Greenplum.
+
+gpadmin-password
+:    Set the guest operating system password for `gpadmin` user. The utility prompts you to enter a password when you enter this command.
+
+primary-segment-vm-count <NUMBER_OF_SEGMENT_VMS>
+:    Set the number of virtual machines to house primary segments. For example: `gpv config set vm primary-segment-vm-count 64`. 
+
+root-password
+:    Set the guest operating system password for `root` user. The utility prompts you to enter a password when you enter this command.
+
+#### <a id="vsphere"></a>vSphere
+
+Configure the settings for vSphere (connection parameters, etc).
+
+```
+gpv config set vsphere <setting>
+```
+
+Settings:
+
+admin-password
+:    Set the password to be used for the vCenter administrator. The utility prompts you to enter a password when you enter this command.
+
+admin-username <USER_NAME>
+:    Set the username of the vCenter administrator.
+
+compute-cluster-name <COMPUTE_CLUSTER_NAME>
+:    Set the name of the compute cluster to use.
+
+datacenter-name <DATACENTER_NAME>
+:    Set the name of the datacenter to use.
+
+storage-name <STORAGE_NAME>
+:    Set the name of the vSphere datastore or datastore cluster. Specifies the name of the storage layer to use within vCenter. For vSAN, specify the datastore name; for PowerFlex, specify the datastore cluster name.
+
+storage-policy <STORAGE_POLICY>
+:    Set the VM storage policy for the storage layer, if applicable. setting specifies the storage policy to be used within vCenter. This setting is required for vSAN only. When specifying the policy, ensure that it is surrounded by quotation marks if the policy's name contains whitespace. For example: `gpv config set vsphere storage-policy "this policy contains spaces"`.
+
+storage-type <STORAGE_TYPE>
+:    Set the type of storage layer to use. specifies the type of storage layer to be targeted.  Acceptable values for STORAGE_TYPE include powerflexand vsan.
+
+vcenter-address <VCENTER_ADDRESS>
+:    Set the address where the target vCenter may be found. The gpv config set vsphere vcenter-address setting specifies the location of the vCenter on which Greenplum will be deployed.  Note that protocols are not
+acceptable in the address (e.g.: http://example.com is invalid because of the prefix http://). For example: `gpv config set vsphere vcenter-address gp.vcenter.example.com`.
+
+vsphere-distributed-switch-mtu <MTU>
+:    Specify the MTU for the vSphere distributed switch. setting specifies Maximum Transmission Unit (MTU) of the port groups on the vSphere distributed switch, in bytes. Valid values range from 1500 to 9000.
+
+

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -1,6 +1,6 @@
 # gpv config
 
-Manage the configuration of a Greenplum cluster. The `gpv config` command group allows a user to configure a Greenplum cluster, import an external configuration, and list the configuration.
+Manage the configuration of a Greenplum Database on vSphere cluster. The `gpv config` command group allows you to configure a Greenplum cluster, import an external configuration, and list the current configuration.
 
 ## <a id="section2"></a>Usage
 
@@ -10,24 +10,37 @@ gpv config <command>
 
 ## <a id="opts"></a>Commands
 
-### <a id="init"></a>Init
+The available commands for `gpv config` are `init`, `list`, and `set`.
 
-Initialize a configuration interactively or import an external configuration. The `gpv config init` command creates a configuration for deploying Greenplum. This configuration may be specified via the user entering each value interactively. It may also be created from an existing configuration yaml file, `file_name`.
+### <a id="init"></a>init
+
+Initialize a configuration interactively or import an external configuration from a file. The `gpv config init` command creates the configuration for deploying a Greenplum Database cluster. You may speficy the configuration parameters entering each value interactively, or from an existing configuration yaml file, `file_name`.
 
 ```
 gpv config init [<file_name>]
 ```
 
-For example, start a new configuration from scratch: gpv config init
-Import an existing configuration: gpv config init /path/to/config.yaml.
+#### <a id="ex_init"></a>Examples
 
-### <a id="list"></a>List
+Start a new configuration from scratch: 
 
-List the current configuration GPV settings. The `gpv config list` command displays the current configuration for deploying Greenplum.
+```
+gpv config init
+```
 
-### <a id="set"></a>Set
+Import an existing configuration from a file: 
 
-Set a single configuration setting. Set an individual setting for GPV deployments related to: database, vSphere, VM, and network.
+```
+gpv config init /tmp/config.yaml
+```
+
+### <a id="list"></a>list
+
+List the current configuration settings. The `gpv config list` command displays the current configuration for deploying Greenplum on vSphere.
+
+### <a id="set"></a>set
+
+Set an individual configuration setting. 
 
 ```
 gpv config set <area>
@@ -35,7 +48,7 @@ gpv config set <area>
 
 Where `area` can be one of the following:
 
-#### <a id="database"></a>Database
+#### <a id="database"></a>database
 
 Configure the settings for the Greenplum Database.
 
@@ -46,14 +59,14 @@ gpv config set database <setting>
 Settings:
 
 deployment-type <type_name>
-:   Specifies a `mirrored` or `mirrorless` deployment. The setting specifies whether the Greenplum deployment will use mirrors or not.  Valid values of TYPE include mirrored and mirrorless. For example: `gpv config set database deployment-type mirrored`. 
+:   Specifies whether the Greenplum deployment uses mirror segments or not. Valid values of `<type_name>` include `mirrored` and `mirrorless`. For example: `gpv config set database deployment-type mirrored`. 
 
 prefix <prefix_name>
-:   Specifies a prefix to be prepended to the resource pool and VM names. The gpv config set database prefix specifies a label which will serve as a prefix for the names of the resource pool and the VMs in the deployed GPV cluster. The resource pool name will be <PREFIX>-greenplum and the VM names will be like <PREFIX>-mdw, <PREFIX-smdw>, and PREFIX-sdw-001, etc.
+:   Specifies a label which serves as a prefix for the names of the resource pool and the virtual machines in the Greenplum cluster. 
 
-#### <a id="network"></a>Network
+#### <a id="network"></a>network
 
-Configure the network settings for Greenplum to interact with itself and the outside world. gpv config set network - Configure network-related settings.
+Configure the network settings for the Greenplum cluster.
 
 ```
 gpv config set network <setting>
@@ -63,6 +76,7 @@ Settings:
 
 base-vm <subsetting>
 :   Configure the network settings for the base virtual machine. The possible sub-settings are:
+
         - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
         - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
         - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -5,7 +5,9 @@ Manage the configuration of a Greenplum Database on vSphere cluster. The `gpv co
 ## <a id="section2"></a>Usage
 
 ```
-gpv config <command>
+gpv config init <file_name>
+gpv config list
+gpv config set <options>
 ```
 
 ## <a id="opts"></a>Commands
@@ -43,10 +45,14 @@ List the current configuration settings. The `gpv config list` command displays 
 Set an individual configuration setting. 
 
 ```
-gpv config set <area>
+gpv config set database
+| config set vm
+| config set vsphere
+| config set network base-vm
+| config set network gp-virtual-etl-bar
+| config set network gp-virtual-external
+| config set network gp-virtual-internal
 ```
-
-Where `area` can be one of the following:
 
 #### <a id="database"></a>database
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -76,8 +76,6 @@ Where `setting` can be one of the following:
 
 base-vm <subsetting>
 :   Configure the network settings for the base virtual machine. The possible sub-settings are:
-
-The possible <subsettings> can be: 
     - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
     - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
     - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -74,87 +74,84 @@ gpv config set network <setting>
 
 Where `setting` can be one of the following:
 
-base-vm <subsetting>
+base-vm <sub-setting>
 :   Configure the network settings for the base virtual machine. The possible sub-settings are:
-    - `gateway-ip <IP>`: Set the gateway Ip address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
-    - `ip <IP>`: Set the static IP address to be used by the base VM when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
-    - `netmask <NETMASK>`: Set the netmask to be used by the base VM to be used by the base VM when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
-    - `network-type <TYPE>`: Set the network type tp be used by the base VM. Specifies how the IP addresses are assigned to the base VM. Valid values for `<TYPE>` are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
+    - `gateway-ip <IP>`: Set the gateway IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm gateway-ip 10.0.0.1`
+    - `ip <IP>`: Set the static IP address for the base virtual machine when `network-type` is set to `static`. For example: `gpv config set network base-vm ip 10.0.0.5`.
+    - `netmask <NETMASK>`: Set the netmask for the base virtual machine when network-type is set to `static`. For example: `gpv config set network base-vm netmask 255.255.255.0`.
+    - `network-type <TYPE>`: Set the network type for base virtual machine. The possible values are `static` and `dhcp`. For example: `gpv config set network base-vm network-type dhcp`.
 
-gp-virtual-etl-bar <subsetting>
+gp-virtual-etl-bar <sub-subsetting>
 :   Configure the network settings for ETL, backup and restore traffic. The possible sub-settings are:
-        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
+    - `cidr <CIDR>`: Set the Classless Inter-Domain Routing (CIDR) for the `gp-virtual-etl-bar` network. For example: `gpv config set network gp-virtual-etl-bar cidr 192.168.2.1/24`.
 
-gp-virtual-external
+gp-virtual-external <sub-subsetting>
 :   Configure the network settings of the routable network for Greenplum clients. The possible sub-settings are:
-        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
-        - `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
-        - `gateway-ip <IP>`: Set the gateway IP of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external gateway-ip 10.0.1.1`.
-        - `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, only one IP address is needed. If the Greenplum deployment type is `mirrored`, two IP addresses are needed. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
-        - `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
+    - `cidr <CIDR>`: Set the CIDR for the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external cidr 10.0.1.1/24`.
+    - `dns-servers <DNS server1> <DNS server 2>`: Set the DNS servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external dns-servers 8.8.8.8 8.8.4.4`.
+    - `gateway-ip <IP>`: Set the gateway IP of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external gateway-ip 10.0.1.1`.
+    - `ips <IP1> <IP2>`: Set the static IPs of the `gp-virtual-external` network. If the Greenplum deployment type is `mirrorless`, you only need one IP address. If the Greenplum deployment type is `mirrored`, you need two IP addresses. For example: `gpv config set network gp-virtual-external ips 10.0.1.2 10.0.1.3`.
+    - `ntp-servers <NTP server1> <NTP server2>`: Set the NTP servers of the `gp-virtual-external` network. For example: `gpv config set network gp-virtual-external ntp-servers time.example1.com time.example2.com`.
 
-gp-virtual-internal
-:   Configure the network settings of the internal communications network among Greenplum virtual machines.
-        - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
+gp-virtual-internal <sub-setting>
+:   Configure the network settings of the internal communications network among Greenplum virtual machines. The possible sub-settings are:
+    - `cidr <CIDR>`: Set the CIDR to be used by the `gp-virtual-internal` network. For example: `gpv config set network gp-virtual-internal cidr 192.168.2.1/24`.
 
-#### <a id="vm"></a>VM
+#### <a id="vm"></a>vm
 
-Configure individual settings which will appear on all VMs in the cluster. 
+Configure individual settings for all virtual machines in the cluster. 
 
 ```
 gpv config set vm <setting>
 ```
 
-Settings:
+Where `setting` can be one of the following:
 
-base-name <NAME>
-:    Set the name of the base VM, which is used during configuring and deploying Greenplum.
+base-name <base-VM-name>
+:    Set the name of the base virtual machine to use during configuring and deploying Greenplum on vSphere.
 
 gpadmin-password
 :    Set the guest operating system password for `gpadmin` user. The utility prompts you to enter a password when you enter this command.
 
-primary-segment-vm-count <NUMBER_OF_SEGMENT_VMS>
+primary-segment-vm-count <number-of-segment-vms>
 :    Set the number of virtual machines to house primary segments. For example: `gpv config set vm primary-segment-vm-count 64`. 
 
 root-password
 :    Set the guest operating system password for `root` user. The utility prompts you to enter a password when you enter this command.
 
-#### <a id="vsphere"></a>vSphere
+#### <a id="vsphere"></a>vsphere
 
-Configure the settings for vSphere (connection parameters, etc).
+Configure the settings for vSphere.
 
 ```
 gpv config set vsphere <setting>
 ```
 
-Settings:
+Where `setting` can be one of the following:
 
 admin-password
-:    Set the password to be used for the vCenter administrator. The utility prompts you to enter a password when you enter this command.
+:    Set the password for the vCenter administrator. The utility prompts you to enter a password when you enter this command.
 
-admin-username <USER_NAME>
+admin-username <user-name>
 :    Set the username of the vCenter administrator.
 
-compute-cluster-name <COMPUTE_CLUSTER_NAME>
+compute-cluster-name <compute-cluster-name>
 :    Set the name of the compute cluster to use.
 
-datacenter-name <DATACENTER_NAME>
+datacenter-name <datacenter-name>
 :    Set the name of the datacenter to use.
 
-storage-name <STORAGE_NAME>
-:    Set the name of the vSphere datastore or datastore cluster. Specifies the name of the storage layer to use within vCenter. For vSAN, specify the datastore name; for PowerFlex, specify the datastore cluster name.
+storage-name <storage-name>
+:    Set the name of the vSphere datastore or datastore cluster. Specify the name of the storage layer to use within vCenter. For vSAN, specify the datastore name; for Dell PowerFlex, specify the datastore cluster name.
 
-storage-policy <STORAGE_POLICY>
-:    Set the VM storage policy for the storage layer, if applicable. setting specifies the storage policy to be used within vCenter. This setting is required for vSAN only. When specifying the policy, ensure that it is surrounded by quotation marks if the policy's name contains whitespace. For example: `gpv config set vsphere storage-policy "this policy contains spaces"`.
+storage-policy <storage-policy>
+:    Set the virtual machine storage policy for the storage layer, if applicable. This setting is required for vSAN only. When specifying the policy, ensure that it is surrounded by quotation marks if the policy's name contains whitespace. For example: `gpv config set vsphere storage-policy "this policy contains spaces"`.
 
-storage-type <STORAGE_TYPE>
-:    Set the type of storage layer to use. specifies the type of storage layer to be targeted.  Acceptable values for STORAGE_TYPE include powerflexand vsan.
+storage-type <storage-type>
+:    Set the type of storage layer to use. Possible values are `powerflex` and `vsan`.
 
-vcenter-address <VCENTER_ADDRESS>
-:    Set the address where the target vCenter may be found. The gpv config set vsphere vcenter-address setting specifies the location of the vCenter on which Greenplum will be deployed.  Note that protocols are not
-acceptable in the address (e.g.: http://example.com is invalid because of the prefix http://). For example: `gpv config set vsphere vcenter-address gp.vcenter.example.com`.
+vcenter-address <vcenter-address>
+:    Set the address of the target vCenter. Do not include the protocol prefix in the address (http://, https://). For example: `gpv config set vsphere vcenter-address gp.vcenter.example.com`.
 
-vsphere-distributed-switch-mtu <MTU>
-:    Specify the MTU for the vSphere distributed switch. setting specifies Maximum Transmission Unit (MTU) of the port groups on the vSphere distributed switch, in bytes. Valid values range from 1500 to 9000.
-
-
+vsphere-distributed-switch-mtu <mtu>
+:    Specify the Maximum Transfer Unit (MTU) for the vSphere distributed switch, in bytes. Valid values range from 1500 to 9000.

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-config.html.md
@@ -1,8 +1,8 @@
 # gpv config
 
-Manage the configuration of a Greenplum Database on vSphere cluster. The `gpv config` command group allows you to configure a Greenplum cluster, import an external configuration, and list the current configuration.
+Manage the configuration of a Greenplum Database on vSphere cluster. 
 
-## <a id="section2"></a>Usage
+## <a id="section2"></a>Synopsis
 
 ```
 gpv config init <file_name>
@@ -10,9 +10,13 @@ gpv config list
 gpv config set <options>
 ```
 
-## <a id="opts"></a>Commands
+## <a id="section3"></a>Description
 
-The available commands for `gpv config` are `init`, `list`, and `set`.
+The `gpv config` command allows you to configure a Greenplum cluster on VMware vSphere, import an external configuration, and list the current configuration.
+
+## <a id="opts"></a>Sub-commands
+
+The available sub-commands for `gpv config` are `init`, `list`, and `set`.
 
 ### <a id="init"></a>init
 
@@ -46,12 +50,12 @@ Set an individual configuration setting.
 
 ```
 gpv config set database
-| config set vm
-| config set vsphere
-| config set network base-vm
-| config set network gp-virtual-etl-bar
-| config set network gp-virtual-external
-| config set network gp-virtual-internal
+gpv config set vm
+gpv config set vsphere
+gpv config set network base-vm
+gpv config set network gp-virtual-etl-bar
+gpv config set network gp-virtual-external
+gpv config set network gp-virtual-internal
 ```
 
 #### <a id="database"></a>database

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
@@ -1,15 +1,22 @@
 # gpv greenplum
 
-Manage the deployment of a Greenplum Database on vSphere cluster. The `gpv greenplum` command group allows you to deploy a Greenplum cluster, list the connection string to the database, and validate any deployed Greenplum cluster.
+Manage the deployment of a Greenplum Database on vSphere cluster. 
 
-## <a id="section2"></a>Usage
+## <a id="section2"></a>Synopsis
 
 ```
-gpv config <command>
+gpv greenplum deploy
+gpv greenplum list
+gpv greenplum validate
 ```
-## <a id="opts"></a>Commands
 
-The available commands for `gpv config` are `deploy`, `list`, and `validate`.
+## <a id="section3"></a>Description
+
+The `gpv greenplum` sub-command allows you to deploy a Greenplum Database cluster on VMware vSphere, list the connection string to the database, and validate any deployed Greenplum cluster.
+
+## <a id="opts"></a>Sub-commands
+
+The available sub-commands for `gpv config` are `deploy`, `list`, and `validate`.
 
 ### <a id="deploy"></a>deploy
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
@@ -1,8 +1,6 @@
 # gpv greenplum
 
-
-Manage the deployment of a Greenplum cluster. The gpv greenplum command group allows a user to deploy Greenplum, list the strings for connecting to Greenplum, and validate any Greenplum which has
-been deployed.
+Manage the deployment of a Greenplum Database on vSphere cluster. The `gpv greenplum` command group allows you to deploy a Greenplum cluster, list the connection string to the database, and validate any deployed Greenplum cluster.
 
 ## <a id="section2"></a>Usage
 
@@ -11,28 +9,29 @@ gpv config <command>
 ```
 ## <a id="opts"></a>Commands
 
-### <a id="deploy"></a>Deploy
+The available commands for `gpv config` are `deploy`, `list`, and `validate`.
 
-Deploy Greenplum based on a user's configuration. Deploy Greenplum based on a user's configuration. 
+### <a id="deploy"></a>deploy
+
+Deploy Greenplum based on your configuration. The `gpv greenplum deploy` command provisions and powers on all the virtual machines, initializes the Greenplum Database cluster, and enables and starts the Greenplum Virtual Service that manages high availability.
 
 ```
 gpv greenplum deploy
 ```
 
-The gpv greenplum deploy will perform the following operations:
+### <a id="list"></a>list
 
-provision and power-on all of the VMs based on the user's configuration
-initialize Greenplum
-enable and start the Greenplum Virtual Service (GPVS) for high availability
-
-### <a id="list"></a>List
-
-Display endpoints for clients to connect to Greenplum. The gpv greenplum list command displays the endpoints which a client must use to interact with Greenplum.  At the moment, the only endpoint which will be displayed is a postgresql connection URI.
+Display an endpoints to connect to Greenplum. The current available option is the PostgreSQL connection Uniform Resource Identifier (URI).
 
 ```
 gpv greenplum list
 ```
-### <a id="validate"></a>Validate
 
-Confirm that the Greenplum deployment is successful. The gpv greenplum validate confirms that the Greenplum cluster is functional and configured properly.
+### <a id="validate"></a>validate
+
+Confirm that the Greenplum Database cluster deployment is successful. 
+
+```
+gpv greenplum validate
+```
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv-greenplum.html.md
@@ -1,0 +1,38 @@
+# gpv greenplum
+
+
+Manage the deployment of a Greenplum cluster. The gpv greenplum command group allows a user to deploy Greenplum, list the strings for connecting to Greenplum, and validate any Greenplum which has
+been deployed.
+
+## <a id="section2"></a>Usage
+
+```
+gpv config <command>
+```
+## <a id="opts"></a>Commands
+
+### <a id="deploy"></a>Deploy
+
+Deploy Greenplum based on a user's configuration. Deploy Greenplum based on a user's configuration. 
+
+```
+gpv greenplum deploy
+```
+
+The gpv greenplum deploy will perform the following operations:
+
+provision and power-on all of the VMs based on the user's configuration
+initialize Greenplum
+enable and start the Greenplum Virtual Service (GPVS) for high availability
+
+### <a id="list"></a>List
+
+Display endpoints for clients to connect to Greenplum. The gpv greenplum list command displays the endpoints which a client must use to interact with Greenplum.  At the moment, the only endpoint which will be displayed is a postgresql connection URI.
+
+```
+gpv greenplum list
+```
+### <a id="validate"></a>Validate
+
+Confirm that the Greenplum deployment is successful. The gpv greenplum validate confirms that the Greenplum cluster is functional and configured properly.
+

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -47,11 +47,11 @@ The following table lists all the information you require in order to configure 
 |Compute cluster name|The virtual compute cluster name|
 |Storage type |The storage provider type (`powerflex` or `vsan`)|
 |Storage name|The datastore name for this deployment|
+|Storage policy|The storage policy name|
 |vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch*|
 |**Database**|**Configuration parameters for Greenplum Database**|
 |Deployment type|Greenplum deployment type (`mirrored` or `mirrorless`)|
 |Greenplum database cluster prefix |Prefix to prepend to the resource pool and virtual machine names. Default is `gpv`|
-|Number of Primay Segment virtual machines | The number of virtual machines for the primary segments. <br/> - For a `mirrored` deployment type the value is `number of primary segments * 2 + 2`. <br/> - For a `mirrorless` deployment type the value is `number of primary segments + 1`|
 |**Base-vm**|**Configuration parameters for the base virtual machine**|
 |Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask|
 |Base VM IP| The IP to use if the network type is `static`|
@@ -71,8 +71,7 @@ The following table lists all the information you require in order to configure 
 |base-VM-name|The name of the base virtual machine, provisioned in the next section|
 |boot password for the root user|The password for the `root` user on the base virtual machine|
 |boot password for the gpadmin user|The password for the `gpadmin` user on the base virtual machine. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
-|number of primary segment VMs|The number of virtual machines for the primary segments. <br/> - for `mirrored` the total number of virtual machines is `number of primary segments * 2 + 2`. <br/> - for `mirrorless` the total number of virtual machines is `number of primary segments + 1`.|
-|||
+|Number of primary segment VMs|The number of virtual machines for the primary segments. For `mirrored`, use `number of primary segments * 2 + 2`. For `mirrorless`, use `number of primary segments + 1`.|
 
 *Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the vSphere distributed switch supports it. If it is less than 9000, you must adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually. See [Configuring Your Systems](../../install_guide/prep_os.html#networking) for more information about MTU.
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -16,15 +16,6 @@ gpv -h | --help
 
 The `gpv` utility automates the deployment of a Greenplum Database cluster on top of virtual platforms such as vSphere. You use `gpv` to specify a Greenplum cluster's configuration; automate the deployment of a base virtual machine, clone the base virtual machine to create a cluster, and initialize a Greenplum Database on the set of virtual machines. See [VMware Greenplum on vSphere](/gpvirtual/vsphere/index.html) for more details.
 
-[gpv base](gpv-base.html)
-:   The base virtual machine commands.
-
-[gpv config](gpv-config.html)
-:   The commands to manage the configuration of the Greenplum deployment.
-
-[gpv greenplum](gpv-greenplum.html)
-:   The Greenplum initialization and validation commands. 
-
 ## <a id="section4"></a>Options
 
 [gpv base](gpv-base.html)

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -74,7 +74,7 @@ The following table lists all the information you require in order to configure 
 |number of primary segment VMs|The number of virtual machines for the primary segments. <br/> - for `mirrored` the total number of virtual machines is `number of primary segments * 2 + 2`. <br/> - for `mirrorless` the total number of virtual machines is `number of primary segments + 1`.|
 |||
 
-*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually.
+*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the vSphere distributed switch supports it. If it is less than 9000, you must adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually. See [Configuring Your Systems](../../install_guide/prep_os.html#networking) for more information about MTU.
 
 ## <a id="exs"></a>Examples 
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -12,8 +12,7 @@ gpv -h, --help
 
 ## <a id="section3"></a>Description 
 
-The `gpv` utility automates the deployment of Greenplum clusters on top of virtual platforms such as vSphere.
-You use `gpv` to specify a Greenplum cluster's configuration; automate the deployment of a base virtual machine, clone the base virtual machine to create a cluster, and initialize a Greenplum Database on the set of virtual machines.
+The `gpv` utility automates the deployment of a Greenplum Database cluster on top of virtual platforms such as vSphere. You use `gpv` to specify a Greenplum cluster's configuration; automate the deployment of a base virtual machine, clone the base virtual machine to create a cluster, and initialize a Greenplum Database on the set of virtual machines. See [VMware Greenplum on vSphere](/gpvirtual/vsphere/index.html) for more details.
 
 ## <a id="info"></a>Required Inputs
 
@@ -29,34 +28,34 @@ The following table lists all the information you require in order to configure 
 |Compute cluster name|The virtual compute cluster name|
 |Storage type |The storage provider type (`powerflex` or `vsan`)|
 |Storage name|The datastore name for this deployment|
-|vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch.*|
+|vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch*|
 |**Database**|**Configuration parameters for Greenplum Database**|
 |Deployment type|Greenplum deployment type (`mirrored` or `mirrorless`)|
 |Greenplum database cluster prefix |Prefix to prepend to the resource pool and virtual machine names. Default is `gpv`|
-|Number of Primay Segment virtual machines | The number of virtual machines for the primary segments. <br/> - For a `mirrored` deployment type the total number of virtual machines is `number of primary segments * 2 + 2`. <br/> - For a `mirrorless` deployment type the total number of virtual machines is `number of primary segments + 1`.|
-|**base-vm**|**Configuration parameters for the base virtual machine**|
-|Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask.|
-|Base VM IP| The IP to use the network type is `static`|
-|Base VM gateway IP|The gateway to use the network type is `static`|
-|Base VM netmask|The Netmask to use the network type is `static`|
+|Number of Primay Segment virtual machines | The number of virtual machines for the primary segments. <br/> - For a `mirrored` deployment type the value is `number of primary segments * 2 + 2`. <br/> - For a `mirrorless` deployment type the value is `number of primary segments + 1`|
+|**Base-vm**|**Configuration parameters for the base virtual machine**|
+|Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask|
+|Base VM IP| The IP to use if the network type is `static`|
+|Base VM gateway IP|The gateway to use if the network type is `static`|
+|Base VM netmask|The Netmask to use if the network type is `static`|
 |**gp-virtual-external**|**Configuration parameters for the routable network**|
-|gp-virtual-external CIDR|The CIDR of the routable network connected to the `mdw` and `smdw` virtual machines to provide the Greenplum database service to the user clients|
-|gp-virtual-external available IPs|The space separated IP addresses used for `mdw` and `smdw`. The second IP (for `smdw`) is only required for `mirrored` deployment|
+|gp-virtual-external CIDR|The Classless Inter-Domain Routing (CIDR) of the routable network connected to the `mdw` and `smdw` virtual machines to provide the Greenplum database service to the user clients|
+|gp-virtual-external available IPs|The space separated IP addresses used for `mdw` and `smdw`. The second IP (for `smdw`) is only required for `mirrored` deployment.|
 |gp-virtual-external DNS servers|Space separated IP addresses of the DNS servers on the routable network|
 |gp-virtual-external NTP servers|Space separated addresses of the NTP servers|
 |gp-virtual-external gateway IP|The gateway IP address|
 |**gp-virtual-internal**|**Configuration parameters for the Greenplum internal network**|
-|gp-virtual-internal CIDR|The internal network CIDR for the interconnect communications between Greenplum VMs|
+|gp-virtual-internal CIDR|The internal network The Classless Inter-Domain Routing (CIDR) for the interconnect communications between Greenplum virtual machines|
 |**gp-virtual-etl-bar**|**Configuration parameters for the ETL-BAR network**|
-|gp-virtual-etl-bar CIDR|The network CIDR for Extraction Transformation Load (`etl`) and/or Backup and Restore (`bar`) network. Usually this network is not routable to the database user clients, but routable to the backup or staging servers. This network allows access to all segments within the Greenplum cluster to ensure maximum throughput for heavy data movement workloads.|
-|**Virtual machine options**|**Configuration parameters for the VMs**|
-|base-VM-name|The name of the base VM, provisioned in the next section|
-|boot password for the root user|The password for the `root` user on the base VM.|
-|boot password for the gpadmin user|The password for the `gpadmin` user on the base VM. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
-|number of primary segment VMs|The number of VMs for the primary segments. <br/> - for `mirrored` the total number of VMs will be `number of primary segments * 2 + 2`. <br/> - for `mirrorless` the total number of VMs will be `number of primary segments + 1`.|
+|gp-virtual-etl-bar CIDR|The network The Classless Inter-Domain Routing (CIDR) for Extraction Transformation Load (`etl`) and/or Backup and Restore (`bar`) network. Usually this network is not routable to the database user clients, but routable to the backup or staging servers. This network allows access to all segments within the Greenplum cluster to ensure maximum throughput for heavy data movement workloads.|
+|**Virtual machine options**|**Configuration parameters for the virtual machines**|
+|base-VM-name|The name of the base virtual machine, provisioned in the next section|
+|boot password for the root user|The password for the `root` user on the base virtual machine|
+|boot password for the gpadmin user|The password for the `gpadmin` user on the base virtual machine. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
+|number of primary segment VMs|The number of virtual machines for the primary segments. <br/> - for `mirrored` the total number of virtual machines is `number of primary segments * 2 + 2`. <br/> - for `mirrorless` the total number of virtual machines is `number of primary segments + 1`.|
 |||
 
-*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the `gp_max_packet_size` GUC manually
+*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually.
 
 ## <a id="section4"></a>Groups
 
@@ -79,19 +78,15 @@ The following table lists all the information you require in order to configure 
 
 ## <a id="exs"></a>Examples 
 
-**Display gpmt version**
+**Display `gpv` version**
 
 ``` 
-gpmt version
+gpv version
 ```
 
-**Collect a core file**
+**Display the online help**
 
 ``` 
-gpmt packcore -cmd collect -core core.1234
+gpv --help
 ```
 
-**Show help for a specific tool**
-
-``` 
-gpmt gp_log_collector -help

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -27,65 +27,8 @@ The `gpv` utility automates the deployment of a Greenplum Database cluster on to
 [gpv greenplum](gpv-greenplum.html)
 :   The Greenplum initialization and validation commands.
 
--version
+version
 :   Print the version information for the `gpv` utility.
 
 -h, --help
 :   Display the online help. 
-
-## <a id="info"></a>Required Inputs
-
-The following table lists all the information you require in order to configure the a base virtual machine template using the `gpv` utility. Be sure you have this information available before you start with the configuration.
-
-|Configuration|Description|
-|-|-| 
-|**vSphere**|**Configuration parameters for vSphere**|
-|vSphere admin username|An administrator account with enough permissions to deploy the Greenplum cluster|
-|vSphere admin password|The password for the administrator account| 
-|vCenter address|The FQDN or IP address of the vCenter (do not include `https://`)|
-|Datacenter name|The virtual data center name|
-|Compute cluster name|The virtual compute cluster name|
-|Storage type |The storage provider type (`powerflex` or `vsan`)|
-|Storage name|The datastore name for this deployment|
-|Storage policy|The storage policy name|
-|vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch*|
-|**Database**|**Configuration parameters for Greenplum Database**|
-|Deployment type|Greenplum deployment type (`mirrored` or `mirrorless`)|
-|Greenplum database cluster prefix |Prefix to prepend to the resource pool and virtual machine names. Default is `gpv`|
-|**Base-vm**|**Configuration parameters for the base virtual machine**|
-|Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask|
-|Base VM IP| The IP to use if the network type is `static`|
-|Base VM gateway IP|The gateway to use if the network type is `static`|
-|Base VM netmask|The Netmask to use if the network type is `static`|
-|**gp-virtual-external**|**Configuration parameters for the routable network**|
-|gp-virtual-external CIDR|The Classless Inter-Domain Routing (CIDR) of the routable network connected to the `mdw` and `smdw` virtual machines to provide the Greenplum database service to the user clients|
-|gp-virtual-external available IPs|The space separated IP addresses used for `mdw` and `smdw`. The second IP (for `smdw`) is only required for `mirrored` deployment.|
-|gp-virtual-external DNS servers|Space separated IP addresses of the DNS servers on the routable network|
-|gp-virtual-external NTP servers|Space separated addresses of the NTP servers|
-|gp-virtual-external gateway IP|The gateway IP address|
-|**gp-virtual-internal**|**Configuration parameters for the Greenplum internal network**|
-|gp-virtual-internal CIDR|The internal network The Classless Inter-Domain Routing (CIDR) for the interconnect communications between Greenplum virtual machines|
-|**gp-virtual-etl-bar**|**Configuration parameters for the ETL-BAR network**|
-|gp-virtual-etl-bar CIDR|The network The Classless Inter-Domain Routing (CIDR) for Extraction Transformation Load (`etl`) and/or Backup and Restore (`bar`) network. Usually this network is not routable to the database user clients, but routable to the backup or staging servers. This network allows access to all segments within the Greenplum cluster to ensure maximum throughput for heavy data movement workloads.|
-|**Virtual machine options**|**Configuration parameters for the virtual machines**|
-|base-VM-name|The name of the base virtual machine, provisioned in the next section|
-|boot password for the root user|The password for the `root` user on the base virtual machine|
-|boot password for the gpadmin user|The password for the `gpadmin` user on the base virtual machine. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
-|Number of primary segment VMs|The number of virtual machines for the primary segments. For `mirrored`, use `number of primary segments * 2 + 2`. For `mirrorless`, use `number of primary segments + 1`.|
-
-*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the vSphere distributed switch supports it. If it is less than 9000, you must adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually. See [Configuring Your Systems](../../install_guide/prep_os.html#networking) for more information about MTU.
-
-## <a id="exs"></a>Examples 
-
-**Display `gpv` version**
-
-``` 
-gpv version
-```
-
-**Display the online help**
-
-``` 
-gpv --help
-```
-

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -1,0 +1,97 @@
+# gpv 
+
+Configures, deploys, and manages Greenplum Database clusters on top of a virtual platform such as VMware vSphere.
+
+## <a id="section2"></a>Synopsis 
+
+```
+gpv <group> <group_options> 
+gpv version
+gpv -h, --help
+```
+
+## <a id="section3"></a>Description 
+
+The `gpv` utility automates the deployment of Greenplum clusters on top of virtual platforms such as vSphere.
+You use `gpv` to specify a Greenplum cluster's configuration; automate the deployment of a base virtual machine, clone the base virtual machine to create a cluster, and initialize a Greenplum Database on the set of virtual machines.
+
+## <a id="info"></a>Required Inputs
+
+The following table lists all the information you require in order to configure the a base virtual machine template using the `gpv` utility. Be sure you have this information available before you start with the configuration.
+
+|Configuration|Description|
+|-|-| 
+|**vSphere**|**Configuration parameters for vSphere**|
+|vSphere admin username|An administrator account with enough permissions to deploy the Greenplum cluster|
+|vSphere admin password|The password for the administrator account| 
+|vCenter address|The FQDN or IP address of the vCenter (do not include `https://`)|
+|Datacenter name|The virtual data center name|
+|Compute cluster name|The virtual compute cluster name|
+|Storage type |The storage provider type (`powerflex` or `vsan`)|
+|Storage name|The datastore name for this deployment|
+|vSphere distributed switch MTU size|The Maximum Transmission Unit (MTU) configured for the vSphere distributed switch.*|
+|**Database**|**Configuration parameters for Greenplum Database**|
+|Deployment type|Greenplum deployment type (`mirrored` or `mirrorless`)|
+|Greenplum database cluster prefix |Prefix to prepend to the resource pool and virtual machine names. Default is `gpv`|
+|Number of Primay Segment virtual machines | The number of virtual machines for the primary segments. <br/> - For a `mirrored` deployment type the total number of virtual machines is `number of primary segments * 2 + 2`. <br/> - For a `mirrorless` deployment type the total number of virtual machines is `number of primary segments + 1`.|
+|**base-vm**|**Configuration parameters for the base virtual machine**|
+|Base VM network type |Available options are `dhcp` or `static` IP for the **base virtual machine only**. <br/> - For `dhcp`, the DHCP server assigns the network settings <br/> - For `static` IP, you must specify the virtual machine IP, the gateway IP, and the netmask.|
+|Base VM IP| The IP to use the network type is `static`|
+|Base VM gateway IP|The gateway to use the network type is `static`|
+|Base VM netmask|The Netmask to use the network type is `static`|
+|**gp-virtual-external**|**Configuration parameters for the routable network**|
+|gp-virtual-external CIDR|The CIDR of the routable network connected to the `mdw` and `smdw` virtual machines to provide the Greenplum database service to the user clients|
+|gp-virtual-external available IPs|The space separated IP addresses used for `mdw` and `smdw`. The second IP (for `smdw`) is only required for `mirrored` deployment|
+|gp-virtual-external DNS servers|Space separated IP addresses of the DNS servers on the routable network|
+|gp-virtual-external NTP servers|Space separated addresses of the NTP servers|
+|gp-virtual-external gateway IP|The gateway IP address|
+|**gp-virtual-internal**|**Configuration parameters for the Greenplum internal network**|
+|gp-virtual-internal CIDR|The internal network CIDR for the interconnect communications between Greenplum VMs|
+|**gp-virtual-etl-bar**|**Configuration parameters for the ETL-BAR network**|
+|gp-virtual-etl-bar CIDR|The network CIDR for Extraction Transformation Load (`etl`) and/or Backup and Restore (`bar`) network. Usually this network is not routable to the database user clients, but routable to the backup or staging servers. This network allows access to all segments within the Greenplum cluster to ensure maximum throughput for heavy data movement workloads.|
+|**Virtual machine options**|**Configuration parameters for the VMs**|
+|base-VM-name|The name of the base VM, provisioned in the next section|
+|boot password for the root user|The password for the `root` user on the base VM.|
+|boot password for the gpadmin user|The password for the `gpadmin` user on the base VM. The `gpadmin` user is required for the Greenplum cluster initialization and management.|
+|number of primary segment VMs|The number of VMs for the primary segments. <br/> - for `mirrored` the total number of VMs will be `number of primary segments * 2 + 2`. <br/> - for `mirrorless` the total number of VMs will be `number of primary segments + 1`.|
+|||
+
+*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the `gp_max_packet_size` GUC manually
+
+## <a id="section4"></a>Groups
+
+[gpv base](gpv-base.html)
+:   The base virtual machine commands.
+
+[gpv config](gpv-config.html)
+:   The commands to manage the configuration of the Greenplum deployment.
+
+[gpv greenplum](gpv-greenplum.html)
+:   The Greenplum initialization and validation commands.
+
+## <a id="section4"></a>Global Options
+
+-version
+:   Print the version information for the `gpv` utility.
+
+-h, --help
+:   Display the online help.
+
+## <a id="exs"></a>Examples 
+
+**Display gpmt version**
+
+``` 
+gpmt version
+```
+
+**Collect a core file**
+
+``` 
+gpmt packcore -cmd collect -core core.1234
+```
+
+**Show help for a specific tool**
+
+``` 
+gpmt gp_log_collector -help

--- a/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpv.html.md
@@ -5,14 +5,42 @@ Configures, deploys, and manages Greenplum Database clusters on top of a virtual
 ## <a id="section2"></a>Synopsis 
 
 ```
-gpv <group> <group_options> 
+gpv base <base_options>
+gpv config <config_options>
+gpv greenplum <greenplum_options>
 gpv version
-gpv -h, --help
+gpv -h | --help
 ```
 
 ## <a id="section3"></a>Description 
 
 The `gpv` utility automates the deployment of a Greenplum Database cluster on top of virtual platforms such as vSphere. You use `gpv` to specify a Greenplum cluster's configuration; automate the deployment of a base virtual machine, clone the base virtual machine to create a cluster, and initialize a Greenplum Database on the set of virtual machines. See [VMware Greenplum on vSphere](/gpvirtual/vsphere/index.html) for more details.
+
+[gpv base](gpv-base.html)
+:   The base virtual machine commands.
+
+[gpv config](gpv-config.html)
+:   The commands to manage the configuration of the Greenplum deployment.
+
+[gpv greenplum](gpv-greenplum.html)
+:   The Greenplum initialization and validation commands. 
+
+## <a id="section4"></a>Options
+
+[gpv base](gpv-base.html)
+:   The base virtual machine commands.
+
+[gpv config](gpv-config.html)
+:   The commands to manage the configuration of the Greenplum deployment.
+
+[gpv greenplum](gpv-greenplum.html)
+:   The Greenplum initialization and validation commands.
+
+-version
+:   Print the version information for the `gpv` utility.
+
+-h, --help
+:   Display the online help. 
 
 ## <a id="info"></a>Required Inputs
 
@@ -56,25 +84,6 @@ The following table lists all the information you require in order to configure 
 |||
 
 *Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the server configuration parameter [gp_max_packet_size](../../ref_guide/config_params/guc-list.html#gp_max_packet_size) manually.
-
-## <a id="section4"></a>Groups
-
-[gpv base](gpv-base.html)
-:   The base virtual machine commands.
-
-[gpv config](gpv-config.html)
-:   The commands to manage the configuration of the Greenplum deployment.
-
-[gpv greenplum](gpv-greenplum.html)
-:   The Greenplum initialization and validation commands.
-
-## <a id="section4"></a>Global Options
-
--version
-:   Print the version information for the `gpv` utility.
-
--h, --help
-:   Display the online help.
 
 ## <a id="exs"></a>Examples 
 

--- a/gpdb-doc/markdown/utility_guide/utility-programs.html.md
+++ b/gpdb-doc/markdown/utility_guide/utility-programs.html.md
@@ -52,6 +52,7 @@ Greenplum Database provides the following utility programs. Superscripts identif
 - [gpstart](ref/gpstart.html)
 - [gpstate](ref/gpstate.html)
 - [gpstop](ref/gpstop.html)
+- [gpv](ref/gpv.html)
 - [pg\_config](ref/pg_config.html)
 - [pg\_dump](ref/pg_dump.html)<sup>3</sup>
 - [pg\_dumpall](ref/pg_dumpall.html)<sup>3</sup>


### PR DESCRIPTION
The Greenplum Virtual Appliance introduces the `gpv` utility. This PR adds the gpv commands to the Greenplum utility reference guide.

Review site:
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/gpv-gva/greenplum-database/utility_guide-ref-gpv.html
Few points:
- The section "Required Inputs" lists all the data user needs to know before starting with the configuration. We decided to bring the table to the reference pages and not the narrative pages in order to have it in one place only, and since the table items are mapped into the command options and sub-options, any future changes to the commands would only have to be reflected on this page.
- How to distribute the gpv reference pages? Currently they are split into three different subpages due to how extensive `gpv config` is. But the other two are very small so maybe it makes more sense to have everything together on one reference page?
- How to format the examples, in particular for the `gpv config` settings and sub-settings?
- @kmacoskey I will need advice on what to do with the section "*Greenplum performs best with jumbo frames. The recommended MTU is 9000 if the VDS supports it. If it's less than 9000, you need to adjust the server configuration parameter [gp_max_packet_size](https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/gpv-gva/greenplum-database/ref_guide-config_params-guc-list.html#gp_max_packet_size) manually.". How do we need to edit it?