### PR TITLE
Confirm AV launcher state in {enable,disable}_autovacuum tests

### DIFF
--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -19,16 +19,17 @@
 -- s/num times hit:\'[4-9]\'/num times hit:\'greater_than_two\'/
 -- end_matchsubs
 -- Prevent autovacuum from dirty-ing buffers.
-alter system set autovacuum = off;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
-             2 | t
-             1 | t
-             0 | t
-            -1 | t
-(4 rows)
-
+-- start_ignore
+\! gpconfig -c autovacuum -v off;
+20230817:14:40:31:2851653 gpconfig:bdoil-ub:bdoil-[INFO]:-completed successfully with parameters '-c autovacuum -v off'
+\! gpstop -au;
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Starting gpstop with args: -au
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Gathering information and validating the environment...
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Segment details from coordinator...
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.64.g42f3fff56a6 build dev'
+20230817:14:40:31:2852058 gpstop:bdoil-ub:bdoil-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
 begin;
 create function num_dirty_on_qes(relid oid) returns setof bigint as
 $$
@@ -239,13 +240,14 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 (8 rows)
 
 -- Reset autovacuum;
-alter system set autovacuum = on;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
-             2 | t
-             1 | t
-             0 | t
-            -1 | t
-(4 rows)
-
+-- start_ignore
+\! gpconfig -c autovacuum -v on;
+20230817:14:40:43:2852133 gpconfig:bdoil-ub:bdoil-[INFO]:-completed successfully with parameters '-c autovacuum -v on'
+\! gpstop -au;
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Starting gpstop with args: -au
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Gathering information and validating the environment...
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Segment details from coordinator...
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.64.g42f3fff56a6 build dev'
+20230817:14:40:43:2852538 gpstop:bdoil-ub:bdoil-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore

--- a/src/test/fsync/sql/bgwriter_checkpoint.sql
+++ b/src/test/fsync/sql/bgwriter_checkpoint.sql
@@ -20,8 +20,11 @@
 -- end_matchsubs
 
 -- Prevent autovacuum from dirty-ing buffers.
-alter system set autovacuum = off;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+
+-- start_ignore
+\! gpconfig -c autovacuum -v off;
+\! gpstop -au;
+-- end_ignore
 
 begin;
 create function num_dirty_on_qes(relid oid) returns setof bigint as
@@ -148,5 +151,7 @@ select gp_inject_fault('fsync_counter', 'status', 2::smallint);
 select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
 
 -- Reset autovacuum;
-alter system set autovacuum = on;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+-- start_ignore
+\! gpconfig -c autovacuum -v on;
+\! gpstop -au;
+-- end_ignore

--- a/src/test/isolation2/expected/disable_autovacuum.out
+++ b/src/test/isolation2/expected/disable_autovacuum.out
@@ -1,10 +1,28 @@
-alter system set autovacuum = off;
-ALTER SYSTEM
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)
+-- start_ignore
+!\retcode gpconfig -c autovacuum -v off;
+-- start_ignore
+20230817:14:42:05:2855408 gpconfig:bdoil-ub:bdoil-[INFO]:-completed successfully with parameters '-c autovacuum -v off'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -au;
+-- start_ignore
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Starting gpstop with args: -au
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Gathering information and validating the environment...
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Segment details from coordinator...
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.5+dev.64.g42f3fff56a6 build dev'
+20230817:14:42:05:2855807 gpstop:bdoil-ub:bdoil-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(false);
+ check_autovacuum 
+------------------
+ t                
+(1 row)

--- a/src/test/isolation2/expected/enable_autovacuum.out
+++ b/src/test/isolation2/expected/enable_autovacuum.out
@@ -1,10 +1,28 @@
-alter system set autovacuum = on;
-ALTER SYSTEM
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)
+-- start_ignore
+!\retcode  gpconfig -c autovacuum -v on;
+-- start_ignore
+20230801:19:41:15:386972 gpconfig:bdoil-ub:bdoil-[INFO]:-completed successfully with parameters '-c autovacuum -v on'
+
+-- end_ignore
+(exited with code 0)
+!\retcode  gpstop -au;
+-- start_ignore
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Starting gpstop with args: -au
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Gathering information and validating the environment...
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Obtaining Segment details from coordinator...
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.4+dev.239.g08189b6c918 build dev'
+20230801:19:41:15:387372 gpstop:bdoil-ub:bdoil-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(true);
+ check_autovacuum 
+------------------
+ t                
+(1 row)

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -165,3 +165,7 @@ CREATE FUNCTION
 -- sequences start/end based on the concurrency level (see AOSegmentGet_startHeapBlock())
 CREATE OR REPLACE FUNCTION populate_pages(relname text, value int, upto tid) RETURNS VOID AS $$ /* in func */ DECLARE curtid tid; /* in func */ BEGIN /* in func */ LOOP /* in func */ EXECUTE format('INSERT INTO %I VALUES($1) RETURNING ctid', relname) INTO curtid USING value; /* in func */ EXIT WHEN curtid > upto; /* in func */ END LOOP; /* in func */ END; $$ /* in func */ LANGUAGE PLPGSQL;
 CREATE FUNCTION
