### PR TITLE
Modify path->locus for foreign table 

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -140,6 +140,30 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
  Settings: optimizer = 'off'
 (7 rows)
 
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: (count(*))
+   ->  Foreign Scan
+         Output: (count(*))
+         Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
+         Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+   ->  Foreign Scan
+         Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+         Relations: (postgres_fdw_gp.gp_ft1 t1) INNER JOIN (postgres_fdw_gp.gp_ft1 t2)
+         Remote SQL: SELECT r1.f1, r1.f2, r1.f3, r2.f1, r2.f2, r2.f3 FROM (postgres_fdw_gp."GP 1" r1 INNER JOIN postgres_fdw_gp."GP 1" r2 ON (((r1.f1 = r2.f1)))) LIMIT 3::bigint
+ Optimizer: Postgres query optimizer
+(7 rows)
+
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      
 ------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -139,6 +139,30 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
  Optimizer: Postgres query optimizer
 (6 rows)
 
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: (count(*))
+   ->  Foreign Scan
+         Output: (count(*))
+         Relations: Aggregate on (postgres_fdw_gp.gp_ft1)
+         Remote SQL: SELECT count(*) FROM postgres_fdw_gp."GP 1"
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)
+   Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+   ->  Foreign Scan
+         Output: t1.f1, t1.f2, t1.f3, t2.f1, t2.f2, t2.f3
+         Relations: (postgres_fdw_gp.gp_ft1 t1) INNER JOIN (postgres_fdw_gp.gp_ft1 t2)
+         Remote SQL: SELECT r1.f1, r1.f2, r1.f3, r2.f1, r2.f2, r2.f3 FROM (postgres_fdw_gp."GP 1" r1 INNER JOIN postgres_fdw_gp."GP 1" r2 ON (((r1.f1 = r2.f1)))) LIMIT 3::bigint
+ Optimizer: Postgres query optimizer
+(7 rows)
+
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      
 ------------------------------------------------------

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -110,6 +110,8 @@ TRUNCATE TABLE postgres_fdw_gp."GP 1";
 set search_path=postgres_fdw_gp;
 alter server loopback options(add num_segments '4');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
+EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;


### PR DESCRIPTION
Only when `create_foreignscan_path()`, can we call `cdbpathlocus_from_baserel()` to get `path->locus` if option mpp_execute = 'all segments'.

When `create_foreign_upper_path()` and `create_foreign_join_path()`, `rel->cdbpolicy` is empty.
In this case, `cdbpathlocus_from_baserel()` will return locus with type `CdbLocusType_Entry` even if mpp_execute = 'all segments'.
This behavior is wrong.

In this commit, we modify the method to get `path->locus` for function `create_foreign_upper_path()` and `create_foreign_join_path()`.
