### PR TITLE
Add segindex to the posix share memory segment name

### DIFF
--- a/src/backend/storage/ipc/dsm_impl.c
+++ b/src/backend/storage/ipc/dsm_impl.c
@@ -229,7 +229,7 @@ dsm_impl_posix(dsm_op op, dsm_handle handle, Size request_size,
 	 * starts, so it is safe to use it here.
 	 *
 	 * However, this increases the length of the name to exceed
-	 * its max available length. For instance, on maxos, the
+	 * its max available length. For instance, on macos, the
 	 * name's max length is 31. Therefor, change the prefix from
 	 * PostgreSQL to GP , which can resolve the above issue.
 	 */


### PR DESCRIPTION
For gp, there may be several segments running on the same host. So, if an application uses 'reloid' as the handle, such as pg_embedding, some concurrency issues will happen. That's due to the memory segment name collisions between those processes. Several different processes which have different segment ids, attach to the same shared memory segment as they have the same name "/PostgreSQL/reloid".

Resolve this issue by adding segindex to the name.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
