### PR TITLE
[6X] minirepro: collect using sequence

### DIFF
--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -12,6 +12,11 @@
  */
 #include "postgres.h"
 
+#include "access/genam.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/pg_attrdef.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_inherits_fn.h"
 #include "catalog/pg_proc.h"
 #include "tcop/tcopprot.h"
@@ -19,6 +24,8 @@
 #include "parser/analyze.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/tqual.h"
 
@@ -82,6 +89,110 @@ get_proc_oids_for_dump()
 }
 
 /*
+ * Collect a list of OIDs of all attribute default of the specified relation,
+ * if they have a dependency from the attribute default to the relation.
+ */
+static List *
+getAttrDefaultOfRel(Oid relid)
+{
+	List	   *result = NIL;
+	Relation	depRel;
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tup;
+
+	depRel = heap_open(DependRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_depend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(RelationRelationId));
+	ScanKeyInit(&key[1],
+				Anum_pg_depend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+							  NULL, 2, key);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_depend deprec = (Form_pg_depend) GETSTRUCT(tup);
+		if (deprec->classid == AttrDefaultRelationId &&
+			deprec->objsubid == 0 &&
+			deprec->refobjsubid != 0)
+		{
+			result = lappend_oid(result, deprec->objid);
+		}
+	}
+
+	systable_endscan(scan);
+	heap_close(depRel, AccessShareLock);
+
+	return result;
+}
+
+/*
+ * Collect a list of OIDs of all sequences referenced by the specified relation,
+ * whether or not they are owned by relation.
+ */
+static List *
+getRefedSequences(Oid relid)
+{
+	List	   *result = getAttrDefaultOfRel(relid);
+	List	   *seqresult = NIL;
+	Relation	depRel;
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tup;
+	ListCell   *lc;
+
+	if (!result)
+		return seqresult;
+
+	depRel = heap_open(DependRelationId, AccessShareLock);
+
+	foreach(lc, result)
+	{
+		Oid objid = lfirst_oid(lc);
+		ScanKeyInit(&key[0],
+				Anum_pg_depend_classid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(AttrDefaultRelationId));
+
+		ScanKeyInit(&key[1],
+				Anum_pg_depend_objid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(objid));
+
+		scan = systable_beginscan(depRel, DependDependerIndexId, true,
+							  NULL, 2, key);
+
+		while (HeapTupleIsValid(tup = systable_getnext(scan)))
+		{
+			Form_pg_depend deprec = (Form_pg_depend) GETSTRUCT(tup);
+
+			/*
+			 * The attrdef have dependency on both relation column and seuqence if they invoke
+			 * nextval(). We need the relkind test)
+			 */
+			if(deprec->refclassid == RelationRelationId &&
+				deprec->refobjsubid == 0 &&
+				get_rel_relkind(deprec->refobjid) == RELKIND_SEQUENCE)
+			{
+				seqresult = lappend_oid(seqresult, deprec->refobjid);
+			}
+		}
+
+		systable_endscan(scan);
+	}
+
+	heap_close(depRel, AccessShareLock);
+
+	return seqresult;
+}
+
+/*
  * Function dumping dependent relation & function oids for a given SQL text
  */
 Datum
@@ -97,6 +208,7 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 	ErrorContextCallback sqlerrcontext;
 	List	   *invalidItems = NIL;
 	List	   *relationOids = NIL;
+	List       *seqrelationOids = NIL;
 	List	   *deduped_relationOids = NIL;
 	List	   *procOids = NIL;
 
@@ -158,6 +270,16 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 	}
 	PG_END_TRY();
 	is_proc_oids_valid = false;
