### PR TITLE
minirepro: collect using sequence

### DIFF
--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -12,6 +12,12 @@
  */
 #include "postgres.h"
 
+#include "access/genam.h"
+#include "access/table.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/pg_attrdef.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_proc.h"
 #include "common/hashfn.h"
@@ -21,6 +27,8 @@
 #include "parser/analyze.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
 #include "utils/syscache.h"
 
 static List *proc_oids_for_dump = NIL;
@@ -83,6 +91,110 @@ get_proc_oids_for_dump()
 }
 
 /*
+ * Collect a list of OIDs of all attribute default of the specified relation,
+ * if they have a dependency from the attribute default to the relation.
+ */
+static List *
+getAttrDefaultOfRel(Oid relid)
+{
+	List	   *result = NIL;
+	Relation	depRel;
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tup;
+
+	depRel = table_open(DependRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_depend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(RelationRelationId));
+	ScanKeyInit(&key[1],
+				Anum_pg_depend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+							  NULL, 2, key);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_depend deprec = (Form_pg_depend) GETSTRUCT(tup);
+		if (deprec->classid == AttrDefaultRelationId &&
+			deprec->objsubid == 0 &&
+			deprec->refobjsubid != 0)
+		{
+			result = lappend_oid(result, deprec->objid);
+		}
+	}
+
+	systable_endscan(scan);
+	table_close(depRel, AccessShareLock);
+
+	return result;
+}
+
+/*
+ * Collect a list of OIDs of all sequences referenced by the specified relation,
+ * whether or not they are owned by relation.
+ */
+static List *
+getRefedSequences(Oid relid)
+{
+	List	   *result = getAttrDefaultOfRel(relid);
+	List	   *seqresult = NIL;
+	Relation	depRel;
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tup;
+	ListCell   *lc;
+
+	if (!result)
+		return seqresult;
+
+	depRel = table_open(DependRelationId, AccessShareLock);
+
+	foreach(lc, result)
+	{
+		Oid objid = lfirst_oid(lc);
+		ScanKeyInit(&key[0],
+				Anum_pg_depend_classid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(AttrDefaultRelationId));
+
+		ScanKeyInit(&key[1],
+				Anum_pg_depend_objid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(objid));
+
+		scan = systable_beginscan(depRel, DependDependerIndexId, true,
+							  NULL, 2, key);
+
+		while (HeapTupleIsValid(tup = systable_getnext(scan)))
+		{
+			Form_pg_depend deprec = (Form_pg_depend) GETSTRUCT(tup);
+
+			/*
+			 * The attrdef have dependency on both relation column and seuqence if they invoke
+			 * nextval(). We need the relkind test)
+			 */
+			if(deprec->refclassid == RelationRelationId &&
+				deprec->refobjsubid == 0 &&
+				get_rel_relkind(deprec->refobjid) == RELKIND_SEQUENCE)
+			{
+				seqresult = lappend_oid(seqresult, deprec->refobjid);
+			}
+		}
+
+		systable_endscan(scan);
+	}
+
+	table_close(depRel, AccessShareLock);
+
+	return seqresult;
+}
+
+/*
  * Function dumping dependent relation & function oids for a given SQL text
  */
 Datum
@@ -98,6 +210,7 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 	ErrorContextCallback sqlerrcontext;
 	List	   *invalidItems = NIL;
 	List	   *relationOids = NIL;
+	List       *seqrelationOids = NIL;
 	List	   *deduped_relationOids = NIL;
 	List	   *procOids = NIL;
 
@@ -161,6 +274,16 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 	}
 	PG_END_TRY();
 	is_proc_oids_valid = false;
