### PR TITLE
Disable some Orca histogram asserts

### DIFF
--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -100,14 +100,16 @@ CHistogram::CHistogram(CMemoryPool *mp, CBucketArray *histogram_buckets,
 	  m_is_col_stats_missing(is_col_stats_missing)
 {
 	GPOS_ASSERT(m_histogram_buckets);
-	GPOS_ASSERT(CDouble(0.0) <= null_freq);
-	GPOS_ASSERT(CDouble(1.0) >= null_freq);
-	GPOS_ASSERT(CDouble(0.0) <= distinct_remaining);
-	GPOS_ASSERT(CDouble(0.0) <= freq_remaining);
-	GPOS_ASSERT(CDouble(1.0) >= freq_remaining);
-	// if distinct_remaining is 0, freq_remaining must be 0 too
-	GPOS_ASSERT_IMP(distinct_remaining < CStatistics::Epsilon,
-					freq_remaining < CStatistics::Epsilon);
+	// FIXME: These assertions are sometimes hit and is indicitive of a bug, but
+	//	currently aren't a high prioritiy and hitting them hides more serious issues
+	//	GPOS_ASSERT(CDouble(0.0) <= null_freq);
+	//	GPOS_ASSERT(CDouble(1.0) >= null_freq);
+	//	GPOS_ASSERT(CDouble(0.0) <= distinct_remaining);
+	//	GPOS_ASSERT(CDouble(0.0) <= freq_remaining);
+	//	GPOS_ASSERT(CDouble(1.0) >= freq_remaining);
+	//	 if distinct_remaining is 0, freq_remaining must be 0 too
+	//	GPOS_ASSERT_IMP(distinct_remaining < CStatistics::Epsilon,
+	//					freq_remaining < CStatistics::Epsilon);
 }
 
 // set histograms null frequency
@@ -1626,16 +1628,17 @@ CHistogram::CombineBuckets(CMemoryPool *mp, CBucketArray *buckets,
 		buckets->AddRef();
 		return buckets;
 	}
-
-#ifdef GPOS_DEBUG
-	CDouble start_frequency(0.0);
-	for (ULONG ul = 0; ul < buckets->Size(); ++ul)
-	{
-		CBucket *bucket = (*buckets)[ul];
-		start_frequency = start_frequency + bucket->GetFrequency();
-	}
-	GPOS_ASSERT(start_frequency <= CDouble(1.0) + CStatistics::Epsilon);
-#endif
+	// FIXME: This assertion is sometimes hit and is indicitive of a bug, but
+	//	currently isn't a high prioritiy and hitting it hides more serious issues
+	//#ifdef GPOS_DEBUG
+	//	CDouble start_frequency(0.0);
+	//	for (ULONG ul = 0; ul < buckets->Size(); ++ul)
+	//	{
+	//		CBucket *bucket = (*buckets)[ul];
+	//		start_frequency = start_frequency + bucket->GetFrequency();
+	//	}
+	//	GPOS_ASSERT(start_frequency <= CDouble(1.0) + CStatistics::Epsilon);
+	//#endif
 
 	CBucketArray *result_buckets = GPOS_NEW(mp) CBucketArray(mp);
 	ULONG bucketsToCombine = buckets->Size() - desired_num_buckets;
@@ -1737,18 +1740,19 @@ CHistogram::CombineBuckets(CMemoryPool *mp, CBucketArray *buckets,
 			result_buckets->Append(bucket->MakeBucketCopy(mp));
 		}
 	}
