### PR TITLE
use "/usr/bin/env bash" in postgres_clean.bash

### DIFF
--- a/contrib/postgres_fdw/postgres_clean.bash
+++ b/contrib/postgres_fdw/postgres_clean.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -d "testdata/pgdata" ] && [ -d "testdata/pgsql" ] ; then
 	pgbin="testdata/pgsql"
 	${pgbin}/bin/pg_ctl -D testdata/pgdata  stop || true


### PR DESCRIPTION
Use "/usr/bin/env bash" is more portable than "/bin/bash".