### PR TITLE
Correct the child order when creating grouping sets for the rollup

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -4738,33 +4738,33 @@ select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls la
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Sort
-   Output: (NULL::integer), (sum(share0_ref2.c1))
-   Sort Key: (NULL::integer)
+   Output: share0_ref2.c2, (sum(share0_ref2.c1))
+   Sort Key: share0_ref2.c2
    ->  Sequence
-         Output: (NULL::integer), (sum(share0_ref2.c1))
+         Output: share0_ref2.c2, (sum(share0_ref2.c1))
          ->  Shared Scan (share slice:id 0:0)
                Output: share0_ref1.c2, share0_ref1.c1
                ->  Foreign Scan on public.ft1
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Finalize Aggregate
-                     Output: NULL::integer, sum(share0_ref2.c1)
-                     ->  Partial Aggregate
-                           Output: PARTIAL sum(share0_ref2.c1)
-                           ->  Shared Scan (share slice:id 0:0)
-                                 Output: share0_ref2.c2, share0_ref2.c1
                ->  Finalize GroupAggregate
-                     Output: share0_ref3.c2, sum(share0_ref3.c1)
-                     Group Key: share0_ref3.c2
+                     Output: share0_ref2.c2, sum(share0_ref2.c1)
+                     Group Key: share0_ref2.c2
                      ->  Sort
-                           Output: (PARTIAL sum(share0_ref3.c1)), share0_ref3.c2
-                           Sort Key: share0_ref3.c2
+                           Output: (PARTIAL sum(share0_ref2.c1)), share0_ref2.c2
+                           Sort Key: share0_ref2.c2
                            ->  Streaming Partial HashAggregate
-                                 Output: PARTIAL sum(share0_ref3.c1), share0_ref3.c2
-                                 Group Key: share0_ref3.c2
+                                 Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c2
+                                 Group Key: share0_ref2.c2
                                  ->  Shared Scan (share slice:id 0:0)
-                                       Output: share0_ref3.c2, share0_ref3.c1
+                                       Output: share0_ref2.c2, share0_ref2.c1
+               ->  Finalize Aggregate
+                     Output: NULL::integer, sum(share0_ref3.c1)
+                     ->  Partial Aggregate
+                           Output: PARTIAL sum(share0_ref3.c1)
+                           ->  Shared Scan (share slice:id 0:0)
+                                 Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
 (29 rows)
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1130,7 +1130,9 @@ CTranslatorUtils::CreateGroupingSetsForRollup(CMemoryPool *mp,
 	CBitSetArray *col_attnos_arr = GPOS_NEW(mp) CBitSetArray(mp);
 	ListCell *lc = nullptr;
 	CBitSet *current_result = GPOS_NEW(mp) CBitSet(mp);
-	// add an empty set for grand total
+	// Maintaining the order of grouping sets is essential because the
+	// UnionAll operator matches each child's distribution with the
+	// distribution of the first child
 	col_attnos_arr->Append(GPOS_NEW(mp) CBitSet(mp));
 	ForEach(lc, grouping_set->content)
 	{

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1130,6 +1130,8 @@ CTranslatorUtils::CreateGroupingSetsForRollup(CMemoryPool *mp,
 	CBitSetArray *col_attnos_arr = GPOS_NEW(mp) CBitSetArray(mp);
 	ListCell *lc = nullptr;
 	CBitSet *current_result = GPOS_NEW(mp) CBitSet(mp);
+	// add an empty set for grand total
+	col_attnos_arr->Append(GPOS_NEW(mp) CBitSet(mp));
 	ForEach(lc, grouping_set->content)
 	{
 		GroupingSet *gs_current = (GroupingSet *) lfirst(lc);
@@ -1142,8 +1144,6 @@ CTranslatorUtils::CreateGroupingSetsForRollup(CMemoryPool *mp,
 		bset->Release();
 		col_attnos_arr->Append(GPOS_NEW(mp) CBitSet(mp, *current_result));
 	}
-	// add an empty set
-	col_attnos_arr->Append(GPOS_NEW(mp) CBitSet(mp));
 	current_result->Release();
 	return col_attnos_arr;
 }

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -456,20 +456,20 @@ where g in (
 --
 -- Test to check the query plan for a ROLLUP query.
 --
-explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1581.63..1786.31 rows=12281 width=20)
-   ->  Finalize HashAggregate  (cost=1581.63..1622.57 rows=4094 width=20)
+explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
          Group Key: cn, vn, pn, (GROUPINGSET_ID())
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1430.56 rows=12085 width=20)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: cn, vn, pn, (GROUPINGSET_ID())
-               ->  Partial MixedAggregate  (cost=0.00..1188.85 rows=12085 width=20)
+               ->  Partial MixedAggregate
                      Hash Key: cn, vn, pn
                      Hash Key: cn, vn
                      Hash Key: cn
                      Group Key: ()
-                     ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=24)
+                     ->  Seq Scan on sale
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -507,29 +507,29 @@ select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
 --
 -- This caused a crash in ROLLUP planning at one point.
 --
-EXPLAIN
+EXPLAIN (costs off)
 SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2597.19..2879.21 rows=16921 width=16)
