### PR TITLE
Harden logic around Orca initialization when out of memory

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -269,9 +269,29 @@ InitGPOPT()
 	}
 	GPOS_CATCH_EX(ex)
 	{
+		// rethrow GPDB exceptions
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
 			PG_RE_THROW();
+		}
+		// For Orca excpetions, need to create a GPDB exception
+		else
+		{
+			if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
+			{
+				if (errstart(ERROR, TEXTDOMAIN))
+				{
+					errcode(ERRCODE_INTERNAL_ERROR);
+					errmsg("No available memory to initialize GPORCA");
+					errfinish(ex.Filename(), ex.Line(), nullptr);
+				}
+			}
+			if (errstart(ERROR, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_INTERNAL_ERROR);
+				errmsg("Failed to initialize GPORCA");
+				errfinish(ex.Filename(), ex.Line(), nullptr);
+			}
 		}
 	}
 	GPOS_CATCH_END;

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -50,11 +50,11 @@ CMemoryPoolPallocManager::UserSizeOfAlloc(const void *ptr)
 	return CMemoryPoolPalloc::UserSizeOfAlloc(ptr);
 }
 
-GPOS_RESULT
+void
 CMemoryPoolPallocManager::Init()
 {
-	return CMemoryPoolManager::SetupGlobalMemoryPoolManager<
-		CMemoryPoolPallocManager, CMemoryPoolPalloc>();
+	CMemoryPoolManager::SetupGlobalMemoryPoolManager<CMemoryPoolPallocManager,
+													 CMemoryPoolPalloc>();
 }
 
 // EOF

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -64,7 +64,7 @@ public:
 	void AddMessage(ELocale locale, CMessage *msg);
 
 	// initializer for global singleton
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -64,7 +64,7 @@ public:
 	}
 
 	// initialize global memory pool
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// destroy global instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -96,7 +96,7 @@ protected:
 
 	// Initialize global memory pool manager using given types
 	template <typename ManagerType, typename PoolType>
-	static GPOS_RESULT
+	static void
 	SetupGlobalMemoryPoolManager()
 	{
 		// raw allocation of memory for internal memory pools
@@ -119,7 +119,7 @@ protected:
 			GPOS_RETHROW(ex);
 		}
 		GPOS_CATCH_END;
-		return GPOS_OK;
+		return;
 	}
 
 public:
@@ -161,7 +161,7 @@ public:
 	virtual ULONG UserSizeOfAlloc(const void *ptr);
 
 	// initialize global instance
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// global accessor
 	static CMemoryPoolManager *

--- a/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
@@ -135,7 +135,7 @@ public:
 	}
 
 	// initialize worker pool manager
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// de-init global instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -130,28 +130,11 @@ gpos_init(struct gpos_init_params *params)
 {
 	CWorker::abort_requested_by_system = params->abort_requested;
 
-	if (GPOS_OK != gpos::CMemoryPoolManager::Init())
-	{
-		return;
-	}
-
-	if (GPOS_OK != gpos::CWorkerPoolManager::Init())
-	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CMessageRepository::Init())
-	{
-		CWorkerPoolManager::Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CCacheFactory::Init())
-	{
-		return;
-	}
+	// errors here are caught in InitGPOPT()
+	gpos::CMemoryPoolManager::Init();
+	gpos::CWorkerPoolManager::Init();
+	gpos::CMessageRepository::Init();
+	gpos::CCacheFactory::Init();
 
 #ifdef GPOS_DEBUG_COUNTERS
 	CDebugCounter::Init();

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -88,7 +88,7 @@ CMessageRepository::LookupMessage(CException exc, ELocale locale)
 //		Initialize global instance of message repository
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CMessageRepository::Init()
 {
 	GPOS_ASSERT(nullptr == m_repository);
@@ -104,8 +104,6 @@ CMessageRepository::Init()
 
 	// detach safety
 	(void) amp.Detach();
-
-	return GPOS_OK;
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -57,40 +57,20 @@ CCacheFactory::Pmp() const
 //		Initializes global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CCacheFactory::Init()
 {
 	GPOS_ASSERT(nullptr == GetFactory() &&
 				"Cache factory was already initialized");
 
-	GPOS_RESULT res = GPOS_OK;
-
 	// create cache factory memory pool
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
-	GPOS_TRY
-	{
-		// create cache factory instance
-		CCacheFactory::m_factory = GPOS_NEW(mp) CCacheFactory(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
 
-		CCacheFactory::m_factory = nullptr;
+	// create cache factory instance
+	CCacheFactory::m_factory = GPOS_NEW(mp) CCacheFactory(mp);
 
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			res = GPOS_OOM;
-		}
-		else
-		{
-			res = GPOS_FAILED;
-		}
-	}
-	GPOS_CATCH_END;
-	return res;
+	return;
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -64,16 +64,13 @@ CMemoryPoolManager::Setup()
 }
 
 // Initialize global memory pool manager using CMemoryPoolTracker
-GPOS_RESULT
+void
 CMemoryPoolManager::Init()
 {
 	if (nullptr == CMemoryPoolManager::m_memory_pool_mgr)
 	{
-		return SetupGlobalMemoryPoolManager<CMemoryPoolManager,
-											CMemoryPoolTracker>();
+		SetupGlobalMemoryPoolManager<CMemoryPoolManager, CMemoryPoolTracker>();
 	}
-
-	return GPOS_OK;
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -59,7 +59,7 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 //		Initializer for global worker pool manager
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CWorkerPoolManager::Init()
 {
 	GPOS_ASSERT(nullptr == WorkerPoolManager());
@@ -67,29 +67,9 @@ CWorkerPoolManager::Init()
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	GPOS_TRY
-	{
-		// create worker pool
-		CWorkerPoolManager::m_worker_pool_manager =
-			GPOS_NEW(mp) CWorkerPoolManager(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// turn in memory pool in case of failure
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
-
-		CWorkerPoolManager::m_worker_pool_manager = nullptr;
-
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			return GPOS_OOM;
-		}
-
-		return GPOS_FAILED;
-	}
-	GPOS_CATCH_END;
-
-	return GPOS_OK;
+	// create worker pool
+	CWorkerPoolManager::m_worker_pool_manager =
+		GPOS_NEW(mp) CWorkerPoolManager(mp);
 }
 
 

--- a/src/include/gpopt/utils/CMemoryPoolPallocManager.h
+++ b/src/include/gpopt/utils/CMemoryPoolPallocManager.h
@@ -40,7 +40,7 @@ public:
 	ULONG UserSizeOfAlloc(const void *ptr) override;
 
 
-	static GPOS_RESULT Init();
+	static void Init();
 };
 }  // namespace gpos
 


### PR DESCRIPTION
During Orca initialization, we'll set up various memory pools and error
contexts that require some memory. If the system is already out of
memory, trying to allocate during Orca initialization may also fail.
This PR hardens some of the logic around this. Previously this would
panic in certain cases, for example if allocation of the hash map in the
memory pool failed, the cleanup step would then segfault.

In all, the initialization logic mixed returning error codes and
catching exceptions. In many cases, it wouldn't pass error codes all the
way up, and the exception catching was incomplete and would swallow some
errors.

In this PR, we get rid of the error code passing and cleanup logic and
heavily simplify it instead. If Orca fails to initialize, rather than
trying to clean up/release the memory before erroring out, we now just
error. We throw exceptions, and catch them in the top layer. In
CGPOptimizer.cpp, we translate the Orca exceptions to GPDB exceptions.

It's difficult to guard every cleanup step in the current approach, and
errors during initialization are such corner cases that we're better off
leaking some tiny resources and erroring than risking a crash.