+
+	/*
+	 * Collect referenced sequences
+	 */
+	foreach(lc, relationOids)
+	{
+		Oid                     relid = lfirst_oid(lc);
+		seqrelationOids = list_concat(seqrelationOids, getRefedSequences(relid));
+	}
+	relationOids = list_concat(relationOids, seqrelationOids);
 
 	/*
 	 * Deduplicate the relation oids

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -7,6 +7,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create materialized view base_mv as select a from base;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create view base_v as select a from base;
+CREATE SEQUENCE minirepro_test_b;
+CREATE TABLE minirepro_test(a serial, b int default nextval('minirepro_test_b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
@@ -15,18 +19,27 @@ declare
   base_oid oid;
   base_mv_oid oid;
   base_v_oid oid;
+  minirepro_test_oid oid;
+  minirepro_test_b_oid oid;
+  minirepro_test_a_seq_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
     base_v_oid = 'base_v'::regclass::oid;
+    minirepro_test_oid = 'minirepro_test'::regclass::oid;
+    minirepro_test_b_oid = 'minirepro_test_b'::regclass::oid;
+    minirepro_test_a_seq_oid = 'minirepro_test_a_seq'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
     t := replace(t, base_v_oid::text, '<base_v>');
+    t := replace(t, minirepro_test_oid::text, '<minirepro_test>');
+    t := replace(t, minirepro_test_b_oid::text, '<minirepro_test_b>');
+    t := replace(t, minirepro_test_a_seq_oid::text, '<minirepro_test_a_seq>');
 
     RETURN t;
 end;
@@ -204,6 +217,15 @@ SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'
  {"relids": "<base_v>,<base_table>", "funcids": ""}
 (1 row)
 
+-- gp_dump_query_oids should output relids of referenced sequences
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM minirepro_test'));
+                                     sanitize_output                                     
+-----------------------------------------------------------------------------------------
+ {"relids": "<minirepro_test>,<minirepro_test_a_seq>,<minirepro_test_b>", "funcids": ""}
+(1 row)
+
+DROP TABLE minirepro_test;
+DROP SEQUENCE minirepro_test_b;
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -3,7 +3,8 @@ drop database if exists gpsd_db_with_hll;
 -- end_ignore
 create database gpsd_db_with_hll;
 \c gpsd_db_with_hll
-create table minirepro_foo(a int, b int[]);
+create sequence minirepro_foo_c_seq cache 1;
+create table minirepro_foo(a int, b int[], c int default nextval('minirepro_foo_c_seq'::regclass), d serial);
 insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
 insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
 insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
@@ -26,6 +27,7 @@ WARNING: This tool collects statistics about your data, including most common va
 Please review output file to ensure it is within corporate policy to transport the output file.
 -- end_ignore
 drop table minirepro_foo;
+drop sequence minirepro_foo_c_seq;
 \! psql -f data/minirepro.sql gpsd_db_with_hll
 You are now connected to database "gpsd_db_with_hll" as user "gpadmin".
 SET
@@ -42,10 +44,18 @@ SET
 SET
 SET
 SET
+CREATE SEQUENCE
 SET
 SET
 CREATE TABLE
+CREATE SEQUENCE
+ALTER SEQUENCE
+ALTER TABLE
 SET
 UPDATE 1
+UPDATE 1
+UPDATE 1
+INSERT 0 1
+INSERT 0 1
 INSERT 0 1
 INSERT 0 1

--- a/src/test/regress/sql/gp_dump_query_oids.sql
+++ b/src/test/regress/sql/gp_dump_query_oids.sql
@@ -4,6 +4,8 @@ CREATE FUNCTION dumptestfunc2(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUA
 create table base(a int);
 create materialized view base_mv as select a from base;
 create view base_v as select a from base;
+CREATE SEQUENCE minirepro_test_b;
+CREATE TABLE minirepro_test(a serial, b int default nextval('minirepro_test_b'));
 
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
@@ -13,18 +15,27 @@ declare
   base_oid oid;
   base_mv_oid oid;
   base_v_oid oid;
+  minirepro_test_oid oid;
+  minirepro_test_b_oid oid;
+  minirepro_test_a_seq_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
     base_v_oid = 'base_v'::regclass::oid;
+    minirepro_test_oid = 'minirepro_test'::regclass::oid;
+    minirepro_test_b_oid = 'minirepro_test_b'::regclass::oid;
+    minirepro_test_a_seq_oid = 'minirepro_test_a_seq'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
     t := replace(t, base_v_oid::text, '<base_v>');
+    t := replace(t, minirepro_test_oid::text, '<minirepro_test>');
+    t := replace(t, minirepro_test_b_oid::text, '<minirepro_test_b>');
+    t := replace(t, minirepro_test_a_seq_oid::text, '<minirepro_test_a_seq>');
 
     RETURN t;
 end;
@@ -99,6 +110,11 @@ SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_v'));
 -- gp_dump_query_oids should output relids of view/materialized view and used/accessed objects when query contains explain analyze command
 SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_mv'));
 SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'));
+-- gp_dump_query_oids should output relids of referenced sequences
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM minirepro_test'));
+
+DROP TABLE minirepro_test;
+DROP SEQUENCE minirepro_test_b;
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -3,7 +3,8 @@ drop database if exists gpsd_db_with_hll;
 -- end_ignore
 create database gpsd_db_with_hll;
 \c gpsd_db_with_hll
-create table minirepro_foo(a int, b int[]);
+create sequence minirepro_foo_c_seq cache 1;
+create table minirepro_foo(a int, b int[], c int default nextval('minirepro_foo_c_seq'::regclass), d serial);
 
 insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
 insert into minirepro_foo values(1, '{10000, 10000, 10000, 10000}');
@@ -16,6 +17,7 @@ analyze minirepro_foo;
 -- end_ignore
 
 drop table minirepro_foo;
+drop sequence minirepro_foo_c_seq;
 
 \! psql -f data/minirepro.sql gpsd_db_with_hll
 


### PR DESCRIPTION
When a table has an explicitly created sequence, the sequence will be ignored by pg_dump if it's not owned by the table.

In pg_dump, implicitly created sequence like SERIAL and GENERATED AS IDENTITY, the referenced sequence will be dumped if the owning table is dumped. But for explicitly created sequence, we should specify sequence's oid if we want to dump the sequence object when the sequence is not owned by table.

Collect oids of sequence which be referenced by table columns in gp_dump_query_oids.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
