### PR TITLE
fix gp_role for CI flaky test 003_recovery_targets

### DIFF
--- a/src/test/recovery/t/003_recovery_targets.pl
+++ b/src/test/recovery/t/003_recovery_targets.pl
@@ -144,7 +144,7 @@ recovery_target_time = '$recovery_time'");
 my $res = run_log(
 	[
 		'pg_ctl',               '-D', $node_standby->data_dir, '-l',
-		$node_standby->logfile, 'start'
+		$node_standby->logfile,  '-o', "-c gp_role=utility", 'start'
 	]);
 ok(!$res, 'invalid recovery startup fails');
 


### PR DESCRIPTION
changes introduced in 1d2b2288d9b made the test flaky as it doesn't explicitly mention the gp_role in the command.
Adding gp_role to the pg_ctl command fixes this issue
