### PR TITLE
Added gp_hyperloglog_merge aggregate function.

### DIFF
--- a/src/include/catalog/pg_aggregate.dat
+++ b/src/include/catalog/pg_aggregate.dat
@@ -676,6 +676,10 @@
   aggtransfn => 'gp_hyperloglog_add_item_agg_default',
   aggfinalfn => 'gp_hyperloglog_comp', aggcombinefn => 'gp_hyperloglog_merge',
   aggtranstype => 'gp_hyperloglog_estimator' },
+{ aggfnoid => 'gp_hyperloglog_merge(gp_hyperloglog_estimator)',
+  aggtransfn => 'gp_hyperloglog_merge',
+  aggfinalfn => 'gp_hyperloglog_comp', aggcombinefn => 'gp_hyperloglog_merge',
+  aggtranstype => 'gp_hyperloglog_estimator' },
 
 # GPDB: additional variants of percentile_cont and percentile_disc
 { aggfnoid => 'gp_percentile_cont(float8,float8,int8,int8)',

--- a/src/test/regress/expected/gp_hyperloglog.out
+++ b/src/test/regress/expected/gp_hyperloglog.out
@@ -97,3 +97,30 @@ SELECT gp_hyperloglog_get_estimate('8gYCAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 -- b) Test convert an invalid hloglog counter.
 SELECT gp_hyperloglog_get_estimate('blah');
 ERROR:  ERROR: The stored counter is version 161 while the library is version 2. Please change library version or use upgrade function to upgrade the counter (gp_hyperloglog.c:970)
+
+-- 5. Test gp_hyperloglog_merge as aggregate function
+-- a) Test aggregate three rows
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_merge(c)) FROM (
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10000) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 100) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10) i
+) T;
+ gp_hyperloglog_get_estimate
+-----------------------------
+            9998.40103485189
+(1 row)
+
+-- b) Test aggregate with nulls
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_merge(c)) FROM (
+    SELECT NULL c
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 100) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10) i
+) T;
+ gp_hyperloglog_get_estimate
+-----------------------------
+             100.30560977271
+(1 row)

--- a/src/test/regress/sql/gp_hyperloglog.sql
+++ b/src/test/regress/sql/gp_hyperloglog.sql
@@ -53,3 +53,22 @@ SELECT gp_hyperloglog_get_estimate('8gYCAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 -- b) Test convert an invalid hloglog counter.
 SELECT gp_hyperloglog_get_estimate('blah');
+
+-- 5. Test gp_hyperloglog_merge as aggregate function
+-- a) Test aggregate three rows
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_merge(c)) FROM (
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10000) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 100) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10) i
+) T;
+
+-- b) Test aggregate with nulls
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_merge(c)) FROM (
+    SELECT NULL c
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 100) i
+    UNION ALL
+    SELECT gp_hyperloglog_accum(i) c FROM generate_series(1, 10) i
+) T;


### PR DESCRIPTION
We would have a partially aggregate table with some dimensions and HLL estimator as value.
We would like to aggregate the table further, reducing the number of dimensions.
So we need `gp_hyperloglog_merge` to work as an aggregate function.

```
CREATE TABLE facts (
city int,
product int,
customer int
);
CREATE TABLE part_agg (
city int,
product int,
unique_customers gp_hyperloglog_estimator
);
INSERT INTO part_agg (city, product, unique_customers)
SELECT city, product, gp_hyperloglog_accum(customer)
GROUP BY city, product;

-- and now we would like to
SELECT city, gp_hyperloglog_get_estimate(gp_hyperloglog_merge(unique_customers))
FROM part_agg
GROUP BY city;
```

In the Redshift there is a similar function, called [HLL_COMBINE](https://docs.aws.amazon.com/redshift/latest/dg/r_HLL_COMBINE.html)

I can also write some docs, if function naming is ok.