-   ->  HashAggregate  (cost=2597.19..2653.59 rows=5640 width=16)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
          Group Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1008.17..2389.35 rows=16628 width=16)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
-               ->  Partial MixedAggregate  (cost=1008.17..2056.79 rows=16628 width=16)
+               ->  Partial MixedAggregate
                      Hash Key: sale.dt, sale.cn, sale.pn, sale.vn
                      Hash Key: sale.dt, sale.cn, sale.pn
                      Hash Key: sale.dt, sale.cn
                      Group Key: ()
-                     ->  Hash Join  (cost=1008.17..1467.52 rows=18800 width=16)
+                     ->  Hash Join
                            Hash Cond: (sale.vn = vendor.vn)
-                           ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=16)
-                           ->  Hash  (cost=590.67..590.67 rows=33400 width=4)
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..590.67 rows=33400 width=4)
-                                       ->  Seq Scan on vendor  (cost=0.00..145.33 rows=11133 width=4)
+                           ->  Seq Scan on sale
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                       ->  Seq Scan on vendor
  Optimizer: Postgres query optimizer
 (17 rows)
 
@@ -575,33 +575,33 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
    
 (34 rows)
 
-EXPLAIN
+EXPLAIN (costs off)
 SELECT DISTINCT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2780.50..3062.52 rows=16921 width=16)
-   ->  HashAggregate  (cost=2780.50..2836.90 rows=5640 width=16)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
          Group Key: sale.vn
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2597.19..2766.40 rows=5640 width=16)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: sale.vn
-               ->  HashAggregate  (cost=2597.19..2653.59 rows=5640 width=16)
+               ->  HashAggregate
                      Group Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1008.17..2389.35 rows=16628 width=16)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
-                           ->  Partial MixedAggregate  (cost=1008.17..2056.79 rows=16628 width=16)
+                           ->  Partial MixedAggregate
                                  Hash Key: sale.dt, sale.cn, sale.pn, sale.vn
                                  Hash Key: sale.dt, sale.cn, sale.pn
                                  Hash Key: sale.dt, sale.cn
                                  Group Key: ()
-                                 ->  Hash Join  (cost=1008.17..1467.52 rows=18800 width=16)
+                                 ->  Hash Join
                                        Hash Cond: (sale.vn = vendor.vn)
-                                       ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=16)
-                                       ->  Hash  (cost=590.67..590.67 rows=33400 width=4)
-                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..590.67 rows=33400 width=4)
-                                                   ->  Seq Scan on vendor  (cost=0.00..145.33 rows=11133 width=4)
+                                       ->  Seq Scan on sale
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                   ->  Seq Scan on vendor
  Optimizer: Postgres query optimizer
 (21 rows)
 

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -454,8 +454,85 @@ where g in (
 (1 row)
 
 --
+-- Test to check the query plan for a ROLLUP query.
+--
+explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1581.63..1786.31 rows=12281 width=20)
+   ->  Finalize HashAggregate  (cost=1581.63..1622.57 rows=4094 width=20)
+         Group Key: cn, vn, pn, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1430.56 rows=12085 width=20)
+               Hash Key: cn, vn, pn, (GROUPINGSET_ID())
+               ->  Partial MixedAggregate  (cost=0.00..1188.85 rows=12085 width=20)
+                     Hash Key: cn, vn, pn
+                     Hash Key: cn, vn
+                     Hash Key: cn
+                     Group Key: ()
+                     ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=24)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+ cn | vn | pn  |   sum   
+----+----+-----+---------
+  1 | 50 | 400 |       0
+  1 | 10 |     |       0
+  2 | 40 |     | 2640000
+  2 | 40 | 100 | 2640000
+  3 | 40 | 200 |       0
+  1 | 30 | 500 |      60
+  3 | 40 |     |       0
+  4 | 40 | 800 |       1
+  4 |    |     |       2
+  1 | 50 |     |       0
+  1 | 20 | 100 |       0
+  3 | 30 | 500 |      60
+  3 | 30 | 600 |      60
+  2 | 50 | 400 |       0
+  2 | 50 |     |       0
+  3 |    |     |     120
+  1 | 30 |     |      60
+  1 | 20 |     |       0
+  2 |    |     | 2640000
+  3 | 30 |     |     120
+  4 | 40 |     |       2
+  4 | 40 | 700 |       1
+  1 | 30 | 300 |       0
+  1 | 10 | 200 |       0
+  1 |    |     |      60
+    |    |     | 2640182
+(26 rows)
+
+--
 -- This caused a crash in ROLLUP planning at one point.
 --
