### PR TITLE
Fix autovacuum-analyze flake

### DIFF
--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -6,6 +6,9 @@
 ALTER SYSTEM SET autovacuum_naptime = 5;
 ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 select * from pg_reload_conf();
+-- start_ignore
+create extension if not exists gp_inject_fault;
+-- end_ignore
 
 --
 -- Test1, sanity test to make sure auto-analyze works
@@ -101,9 +104,9 @@ select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
 -- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
 -- Track that we have updated the attributes stats in pg_statistic when finished
-SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart', 1, -1, 0, 1);
 -- Suspend the autovacuum worker from analyze before
-SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart', 1, -1, 0, 1);
 
 -- Insert data into final partition to trigger stats collection for root partition
 1&: insert into rankpart select i, (i%2)+8, i from generate_series(1,8000)i;

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -263,13 +263,13 @@ SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpar
  Success:        
 (1 row)
 -- Track that we have updated the attributes stats in pg_statistic when finished
-SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 -- Suspend the autovacuum worker from analyze before
-SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart_1_prt_6', 1, -1, 0, 1);
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'rankpart', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
@@ -303,7 +303,7 @@ select datname, query from pg_stat_activity where query like '%ANALYZE%' and dat
  datname        | query                                                                                                    
 ----------------+----------------------------------------------------------------------------------------------------------
  isolation2test | select datname, query from pg_stat_activity where query like '%ANALYZE%' and datname=current_database(); 
- isolation2test | autovacuum: ANALYZE public.rankpart_1_prt_6                                                              
+ isolation2test | autovacuum: ANALYZE public.rankpart                                                                      
 (2 rows)
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
  gp_inject_fault 


### PR DESCRIPTION
Previously, we were checking that the leaf partition was analyzed and immediately querying if the root stats had been populated. While the root stats are merged right after, there is a short time window and if the stats are queried in this window, the root stats would not yet be populated. Instead, wait for the analyze (merge) of the root partition to be completed.