### PR TITLE
Add error/warning when exchanging/attach an external table

### DIFF
--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -127,6 +127,8 @@ GetExtTableEntryIfExists(Oid relid)
 
 	extentry = GetExtFromForeignTableOptions(ft->options, relid);
 
+	pfree(ft);
+
 	return extentry;
 }
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -20103,6 +20103,25 @@ ATExecAttachPartition(List **wqueue, Relation rel, PartitionCmd *cmd)
 						   RelationGetRelationName(rel),
 						   RelationGetRelationName(attachrel))));
 
+	/* GPDB: some error checking for writable external tables. This is to keep same behavior as pre-7X. */
+	if (attachrel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+	{
+		ExtTableEntry *exttable = GetExtTableEntryIfExists(attachrel->rd_id);
+		/* writable external table not allowed to be attached/exchanged */
+		if (exttable && exttable->iswritable)
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("cannot attach a WRITABLE external table")));
+
+		/* readable external table: throw a warning about no validation (only printed for coordinator/utility mode) */
+		else if (exttable && !exttable->iswritable && Gp_role != GP_ROLE_EXECUTE)
+			ereport(NOTICE,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("partition constraints are not validated when attaching a readable external table")));
+		if (exttable)
+			pfree(exttable);
+	}
+
 	/* If the parent is permanent, so must be all of its partitions. */
 	if (rel->rd_rel->relpersistence != RELPERSISTENCE_TEMP &&
 		attachrel->rd_rel->relpersistence == RELPERSISTENCE_TEMP)

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3726,8 +3726,8 @@ opt_table_partition_exchange_validate:
 			{
 				$$ = +1;
 				ereport(NOTICE,
-						(errmsg("specifying \"WITH VALIDATION\" acts as no operation. "
-								"If the new partition is a regular table, validation is performed "
+						(errmsg("specifying \"WITH VALIDATION\" acts as no operation"),
+						 errdetail("If the new partition is a regular table, validation is performed "
 								"to make sure all the rows obey partition constraint. "
 								"If the new partition is external or foreign table, no validation is performed.")));
 			}
@@ -3735,8 +3735,8 @@ opt_table_partition_exchange_validate:
 			{
 				$$ = +0;
 				ereport(NOTICE,
-						(errmsg("specifying \"WITHOUT VALIDATION\" acts as no operation. "
-								"If the new partition is a regular table, validation is performed "
+						(errmsg("specifying \"WITHOUT VALIDATION\" acts as no operation"),
+						 errdetail("If the new partition is a regular table, validation is performed "
 								"to make sure all the rows obey partition constraint. "
 								"If the new partition is external or foreign table, no validation is performed.")));
 			}

--- a/src/test/regress/expected/partindex_test.out
+++ b/src/test/regress/expected/partindex_test.out
@@ -422,6 +422,7 @@ format 'csv';
 alter table exchange_sub_partition
 alter partition for (integer '2')
 exchange partition for (integer '2') with table exchange_external_table;
+NOTICE:  partition constraints are not validated when attaching a readable external table
 select * from exchange_sub_partition;
  a | b 
 ---+---

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -388,7 +388,8 @@ alter table foo_p exchange partition for(6) with table bar_p;
 ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
 alter table foo_p exchange partition for(6) with table bar_p without
 validation;
-NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
+NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation
+DETAIL:  If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
 ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
 analyze foo_p;
 select * from foo_p;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -594,6 +594,7 @@ ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has chil
 create table foo_p (i int, j int) distributed by (i) partition by range(j) (start(1) end(10) every(2));
 create readable external table bar_p(i int, j int) location ('gpfdist://host.invalid:8000/file') format 'text';
 alter table foo_p exchange partition for(3) with table bar_p;
+NOTICE:  partition constraints are not validated when attaching a readable external table
 truncate foo_p;
 ERROR:  "foo_p_1_prt_2" is not a table
 drop table foo_p;

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2833,10 +2833,12 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO exchange_tbl VALUES (100);
 ALTER TABLE validation_syntax_tbl EXCHANGE PARTITION p1 WITH TABLE exchange_tbl WITH VALIDATION;
-NOTICE:  specifying "WITH VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
+NOTICE:  specifying "WITH VALIDATION" acts as no operation
+DETAIL:  If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
 ERROR:  partition constraint is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
 ALTER TABLE validation_syntax_tbl EXCHANGE PARTITION p1 WITH TABLE exchange_tbl WITHOUT VALIDATION;
-NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
+NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation
+DETAIL:  If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
 ERROR:  partition constraint is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
 DROP TABLE exchange_tbl;
 DROP TABLE validation_syntax_tbl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -388,7 +388,8 @@ alter table foo_p exchange partition for(6) with table bar_p;
 ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
 alter table foo_p exchange partition for(6) with table bar_p without
 validation;
-NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
+NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation
+DETAIL:  If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
 ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
 analyze foo_p;
 select * from foo_p;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -594,6 +594,7 @@ ERROR:  cannot EXCHANGE PARTITION for relation "sto_ao_ao" -- partition has chil
 create table foo_p (i int, j int) distributed by (i) partition by range(j) (start(1) end(10) every(2));
 create readable external table bar_p(i int, j int) location ('gpfdist://host.invalid:8000/file') format 'text';
 alter table foo_p exchange partition for(3) with table bar_p;
+NOTICE:  partition constraints are not validated when attaching a readable external table
 truncate foo_p;
 ERROR:  "foo_p_1_prt_2" is not a table
 drop table foo_p;

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -256,6 +256,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create external web table p2_ext (like p1) EXECUTE 'cat something.txt' FORMAT 'TEXT';
 alter table ext_part attach partition p1 for values in (1);
 alter table ext_part attach partition p2_ext for values in (2);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 explain insert into ext_part values (1);
                       QUERY PLAN                      
 ------------------------------------------------------

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -304,6 +304,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create external web table p2_ext (like p1) EXECUTE 'cat something.txt' FORMAT 'TEXT';
 alter table ext_part attach partition p1 for values in (1);
 alter table ext_part attach partition p2_ext for values in (2);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 explain insert into ext_part values (1);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Insert with External/foreign partition storage types

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3637,17 +3637,17 @@ ALTER TABLE ext_r_dist SET DISTRIBUTED BY (a); -- should error out altering read
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
 CREATE TABLE part_child (LIKE part_root);
-CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE part_ext_r(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ');
+CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE part_root ATTACH PARTITION part_child FOR VALUES FROM (0) TO (10);
-ALTER TABLE part_root ATTACH PARTITION part_ext_w FOR VALUES FROM (10) TO (20);
+ALTER TABLE part_root ATTACH PARTITION part_ext_r FOR VALUES FROM (10) TO (20);
 
--- Adding column should work fine
+-- Adding column on readable external table should work fine
 ALTER TABLE part_root ADD COLUMN b int;
-INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
 
--- altering distribution policy should work fine 
+-- altering distribution policy on writable external table should work fine
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
-ALTER TABLE part_root SET DISTRIBUTED BY (b);
+ALTER TABLE part_ext_w SET DISTRIBUTED BY (b);
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
 
 DROP TABLE part_root;

--- a/src/test/regress/input/part_external_table.source
+++ b/src/test/regress/input/part_external_table.source
@@ -121,3 +121,51 @@ explain select * from part where b = 53;
 
 -- only select foreign scans
 explain select * from part where b > 22;
+
+--
+-- exchange & attach partition
+--
+alter table part add partition exch1 start(60) end (70);
+alter table part add partition exch2 start(70) end (80);
+
+-- exchange with external tables
+create external web table p3_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p4_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+
+-- allow exchange readable external table
+alter table part exchange partition exch1 with table p3_e;
+
+-- should disallow writable external table
+alter table part exchange partition exch1 with table p4_e;
+
+-- exchange with foreign tables
+CREATE SERVER file_server3 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft3 (
+	a int,
+	b int
+) SERVER file_server3
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+
+-- exchange works, but no error checking like for external tables
+alter table part exchange partition exch2 with table ft3;
+
+-- same tests for attach partition
+create external web table p5_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p6_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+
+-- allow attach readable external table
+alter table part attach partition p5_e for values from (80) to (90);
+
+-- should disallow writable external table
+alter table part attach partition p6_e for values from (90) to (100);
+
+-- attach foreign table
+CREATE SERVER file_server4 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft4 (
+	a int,
+	b int
+) SERVER file_server4
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+
+-- exchange works, but no error checking like for external tables
+alter table part attach partition ft4 for values from (100) to (110);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4916,6 +4916,7 @@ INSERT INTO test_part_integrity_p1 VALUES (1,2),(1,3);
 CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'echo 2,2;echo 2,3' ON MASTER FORMAT 'CSV';
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 SELECT * FROM test_part_integrity;
  a | b 
 ---+---
@@ -4958,20 +4959,21 @@ ERROR:  cannot set distribution policy of readable external table "ext_r_dist"
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
 CREATE TABLE part_child (LIKE part_root);
-CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE part_ext_r(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ');
+CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE part_root ATTACH PARTITION part_child FOR VALUES FROM (0) TO (10);
-ALTER TABLE part_root ATTACH PARTITION part_ext_w FOR VALUES FROM (10) TO (20);
--- Adding column should work fine
+ALTER TABLE part_root ATTACH PARTITION part_ext_r FOR VALUES FROM (10) TO (20);
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- Adding column on readable external table should work fine
 ALTER TABLE part_root ADD COLUMN b int;
-INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
--- altering distribution policy should work fine 
+-- altering distribution policy on writable external table should work fine
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
  policytype | distkey 
 ------------+---------
  p          | 1
 (1 row)
 
-ALTER TABLE part_root SET DISTRIBUTED BY (b);
+ALTER TABLE part_ext_w SET DISTRIBUTED BY (b);
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
  policytype | distkey 
 ------------+---------

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -4918,6 +4918,7 @@ INSERT INTO test_part_integrity_p1 VALUES (1,2),(1,3);
 CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) EXECUTE 'echo 2,2;echo 2,3' ON MASTER FORMAT 'CSV';
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 SELECT * FROM test_part_integrity;
  a | b 
 ---+---
@@ -4960,20 +4961,21 @@ ERROR:  cannot set distribution policy of readable external table "ext_r_dist"
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
 CREATE TABLE part_child (LIKE part_root);
-CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE part_ext_r(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ');
+CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE part_root ATTACH PARTITION part_child FOR VALUES FROM (0) TO (10);
-ALTER TABLE part_root ATTACH PARTITION part_ext_w FOR VALUES FROM (10) TO (20);
--- Adding column should work fine
+ALTER TABLE part_root ATTACH PARTITION part_ext_r FOR VALUES FROM (10) TO (20);
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- Adding column on readable external table should work fine
 ALTER TABLE part_root ADD COLUMN b int;
-INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
--- altering distribution policy should work fine 
+-- altering distribution policy on writable external table should work fine
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
  policytype | distkey 
 ------------+---------
  p          | 1
 (1 row)
 
-ALTER TABLE part_root SET DISTRIBUTED BY (b);
+ALTER TABLE part_ext_w SET DISTRIBUTED BY (b);
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'part_ext_w'::regclass;
  policytype | distkey 
 ------------+---------

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1434,6 +1434,7 @@ COPY 26
 CREATE EXTERNAL WEB TABLE ext_dec17(LIKE sales_1_prt_dec17) EXECUTE 'printf "12\t2017-12-01\t21.00\n"' ON COORDINATOR FORMAT 'text';
 CREATE EXTERNAL TABLE
 ALTER TABLE sales EXCHANGE PARTITION dec17 WITH TABLE ext_dec17;
+NOTICE:  partition constraints are not validated when attaching a readable external table
 ALTER TABLE
 DROP TABLE ext_dec17;
 DROP TABLE

--- a/src/test/regress/output/part_external_table.source
+++ b/src/test/regress/output/part_external_table.source
@@ -33,7 +33,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create external table p1_e (a int, b int) location ('file://@hostname@@abs_srcdir@/data/part1.csv') format 'csv';
 create external table p2_e (a int, b int) location ('file://@hostname@@abs_srcdir@/data/part2.csv') format 'csv';
 alter table part attach partition p1_e for values from (0) to (10);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 alter table part attach partition p2_e for values from (10) to (19);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 analyze part;
 WARNING:  skipping "p2_e" --- cannot analyze this foreign table
 WARNING:  skipping "p1_e" --- cannot analyze this foreign table
@@ -403,3 +405,44 @@ explain select * from part where b > 22;
  Optimizer: Postgres query optimizer
 (14 rows)
 
+--
+-- exchange & attach partition
+--
+alter table part add partition exch1 start(60) end (70);
+alter table part add partition exch2 start(70) end (80);
+-- exchange with external tables
+create external web table p3_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p4_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+-- allow exchange readable external table
+alter table part exchange partition exch1 with table p3_e;
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- should disallow writable external table
+alter table part exchange partition exch1 with table p4_e;
+ERROR:  cannot attach a WRITABLE external table
+-- exchange with foreign tables
+CREATE SERVER file_server3 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft3 (
+	a int,
+	b int
+) SERVER file_server3
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+-- exchange works, but no error checking like for external tables
+alter table part exchange partition exch2 with table ft3;
+-- same tests for attach partition
+create external web table p5_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p6_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+-- allow attach readable external table
+alter table part attach partition p5_e for values from (80) to (90);
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- should disallow writable external table
+alter table part attach partition p6_e for values from (90) to (100);
+ERROR:  cannot attach a WRITABLE external table
+-- attach foreign table
+CREATE SERVER file_server4 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft4 (
+	a int,
+	b int
+) SERVER file_server4
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+-- exchange works, but no error checking like for external tables
+alter table part attach partition ft4 for values from (100) to (110);

--- a/src/test/regress/output/part_external_table_optimizer.source
+++ b/src/test/regress/output/part_external_table_optimizer.source
@@ -33,7 +33,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create external table p1_e (a int, b int) location ('file://@hostname@@abs_srcdir@/data/part1.csv') format 'csv';
 create external table p2_e (a int, b int) location ('file://@hostname@@abs_srcdir@/data/part2.csv') format 'csv';
 alter table part attach partition p1_e for values from (0) to (10);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 alter table part attach partition p2_e for values from (10) to (19);
+NOTICE:  partition constraints are not validated when attaching a readable external table
 analyze part;
 WARNING:  skipping "p2_e" --- cannot analyze this foreign table
 WARNING:  skipping "p1_e" --- cannot analyze this foreign table
@@ -402,3 +404,44 @@ explain select * from part where b > 22;
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
+--
+-- exchange & attach partition
+--
+alter table part add partition exch1 start(60) end (70);
+alter table part add partition exch2 start(70) end (80);
+-- exchange with external tables
+create external web table p3_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p4_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+-- allow exchange readable external table
+alter table part exchange partition exch1 with table p3_e;
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- should disallow writable external table
+alter table part exchange partition exch1 with table p4_e;
+ERROR:  cannot attach a WRITABLE external table
+-- exchange with foreign tables
+CREATE SERVER file_server3 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft3 (
+	a int,
+	b int
+) SERVER file_server3
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+-- exchange works, but no error checking like for external tables
+alter table part exchange partition exch2 with table ft3;
+-- same tests for attach partition
+create external web table p5_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+create writable external web table p6_e (a int, b int) execute 'cat > @abs_srcdir@/data/part-ext.csv' format 'csv' (delimiter as '|' null as 'null' escape as ' ');
+-- allow attach readable external table
+alter table part attach partition p5_e for values from (80) to (90);
+NOTICE:  partition constraints are not validated when attaching a readable external table
+-- should disallow writable external table
+alter table part attach partition p6_e for values from (90) to (100);
+ERROR:  cannot attach a WRITABLE external table
+-- attach foreign table
+CREATE SERVER file_server4 FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE ft4 (
+	a int,
+	b int
+) SERVER file_server4
+OPTIONS ( filename '/does/not/exist.csv', format 'csv');
+-- exchange works, but no error checking like for external tables
+alter table part attach partition ft4 for values from (100) to (110);


### PR DESCRIPTION
In 7X, external tables are essentially just one kind of foreign tables. Also, because EXCHANGE PARTITION is now just DETACH+ATTACH PARTITION, exchanging partition with an external table has the same behavior as attaching a foreign table in upstream.

Because of that, there were certain restrictions that got lost for exchanging external tables: (1) we cannot exchange a writable external table in; (2) we cannot exchange a readable external table in w/o "WITHOUT VALIDATION" clause.

For (1): we should bring that restriction back, because otherwise there would always be an error when scanning that partition (unless the query is written in a way that avoids scanning that particular partition). To disallow having a write-only external partition makes more sense. And, keeping existing behavior is probably preferred for those who still use external tables than foreign tables.

For (2): in 7X, WITH/WITHOUT VALIDATION becomes a no-op[1]: we will always validate the new partition *if possible*, even user specifies WITHOUT VALIDATION. In case it is not possible such as for foreign tables, we will ignore validation which is the same behavior as ATTACH PARTITION in upstream [2]. Therefore, it doesn't make sense to continue asking users to add a no-op clause anymore. The ask for WITHOUT VALIDATION is essentially to raise user awareness about this issue. Therefore, we can add WARNING to server the same purpose.

[1] https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-sql_commands-ALTER_TABLE.html
[2] https://www.postgresql.org/docs/12/sql-createforeigntable.html

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/exttable-exchange-part

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
