### PR TITLE
Change the portal strategy for modifying CTE case

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -336,6 +336,9 @@ ChoosePortalStrategy(List *stmts)
 	/* Note For CreateTableAs, we still use PORTAL_MULTI_QUERY (not like PG)
 	 * since QE needs to use DestRemote to deliver completionTag to QD and
 	 * use DestIntoRel to insert tuples into the table(s).
+	 *
+	 * For modifying CTE we use PORTAL_MULTI_QUERY at QE nodes, because
+	 * we don't need saving the result inside portal's tuple store.
 	 */
 	if (list_length(stmts) == 1)
 	{
@@ -375,10 +378,11 @@ ChoosePortalStrategy(List *stmts)
 					pstmt->copyIntoClause == NULL &&
 					pstmt->refreshClause == NULL)
 				{
-					if (pstmt->hasModifyingCTE)
-						return PORTAL_ONE_MOD_WITH;
-					else
+					if (!pstmt->hasModifyingCTE)
 						return PORTAL_ONE_SELECT;
+					if (Gp_role != GP_ROLE_EXECUTE)
+						return PORTAL_ONE_MOD_WITH;
+					return PORTAL_MULTI_QUERY;
 				}
 				if (pstmt->commandType == CMD_UTILITY)
 				{

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -78,3 +78,54 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
 
 drop table sort_error_test1;
 drop table sort_error_test2;
+-- The statistics for modifying CTEs used to be reported as "never executed",
+-- when all plan nodes were executed and some stat information was expected.
+-- Test QD recieving the stats from all slices and showing it in explain output.
+--start_ignore
+DROP TABLE IF EXISTS with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+CREATE TABLE with_dml (i int, j int) DISTRIBUTED BY (i);
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    INSERT INTO with_dml SELECT i, i * 100 FROM generate_series(1,5) i
+    RETURNING i
+) SELECT * FROM cte;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Insert on with_dml (actual rows=3 loops=1)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=3 loops=1)
+               Hash Key: i.i
+               ->  Function Scan on generate_series i (actual rows=5 loops=1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    UPDATE with_dml SET j = j + 1
+    RETURNING i
+) SELECT * FROM cte;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Update on with_dml (actual rows=3 loops=1)
+         ->  Seq Scan on with_dml (actual rows=3 loops=1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    DELETE FROM with_dml WHERE i > 0
+    RETURNING i
+) SELECT * FROM cte;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Delete on with_dml (actual rows=3 loops=1)
+         ->  Seq Scan on with_dml (actual rows=3 loops=1)
+               Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+DROP TABLE with_dml;

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -79,3 +79,54 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
 
 drop table sort_error_test1;
 drop table sort_error_test2;
+-- The statistics for modifying CTEs used to be reported as "never executed",
+-- when all plan nodes were executed and some stat information was expected.
+-- Test QD recieving the stats from all slices and showing it in explain output.
+--start_ignore
+DROP TABLE IF EXISTS with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+CREATE TABLE with_dml (i int, j int) DISTRIBUTED BY (i);
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    INSERT INTO with_dml SELECT i, i * 100 FROM generate_series(1,5) i
+    RETURNING i
+) SELECT * FROM cte;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Insert on with_dml (actual rows=3 loops=1)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=3 loops=1)
+               Hash Key: i.i
+               ->  Function Scan on generate_series i (actual rows=5 loops=1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    UPDATE with_dml SET j = j + 1
+    RETURNING i
+) SELECT * FROM cte;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Update on with_dml (actual rows=3 loops=1)
+         ->  Seq Scan on with_dml (actual rows=3 loops=1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    DELETE FROM with_dml WHERE i > 0
+    RETURNING i
+) SELECT * FROM cte;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
+   ->  Delete on with_dml (actual rows=3 loops=1)
+         ->  Seq Scan on with_dml (actual rows=3 loops=1)
+               Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+DROP TABLE with_dml;

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -37,3 +37,27 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
     from gp_segment_configuration where role = 'p' and content > -1;
 drop table sort_error_test1;
 drop table sort_error_test2;
+
+-- The statistics for modifying CTEs used to be reported as "never executed",
+-- when all plan nodes were executed and some stat information was expected.
+-- Test QD recieving the stats from all slices and showing it in explain output.
+--start_ignore
+DROP TABLE IF EXISTS with_dml;
+--end_ignore
+CREATE TABLE with_dml (i int, j int) DISTRIBUTED BY (i);
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    INSERT INTO with_dml SELECT i, i * 100 FROM generate_series(1,5) i
+    RETURNING i
+) SELECT * FROM cte;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    UPDATE with_dml SET j = j + 1
+    RETURNING i
+) SELECT * FROM cte;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+WITH cte AS (
+    DELETE FROM with_dml WHERE i > 0
+    RETURNING i
+) SELECT * FROM cte;
+DROP TABLE with_dml;


### PR DESCRIPTION
In vanilla PG and Greenplum queries containing modifying CTE are executed with portal strategy `PORTAL_ONE_MOD_WITH`, which involves storing the result of the query in portal's tuple store, which the final result is then fetched from. This strategy is fair enough and helps us avoid executing modifying operation several times, for example, when one need to fetch the query result partially. However, in Greenplum case executing this strategy at QE nodes is redundant, because clients communicate with the system throught the QD node. Therefore, this commit proposes another type of strategy for execution at QE nodes.

Moreover, when a query contains modifying CTE, EXPLAIN ANALYZE reports most of plan nodes as "never executed", even though the corresponding nodes have been fully executed and have returned the tuples. This problem arise because of `PORTAL_ONE_MOD_WITH` execution strategy, according to which the extra pq message with tuple description is sent to QD, and the statistics can't be retrieved properly in `cdbexplain_recvExecStats` function.

The simpliest query with modifying cte returns the follwing output:
```
create table with_dml (i int, j int) distributed by (i);
explain analyze    
with cte as
(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
select *  from cte;
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..12.50 rows=1000 width=4) (actual time=2.655..2.696 rows=5 loops=1)
   ->  Insert on with_dml  (cost=0.00..12.50 rows=334 width=4) (never executed)
         ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..12.50 rows=1000 width=4) (never executed)
               Hash Key: i.i
               ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=334 width=4) (never executed)
 Planning time: 4.203 ms
   (slice0)    Executor memory: 63K bytes.
   (slice1)    
   (slice2)    
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution time: 3.537 ms
(12 rows)

with cte as
(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
select * from cte;
 i |  j  
---+-----
 2 | 200
 3 | 300
 4 | 400
 1 | 100
 5 | 500
(5 rows)

```
As we can see, the result EXPLAIN ANALYZE output does not show the stats for most plan nodes, however the execution flows correctly. The main point is to bring the stats back.