### PR TITLE
change gp_resource_group_cpu_limit to the default value after test

### DIFF
--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -671,7 +671,7 @@ setcpulimit_v2(Oid group, int cpu_hard_limit)
 	if (cpu_hard_limit > 0)
 	{
 		writeInt64(group, BASEDIR_GPDB, component, "cpu.max",
-				   system_cfs_quota_us * cpu_hard_limit / 100);
+				   system_cfs_quota_us * cpu_hard_limit * gp_resource_group_cpu_limit / 100);
 	}
 	else
 	{

--- a/src/test/isolation2/expected/resgroup/resgroup_cpu_max_percent.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cpu_max_percent.out
@@ -33,8 +33,8 @@ CREATE FUNCTION
 -- verify_cpu_usage: calculate each QE's average cpu usage using all the data in
 -- the table cpu_usage_sample. And compare the average value to the expected value.
 -- return true if the practical value is close to the expected value.
-CREATE OR REPLACE FUNCTION verify_cpu_usage(groupname TEXT, expect_cpu_usage INT, err_rate INT) RETURNS BOOL AS $$ import json import functools 
-all_info = plpy.execute(''' SELECT sample::json->'{name}' AS cpu FROM cpu_usage_samples '''.format(name=groupname)) usage = float(all_info[0]['cpu']) 
+CREATE OR REPLACE FUNCTION verify_cpu_usage(groupname TEXT, expect_cpu_usage INT, err_rate INT) RETURNS BOOL AS $$ all_info = plpy.execute(''' SELECT sample::json->'{name}' AS cpu FROM cpu_usage_samples '''.format(name=groupname)) 
+results = [float(_['cpu']) for _ in all_info] usage = sum(results) / len(results) 
 return abs(usage - expect_cpu_usage) <= err_rate $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
@@ -46,6 +46,14 @@ CREATE FUNCTION
 
 CREATE VIEW cancel_all AS SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM % WHERE busy%';
 CREATE VIEW
+
+-- The test cases for the value of gp_resource_group_cpu_limit equals 0.9,
+-- do not change it during the test.
+show gp_resource_group_cpu_limit;
+ gp_resource_group_cpu_limit 
+-----------------------------
+ 0.9                         
+(1 row)
 
 -- create two resource groups
 CREATE RESOURCE GROUP rg1_cpu_test WITH (concurrency=5, cpu_max_percent=-1, cpu_weight=100);
@@ -498,7 +506,7 @@ SET
 -- a group should not burst to use all the cpu usage
 -- when it's the only one with running queries.
 --
--- so the cpu usage shall be 10%
+-- so the cpu usage shall be 0.9 * 10%
 --
 
 10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
@@ -561,7 +569,7 @@ TRUNCATE TABLE
           
 (1 row)
 1:TRUNCATE TABLE cpu_usage_samples;
-TRUNCATE
+TRUNCATE TABLE
 1:SELECT fetch_sample();
  fetch_sample                                                                                                 
 --------------------------------------------------------------------------------------------------------------
@@ -615,7 +623,7 @@ TRUNCATE
 -- end_ignore
 
 -- verify it
-1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+1:SELECT verify_cpu_usage('rg1_cpu_test', 9, 2);
  verify_cpu_usage 
 ------------------
  t                
@@ -667,8 +675,8 @@ SET
 --
 -- rg1_cpu_test:rg2_cpu_test is 10:20, so:
 --
--- - rg1_cpu_test gets 10%;
--- - rg2_cpu_test gets 20%;
+-- - rg1_cpu_test gets 0.9 * 10%;
+-- - rg2_cpu_test gets 0.9 * 20%;
 --
 
 10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
@@ -790,12 +798,12 @@ TRUNCATE TABLE
 (1 row)
 -- end_ignore
 
-1:SELECT verify_cpu_usage('rg1_cpu_test', 10, 2);
+1:SELECT verify_cpu_usage('rg1_cpu_test', 9, 2);
  verify_cpu_usage 
 ------------------
  t                
 (1 row)
-1:SELECT verify_cpu_usage('rg2_cpu_test', 20, 2);
+1:SELECT verify_cpu_usage('rg2_cpu_test', 18, 2);
  verify_cpu_usage 
 ------------------
  t                

--- a/src/test/isolation2/expected/resgroup/resgroup_cpuset.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cpuset.out
@@ -21,6 +21,14 @@ CREATE VIEW
 CREATE VIEW cancel_all AS SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM busy%';
 CREATE VIEW
 
+-- The test cases for the value of gp_resource_group_cpu_limit equals 0.9,
+-- do not change it during the test.
+show gp_resource_group_cpu_limit;
+ gp_resource_group_cpu_limit 
+-----------------------------
+ 0.9                         
+(1 row)
+
 CREATE RESOURCE GROUP rg1_cpuset_test WITH (cpuset='0');
 CREATE RESOURCE GROUP
 CREATE ROLE role1_cpuset_test RESOURCE GROUP rg1_cpuset_test;
@@ -149,7 +157,7 @@ select pg_sleep(5);
 
 11: BEGIN;
 BEGIN
-11: select max(cpu_usage)::float >= 65 from gp_toolkit.gp_resgroup_status_per_host where groupname='rg1_cpuset_test';
+11: select max(cpu_usage)::float >= 65 * 0.9 from gp_toolkit.gp_resgroup_status_per_host where groupname='rg1_cpuset_test';
  ?column? 
 ----------
  t        

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -538,7 +538,7 @@ ALTER RESOURCE GROUP
 0: DROP RESOURCE GROUP rg_test_group;
 DROP RESOURCE GROUP
 -- start_ignore
-!\retcode gpconfig -c gp_resource_group_cpu_limit -v 1;
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/sql/resgroup/resgroup_cpuset.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cpuset.sql
@@ -34,6 +34,10 @@ CREATE VIEW cancel_all AS
     FROM pg_stat_activity
     WHERE query LIKE 'SELECT * FROM busy%';
 
+-- The test cases for the value of gp_resource_group_cpu_limit equals 0.9, 
+-- do not change it during the test.
+show gp_resource_group_cpu_limit;
+
 CREATE RESOURCE GROUP rg1_cpuset_test WITH (cpuset='0');
 CREATE ROLE role1_cpuset_test RESOURCE GROUP rg1_cpuset_test;
 
@@ -100,7 +104,8 @@ select * from cancel_all;
 select pg_sleep(5);
 
 11: BEGIN;
-11: select max(cpu_usage)::float >= 65 from gp_toolkit.gp_resgroup_status_per_host where groupname='rg1_cpuset_test';
+11: select max(cpu_usage)::float >= 65 * 0.9 
+from gp_toolkit.gp_resgroup_status_per_host where groupname='rg1_cpuset_test';
 -- cancel the transaction
 -- start_ignore
 select * from cancel_all;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -271,7 +271,7 @@ DROP RESOURCE GROUP rg_test_group;
 0: ALTER RESOURCE GROUP rg_test_group SET cpu_max_percent 100;
 0: DROP RESOURCE GROUP rg_test_group;
 -- start_ignore
-!\retcode gpconfig -c gp_resource_group_cpu_limit -v 1; 
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 !\retcode gpstop -ari;
 -- end_ignore
 


### PR DESCRIPTION
The test cases in `resgroup_cpu_max_percent` is designed for the value of
`gp_resource_group_cpu_limit` equals 0.9, but I set it to 1 in #15699.

Because the test results allow for a 10% deviation, it is possible to pass the 
test incorrectly in most cases.
