### PR TITLE
Fix error of unique index key order (#16013) on 7X

### DIFF
--- a/src/test/regress/expected/gp_index.out
+++ b/src/test/regress/expected/gp_index.out
@@ -1,3 +1,10 @@
+-- start_matchsubs
+-- Note: In init_file there is a regex which will remove any line including
+-- "Distributed by", so we cannot check the result e.g. "Distributed by (i)".
+-- This regex is to overwrite the regex.
+-- m/Distributed by/
+-- s/Distributed by/Distributedby/
+-- end_matchsubs
 --
 -- Greenplum disallows concurrent index creation. It allows concurrent index
 -- drops, so we want to test for it. Though, due to this difference with
@@ -108,6 +115,61 @@ Indexes:
 Distributed by: (k)
 
 DROP TABLE tbl_create_index;
+-- create partition table with dist keys (a,b,c)
+CREATE TABLE foo1 (a int, b int, c int)  DISTRIBUTED BY (a,b,c) PARTITION BY RANGE(a)
+(PARTITION p1 START (1) END (10000) INCLUSIVE,
+PARTITION p2 START (10001) END (100000) INCLUSIVE,
+PARTITION p3 START (100001) END (1000000) INCLUSIVE);
+-- create unique index with same keys but different order (a,c,b)
+create unique index acb_idx on public.foo1 using btree(a,c,b);
+-- alter table by add partition
+alter table public.foo1 add partition p4 START (1000001) END (2000000) INCLUSIVE;
+-- check the status of the new partition: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p4
+                               Table "public.foo1_1_prt_p4"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+ c      | integer |           |          |         | plain   |              | 
+Partition of: foo1 FOR VALUES FROM (1000001) TO (2000001)
+Partition constraint: ((a IS NOT NULL) AND (a >= 1000001) AND (a < 2000001))
+Indexes:
+    "foo1_1_prt_p4_a_c_b_idx" UNIQUE, btree (a, c, b)
+Distributed by: (a, b, c)
+
+-- alter table by split partition
+alter table public.foo1 split partition p1 at(500) into (partition p1_0, partition p1_1);
+-- check the status of the split partitions: new dist keys should be consistent
+-- to the parent table
+\d+ foo1_1_prt_p1_0
+                              Table "public.foo1_1_prt_p1_0"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+ c      | integer |           |          |         | plain   |              | 
+Partition of: foo1 FOR VALUES FROM (1) TO (500)
+Partition constraint: ((a IS NOT NULL) AND (a >= 1) AND (a < 500))
+Indexes:
+    "foo1_1_prt_p1_0_a_c_b_idx" UNIQUE, btree (a, c, b)
+Distributed by: (a, b, c)
+
+\d+ foo1_1_prt_p1_1
+                              Table "public.foo1_1_prt_p1_1"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+ c      | integer |           |          |         | plain   |              | 
+Partition of: foo1 FOR VALUES FROM (500) TO (10001)
+Partition constraint: ((a IS NOT NULL) AND (a >= 500) AND (a < 10001))
+Indexes:
+    "foo1_1_prt_p1_1_a_c_b_idx" UNIQUE, btree (a, c, b)
+Distributed by: (a, b, c)
+
+DROP TABLE foo1;
 -- Coverage to ensure that reltuples, relpages and relallvisible are updated
 -- correctly upon an index build (i.e. CREATE INDEX) on heap tables.
 -- Note: relallvisible is not maintained for indexes.
@@ -119,6 +181,8 @@ CREATE INDEX ON index_build_relstats_heap(a);
 -- Validate QEs
 SELECT gp_segment_id, count(*) FROM index_build_relstats_heap
 GROUP BY gp_segment_id ORDER BY gp_segment_id;
+NOTICE:  One or more columns in the following table(s) do not have statistics: index_build_relstats_heap
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
  gp_segment_id | count 
 ---------------+-------
              0 |     5


### PR DESCRIPTION
The fix is partially check-pick from
https://github.com/greenplum-db/gpdb/pull/16013. On GPDB7, code fix is not needed, but we still need a test case to cover the scenario of unique index key order of partition table. So I merged the test case with minor changes of regex to handle 7X env.

