### PR TITLE
Load pageinspect implicitly for regress/isolation2

### DIFF
--- a/src/test/isolation2/expected/ao_partial_scan.out
+++ b/src/test/isolation2/expected/ao_partial_scan.out
@@ -5,9 +5,6 @@
 -- varblocks get scanned and verify it against the range of block directory
 -- entries that should be involved.
 
-CREATE EXTENSION pageinspect;
-CREATE EXTENSION
-
 --------------------------------------------------------------------------------
 ----                            ao_row tables
 --------------------------------------------------------------------------------
@@ -1657,6 +1654,3 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
  1          | 33554432 | 1      | f        | f        | f           | f     | {1 .. 1}   
  2          | 33554433 | 1      | f        | f        | f           | f     | {20 .. 20} 
 (2 rows)
-
-DROP EXTENSION pageinspect;
-DROP EXTENSION

--- a/src/test/isolation2/expected/bitmap_index_inspect.out
+++ b/src/test/isolation2/expected/bitmap_index_inspect.out
@@ -3,8 +3,6 @@
 -- inspect functions run against a single node, as opposed to the entire GP cluster)
 
 -- Setup
-1U: CREATE EXTENSION pageinspect;
-CREATE EXTENSION
 1U: CREATE TABLE bmtest_t1(i int, bmfield int);
 CREATE TABLE
 1U: CREATE INDEX bmtest_i1 ON bmtest_t1 USING bitmap(bmfield);
@@ -64,5 +62,3 @@ ERROR:  block 1 is not a bitmap page, it is a LOV item page (bmfuncs.c:507)
 -- cleanup
 1U: DROP TABLE bmtest_t1;
 DROP TABLE
-1U: DROP EXTENSION pageinspect;
-DROP EXTENSION

--- a/src/test/isolation2/expected/brin_heap.out
+++ b/src/test/isolation2/expected/brin_heap.out
@@ -2,8 +2,6 @@
 -- White-box tests are necessary to ensure that summarization is done
 -- successfully (to avoid cases where ranges have brin data tuples without
 -- values or where the range is not covered by the revmap etc)
-CREATE EXTENSION pageinspect;
-CREATE EXTENSION
 
 -- Turn off sequential scans to force usage of BRIN indexes for scans.
 SET enable_seqscan TO off;
@@ -317,5 +315,3 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid) FROM gp_segment_
 
 RESET enable_seqscan;
 RESET
-DROP EXTENSION pageinspect;
-DROP EXTENSION

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -204,8 +204,6 @@ DROP TABLE
 
 
 -- Same set of tests for bitmap LOV insert.
-create extension if not exists pageinspect;
-CREATE EXTENSION
 
 -- Function to check the bitmap lov content regarding the column 'b'
 -- which is the table column that we will have bitmap created on.
@@ -401,9 +399,6 @@ SET
  1 
  2 
 (2 rows)
-
-1: drop extension pageinspect;
-DROP EXTENSION
 
 -- Test for aoseg: suspend the insert into aoseg table before we mark the row frozen.
 -- Another session should still be able to choose a different segno.

--- a/src/test/isolation2/input/uao/brin.source
+++ b/src/test/isolation2/input/uao/brin.source
@@ -2,7 +2,6 @@
 -- White-box tests are necessary to ensure that summarization is done
 -- successfully (to avoid cases where ranges have brin data tuples without
 -- values or where the range is not covered by the revmap etc)
-CREATE EXTENSION pageinspect;
 
 -- Turn off sequential scans to force usage of BRIN indexes for scans.
 SET enable_seqscan TO off;
@@ -666,4 +665,3 @@ SELECT brin_summarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
   'brin_abort_fullpage_@amname@_i_idx') ORDER BY blknum, attnum;
 
 RESET enable_seqscan;
-DROP EXTENSION pageinspect;

--- a/src/test/isolation2/input/uao/brin_chain.source
+++ b/src/test/isolation2/input/uao/brin_chain.source
@@ -1,8 +1,6 @@
 -- Tests for BRIN chaining for AO/CO tables
 -- These are in a separate file as they take longer and deal with more data.
 
-CREATE EXTENSION pageinspect;
-
 -- All tests insert rows into content=1.
 
 -- We create an append-optimized table with the following characteristics:
@@ -59,5 +57,3 @@ SET enable_seqscan TO off;
 SET optimizer TO off;
 EXPLAIN SELECT count(*) FROM brin_chain_@amname@ WHERE i > '1' and i < '3';
 SELECT count(*) FROM brin_chain_@amname@ WHERE i > '1' and i < '3';