+EXPLAIN
+SELECT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2597.19..2879.21 rows=16921 width=16)
+   ->  HashAggregate  (cost=2597.19..2653.59 rows=5640 width=16)
+         Group Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1008.17..2389.35 rows=16628 width=16)
+               Hash Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
+               ->  Partial MixedAggregate  (cost=1008.17..2056.79 rows=16628 width=16)
+                     Hash Key: sale.dt, sale.cn, sale.pn, sale.vn
+                     Hash Key: sale.dt, sale.cn, sale.pn
+                     Hash Key: sale.dt, sale.cn
+                     Group Key: ()
+                     ->  Hash Join  (cost=1008.17..1467.52 rows=18800 width=16)
+                           Hash Cond: (sale.vn = vendor.vn)
+                           ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=16)
+                           ->  Hash  (cost=590.67..590.67 rows=33400 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..590.67 rows=33400 width=4)
+                                       ->  Seq Scan on vendor  (cost=0.00..145.33 rows=11133 width=4)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
 SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
@@ -497,6 +574,36 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
  40
    
 (34 rows)
+
+EXPLAIN
+SELECT DISTINCT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2780.50..3062.52 rows=16921 width=16)
+   ->  HashAggregate  (cost=2780.50..2836.90 rows=5640 width=16)
+         Group Key: sale.vn
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2597.19..2766.40 rows=5640 width=16)
+               Hash Key: sale.vn
+               ->  HashAggregate  (cost=2597.19..2653.59 rows=5640 width=16)
+                     Group Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1008.17..2389.35 rows=16628 width=16)
+                           Hash Key: sale.dt, sale.cn, sale.pn, sale.vn, (GROUPINGSET_ID())
+                           ->  Partial MixedAggregate  (cost=1008.17..2056.79 rows=16628 width=16)
+                                 Hash Key: sale.dt, sale.cn, sale.pn, sale.vn
+                                 Hash Key: sale.dt, sale.cn, sale.pn
+                                 Hash Key: sale.dt, sale.cn
+                                 Group Key: ()
+                                 ->  Hash Join  (cost=1008.17..1467.52 rows=18800 width=16)
+                                       Hash Cond: (sale.vn = vendor.vn)
+                                       ->  Seq Scan on sale  (cost=0.00..222.00 rows=18800 width=16)
+                                       ->  Hash  (cost=590.67..590.67 rows=33400 width=4)
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..590.67 rows=33400 width=4)
+                                                   ->  Seq Scan on vendor  (cost=0.00..145.33 rows=11133 width=4)
+ Optimizer: Postgres query optimizer
+(21 rows)
 
 SELECT DISTINCT sale.vn
 FROM sale,vendor

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -456,47 +456,47 @@ where g in (
 --
 -- Test to check the query plan for a ROLLUP query.
 --
-explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2155.00 rows=1 width=20)
-   ->  Sequence  (cost=0.00..2155.00 rows=1 width=20)
-         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=1)
-               ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=24)
-         ->  Append  (cost=0.00..1724.00 rows=1 width=20)
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
+explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on sale
+         ->  Append
+               ->  GroupAggregate
                      Group Key: share0_ref2.cn, share0_ref2.vn, share0_ref2.pn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=24)
+                     ->  Sort
                            Sort Key: share0_ref2.cn, share0_ref2.vn, share0_ref2.pn
