### PR TITLE
Throw error if query contains several references to modifying CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2962,6 +2962,14 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 	if (!is_shared)
 	{
+		/*
+		 * If plan sharing is disabled, we avoid performing DML inside CTE for
+		 * multi reference case. Otherwise, it'll cause duplicated DML operations.
+		 */
+		if (cte->cterefcount > 1 &&
+			((Query *) cte->ctequery)->commandType != CMD_SELECT)
+			elog(ERROR, "Too much references to non-SELECT CTE");
+
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 
 		/*

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2359,3 +2365,29 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2373,3 +2379,29 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2971)
+drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -1,3 +1,10 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
+
 drop table if exists with_test1 cascade;
 create table with_test1 (i int, t text, value int) distributed by (i);
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
@@ -461,3 +468,26 @@ UNION ALL
   SELECT 'sleep', 1 where pg_sleep(1) is not null
 UNION ALL
   SELECT 'c', j FROM cte;
+
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations.
+--start_ignore
+drop table if exists with_dml;
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+drop table with_dml;


### PR DESCRIPTION
Multiple references to modifying CTEs can lead to DML operations being dublicated. This commit proposes the restriction, in case of non-fulfillment of which the informative error is thrown. The if-clause, which checks whether current cte is referenced more than once and subplan sharing is disabled, is proposed. If it is true, the error is thrown. This solution should be replaced with more complex logic in future, providing the proper materialization and rescan of modifying CTE.

The simpliest example of undesired behaviour:
```
create table with_dml (i int, j int) distributed by (i);
with cte as (
    insert into with_dml select i, i * 100 from generate_series(1,5) i
    returning i
) select count(*) from cte where i < (select sum(i) from cte);
count 
-------
     5
(1 row)

select * from with_dml;
 i |  j  
---+-----
 2 | 200
 3 | 300
 4 | 400
 2 | 200
 3 | 300
 4 | 400
 1 | 100
 1 | 100
 5 | 500
 5 | 500
(10 rows)

```