### PR TITLE
Declare ACL mode as a ULONG

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5210,7 +5210,7 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
 	}
 
-	INT acl_mode = table_descr->GetAclMode();
+	ULONG acl_mode = table_descr->GetAclMode();
 	GPOS_ASSERT(acl_mode >= 0 &&
 				acl_mode <= std::numeric_limits<AclMode>::max());
 	AclMode required_perms = static_cast<AclMode>(acl_mode);

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -129,7 +129,7 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	INT required_perms = static_cast<INT>(rte->requiredPerms);
+	ULONG required_perms = static_cast<ULONG>(rte->requiredPerms);
 	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(
 		mp, mdid, table_mdname, rte->checkAsUser, rte->rellockmode,
 		required_perms, assigned_query_id_for_target_rel);

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -89,7 +89,7 @@ private:
 	INT m_lockmode;
 
 	// acl mode from the parser
-	INT m_acl_mode;
+	ULONG m_acl_mode;
 
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
@@ -105,7 +105,7 @@ public:
 					 BOOL convert_hash_to_random,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
-					 ULONG ulExecuteAsUser, INT lockmode, INT acl_mode,
+					 ULONG ulExecuteAsUser, INT lockmode, ULONG acl_mode,
 					 ULONG assigned_query_id_for_target_rel);
 
 	// dtor
@@ -154,7 +154,7 @@ public:
 		return m_lockmode;
 	}
 
-	INT
+	ULONG
 	GetAclMode() const
 	{
 		return m_acl_mode;

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -38,7 +38,7 @@ CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
 	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
-	INT lockmode, INT acl_mode, ULONG assigned_query_id_for_target_rel)
+	INT lockmode, ULONG acl_mode, ULONG assigned_query_id_for_target_rel)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -20,6 +20,7 @@
 #include "naucrates/md/CMDName.h"
 #include "naucrates/md/IMDId.h"
 
+#define GPDXL_ACL_UNDEFINED (gpos::ulong_max)
 // default value for m_assigned_query_id_for_target_rel - no assigned query for table descriptor
 #define UNASSIGNED_QUERYID 0
 
@@ -54,7 +55,7 @@ private:
 	INT m_lockmode;
 
 	// acl mode from the parser
-	INT m_acl_mode;
+	ULONG m_acl_mode;
 
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
@@ -69,7 +70,7 @@ public:
 
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-				   ULONG ulExecuteAsUser, int lockmode, INT acl_mode,
+				   ULONG ulExecuteAsUser, int lockmode, ULONG acl_mode,
 				   ULONG assigned_query_id_for_target_rel = UNASSIGNED_QUERYID);
 
 	~CDXLTableDescr() override;
@@ -95,7 +96,7 @@ public:
 	INT LockMode() const;
 
 	// acl mode
-	INT GetAclMode() const;
+	ULONG GetAclMode() const;
 
 	// get the column descriptor at the given position
 	const CDXLColDescr *GetColumnDescrAt(ULONG idx) const;

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1527,9 +1527,9 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 		dxl_memory_manager, attrs, EdxltokenLockMode, EdxltokenTableDescr,
 		true /* is_optional */, -1);
 
-	INT acl_mode = ExtractConvertAttrValueToInt(
+	ULONG acl_mode = ExtractConvertAttrValueToUlong(
 		dxl_memory_manager, attrs, EdxltokenAclMode, EdxltokenTableDescr,
-		true /* is_optional */, -1);
+		true /* is_optional */, GPDXL_ACL_UNDEFINED);
 
 	if (nullptr != execute_as_user_xml)
 	{

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -21,7 +21,6 @@ using namespace gpdxl;
 
 #define GPDXL_DEFAULT_USERID 0
 #define GPDXL_INVALID_LOCKMODE -1
-#define GPDXL_ACL_NO_RIGHTS 0
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -33,7 +32,7 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 							   ULONG ulExecuteAsUser, int lockmode,
-							   INT acl_mode,
+							   ULONG acl_mode,
 							   ULONG assigned_query_id_for_target_rel)
 	: m_mdid(mdid),
 	  m_mdname(mdname),
@@ -128,7 +127,7 @@ CDXLTableDescr::LockMode() const
 	return m_lockmode;
 }
 
-INT
+ULONG
 CDXLTableDescr::GetAclMode() const
 {
 	return m_acl_mode;
@@ -229,7 +228,7 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 			CDXLTokens::GetDXLTokenStr(EdxltokenLockMode), LockMode());
 	}
 
-	if (GPDXL_ACL_NO_RIGHTS <= GetAclMode())
+	if (GPDXL_ACL_UNDEFINED != GetAclMode())
 	{
 		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenAclMode), GetAclMode());


### PR DESCRIPTION
Since it is a bitmap of uint32 in the parser (see parsenodes.h), it ought to be declared as a ULONG in ORCA (corresponds to uint32_t).

This also rids us of the compiler WARNING:

CTranslatorDXLToPlStmt.cpp:5215:42: warning: comparison of integer expressions of different signedness: ‘gpos::INT’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
 5215 |                                 acl_mode <= std::numeric_limits<AclMode>::max());
      |                                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/orca_fix_acl_mode