-
-DROP EXTENSION pageinspect;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -358,5 +358,4 @@ test: spilling_hashagg
 test: brin_heap
 
 # Intensive tests for BRIN
-test: uao/brin_chain_row
-test: uao/brin_chain_column
+test: uao/brin_chain_row uao/brin_chain_column

--- a/src/test/isolation2/output/uao/brin.source
+++ b/src/test/isolation2/output/uao/brin.source
@@ -2,8 +2,6 @@
 -- White-box tests are necessary to ensure that summarization is done
 -- successfully (to avoid cases where ranges have brin data tuples without
 -- values or where the range is not covered by the revmap etc)
-CREATE EXTENSION pageinspect;
-CREATE EXTENSION
 
 -- Turn off sequential scans to force usage of BRIN indexes for scans.
 SET enable_seqscan TO off;
@@ -1492,5 +1490,3 @@ SELECT brin_summarize_range('brin_abort_fullpage_@amname@_i_idx', 33559886);
 
 RESET enable_seqscan;
 RESET
-DROP EXTENSION pageinspect;
-DROP EXTENSION

--- a/src/test/isolation2/output/uao/brin_chain.source
+++ b/src/test/isolation2/output/uao/brin_chain.source
@@ -1,9 +1,6 @@
 -- Tests for BRIN chaining for AO/CO tables
 -- These are in a separate file as they take longer and deal with more data.
 
-CREATE EXTENSION pageinspect;
-CREATE EXTENSION
-
 -- All tests insert rows into content=1.
 
 -- We create an append-optimized table with the following characteristics:
@@ -131,6 +128,3 @@ SELECT count(*) FROM brin_chain_@amname@ WHERE i > '1' and i < '3';
 -----------
  180004000 
 (1 row)
-
-DROP EXTENSION pageinspect;
-DROP EXTENSION

--- a/src/test/isolation2/sql/ao_partial_scan.sql
+++ b/src/test/isolation2/sql/ao_partial_scan.sql
@@ -5,8 +5,6 @@
 -- varblocks get scanned and verify it against the range of block directory
 -- entries that should be involved.
 
-CREATE EXTENSION pageinspect;
-
 --------------------------------------------------------------------------------
 ----                            ao_row tables
 --------------------------------------------------------------------------------
@@ -521,5 +519,3 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 
 -- Sanity: the summary info is reflected in the data page.
 1U: SELECT * FROM brin_page_items(get_raw_page('aoco_partial_scan4_i_idx', 2), 'aoco_partial_scan4_i_idx');
-
-DROP EXTENSION pageinspect;

--- a/src/test/isolation2/sql/bitmap_index_inspect.sql
+++ b/src/test/isolation2/sql/bitmap_index_inspect.sql
@@ -3,7 +3,6 @@
 -- inspect functions run against a single node, as opposed to the entire GP cluster)
 
 -- Setup
-1U: CREATE EXTENSION pageinspect;
 1U: CREATE TABLE bmtest_t1(i int, bmfield int);
 1U: CREATE INDEX bmtest_i1 ON bmtest_t1 USING bitmap(bmfield);
 1U: INSERT INTO bmtest_t1 SELECT i,1 FROM generate_series(1, 1000) i;
@@ -35,4 +34,3 @@
 
 -- cleanup
 1U: DROP TABLE bmtest_t1;
-1U: DROP EXTENSION pageinspect;

--- a/src/test/isolation2/sql/brin_heap.sql
+++ b/src/test/isolation2/sql/brin_heap.sql
@@ -2,7 +2,6 @@
 -- White-box tests are necessary to ensure that summarization is done
 -- successfully (to avoid cases where ranges have brin data tuples without
 -- values or where the range is not covered by the revmap etc)
-CREATE EXTENSION pageinspect;
 
 -- Turn off sequential scans to force usage of BRIN indexes for scans.
 SET enable_seqscan TO off;
@@ -141,4 +140,3 @@ SELECT gp_inject_fault('brin_bitmap_page_added', 'reset', dbid)
 FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 
 RESET enable_seqscan;
-DROP EXTENSION pageinspect;

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -101,7 +101,6 @@
 
 
 -- Same set of tests for bitmap LOV insert.
-create extension if not exists pageinspect;
 
 -- Function to check the bitmap lov content regarding the column 'b'
 -- which is the table column that we will have bitmap created on.