+
+	/*
+	 * Collect referenced sequences
+	 */
+	foreach(lc, relationOids)
+	{
+		Oid                     relid = lfirst_oid(lc);
+		seqrelationOids = list_concat(seqrelationOids, getRefedSequences(relid));
+	}
+	relationOids = list_concat(relationOids, seqrelationOids);
 
 	/*
 	 * Deduplicate the relation oids

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -7,6 +7,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create materialized view base_mv as select a from base;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create view base_v as select a from base;
+CREATE SEQUENCE minirepro_test_b;
+CREATE TABLE minirepro_test(a serial, b int default nextval('minirepro_test_b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
@@ -15,18 +19,27 @@ declare
   base_oid oid;
   base_mv_oid oid;
   base_v_oid oid;
+  minirepro_test_oid oid;
+  minirepro_test_b_oid oid;
+  minirepro_test_a_seq_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
     base_v_oid = 'base_v'::regclass::oid;
+    minirepro_test_oid = 'minirepro_test'::regclass::oid;
+    minirepro_test_b_oid = 'minirepro_test_b'::regclass::oid;
+    minirepro_test_a_seq_oid = 'minirepro_test_a_seq'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
     t := replace(t, base_v_oid::text, '<base_v>');
+    t := replace(t, minirepro_test_oid::text, '<minirepro_test>');
+    t := replace(t, minirepro_test_b_oid::text, '<minirepro_test_b>');
+    t := replace(t, minirepro_test_a_seq_oid::text, '<minirepro_test_a_seq>');
 
     RETURN t;
 end;
@@ -180,6 +193,15 @@ SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'
  {"relids": "<base_v>,<base_table>", "funcids": ""}
 (1 row)
 
+-- gp_dump_query_oids should output relids of referenced sequences
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM minirepro_test'));
+                                     sanitize_output                                     
+-----------------------------------------------------------------------------------------
+ {"relids": "<minirepro_test>,<minirepro_test_a_seq>,<minirepro_test_b>", "funcids": ""}
+(1 row)
+
+DROP TABLE minirepro_test;
+DROP SEQUENCE minirepro_test_b;
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -45,7 +45,8 @@ Indexes:
 --------------------------------------------------------------------------------
 -- Scenario: User table without hll flag
 --------------------------------------------------------------------------------
-create table minirepro_foo(a int) partition by range(a);
+create sequence minirepro_foo_b_seq cache 1;
+create table minirepro_foo(a int, b int default nextval('minirepro_foo_b_seq'::regclass), c serial) partition by range(a);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table minirepro_foo_1 partition of minirepro_foo for values from (1) to (5);
@@ -57,6 +58,7 @@ analyze minirepro_foo;
 -- end_ignore
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
+drop sequence minirepro_foo_b_seq;
 -- start_ignore
 \! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
@@ -76,14 +78,24 @@ SET
 SET
 SET
 SET
+CREATE SEQUENCE
 SET
 SET
 CREATE TABLE
+CREATE SEQUENCE
+ALTER SEQUENCE
 CREATE TABLE
+ALTER TABLE
 ALTER TABLE
 SET
 UPDATE 1
 UPDATE 1
+UPDATE 1
+UPDATE 1
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
+INSERT 0 1
 INSERT 0 1
 INSERT 0 1
 -- end_ignore
@@ -122,11 +134,16 @@ from pg_statistic where starelid IN ('minirepro_foo'::regclass, 'minirepro_foo_1
  staattnum | stainherit | stanullfrac | stawidth | stadistinct | stakind1 | stakind2 | stakind3 | stakind4 | stakind5 | staop1 | staop2 | staop3 | staop4 | staop5 | stacoll1 | stacoll2 | stacoll3 | stacoll4 | stacoll5 | stanumbers1 | stanumbers2 | stanumbers3 | stanumbers4 | stanumbers5 | stavalues1 | stavalues2 | stavalues3 | stavalues4 | stavalues5 
 -----------+------------+-------------+----------+-------------+----------+----------+----------+----------+----------+--------+--------+--------+--------+--------+----------+----------+----------+----------+----------+-------------+-------------+-------------+-------------+-------------+------------+------------+------------+------------+------------
          1 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
+         2 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
+         3 | t          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
          1 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
-(2 rows)
+         2 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
+         3 | f          |           0 |        4 |          -1 |        0 |        0 |        0 |        0 |        0 |      0 |      0 |      0 |      0 |      0 |        0 |        0 |        0 |        0 |        0 |             |             |             |             |             |            |            |            |            | 
+(6 rows)
 
 -- Cleanup
 drop table minirepro_foo;
+drop sequence minirepro_foo_b_seq;
 --------------------------------------------------------------------------------
 -- Scenario: User table with hll flag
 --------------------------------------------------------------------------------

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -11,7 +11,8 @@
 -- Scenario: User table without hll flag
 --------------------------------------------------------------------------------
 
-create table minirepro_foo(a int) partition by range(a);
+create sequence minirepro_foo_b_seq cache 1;
+create table minirepro_foo(a int, b int default nextval('minirepro_foo_b_seq'::regclass), c serial) partition by range(a);
 create table minirepro_foo_1 partition of minirepro_foo for values from (1) to (5);
 insert into minirepro_foo values(1);
 analyze minirepro_foo;
@@ -25,6 +26,7 @@ analyze minirepro_foo;
 
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
+drop sequence minirepro_foo_b_seq;
 
 -- start_ignore
 \! psql -Xf data/minirepro.sql regression
@@ -65,6 +67,7 @@ from pg_statistic where starelid IN ('minirepro_foo'::regclass, 'minirepro_foo_1
 
 -- Cleanup
 drop table minirepro_foo;
+drop sequence minirepro_foo_b_seq;
 
 --------------------------------------------------------------------------------
 -- Scenario: User table with hll flag


### PR DESCRIPTION
When a table has an explicitly created sequence, the sequence will be ignored by pg_dump if it's not owned by the table.

In pg_dump, implicitly created sequence like SERIAL and GENERATED AS IDENTITY, the referenced sequence will be dumped if the owning table is dumped. But for explicitly created sequence, we should specify sequence's oid if we want to dump the sequence object when the sequence is not owned by table.

Collect oids of sequence which be referenced by table columns in gp_dump_query_oids.

Fix issue #15856
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
