### PR TITLE
[6X] Fix replication slot inactive issue post differential recovery. (#15981)

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -631,6 +631,7 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
     def test_basebackup_run_passes(self, mock1, mock2):
         self.diff_recovery_cmd.run()
         expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  replication_slot_name='internal_wal_replication_slot',
                                   target_gp_dbid=2, recovery_mode=False)
         self._assert_basebackup_runs(expected_init_args)
         self._assert_cmd_passed()
@@ -755,6 +756,7 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
         self.diff_recovery_cmd.run()
 
         expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  replication_slot_name='internal_wal_replication_slot',
                                   target_gp_dbid=2, recovery_mode=False)
 
         self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
@@ -775,6 +777,7 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
 
         self.diff_recovery_cmd.run()
         expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  replication_slot_name='internal_wal_replication_slot',
                                   target_gp_dbid=2, recovery_mode=False)
         self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
         self.assertEqual(expected_init_args, self.mock_pgbasebackup_init.call_args)

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -91,8 +91,9 @@ class DifferentialRecovery(Command):
         self.era = era
         self.logger = logger
         self.error_type = RecoveryErrorType.DEFAULT_ERROR
+        self.replication_slot_name = 'internal_wal_replication_slot'
         self.replication_slot = PgReplicationSlot(self.recovery_info.source_hostname, self.recovery_info.source_port,
-                                                  'internal_wal_replication_slot')
+                                                  self.replication_slot_name)
 
     @set_recovery_cmd_results
     def run(self):
@@ -238,6 +239,7 @@ class DifferentialRecovery(Command):
                            self.recovery_info.source_hostname,
                            str(self.recovery_info.source_port),
                            writeconffilesonly=True,
+                           replication_slot_name=self.replication_slot_name,
                            target_gp_dbid=self.recovery_info.target_segment_dbid,
                            recovery_mode=False)
         self.logger.debug("Running pg_basebackup to only write configuration files")

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -9,6 +9,7 @@ Feature: gprecoverseg tests
          When the user runs "gprecoverseg <args>"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
+          And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
           And the database segments are in execute mode
 
@@ -16,6 +17,7 @@ Feature: gprecoverseg tests
          When the user runs "gprecoverseg -ra"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
+          And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
           And the other tablespace is valid
           And the database segments are in execute mode
@@ -81,6 +83,7 @@ Feature: gprecoverseg tests
          When the user runs "gprecoverseg -a --differential"
          Then gprecoverseg should return a return code of 0
           And verify that mirror on content 0,1,2 is up
+          And verify replication slot internal_wal_replication_slot is available on all the segments
           And the cluster is rebalanced
 
     @demo_cluster
@@ -102,6 +105,7 @@ Feature: gprecoverseg tests
          When the user runs "gprecoverseg -a --differential"
          Then gprecoverseg should return a return code of 0
           And verify that mirror on content 0,1,2 is up
+          And verify replication slot internal_wal_replication_slot is available on all the segments
           And the cluster is rebalanced
 
     Scenario: full recovery works with tablespaces
@@ -219,6 +223,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Successfully finished pg_controldata.* for dbid.*" to stdout
         And the segments are synchronized
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         And check segment conf: postgresql.conf
      Examples:
         | scenario     | args               |
@@ -310,6 +315,7 @@ Feature: gprecoverseg tests
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
         And all the segments are running
         And the segments are synchronized
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         And check segment conf: postgresql.conf
 
   Scenario: gprecoverseg does not display rsync progress to the user when --no-progress option is specified
@@ -654,6 +660,7 @@ Feature: gprecoverseg tests
     When the user runs "gprecoverseg -ra"
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
+    And verify replication slot internal_wal_replication_slot is available on all the segments
     And the tablespace is valid
     And the other tablespace is valid
     And the database segments are in execute mode
@@ -1504,6 +1511,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Heap checksum setting is consistent between master and the segments that are candidates for recoverseg" to stdout
         And all the segments are running
         And the segments are synchronized
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3955,7 +3955,7 @@ def impl(context, slot):
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
     segments = gparray.getDbList()
     dbname = "template1"
-    query = "SELECT count(*) FROM pg_catalog.pg_replication_slots WHERE slot_name = '{}'".format(slot)
+    query = "SELECT count(*) FROM pg_catalog.pg_replication_slots WHERE slot_name = '{}' and active = 't'".format(slot)
 
     for seg in segments:
         if seg.isSegmentPrimary(current_role=True):
@@ -3965,7 +3965,7 @@ def impl(context, slot):
                                         utility=True, unsetSearchPath=False)) as conn:
                 result = dbconn.execSQLForSingleton(conn, query)
                 if result == 0:
