### PR TITLE
Remove a FIXME in cdbaocsam.h

### DIFF
--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -315,17 +315,6 @@ typedef struct IndexFetchAOCOData
 	bool                *proj;
 } IndexFetchAOCOData;
 
-/*
- * GPDB_12_MERGE_FIXME:
- * Descriptor for fetches from table via bitmap. In upstream the code goes
- * through table_beginscan() and it should be the same struct in all cases.
- * However in GPDB extra info is needed which should not be initialized or
- * computed for all scan calls. A new method has been added (with a MERGE_FIXME)
- * which is only used for bitmap scans. Take advantage of it and create a new
- * struct to contain only the information needed. 
- */
-
-
 typedef struct AOCSHeaderScanDescData
 {
 	Oid   relid;  /* relid of the relation */


### PR DESCRIPTION
The FIXME reads quite confusing at first: it is placed between two things that are unrelated to bitmap. It is not clear what exactly is the "new method" that is supposed to have another MERGE_FIXME, and what exactly should we store in the "new struct".

When looking at the original commit that introduced it: fb7f49c1a20b61f079614dd44aad1153ff723e72, it becomes somewhat clearer that the original purpose of this FIXME might have been actually addressed by the same commit. The "new method" it talks about is the scan_begin_extractcolumns_bm() handler, which had a MERGE_FIXME at that time: https://github.com/greenplum-db/gpdb/commit/fb7f49c1a20b61f079614dd44aad1153ff723e72#diff-bfe700fba9b92e12fb7e0d77101d4bef63591973e55662f6fffdf66e2333d919R216-R219. And the "new struct" is the AOCSBitmapScanData which the commit took out from AOCSScanDescData for bitmap-related things. Therefore, this FIXME message seems to be left there by mistake. Remove it now.

Thanks to @soumyadeep2007 for discussion and help with the archaeology.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