+
+-- Check if autovacuum is enabled/disabled by inspecting the av launcher.
+CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS $$ declare retries int; /* in func */ expected_count int; /* in func */ begin retries := 1200; /* in func */ if enabled then /* (1 for each primary and 1 for the coordinator) */ expected_count := 4; /* in func */ else expected_count := 0; /* in func */ end if; /* in func */ loop if (select count(*) = expected_count from gp_stat_activity where backend_type = 'autovacuum launcher') then return true; /* in func */ end if; /* in func */ if retries <= 0 then return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE FUNCTION

--- a/src/test/isolation2/sql/disable_autovacuum.sql
+++ b/src/test/isolation2/sql/disable_autovacuum.sql
@@ -1,2 +1,9 @@
-alter system set autovacuum = off;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+-- start_ignore
+!\retcode gpconfig -c autovacuum -v off;
+!\retcode gpstop -au;
+-- end_ignore
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(false);

--- a/src/test/isolation2/sql/enable_autovacuum.sql
+++ b/src/test/isolation2/sql/enable_autovacuum.sql
@@ -1,2 +1,9 @@
-alter system set autovacuum = on;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+-- start_ignore
+!\retcode  gpconfig -c autovacuum -v on;
+!\retcode  gpstop -au;
+-- end_ignore
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(true);

--- a/src/test/regress/expected/disable_autovacuum.out
+++ b/src/test/regress/expected/disable_autovacuum.out
@@ -1,10 +1,41 @@
-alter system set autovacuum = off;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
-             2 | t
-             1 | t
-             0 | t
-            -1 | t
-(4 rows)
+-- start_ignore
+\! gpconfig -c autovacuum -v off;
+\! gpstop -au;
+-- end_ignore
+-- Check if autovacuum is enabled/disabled by inspecting the av launcher.
+CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS
+$$
+declare
+	retries int;
+	expected_count int;
+begin
+	retries := 1200;
+	if enabled then
+		/* (1 for each primary and 1 for the coordinator) */
+		expected_count := 4;
+	else 
+		expected_count := 0;
+	end if;
+	loop
+		if (select count(*) = expected_count from gp_stat_activity
+			where backend_type = 'autovacuum launcher') then
+			return true;
+		end if;
+		if retries <= 0 then
+			return false;
+		end if;
+		perform pg_sleep(0.1);
+		retries := retries - 1;
+	end loop;
+end;
+$$
+language plpgsql;
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(false);
+ check_autovacuum 
+------------------
+ t
+(1 row)
 

--- a/src/test/regress/expected/enable_autovacuum.out
+++ b/src/test/regress/expected/enable_autovacuum.out
@@ -1,10 +1,41 @@
-alter system set autovacuum = on;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
-             2 | t
-             1 | t
-             0 | t
-            -1 | t
-(4 rows)
+-- start_ignore
+\! gpconfig -c autovacuum -v on;
+\! gpstop -au;
+-- end_ignore
+-- Check if autovacuum is enabled/disabled by inspecting the av launcher.
+CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS
+$$
+declare
+	retries int;
+	expected_count int;
+begin
+	retries := 1200;
+	if enabled then
+		/* (1 for each primary and 1 for the coordinator) */
+		expected_count := 4;
+	else 
+		expected_count := 0;
+	end if;
+	loop
+		if (select count(*) = expected_count from gp_stat_activity
+			where backend_type = 'autovacuum launcher') then
+			return true;
+		end if;
+		if retries <= 0 then
+			return false;
+		end if;
+		perform pg_sleep(0.1);
+		retries := retries - 1;
+	end loop;
+end;
+$$
+language plpgsql;
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(true);
+ check_autovacuum 
+------------------
+ t
+(1 row)
 

