### PR TITLE
Fix redundant columns of mutlistage-agg plan

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -155,6 +155,12 @@ typedef struct
 	AggStrategy strat;
 } split_rollup_data;
 
+typedef struct
+{
+	PathTarget *partial_target;
+	List *grps_tlist;
+} deconstruct_expr_context;
+
 /* Local functions */
 static Node *preprocess_expression(PlannerInfo *root, Node *expr, int kind);
 static void preprocess_qual_conditions(PlannerInfo *root, Node *jtnode);
@@ -5741,6 +5747,93 @@ create_scatter_path(PlannerInfo *root, List *scatterClause, Path *path)
 	return path;
 }
 
+/*
+ * Function: deconstruct_expr_walker
+ *
+ * Work for deconstruct_expr.
+ */
+static bool
+deconstruct_expr_walker(Node *node, deconstruct_expr_context *ctx)
+{
+	ListCell *lc;
+
+	if (node == NULL)
+	{
+		return false;
+	}
+	else if (IsA(node, Var))
+	{
+		if (((Var *) node)->varlevelsup != 0)
+			elog(ERROR, "Upper-level Var found where not expected");
+
+		add_new_column_to_pathtarget(ctx->partial_target, (Expr *)node);
+		return false;
+	}
+	else if (IsA(node, PlaceHolderVar))
+	{
+		if (((PlaceHolderVar *) node)->phlevelsup != 0)
+			elog(ERROR, "Upper-level PlaceHolderVar found where not expected");
+
+		add_new_column_to_pathtarget(ctx->partial_target, (Expr *)node);
+		return false;
+	}
+	else if (IsA(node, Aggref))
+	{
+		if (((Aggref *) node)->agglevelsup != 0)
+			elog(ERROR, "Upper-level Aggref found where not expected");
+
+		add_new_column_to_pathtarget(ctx->partial_target, (Expr *)node);
+		return false;
+	}
+	else if (IsA(node, GroupId))
+	{
+		if (((GroupId *) node)->agglevelsup != 0)
+			elog(ERROR, "Upper-level GROUP_ID found where not expected");
+
+		add_new_column_to_pathtarget(ctx->partial_target, (Expr *)node);
+		return false;
+	}
+	else if (IsA(node, GroupingFunc))
+	{
+		if (((GroupingFunc *) node)->agglevelsup != 0)
+			elog(ERROR, "Upper-level GROUPING found where not expected");
+
+		add_new_column_to_pathtarget(ctx->partial_target, (Expr *)node);
+		return false;
+	}
+	else
+	{
+		foreach(lc, ctx->grps_tlist)
+		{
+			Expr *grp_expr = (Expr *)lfirst(lc);
+
+			/* just return if node equal to group column */
+			if (equal(node, grp_expr))
+			{
+				return false;
+			}
+		}
+	}
+
+	return expression_tree_walker(node, deconstruct_expr_walker, (void *) ctx);
+}
+
+/*
+ * Function: deconstruct_expr
+ *
+ * Prepare an expression for execution within 2-stage aggregation.
+ * This involves adding targets as needed to the target list of the
+ * first (partial) aggregation.
+ */
+static bool
+deconstruct_expr(Expr *expr, PathTarget *partial_target, List *grps_tlist)
+{
+	deconstruct_expr_context ctx;
+	ctx.partial_target = partial_target;
+	ctx.grps_tlist = grps_tlist;
+
+	return deconstruct_expr_walker((Node *) expr, &ctx);
+}
 
 /*
  * make_group_input_target
@@ -5863,15 +5956,13 @@ make_partial_grouping_target(PlannerInfo *root,
 {
 	Query	   *parse = root->parse;
 	PathTarget *partial_target;
-	List	   *non_group_cols;
-	List	   *non_group_exprs;
-	int			i;
+	List	   *non_group_cols = NULL;
+	List	   *grps_tlist = NULL;
+	int			i = 0;
 	ListCell   *lc;
 
 	partial_target = create_empty_pathtarget();
-	non_group_cols = NIL;
 
-	i = 0;
 	foreach(lc, grouping_target->exprs)
 	{
 		Expr	   *expr = (Expr *) lfirst(lc);
@@ -5885,6 +5976,7 @@ make_partial_grouping_target(PlannerInfo *root,
 			 * (This allows the upper agg step to repeat the grouping calcs.)
 			 */
 			add_column_to_pathtarget(partial_target, expr, sgref);