@@ -192,8 +191,6 @@ $$ LANGUAGE plpgsql;
 0U: set enable_seqscan = on;
 0U: select insert_bm_lov_res();
 0U: select * from bm_lov_res;
-
-1: drop extension pageinspect;
 
 -- Test for aoseg: suspend the insert into aoseg table before we mark the row frozen.
 -- Another session should still be able to choose a different segno.

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -1,13 +1,13 @@
--- Creating extension to test alter extension
--- Assume: pageinspect is shipped by default
-CREATE EXTENSION pageinspect;
+-- Simple smoke test for ALTER EXTENSION
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
+-- pageinspect has already been installed by the pg_regress framework
 ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
 DROP EXTENSION pageinspect;
+CREATE EXTENSION pageinspect;
 -- Test creating an extension that already exists. Nothing too exciting about
 -- it, but let's keep up the test coverage.
 CREATE EXTENSION gp_inject_fault;

--- a/src/test/regress/expected/brin_interface.out
+++ b/src/test/regress/expected/brin_interface.out
@@ -1,5 +1,4 @@
 -- Additional tests that exercise the BRIN user interface
-CREATE EXTENSION pageinspect;
 CREATE TABLE brin_interface(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -338,5 +337,3 @@ SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_id
              8
 (1 row)
 
-DROP EXTENSION pageinspect CASCADE;
-NOTICE:  drop cascades to view revmap_page1

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -418,7 +418,6 @@ VACUUM FULL pg_authid, pg_database;
 -- Test that VACUUM FREEZE should leave no unfrozen rows in pg_stat_last_operation and pg_stat_last_shoperation
 drop table if exists vacfrzt;
 drop database if exists vacfrzdb;
-create extension if not exists pageinspect;
 -- autovacuum needs to be turned off for this test
 show autovacuum;
  autovacuum 

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2622,6 +2622,11 @@ create_database(const char *dbname)
 	 * relied heavily. So let's just load gp_toolkit here.
 	 */
 	add_stringlist_item(&loadextension, "gp_toolkit");
+	/*
+	 * GPDB: We rely heavily on pageinspect for many tests, especially for BRIN,
+	 * so load it here.
+	 */
+	add_stringlist_item(&loadextension, "pageinspect");
 	for (sl = loadextension; sl != NULL; sl = sl->next)
 	{
 		header(_("installing %s"), sl->str);

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -1,16 +1,15 @@
--- Creating extension to test alter extension
--- Assume: pageinspect is shipped by default
-CREATE EXTENSION pageinspect;
-
+-- Simple smoke test for ALTER EXTENSION
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
 
+-- pageinspect has already been installed by the pg_regress framework
 ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
 ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
 
 DROP EXTENSION pageinspect;
+CREATE EXTENSION pageinspect;
 
 -- Test creating an extension that already exists. Nothing too exciting about
 -- it, but let's keep up the test coverage.

--- a/src/test/regress/sql/brin_interface.sql
+++ b/src/test/regress/sql/brin_interface.sql
@@ -1,6 +1,4 @@
 -- Additional tests that exercise the BRIN user interface
-CREATE EXTENSION pageinspect;
-
 CREATE TABLE brin_interface(i int);
 INSERT INTO brin_interface SELECT * FROM generate_series(1, 5000);
 CREATE INDEX ON brin_interface USING brin(i) WITH (pages_per_range=1);
@@ -129,6 +127,3 @@ REINDEX INDEX brin_ppr_atsetam_i_idx;
 SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
 ALTER TABLE brin_ppr_atsetam SET ACCESS METHOD ao_row;
 SELECT pagesperrange FROM brin_metapage_info(get_raw_page('brin_ppr_atsetam_i_idx', 0));
-
-DROP EXTENSION pageinspect CASCADE;
-

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -295,7 +295,6 @@ VACUUM FULL pg_authid, pg_database;
 
 drop table if exists vacfrzt;
 drop database if exists vacfrzdb;
-create extension if not exists pageinspect;
 -- autovacuum needs to be turned off for this test
 show autovacuum;
 


### PR DESCRIPTION
pageinspect is necessary for many tests, so load it up front like we do
for gp_inject_fault and gp_toolkit. This means we can remain all CREATE
EXTENSION/DROP EXTENSION commands for pageinspect (barring the
alter_extension test).

This also enables us to parallelize the brin_chain tests, since we no
longer have to worry about concurrent drops of pageinspect. This shaves
off 4-5mins off of total ICW runtime.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pageinspect_icw