-                    raise Exception("Slot does not exist for host:{}, port:{}".format(host, port))
+                    raise Exception("Slot either does not exist or is inactive for host:{}, port:{}".format(host, port))
 
 
 @given('gp_stat_replication table has pg_basebackup entry for content {contentid}')


### PR DESCRIPTION
Closes:#15952
Cherry-pick: #15981
### Issue: 
Differential recovery left the replication slot in the inactive state, and because of that wal keeps accumulating on the primary. 

### Steps to reproduce:
1. check if the database is up and running.
2. make any of the mirrors down, and wait for the configuration to update.
3. run differential recovery, this will make the down mirror up and start the segment.
4. check the pg_replication_slot table, where you will find the slot is in an inactive state, and active_pid column will be empty.

****Expectation**: post recovery the replication_slot should be active.**

### RCA:
Firstly check the pg_replication_slots table post differential recovery.
```
          slot_name           | plugin | slot_type | datoid | database | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | safe_wal_size
-------------------------------+--------+-----------+--------+----------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+---------------
internal_wal_replication_slot |        | physical  |        |          | f         | f      |            |      |              | 1/A0000028  |                     | extended   |
```
in the table for the slot active was false, and restart_lsn was updated to last checkpoint, but was not updating when the load was coming.

verified that the walsender and walreceiver process was running.
```
[~/workspace/gpdb: {diff_performance} ?]$ ps -ef | grep walsender
  501 62956 62929   0  8:12PM ??         0:00.03 postgres:  7002, walsender shrakesh 127.0.0.1(52393) streaming 4/E16AD98
  
[~/workspace/gpdb: {diff_performance} ?]$ ps -ef | grep walreceiver
  501 62955 62934   0  8:12PM ??         0:00.47 postgres:  7005, walreceiver   streaming 4/E16AD98
```
verified the replication on pg_stat_replication, the state was shwoing streaming (something like shown in below table, taken from a different session so pid and lsn might differ)
```
[~/workspace/gpdb/gpMgmt: {diff_performance} ?]$ psql -c "select * from gp_dist_random('pg_stat_replication')"
  pid  | usesysid | usename  | application_name | client_addr | client_hostname | client_port |          backend_start           | backend_xmin |   state   |  sent_lsn  | write_lsn  | flush_lsn  | replay_lsn | write_lag | flush_lag | replay_lag | sync_priority | sync_state |            reply_time
-------+----------+----------+------------------+-------------+-----------------+-------------+----------------------------------+--------------+-----------+------------+------------+------------+------------+-----------+-----------+------------+---------------+------------+----------------------------------
 73552 |       10 | shrakesh | gp_walreceiver   | 127.0.0.1   |                 |       56139 | 2023-07-11 23:55:33.642063+05:30 |              | streaming | 5/BC000060 | 5/BC000060 | 5/BC000060 | 5/BC000060 |           |           |            |             1 | sync       | 2023-07-11 23:58:04.230946+05:30
 29480 |       10 | shrakesh | gp_walreceiver   | 127.0.0.1   |                 |       54595 | 2023-07-11 22:30:36.53532+05:30  |              | streaming | 5/AE678640 | 5/AE678640 | 5/AE678640 | 5/AE678640 |           |           |            |             1 | sync       | 2023-07-11 23:58:03.451138+05:30
 29488 |       10 | shrakesh | gp_walreceiver   | 127.0.0.1   |                 |       54596 | 2023-07-11 22:30:36.570468+05:30 |              | streaming | 5/AE955C28 | 5/AE955C28 | 5/AE955C28 | 5/AE955C28 |           |           |            |             1 | sync       | 2023-07-11 23:58:03.626321+05:30
```
was not sure why it is happening, did some debug sessions and found that the postgresql.auto.conf generated after differential recovery was missing the information about primary_slot_name = 'internal_wal_replication_slot'
this setting is required to specify an existing replication slot to be used when connecting to the sending server via streaming replication to control resource removal on the primary.

Why it is not appending primary_slot_name to postgresql.auto.conf ?

when we run pg_basebackup with --write-conf-file option it generates the recovery conf file ( postgresql.auto.conf) and internal.auto.conf. postgresql.auto.conf contains the replication details.
but in the function GenerateRecoveryConfig() there is a check

```
if (replication_slot)
{
	/* unescaped: ReplicationSlotValidateName allows [a-z0-9_] only */
	appendPQExpBuffer(contents, "primary_slot_name = '%s'\n",
					  replication_slot);
}
```
As we are not providing slot name while running pg_basebackup with --write-conf-files-only option it was not able to append the primary_slot_name info.

### Fix:
1. Updated the pg_basebackup call to pass slot in differential recovery.
2. Updated affected test cases
3. Updated the step to check for the active state of the replication slot along with its existence.
4. Added verify replication slot step to a few more scenarios.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