-                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=24)
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Finalize GroupAggregate
                      Group Key: share0_ref3.cn, share0_ref3.vn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Sort
                            Sort Key: share0_ref3.cn, share0_ref3.vn
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: share0_ref3.cn, share0_ref3.vn
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Partial GroupAggregate
                                        Group Key: share0_ref3.cn, share0_ref3.vn
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=20)
+                                       ->  Sort
                                              Sort Key: share0_ref3.cn, share0_ref3.vn
-                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=20)
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Shared Scan (share slice:id 2:0)
+               ->  Finalize GroupAggregate
                      Group Key: share0_ref4.cn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort
                            Sort Key: share0_ref4.cn
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: share0_ref4.cn
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Partial GroupAggregate
                                        Group Key: share0_ref4.cn
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Sort
                                              Sort Key: share0_ref4.cn
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=16)
-               ->  Result  (cost=0.00..431.00 rows=1 width=20)
-                     ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Shared Scan (share slice:id 3:0)
+               ->  Result
+                     ->  Redistribute Motion 1:3  (slice4)
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Shared Scan (share slice:id 5:0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (39 rows)
 
@@ -534,57 +534,57 @@ select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
 --
 -- This caused a crash in ROLLUP planning at one point.
 --
-EXPLAIN
+EXPLAIN (costs off)
 SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
-   ->  Sequence  (cost=0.00..2161.00 rows=1 width=4)
-         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..437.00 rows=1 width=1)
-               ->  Nested Loop  (cost=0.00..437.00 rows=1 width=16)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Nested Loop
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: sale.vn
-                           ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Index Scan using vendor_pkey on vendor  (cost=0.00..6.00 rows=1 width=1)
+                           ->  Seq Scan on sale
+                     ->  Index Scan using vendor_pkey on vendor
                            Index Cond: (vn = sale.vn)
-         ->  Append  (cost=0.00..1724.00 rows=1 width=4)
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+         ->  Append
+               ->  GroupAggregate
                      Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Sort
                            Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=16)
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  GroupAggregate
                      Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort
                            Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  GroupAggregate
                                        Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                       ->  Sort
                                              Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=12)
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Shared Scan (share slice:id 3:0)
+               ->  GroupAggregate
                      Group Key: share0_ref4.dt, share0_ref4.cn
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Sort
                            Sort Key: share0_ref4.dt, share0_ref4.cn
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                  Hash Key: share0_ref4.dt, share0_ref4.cn
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  GroupAggregate
                                        Group Key: share0_ref4.dt, share0_ref4.cn
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Sort
                                              Sort Key: share0_ref4.dt, share0_ref4.cn
-                                             ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=1 width=8)
-               ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
-                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Shared Scan (share slice:id 4:0)
+               ->  Result
+                     ->  Redistribute Motion 1:3  (slice5)
+                           ->  Aggregate
+                                 ->  Gather Motion 3:1  (slice6; segments: 3)
+                                       ->  Aggregate
+                                             ->  Shared Scan (share slice:id 6:0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (45 rows)
 
@@ -630,67 +630,67 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
    
 (34 rows)
 
-EXPLAIN
+EXPLAIN (costs off)
 SELECT DISTINCT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
-   ->  GroupAggregate  (cost=0.00..2161.00 rows=1 width=4)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
          Group Key: share0_ref2.vn
-         ->  Sort  (cost=0.00..2161.00 rows=1 width=4)
+         ->  Sort
                Sort Key: share0_ref2.vn
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: share0_ref2.vn
-                     ->  GroupAggregate  (cost=0.00..2161.00 rows=1 width=4)
+                     ->  GroupAggregate
                            Group Key: share0_ref2.vn
-                           ->  Sort  (cost=0.00..2161.00 rows=1 width=4)
+                           ->  Sort
                                  Sort Key: share0_ref2.vn
-                                 ->  Sequence  (cost=0.00..2161.00 rows=1 width=4)
-                                       ->  Shared Scan (share slice:id 2:0)  (cost=0.00..437.00 rows=1 width=1)
-                                             ->  Nested Loop  (cost=0.00..437.00 rows=1 width=16)
+                                 ->  Sequence
+                                       ->  Shared Scan (share slice:id 2:0)
+                                             ->  Nested Loop
                                                    Join Filter: true
-                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                          Hash Key: sale.vn
-                                                         ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=16)
-                                                   ->  Index Scan using vendor_pkey on vendor  (cost=0.00..6.00 rows=1 width=1)
+                                                         ->  Seq Scan on sale
+                                                   ->  Index Scan using vendor_pkey on vendor
                                                          Index Cond: (vn = sale.vn)
