### PR TITLE
Revert "Only super user can set the GUC gp_resource_group_bypass."

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2766,7 +2766,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_resource_group_bypass", PGC_SUSET, RESOURCES,
+		{"gp_resource_group_bypass", PGC_USERSET, RESOURCES,
 			gettext_noop("If the value is true, the query in this session will not be limited by resource group."),
 			NULL
 		},

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass.out
@@ -19,12 +19,6 @@ SET ROLE role_bypass;
 SET
 CREATE TABLE t_bypass(a int) distributed by (a);
 CREATE TABLE
-
--- gp_resource_group_bypass can only be set by super user
--- below set statement will error out
-set gp_resource_group_bypass = 1;
-ERROR:  permission denied to set parameter "gp_resource_group_bypass"
-
 RESET ROLE;
 RESET
 

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
@@ -12,11 +12,6 @@ CREATE ROLE role_bypass RESOURCE GROUP rg_bypass;
 
 SET ROLE role_bypass;
 CREATE TABLE t_bypass(a int) distributed by (a);
-
--- gp_resource_group_bypass can only be set by super user
--- below set statement will error out
-set gp_resource_group_bypass = 1;
-
 RESET ROLE;
 
 -- Session1: pure-catalog query will be unassigned and bypassed.


### PR DESCRIPTION
This reverts commit 85d943910c74b48e606515fc18a7d4a99e197dbc.

Bypass resgroup still will put proc into cgroup and use a small value of query memory so it will not impact system too much. Revert previous commit let other application like GPCC can work easily.