### PR TITLE
Reset plan cache to prevent flakes in ICW privileges

### DIFF
--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -5,6 +5,9 @@
 -- m/DETAIL:  Failing row contains \(.*\) = \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\) = \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
+-- We use "discard plans" to reset the plan cache, to re-plan
+-- prepared statements and log ORCA fallbacks. This should help
+-- prevent flakes when we create multiple views.
 set optimizer_trace_fallback = on;
 set enable_nestloop=on;
 set optimizer_enable_nljoin = on;
@@ -254,6 +257,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
 
 -- This should also be a nestloop, but the security barrier forces the inner
 -- scan to be materialized
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
                          QUERY PLAN                         
 ------------------------------------------------------------
@@ -297,7 +301,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
  Optimizer: Postgres query optimizer
 (10 rows)
 
--- reset the plan cache, sometimes it would re-plan these prepared statements and log ORCA fallbacks
 discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
                          QUERY PLAN                         
@@ -333,6 +336,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y
 (10 rows)
 
 -- But a security barrier view isolates the leaky operator.
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y
   WHERE x.a = y.b and abs(y.a) <<< 5;
                          QUERY PLAN                         

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -5,6 +5,9 @@
 -- m/DETAIL:  Failing row contains \(.*\) = \(.*\)/
 -- s/DETAIL:  Failing row contains \(.*\) = \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
+-- We use "discard plans" to reset the plan cache, to re-plan
+-- prepared statements and log ORCA fallbacks. This should help
+-- prevent flakes when we create multiple views.
 set optimizer_trace_fallback = on;
 set enable_nestloop=on;
 set optimizer_enable_nljoin = on;
@@ -264,6 +267,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
 
 -- This should also be a nestloop, but the security barrier forces the inner
 -- scan to be materialized
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: views with security_barrier ON
@@ -312,7 +316,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
--- reset the plan cache, sometimes it would re-plan these prepared statements and log ORCA fallbacks
 discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -353,10 +356,13 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y
 (11 rows)
 
 -- But a security barrier view isolates the leaky operator.
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y
   WHERE x.a = y.b and abs(y.a) <<< 5;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: views with security_barrier ON
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -6,6 +6,10 @@
 -- s/DETAIL:  Failing row contains \(.*\) = \(.*\)/DETAIL:  Failing row contains (#####)/
 -- end_matchsubs
 
+-- We use "discard plans" to reset the plan cache, to re-plan
+-- prepared statements and log ORCA fallbacks. This should help
+-- prevent flakes when we create multiple views.
+
 set optimizer_trace_fallback = on;
 set enable_nestloop=on;
 set optimizer_enable_nljoin = on;
@@ -177,6 +181,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
 
 -- This should also be a nestloop, but the security barrier forces the inner
 -- scan to be materialized
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
 
 -- Check if regress_priv_user2 can break security.
@@ -194,7 +199,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12 WHERE a >>> 0;
 -- These plans should continue to use a nestloop, since they execute with the
 -- privileges of the view owner.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
--- reset the plan cache, sometimes it would re-plan these prepared statements and log ORCA fallbacks
+
 discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y WHERE x.a = y.b;
 
@@ -203,6 +208,7 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y
   WHERE x.a = y.b and abs(y.a) <<< 5;
 
 -- But a security barrier view isolates the leaky operator.
+discard plans;
 EXPLAIN (COSTS OFF) SELECT * FROM atest12sbv x, atest12sbv y
   WHERE x.a = y.b and abs(y.a) <<< 5;
 


### PR DESCRIPTION
Since privileges suite was restored on ORCA, we have been observing flakes associated with creations of multiple views. When we query these views, ORCA may fall back once or multiple times. The fallback info is flagged as plan diffs since we have the trace fallback GUC on. This PR adds "discard plans" to release all cached plans. Now that we force re-planning, we expect to log each ORCA fallback and have a consistent output.