### PR TITLE
[7X] Keep order while removing duplicated paths.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -19,7 +19,7 @@ for executing this set of commands.
 
 from queue import Queue, Empty
 from threading import Thread
-
+from collections import OrderedDict
 import os
 import signal
 import subprocess
@@ -652,8 +652,8 @@ def findCmdInPath(cmd):
         CMDPATH.append(GPHOME)
 
     # remove duplicate paths
-    seen = set()
-    CMDPATH = [p for p in CMDPATH if (p not in seen or seen.add(p))]
+    unique_paths = OrderedDict.fromkeys(CMDPATH)
+    CMDPATH = list(unique_paths.keys())
 
     if cmd not in CMD_CACHE:
         for p in CMDPATH:

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -647,12 +647,13 @@ def findCmdInPath(cmd):
     CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
                '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
     CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
-    # remove duplicate paths
-    CMDPATH = list(set(CMDPATH))
 
     if GPHOME:
         CMDPATH.append(GPHOME)
 
+    # remove duplicate paths
+    seen = set()
+    CMDPATH = [p for p in CMDPATH if (p not in seen or seen.add(p))]
 
     if cmd not in CMD_CACHE:
         for p in CMDPATH:


### PR DESCRIPTION
When inserting elements to Python's `set()`, it doesn't guarantee the elements' order. The commit f8dd733 is causing flaky failure in our CI. This patch helps fix it.

Failed job: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_main/jobs/check_centos/builds/608

Minimal reproduction script:

```
➜  /tmp python a.py
-------
['/usr/sbin', '/opt/sfw/bin', '/usr/share/Modules/bin', '/usr/local/greenplum-db-devel/bin', '/opt/Navisphere/bin', '/usr/ucb', '/usr/sfw/bin', '/sbin', '/usr/kerberos/bin', '/usr/local/bin', '/sw/bin', '/root/bin', '/bin', '/usr/bin', '/usr/local/go/bin', '/usr/local/sbin']
-------
➜  /tmp python a.py
-------
['/opt/sfw/bin', '/usr/bin', '/usr/ucb', '/usr/local/bin', '/opt/Navisphere/bin', '/usr/share/Modules/bin', '/usr/local/sbin', '/bin', '/usr/local/go/bin', '/root/bin', '/usr/kerberos/bin', '/sbin', '/usr/sbin', '/sw/bin', '/usr/local/greenplum-db-devel/bin', '/usr/sfw/bin']
-------
➜  /tmp python a.py
-------
['/usr/local/sbin', '/usr/local/go/bin', '/usr/sfw/bin', '/usr/local/bin', '/usr/sbin', '/usr/share/Modules/bin', '/usr/ucb', '/usr/kerberos/bin', '/sbin', '/opt/sfw/bin', '/usr/bin', '/sw/bin', '/bin', '/opt/Navisphere/bin', '/usr/local/greenplum-db-devel/bin', '/root/bin']
-------
➜  /tmp cat a.py
import os

PATHENV = "/usr/local/greenplum-db-devel/bin:/usr/share/Modules/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/bin"

CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
           '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
CMDPATH = CMDPATH + PATHENV.split(os.pathsep)
CMDPATH = list(set(CMDPATH))
print("-------")
print(CMDPATH)
print("-------")
```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-keep-order-while-removing-duplicate-paths-rocky8

Let's wait until the pipeline turning green :P