-                                       ->  Append  (cost=0.00..1724.00 rows=1 width=4)
-                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Append
+                                             ->  GroupAggregate
                                                    Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                                   ->  Sort
                                                          Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
-                                                         ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=16)
-                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                         ->  Shared Scan (share slice:id 2:0)
+                                             ->  GroupAggregate
                                                    Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                   ->  Sort
                                                          Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                                                Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                                               ->  GroupAggregate
                                                                      Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                                     ->  Sort
                                                                            Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
-                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                                           ->  Shared Scan (share slice:id 4:0)
+                                             ->  GroupAggregate
                                                    Group Key: share0_ref4.dt, share0_ref4.cn
-                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Sort
                                                          Sort Key: share0_ref4.dt, share0_ref4.cn
-                                                         ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Redistribute Motion 3:3  (slice5; segments: 3)
                                                                Hash Key: share0_ref4.dt, share0_ref4.cn
-                                                               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  GroupAggregate
                                                                      Group Key: share0_ref4.dt, share0_ref4.cn
-                                                                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Sort
                                                                            Sort Key: share0_ref4.dt, share0_ref4.cn
-                                                                           ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Redistribute Motion 1:3  (slice6)  (cost=0.00..431.00 rows=1 width=1)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
-                                                               ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
-                                                                           ->  Shared Scan (share slice:id 7:0)  (cost=0.00..431.00 rows=1 width=1)
+                                                                           ->  Shared Scan (share slice:id 5:0)
+                                             ->  Result
+                                                   ->  Redistribute Motion 1:3  (slice6)
+                                                         ->  Aggregate
+                                                               ->  Gather Motion 3:1  (slice7; segments: 3)
+                                                                     ->  Aggregate
+                                                                           ->  Shared Scan (share slice:id 7:0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (55 rows)
 

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -454,8 +454,140 @@ where g in (
 (1 row)
 
 --
+-- Test to check the query plan for a ROLLUP query.
+--
+explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2155.00 rows=1 width=20)
+   ->  Sequence  (cost=0.00..2155.00 rows=1 width=20)
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=24)
+         ->  Append  (cost=0.00..1724.00 rows=1 width=20)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
+                     Group Key: share0_ref2.cn, share0_ref2.vn, share0_ref2.pn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=24)
+                           Sort Key: share0_ref2.cn, share0_ref2.vn, share0_ref2.pn
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=24)
+               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                     Group Key: share0_ref3.cn, share0_ref3.vn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                           Sort Key: share0_ref3.cn, share0_ref3.vn
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                 Hash Key: share0_ref3.cn, share0_ref3.vn
+                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                       Group Key: share0_ref3.cn, share0_ref3.vn
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=20)
+                                             Sort Key: share0_ref3.cn, share0_ref3.vn
+                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=20)
+               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     Group Key: share0_ref4.cn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                           Sort Key: share0_ref4.cn
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 Hash Key: share0_ref4.cn
+                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                       Group Key: share0_ref4.cn
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                             Sort Key: share0_ref4.cn
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=16)
+               ->  Result  (cost=0.00..431.00 rows=1 width=20)
+                     ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(39 rows)
+
+select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+ cn | vn | pn  |   sum   
+----+----+-----+---------
+  1 | 10 | 200 |       0
+  3 | 30 | 500 |      60
+  2 | 40 |     | 2640000
+  3 | 40 |     |       0
+  2 | 50 | 400 |       0
+  3 | 30 | 600 |      60
+  4 | 40 | 800 |       1
+  3 | 30 |     |     120
+  4 | 40 |     |       2
+  2 |    |     | 2640000
+  3 |    |     |     120
+  4 |    |     |       2
+  1 | 20 | 100 |       0
+  1 | 30 | 300 |       0
+  1 | 30 | 500 |      60
+  1 | 50 | 400 |       0
+  2 | 40 | 100 | 2640000
+  3 | 40 | 200 |       0
+  4 | 40 | 700 |       1
+  1 | 10 |     |       0
+  1 | 20 |     |       0
+  1 | 30 |     |      60
+  1 | 50 |     |       0
+  2 | 50 |     |       0
+  1 |    |     |      60
+    |    |     | 2640182
+(26 rows)
+
+--
 -- This caused a crash in ROLLUP planning at one point.
 --