--- a/src/test/regress/expected/vacuum_ao_aux_only.out
+++ b/src/test/regress/expected/vacuum_ao_aux_only.out
@@ -3,16 +3,6 @@
 CREATE DATABASE vac_ao_aux;
 \c vac_ao_aux
 CREATE EXTENSION gp_inject_fault;
-ALTER SYSTEM SET autovacuum = off;;
--- start_ignore
-\! gpstop -u;
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18102.g5fee1f1ac9 build dev'
-20230222:13:13:53:121318 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
--- end_ignore
 -- Test VACUUM AO_AUX_ONLY without providing a relation list
 CREATE TABLE vac_example_heap(i int, j int) DISTRIBUTED BY (i);
 INSERT INTO vac_example_heap SELECT j,j FROM generate_series(1, 1000000)j;

--- a/src/test/regress/sql/disable_autovacuum.sql
+++ b/src/test/regress/sql/disable_autovacuum.sql
@@ -1,2 +1,38 @@
-alter system set autovacuum = off;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+-- start_ignore
+\! gpconfig -c autovacuum -v off;
+\! gpstop -au;
+-- end_ignore
+
+-- Check if autovacuum is enabled/disabled by inspecting the av launcher.
+CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS
+$$
+declare
+	retries int;
+	expected_count int;
+begin
+	retries := 1200;
+	if enabled then
+		/* (1 for each primary and 1 for the coordinator) */
+		expected_count := 4;
+	else 
+		expected_count := 0;
+	end if;
+	loop
+		if (select count(*) = expected_count from gp_stat_activity
+			where backend_type = 'autovacuum launcher') then
+			return true;
+		end if;
+		if retries <= 0 then
+			return false;
+		end if;
+		perform pg_sleep(0.1);
+		retries := retries - 1;
+	end loop;
+end;
+$$
+language plpgsql;
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(false);

--- a/src/test/regress/sql/enable_autovacuum.sql
+++ b/src/test/regress/sql/enable_autovacuum.sql
@@ -1,2 +1,38 @@
-alter system set autovacuum = on;
-select gp_segment_id, pg_reload_conf() from gp_id union select gp_segment_id, pg_reload_conf() from gp_dist_random('gp_id');
+-- start_ignore
+\! gpconfig -c autovacuum -v on;
+\! gpstop -au;
+-- end_ignore
+
+-- Check if autovacuum is enabled/disabled by inspecting the av launcher.
+CREATE or REPLACE FUNCTION check_autovacuum (enabled boolean) RETURNS bool AS
+$$
+declare
+	retries int;
+	expected_count int;
+begin
+	retries := 1200;
+	if enabled then
+		/* (1 for each primary and 1 for the coordinator) */
+		expected_count := 4;
+	else 
+		expected_count := 0;
+	end if;
+	loop
+		if (select count(*) = expected_count from gp_stat_activity
+			where backend_type = 'autovacuum launcher') then
+			return true;
+		end if;
+		if retries <= 0 then
+			return false;
+		end if;
+		perform pg_sleep(0.1);
+		retries := retries - 1;
+	end loop;
+end;
+$$
+language plpgsql;
+
+-- Impose a stronger exit criteria for this test:
+-- the AV launcher has shut down (and by extension the workers) following the config change.
+-- This is done to ensure tests in the suite immediately following this one are run under the right conditions.
+select check_autovacuum(true);

--- a/src/test/regress/sql/vacuum_ao_aux_only.sql
+++ b/src/test/regress/sql/vacuum_ao_aux_only.sql
@@ -5,11 +5,6 @@ CREATE DATABASE vac_ao_aux;
 
 CREATE EXTENSION gp_inject_fault;
 
-ALTER SYSTEM SET autovacuum = off;;
--- start_ignore
-\! gpstop -u;
--- end_ignore
-
 -- Test VACUUM AO_AUX_ONLY without providing a relation list
 CREATE TABLE vac_example_heap(i int, j int) DISTRIBUTED BY (i);
 INSERT INTO vac_example_heap SELECT j,j FROM generate_series(1, 1000000)j;


### PR DESCRIPTION
We are encouraging the use of gpconfig/gpstop -u to toggle
autovacuum on/off. This is preferred over ALTER SYSTEM because the ALTER
doesn't make the changes on the mirrors. If there is a failover in the
test suite, some segments will have out of sync autovacuum settings.

Also, we want to ensure the autovacuum launchers are correctly
started/stopped after the gpstop -u, so busy wait for up to 2min in the
test.

Remove ALTER SYSTEM set autovacuum commands in vacuum_ao_aux_only test.
This test is run in the part of the schedule with autovacuum disabled.