+			grps_tlist = lappend(grps_tlist, expr);
 		}
 		else
 		{
@@ -5911,12 +6003,11 @@ make_partial_grouping_target(PlannerInfo *root,
 	 * be present already.)  Note this includes Vars used in resjunk items, so
 	 * we are covering the needs of ORDER BY and window specifications.
 	 */
-	non_group_exprs = pull_var_clause((Node *) non_group_cols,
-									  PVC_INCLUDE_AGGREGATES |
-									  PVC_RECURSE_WINDOWFUNCS |
-									  PVC_INCLUDE_PLACEHOLDERS);
-
-	add_new_columns_to_pathtarget(partial_target, non_group_exprs);
+	foreach(lc, non_group_cols)
+	{
+		Expr *expr = (Expr *) lfirst(lc);
+		deconstruct_expr(expr, partial_target, grps_tlist);
+	}
 
 	/*
 	 * Adjust Aggrefs to put them in partial mode.  At this point all Aggrefs
@@ -5946,7 +6037,6 @@ make_partial_grouping_target(PlannerInfo *root,
 	}
 
 	/* clean up cruft */
-	list_free(non_group_exprs);
 	list_free(non_group_cols);
 
 	/* XXX this causes some redundant cost calculation ... */

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1840,6 +1840,84 @@ SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
 (1 row)
 
 drop table tx;
+-- Eliminate unuseful columns of targetlist in multistage-agg
+create table ex1(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table ex2(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ex1 select i,i,i from generate_series(1, 10) i;
+insert into ex2 select i,i,i from generate_series(1, 10) i;
+explain (verbose on, costs off) select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((COALESCE(ex2.b, 1) / 2)), (sum(ex1.a))
+   ->  Finalize HashAggregate
+         Output: ((COALESCE(ex2.b, 1) / 2)), sum(ex1.a)
+         Group Key: ((COALESCE(ex2.b, 1) / 2))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: ((COALESCE(ex2.b, 1) / 2)), (PARTIAL sum(ex1.a))
+               Hash Key: ((COALESCE(ex2.b, 1) / 2))
+               ->  Partial HashAggregate
+                     Output: ((COALESCE(ex2.b, 1) / 2)), PARTIAL sum(ex1.a)
+                     Group Key: (COALESCE(ex2.b, 1) / 2)
+                     ->  Hash Join
+                           Output: (COALESCE(ex2.b, 1) / 2), ex1.a
+                           Hash Cond: (ex1.a = ex2.a)
+                           ->  Seq Scan on bfv_aggregate.ex1
+                                 Output: ex1.a, ex1.b, ex1.c
+                           ->  Hash
+                                 Output: ex2.b, ex2.a
+                                 ->  Seq Scan on bfv_aggregate.ex2
+                                       Output: ex2.b, ex2.a
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(22 rows)
+
+select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+ ?column? | sum 
+----------+-----
+        4 |  17
+        2 |   9
+        3 |  13
+        1 |   5
+        0 |   1
+        5 |  10
+(6 rows)
+
+explain (verbose on, costs off) SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((b / 2)), ((sum(b) * ((b / 2))))
+   ->  Finalize HashAggregate
+         Output: ((b / 2)), (sum(b) * ((b / 2)))
+         Group Key: ((ex1.b / 2))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: ((b / 2)), (PARTIAL sum(b))
+               Hash Key: ((b / 2))
+               ->  Partial HashAggregate
+                     Output: ((b / 2)), PARTIAL sum(b)
+                     Group Key: (ex1.b / 2)
+                     ->  Seq Scan on bfv_aggregate.ex1
+                           Output: (b / 2), b
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(15 rows)
+
+SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+ ?column? | ?column? 
+----------+----------
+        4 |       68
+        2 |       18
+        3 |       39
+        5 |       50
+        1 |        5
+        0 |        0
+(6 rows)
+
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 set optimizer_force_multistage_agg to on;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1869,6 +1869,94 @@ SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
 (1 row)
 
 drop table tx;
+-- Eliminate unuseful columns of targetlist in multistage-agg
+create table ex1(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table ex2(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ex1 select i,i,i from generate_series(1, 10) i;
+insert into ex2 select i,i,i from generate_series(1, 10) i;
+explain (verbose on, costs off) select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (((COALESCE(ex2.b, 1)) / 2)), (sum(ex1.a))
+   ->  Finalize GroupAggregate
+         Output: (((COALESCE(ex2.b, 1)) / 2)), sum(ex1.a)
+         Group Key: (((COALESCE(ex2.b, 1)) / 2))
+         ->  Sort
+               Output: (((COALESCE(ex2.b, 1)) / 2)), (PARTIAL sum(ex1.a))
+               Sort Key: (((COALESCE(ex2.b, 1)) / 2))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: (((COALESCE(ex2.b, 1)) / 2)), (PARTIAL sum(ex1.a))
+                     Hash Key: (((COALESCE(ex2.b, 1)) / 2))
+                     ->  Partial GroupAggregate
+                           Output: (((COALESCE(ex2.b, 1)) / 2)), PARTIAL sum(ex1.a)
+                           Group Key: (((COALESCE(ex2.b, 1)) / 2))
+                           ->  Sort
+                                 Output: (((COALESCE(ex2.b, 1)) / 2)), ex1.a
+                                 Sort Key: (((COALESCE(ex2.b, 1)) / 2))
+                                 ->  Hash Join
+                                       Output: ((COALESCE(ex2.b, 1)) / 2), ex1.a
+                                       Hash Cond: (ex2.a = ex1.a)
+                                       ->  Seq Scan on bfv_aggregate.ex2
+                                             Output: COALESCE(ex2.b, 1), ex2.a
+                                       ->  Hash
+                                             Output: ex1.a
+                                             ->  Seq Scan on bfv_aggregate.ex1
+                                                   Output: ex1.a
+ Optimizer: Pivotal Optimizer (GPORCA)
+(27 rows)
+
+select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+ ?column? | sum 
+----------+-----
+        0 |   1
+        1 |   5
+        5 |  10
+        2 |   9
+        3 |  13
+        4 |  17
+(6 rows)
+
+explain (verbose on, costs off) SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: ((b / 2)), ((sum(b) * ((b / 2))))
+   ->  Finalize GroupAggregate
+         Output: ((b / 2)), (sum(b) * ((b / 2)))
+         Group Key: ((ex1.b / 2))
+         ->  Sort
+               Output: ((b / 2)), (PARTIAL sum(b))
+               Sort Key: ((ex1.b / 2))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: ((b / 2)), (PARTIAL sum(b))
+                     Hash Key: ((b / 2))
+                     ->  Partial GroupAggregate
+                           Output: ((b / 2)), PARTIAL sum(b)
+                           Group Key: ((ex1.b / 2))
+                           ->  Sort
+                                 Output: ((b / 2)), b
+                                 Sort Key: ((ex1.b / 2))
+                                 ->  Seq Scan on bfv_aggregate.ex1
+                                       Output: (b / 2), b
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+ ?column? | ?column? 
+----------+----------
+        2 |       18
+        3 |       39
+        4 |       68
+        0 |        0
+        1 |        5
+        5 |       50
+(6 rows)
+
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 set optimizer_force_multistage_agg to on;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1479,6 +1479,16 @@ SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
 SELECT MIN(tx.c1) FROM tx GROUP BY (tx.c1)::VARCHAR;
 drop table tx;
 
+-- Eliminate unuseful columns of targetlist in multistage-agg
+create table ex1(a int, b int, c int);
+create table ex2(a int, b int, c int);
+insert into ex1 select i,i,i from generate_series(1, 10) i;
+insert into ex2 select i,i,i from generate_series(1, 10) i;
+explain (verbose on, costs off) select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+select ex2.b/2, sum(ex1.a) from ex1, (select a, coalesce(b, 1) b from ex2) ex2 where ex1.a = ex2.a group by ex2.b/2;
+explain (verbose on, costs off) SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+SELECT b/2, sum(b) * (b/2) FROM ex1  GROUP BY b/2;
+
 -- ORCA should pick singlestage-agg plan when multistage-agg guc is true
 -- and distribution type is universal/replicated
 


### PR DESCRIPTION
Partial Agg emitted reductant columns in targetlist especially on multi-stage agg scenario(upstream didn't have this concern since they don't have mutlistage-agg path).
```
postgres=# explain verbose SELECT b/2, sum(b) * (b/2) FROM t1  GROUP BY b/2 ORDER BY b/2;
                                                 QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=506.05..520.22 rows=1000 width=12)
   Output: ((b / 2)), ((sum(b) * ((b / 2))))
   Merge Key: ((b / 2))
   ->  Sort  (cost=506.05..506.88 rows=333 width=12)
         Output: ((b / 2)), ((sum(b) * ((b / 2))))
         Sort Key: ((t1.b / 2))
         ->  Finalize HashAggregate  (cost=486.25..492.08 rows=333 width=12)
               Output: ((b / 2)), (sum(b) * ((b / 2)))
               Group Key: ((t1.b / 2))
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=448.75..481.25 rows=1000 width=16)
                     Output: ((b / 2)), (PARTIAL sum(b)), b
                     Hash Key: ((b / 2))
                     ->  Partial HashAggregate  (cost=448.75..461.25 rows=1000 width=16)
                           Output: ((b / 2)), PARTIAL sum(b), b
                           Group Key: (t1.b / 2)
                           ->  Seq Scan on public.t1  (cost=0.00..330.25 rows=23700 width=8)
                                 Output: (b / 2), b
 Optimizer: Postgres query optimizer
```
Look at the plan above in Partial HashAggregate Node, `(b / 2) `is the group column and `PARTIAL sum(b) `is the first stage Aggref, they all should be emitted. But `column b` is unuseful, the upper plan will not reference it, so we should remove it. And I also think it’s a general issue as we create targetlists for Partial Agg.
Now we use `pull_var_clause()` for pull-up vars, aggref and placeholdervar of the top targetlist, but there are missed cases -- targetentry exists in group clause like` (b / 2) `column above -- we should keep` (b/2)` as group clause rather than pulling up it. For implementing it, `deconstruct_expr()` works for what we mentioned above, not pull-up `Exprs` anymore if it is a group clause.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