-
-#ifdef GPOS_DEBUG
-	CDouble end_frequency(0.0);
-	for (ULONG ul = 0; ul < result_buckets->Size(); ++ul)
-	{
-		CBucket *bucket = (*result_buckets)[ul];
-		end_frequency = end_frequency + bucket->GetFrequency();
-	}
-
-	GPOS_ASSERT(start_frequency - end_frequency <=
-				CDouble(0.0) + CStatistics::Epsilon);
-#endif
+	// FIXME: This assertion is sometimes hit and is indicitive of a bug, but
+	//	currently isn't a high prioritiy and hitting it hides more serious issues
+	//#ifdef GPOS_DEBUG
+	//	CDouble end_frequency(0.0);
+	//	for (ULONG ul = 0; ul < result_buckets->Size(); ++ul)
+	//	{
+	//		CBucket *bucket = (*result_buckets)[ul];
+	//		end_frequency = end_frequency + bucket->GetFrequency();
+	//	}
+	//
+	//	GPOS_ASSERT(start_frequency - end_frequency <=
+	//				CDouble(0.0) + CStatistics::Epsilon);
+	//#endif
 
 	// FIXME: the desired_num_buckets handling is broken for singleton buckets
 	// While it limits the number of buckets for non-singleton buckets, singleton buckets

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -102,14 +102,16 @@ CHistogram::CHistogram(CMemoryPool *mp, CBucketArray *histogram_buckets,
 	GPOS_ASSERT(m_histogram_buckets);
 	// FIXME: These assertions are sometimes hit and is indicitive of a bug, but
 	//	currently aren't a high prioritiy and hitting them hides more serious issues
-	//	GPOS_ASSERT(CDouble(0.0) <= null_freq);
-	//	GPOS_ASSERT(CDouble(1.0) >= null_freq);
-	//	GPOS_ASSERT(CDouble(0.0) <= distinct_remaining);
-	//	GPOS_ASSERT(CDouble(0.0) <= freq_remaining);
-	//	GPOS_ASSERT(CDouble(1.0) >= freq_remaining);
-	//	 if distinct_remaining is 0, freq_remaining must be 0 too
-	//	GPOS_ASSERT_IMP(distinct_remaining < CStatistics::Epsilon,
-	//					freq_remaining < CStatistics::Epsilon);
+#if 0
+		GPOS_ASSERT(CDouble(0.0) <= null_freq);
+		GPOS_ASSERT(CDouble(1.0) >= null_freq);
+		GPOS_ASSERT(CDouble(0.0) <= distinct_remaining);
+		GPOS_ASSERT(CDouble(0.0) <= freq_remaining);
+		GPOS_ASSERT(CDouble(1.0) >= freq_remaining);
+		 if distinct_remaining is 0, freq_remaining must be 0 too
+		GPOS_ASSERT_IMP(distinct_remaining < CStatistics::Epsilon,
+						freq_remaining < CStatistics::Epsilon);
+#endif
 }
 
 // set histograms null frequency
@@ -1630,15 +1632,17 @@ CHistogram::CombineBuckets(CMemoryPool *mp, CBucketArray *buckets,
 	}
 	// FIXME: This assertion is sometimes hit and is indicitive of a bug, but
 	//	currently isn't a high prioritiy and hitting it hides more serious issues
-	//#ifdef GPOS_DEBUG
-	//	CDouble start_frequency(0.0);
-	//	for (ULONG ul = 0; ul < buckets->Size(); ++ul)
-	//	{
-	//		CBucket *bucket = (*buckets)[ul];
-	//		start_frequency = start_frequency + bucket->GetFrequency();
-	//	}
-	//	GPOS_ASSERT(start_frequency <= CDouble(1.0) + CStatistics::Epsilon);
-	//#endif
+#if 0
+#ifdef GPOS_DEBUG
+		CDouble start_frequency(0.0);
+		for (ULONG ul = 0; ul < buckets->Size(); ++ul)
+		{
+			CBucket *bucket = (*buckets)[ul];
+			start_frequency = start_frequency + bucket->GetFrequency();
+		}
+		GPOS_ASSERT(start_frequency <= CDouble(1.0) + CStatistics::Epsilon);
+#endif
+#endif
 
 	CBucketArray *result_buckets = GPOS_NEW(mp) CBucketArray(mp);
 	ULONG bucketsToCombine = buckets->Size() - desired_num_buckets;
@@ -1742,17 +1746,19 @@ CHistogram::CombineBuckets(CMemoryPool *mp, CBucketArray *buckets,
 	}
 	// FIXME: This assertion is sometimes hit and is indicitive of a bug, but
 	//	currently isn't a high prioritiy and hitting it hides more serious issues
-	//#ifdef GPOS_DEBUG
-	//	CDouble end_frequency(0.0);
-	//	for (ULONG ul = 0; ul < result_buckets->Size(); ++ul)
-	//	{
-	//		CBucket *bucket = (*result_buckets)[ul];
-	//		end_frequency = end_frequency + bucket->GetFrequency();
-	//	}
-	//
-	//	GPOS_ASSERT(start_frequency - end_frequency <=
-	//				CDouble(0.0) + CStatistics::Epsilon);
-	//#endif
+#if 0
+#ifdef GPOS_DEBUG
+		CDouble end_frequency(0.0);
+		for (ULONG ul = 0; ul < result_buckets->Size(); ++ul)
+		{
+			CBucket *bucket = (*result_buckets)[ul];
+			end_frequency = end_frequency + bucket->GetFrequency();
+		}
+
+		GPOS_ASSERT(start_frequency - end_frequency <=
+					CDouble(0.0) + CStatistics::Epsilon);
+#endif
+#endif
 
 	// FIXME: the desired_num_buckets handling is broken for singleton buckets
 	// While it limits the number of buckets for non-singleton buckets, singleton buckets


### PR DESCRIPTION
These assertions were added to ensure that statistical operations on histograms in Orca are as expected. While they're valid assertions, fixing them simply isn't a super high priority at this time. Keeping them included ends up hiding more potentially serious bugs and makes debugging issues more cumbersome. Instead, comment these assertions out for now until we have some time to properly dig into the issue.