+EXPLAIN
+SELECT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..2161.00 rows=1 width=4)
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..437.00 rows=1 width=1)
+               ->  Nested Loop  (cost=0.00..437.00 rows=1 width=16)
+                     Join Filter: true
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                           Hash Key: sale.vn
+                           ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Index Scan using vendor_pkey on vendor  (cost=0.00..6.00 rows=1 width=1)
+                           Index Cond: (vn = sale.vn)
+         ->  Append  (cost=0.00..1724.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                     Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                           Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=16)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                     Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                           Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                       Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                             Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                     Group Key: share0_ref4.dt, share0_ref4.cn
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: share0_ref4.dt, share0_ref4.cn
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: share0_ref4.dt, share0_ref4.cn
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       Group Key: share0_ref4.dt, share0_ref4.cn
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                             Sort Key: share0_ref4.dt, share0_ref4.cn
+                                             ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(45 rows)
+
 SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
@@ -497,6 +629,70 @@ GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
  40
    
 (34 rows)
+
+EXPLAIN
+SELECT DISTINCT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
+   ->  GroupAggregate  (cost=0.00..2161.00 rows=1 width=4)
+         Group Key: share0_ref2.vn
+         ->  Sort  (cost=0.00..2161.00 rows=1 width=4)
+               Sort Key: share0_ref2.vn
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2161.00 rows=1 width=4)
+                     Hash Key: share0_ref2.vn
+                     ->  GroupAggregate  (cost=0.00..2161.00 rows=1 width=4)
+                           Group Key: share0_ref2.vn
+                           ->  Sort  (cost=0.00..2161.00 rows=1 width=4)
+                                 Sort Key: share0_ref2.vn
+                                 ->  Sequence  (cost=0.00..2161.00 rows=1 width=4)
+                                       ->  Shared Scan (share slice:id 2:0)  (cost=0.00..437.00 rows=1 width=1)
+                                             ->  Nested Loop  (cost=0.00..437.00 rows=1 width=16)
+                                                   Join Filter: true
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                                         Hash Key: sale.vn
+                                                         ->  Seq Scan on sale  (cost=0.00..431.00 rows=1 width=16)
+                                                   ->  Index Scan using vendor_pkey on vendor  (cost=0.00..6.00 rows=1 width=1)
+                                                         Index Cond: (vn = sale.vn)
+                                       ->  Append  (cost=0.00..1724.00 rows=1 width=4)
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                                   Group Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                                         Sort Key: share0_ref2.dt, share0_ref2.cn, share0_ref2.pn, share0_ref2.vn
+                                                         ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=1 width=16)
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                   Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                         Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                                               Hash Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                                                     Group Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                                           Sort Key: share0_ref3.dt, share0_ref3.cn, share0_ref3.pn
+                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                   Group Key: share0_ref4.dt, share0_ref4.cn
+                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                                         Sort Key: share0_ref4.dt, share0_ref4.cn
+                                                         ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               Hash Key: share0_ref4.dt, share0_ref4.cn
+                                                               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     Group Key: share0_ref4.dt, share0_ref4.cn
+                                                                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                                                           Sort Key: share0_ref4.dt, share0_ref4.cn
+                                                                           ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                   ->  Redistribute Motion 1:3  (slice6)  (cost=0.00..431.00 rows=1 width=1)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                               ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=1)
+                                                                           ->  Shared Scan (share slice:id 7:0)  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(55 rows)
 
 SELECT DISTINCT sale.vn
 FROM sale,vendor

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -972,28 +972,28 @@ explain (costs off)
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: (NULL::integer)
+   Merge Key: share0_ref2.a
    ->  Sort
-         Sort Key: (NULL::integer)
+         Sort Key: share0_ref2.a
          ->  Sequence
                ->  Shared Scan (share slice:id 1:0)
                      ->  Seq Scan on gstest2
-               ->  Redistribute Motion 1:3  (slice2)
-                     ->  Append
+               ->  Append
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Result
+                                       Filter: (share0_ref2.a IS DISTINCT FROM 1)
+                                       ->  Shared Scan (share slice:id 1:0)
+                     ->  Result
+                           Filter: ((NULL::integer) IS DISTINCT FROM 1)
                            ->  Result
