### PR TITLE
Attach a resource group even QD is in bypass mode

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1692,6 +1692,10 @@ SwitchResGroupOnSegment(const char *buf, int len)
 
 		Assert(bypassedGroup != NULL);
 
+		/* Add into cgroup */
+		cgroupOpsRoutine->attachcgroup(bypassedGroup->groupId, MyProcPid,
+									   caps.cpuMaxPercent == CPU_MAX_PERCENT_DISABLED);
+
 		return;
 	}
 

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -520,6 +520,45 @@ SELECT groupname,cpu_max_percent,cpuset FROM gp_toolkit.gp_resgroup_config WHERE
 DROP RESOURCE GROUP rg_test_group;
 DROP RESOURCE GROUP
 
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, concurrency=5);
+CREATE RESOURCE GROUP
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+CREATE ROLE
+SET ROLE rg_test_role;
+SET
+CREATE TABLE rg_test_group_table(a int);
+CREATE TABLE
+SELECT count(*) FROM rg_test_group_table;
+ count 
+-------
+ 0     
+(1 row)
+SELECT is_session_in_group(pg_backend_pid(), 'rg_test_group');
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+RESET ROLE;
+RESET
+SELECT count(*) FROM rg_test_group_table;
+ count 
+-------
+ 0     
+(1 row)
+SELECT is_session_in_group(pg_backend_pid(), 'admin_group');
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+DROP TABLE rg_test_group_table;
+DROP TABLE
+DROP ROLE rg_test_role;
+DROP ROLE
+DROP RESOURCE GROUP rg_test_group;
+DROP RESOURCE GROUP
+
+
+
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -557,8 +557,6 @@ DROP ROLE
 DROP RESOURCE GROUP rg_test_group;
 DROP RESOURCE GROUP
 
-
-
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -275,8 +275,6 @@ DROP TABLE rg_test_group_table;
 DROP ROLE rg_test_role;
 DROP RESOURCE GROUP rg_test_group;
 
-
-
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -262,6 +262,21 @@ ALTER RESOURCE GROUP rg_test_group SET cpu_max_percent 10;
 SELECT groupname,cpu_max_percent,cpuset FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
 
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, concurrency=5);
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+SET ROLE rg_test_role;
+CREATE TABLE rg_test_group_table(a int);
+SELECT count(*) FROM rg_test_group_table;
+SELECT is_session_in_group(pg_backend_pid(), 'rg_test_group');
+RESET ROLE;
+SELECT count(*) FROM rg_test_group_table;
+SELECT is_session_in_group(pg_backend_pid(), 'admin_group');
+DROP TABLE rg_test_group_table;
+DROP ROLE rg_test_role;
+DROP RESOURCE GROUP rg_test_group;
+
+
+
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;


### PR DESCRIPTION
Currently, QD will not attach a resource group if QD is in bypass mode when it's already 
running in bypass mode, things will go wrong if we change role, just like:

```
CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10, concurrency=5);
CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;

SET ROLE rg_test_role;
CREATE TABLE rg_test_group_table(a int);

-- Since rg_test_group_table is empty, the total cost of this SQL will be less than min_cost,
-- so it'll run in bypass mode
SELECT count(*) FROM rg_test_group_table;
SELECT is_session_in_group(pg_backend_pid(), 'rg_test_group');
RESET ROLE;

-- Still running in bypass mode, but the role is not rg_test_role
SELECT count(*) FROM rg_test_group_table;
SELECT is_session_in_group(pg_backend_pid(), 'admin_group');
DROP TABLE rg_test_group_table;
```