### PR TITLE
AT-SET-AM/AT-SET-RELOPTIONS: Skip foreign tables

### DIFF
--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1722,3 +1722,97 @@ SELECT * FROM atsetam_dropcol;
  1
 (1 row)
 
+-- ATSETAM and AT SET reloptions with foreign tables.
+CREATE READABLE EXTERNAL TABLE at_external(i int, j int)
+    LOCATION ('gpfdist://host.invalid:8000/file') FORMAT 'text';
+-- Should be a no-op.
+ALTER TABLE at_external SET ACCESS METHOD ao_row;
+NOTICE:  skipping foreign table "at_external" for ALTER operation
+\d at_external
+               Foreign table "public.at_external"
+ Column |  Type   | Collation | Nullable | Default | FDW options 
+--------+---------+-----------+----------+---------+-------------
+ i      | integer |           |          |         | 
+ j      | integer |           |          |         | 
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+
+-- Should be a no-op.
+ALTER TABLE at_external SET (compresstype=zlib);
+NOTICE:  skipping foreign table "at_external" for ALTER operation
+\d at_external
+               Foreign table "public.at_external"
+ Column |  Type   | Collation | Nullable | Default | FDW options 
+--------+---------+-----------+----------+---------+-------------
+ i      | integer |           |          |         | 
+ j      | integer |           |          |         | 
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+
+-- Now make the table an external partition.
+CREATE TABLE at_part_w_external(i int, j int) DISTRIBUTED BY (i)
+    PARTITION BY RANGE(j) (START(1) END(3) EVERY(1));
+ALTER TABLE at_part_w_external ATTACH PARTITION at_external FOR VALUES FROM (3) TO (4);
+SELECT relname, a.amname, relkind, reloptions FROM pg_class c
+    LEFT OUTER JOIN pg_am a ON c.relam = a.oid
+    WHERE relname LIKE 'at_part_w_external%' OR relname = 'at_external';
+          relname           | amname | relkind | reloptions 
+----------------------------+--------+---------+------------
+ at_part_w_external_1_prt_2 | heap   | r       | 
+ at_external                |        | f       | 
+ at_part_w_external         | heap   | p       | 
+ at_part_w_external_1_prt_1 | heap   | r       | 
+(4 rows)
+
+-- Should set the access method for all tables, except the foreign partition.
+ALTER TABLE at_part_w_external SET ACCESS METHOD ao_column;
+NOTICE:  skipping foreign table "at_external" for ALTER operation
+SELECT relname, a.amname, relkind, reloptions FROM pg_class c
+    LEFT OUTER JOIN pg_am a ON c.relam = a.oid
+    WHERE relname LIKE 'at_part_w_external%' OR relname = 'at_external';
+          relname           |  amname   | relkind |                            reloptions                             
+----------------------------+-----------+---------+-------------------------------------------------------------------
+ at_external                |           | f       | 
+ at_part_w_external         | ao_column | p       | {blocksize=65536,compresslevel=5,compresstype=zlib}
+ at_part_w_external_1_prt_1 | ao_column | r       | {blocksize=65536,compresslevel=5,compresstype=zlib,checksum=true}
+ at_part_w_external_1_prt_2 | ao_column | r       | {blocksize=65536,compresslevel=5,compresstype=zlib,checksum=true}
+(4 rows)
+
+SELECT c.relname, a.attnum, attoptions
+    FROM pg_attribute_encoding a JOIN pg_class c ON a.attrelid = c.oid
+    WHERE c.relname LIKE 'at_part_w_external%' OR c.relname = 'at_external';
+          relname           | attnum |                     attoptions                      
+----------------------------+--------+-----------------------------------------------------
+ at_part_w_external_1_prt_1 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_1 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external         |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external         |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_2 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_2 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+(6 rows)
+
+-- Should set the reloptions for all tables, except the foreign partition.
+ALTER TABLE at_part_w_external SET (compresstype=zlib, compresslevel=8);
+NOTICE:  skipping foreign table "at_external" for ALTER operation
+SELECT relname, a.amname, relkind, reloptions FROM pg_class c
+    LEFT OUTER JOIN pg_am a ON c.relam = a.oid
+    WHERE relname LIKE 'at_part_w_external%' OR relname = 'at_external';
+          relname           |  amname   | relkind |                            reloptions                             
+----------------------------+-----------+---------+-------------------------------------------------------------------
+ at_external                |           | f       | 
+ at_part_w_external         | ao_column | p       | {blocksize=65536,compresstype=zlib,compresslevel=8}
+ at_part_w_external_1_prt_1 | ao_column | r       | {blocksize=65536,checksum=true,compresstype=zlib,compresslevel=8}
+ at_part_w_external_1_prt_2 | ao_column | r       | {blocksize=65536,checksum=true,compresstype=zlib,compresslevel=8}
+(4 rows)
+
+SELECT c.relname, a.attnum, attoptions
+    FROM pg_attribute_encoding a JOIN pg_class c ON a.attrelid = c.oid
+    WHERE c.relname LIKE 'at_part_w_external%' OR c.relname = 'at_external';
+          relname           | attnum |                     attoptions                      
+----------------------------+--------+-----------------------------------------------------
+ at_part_w_external         |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external         |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_1 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_1 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_2 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ at_part_w_external_1_prt_2 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+(6 rows)
+


### PR DESCRIPTION
When ALTERing the access method or reloptions of tables in a hybrid
partition hierarchy containing foreign tables, we used to ERROR out when
a foreign table was encountered (as these operations don't make sense
for foreign tables).

Based on feedback, we want to skip such tables during AT recursion and
apply the change to all other tables. Such tables are now skipped with a
NOTICE to the user. For consistency, attempting these operations on
standalone/leaf foreign tables will also result in the same NOTICE:

NOTICE:  skipping foreign table "%s" for ALTER operation

If there are multiple foreign tables in a partition hierarchy, the
NOTICE will get printed once for each such table. Although that may be
verbose, that feels better than a silent no-op.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/atset_foreign