-                                 Filter: ((NULL::integer) IS DISTINCT FROM 1)
-                                 ->  Finalize Aggregate
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)
-                                             ->  Partial Aggregate
-                                                   ->  Shared Scan (share slice:id 3:0)
-                           ->  Gather Motion 3:1  (slice4; segments: 3)
-                                 ->  GroupAggregate
-                                       Group Key: share0_ref3.a
-                                       ->  Sort
-                                             Sort Key: share0_ref3.a
-                                             ->  Result
-                                                   Filter: (share0_ref3.a IS DISTINCT FROM 1)
-                                                   ->  Shared Scan (share slice:id 4:0)
+                                 ->  Redistribute Motion 1:3  (slice2)
+                                       ->  Finalize Aggregate
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                   ->  Partial Aggregate
+                                                         ->  Shared Scan (share slice:id 3:0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -333,11 +333,28 @@ where g in (
   select rank() over (order by x) from generate_series(1,5) x
 );
 
+--
+-- Test to check the query plan for a ROLLUP query.
+--
+explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
 
 --
 -- This caused a crash in ROLLUP planning at one point.
 --
+EXPLAIN
 SELECT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+
+SELECT sale.vn
+FROM sale,vendor
+WHERE sale.vn=vendor.vn
+GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+
+EXPLAIN
+SELECT DISTINCT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -336,13 +336,13 @@ where g in (
 --
 -- Test to check the query plan for a ROLLUP query.
 --
-explain select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
+explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
 select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn,vn,pn);
 
 --
 -- This caused a crash in ROLLUP planning at one point.
 --
-EXPLAIN
+EXPLAIN (costs off)
 SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
@@ -353,7 +353,7 @@ FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
 
-EXPLAIN
+EXPLAIN (costs off)
 SELECT DISTINCT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn


### PR DESCRIPTION
Issue:
      Performance drop observed with TPCDS-DS query-167
RCA:
      When a query involves a ROLLUP, we observed that the order of
children under the append operator has changed. The first child of the append operator has a distribution of "SINGLETON," which results in all inner children inheriting the same distribution. As a consequence, Gather Motion operations are performed for all the aggregators under the Append operator, leading to increased execution time for the append operator in TPC-DS query 167.

FIX:
      The PR addresses the issue by fixing the order of children while
creating grouping sets for the rollup during the query to DXL translation.

Setup:
create table foo (a int, b int, c int);
insert into foo select i, i, i from generate_series(1, 10)i; analyze foo;
select a, b, sum(c) from foo group by rollup(a, b);

Before Fix:
```
                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=21 width=16)
   ->  Sequence  (cost=0.00..1724.00 rows=7 width=16)
         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=1)
               ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=12)
         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1293.00 rows=7 width=16)
               ->  Append  (cost=0.00..1293.00 rows=21 width=16)
                     ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                 ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=4)
                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=10 width=16)
                           ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=16)
                                 Group Key: share0_ref3.a, share0_ref3.b
                                 ->  Sort  (cost=0.00..431.00 rows=4 width=12)
                                       Sort Key: share0_ref3.a, share0_ref3.b
                                       ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=12)
                     ->  Result  (cost=0.00..431.00 rows=10 width=16)
                           ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..431.00 rows=10 width=12)
                                 ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=12)
                                       Group Key: share0_ref4.a
                                       ->  Sort  (cost=0.00..431.00 rows=4 width=8)
                                             Sort Key: share0_ref4.a
                                             ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
```

After Fix:
 ```
                                                    QUERY PLAN
---------------------------------------------------------------------------------------------------------------------- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=21 width=16)
  ->  Sequence  (cost=0.00..1724.00 rows=7 width=16)
        ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=1)
              ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=12)
        ->  Append  (cost=0.00..1293.00 rows=7 width=16)
              ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=16)
                    Group Key: share0_ref2.a, share0_ref2.b
                    ->  Sort  (cost=0.00..431.00 rows=4 width=12)
                          Sort Key: share0_ref2.a, share0_ref2.b
                          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=12)
              ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=12)
                    Group Key: share0_ref3.a
                    ->  Sort  (cost=0.00..431.00 rows=4 width=8)
                          Sort Key: share0_ref3.a
                          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=8)
              ->  Result  (cost=0.00..431.00 rows=1 width=16)
                    ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
                          ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                      ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                            ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=4)
Optimizer: Pivotal Optimizer (GPORCA)
```
