### PR TITLE
Fix flakiness due to waiting for different number of fault triggers

### DIFF
--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -247,19 +247,6 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
 -- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
 -- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
 -- in which vacuum worker isn't changed.
-ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
-ALTER SYSTEM
-ALTER SYSTEM SET gp_fts_probe_interval to 10;
-ALTER SYSTEM
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)
-
 DROP TABLE IF EXISTS vacuum_progress_ao_column;
 DROP TABLE
 CREATE TABLE vacuum_progress_ao_column(i int, j int);
@@ -465,15 +452,3 @@ reset Debug_appendonly_print_compaction;
 RESET
 reset default_table_access_method;
 RESET
-ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
-ALTER SYSTEM
-ALTER SYSTEM RESET gp_fts_probe_interval;
-ALTER SYSTEM
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -290,7 +290,7 @@ DELETE 50000
 SET
 1&: vacuum vacuum_progress_ao_column;  <waiting ...>
 
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
@@ -351,7 +351,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point
 -- due to FTS version being changed.
-2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
@@ -385,7 +385,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
  Success:        
 (3 rows)
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -122,11 +122,13 @@ SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_confi
  Success:        
  Success:        
 (3 rows)
-SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- After compacting all segfiles we expect 50000 dead tuples
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
@@ -154,11 +156,13 @@ SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment
  Success:        
  Success:        
 (3 rows)
-SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We should have skipped recycling the awaiting drop segment because the segment was still visible to the SELECT gp_wait_until_triggered_fault query.
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
@@ -339,7 +343,7 @@ DELETE 50000
 SET
 1&: vacuum vacuum_progress_ao_row;  <waiting ...>
 
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -296,19 +296,6 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
 -- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
 -- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
 -- in which vacuum worker isn't changed.
-ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
-ALTER SYSTEM
-ALTER SYSTEM SET gp_fts_probe_interval to 10;
-ALTER SYSTEM
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)
-
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 DROP TABLE
 CREATE TABLE vacuum_progress_ao_row(i int, j int);
@@ -514,15 +501,3 @@ reset Debug_appendonly_print_compaction;
 RESET
 reset default_table_access_method;
 RESET
-ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
-ALTER SYSTEM
-ALTER SYSTEM RESET gp_fts_probe_interval;
-ALTER SYSTEM
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
- gp_segment_id | pg_reload_conf 
----------------+----------------
- 2             | t              
- 1             | t              
- 0             | t              
- -1            | t              
-(4 rows)

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -124,7 +124,7 @@ DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
 1: set debug_appendonly_print_compaction to on;
 1&: vacuum vacuum_progress_ao_column;
 
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
 -- Non-zero progressing data num_dead_tuples is showed up.
 select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
@@ -145,14 +145,14 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point
 -- due to FTS version being changed.
-2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_worker_changed', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- now seg1's mirror is marked as down
 2: SELECT content, role, preferred_role, mode, status FROM gp_segment_configuration WHERE content > -1;
 
 -- Resume execution and entering post_cleaup phase, suspend at the end of it.
 2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
 -- The previous collected num_dead_tuples in compact phase is zero.
 select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -102,10 +102,6 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
 -- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
 -- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
 -- in which vacuum worker isn't changed.
-ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
-ALTER SYSTEM SET gp_fts_probe_interval to 10;
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
-
 DROP TABLE IF EXISTS vacuum_progress_ao_column;
 CREATE TABLE vacuum_progress_ao_column(i int, j int);
 CREATE INDEX on vacuum_progress_ao_column(i);
@@ -176,6 +172,3 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
 reset Debug_appendonly_print_compaction;
 reset default_table_access_method;
-ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
-ALTER SYSTEM RESET gp_fts_probe_interval;
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -52,7 +52,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume execution and suspend again after compacting all segfiles
 SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- After compacting all segfiles we expect 50000 dead tuples
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
@@ -60,7 +60,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume execution and entering post_cleaup phase, suspend at the end of it.
 SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We should have skipped recycling the awaiting drop segment because the segment was still visible to the SELECT gp_wait_until_triggered_fault query.
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
@@ -128,7 +128,7 @@ DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 1: set debug_appendonly_print_compaction to on;
 1&: vacuum vacuum_progress_ao_row;
 
-2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 3, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+2: SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
 -- Non-zero progressing data num_dead_tuples is showed up.
 select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -106,10 +106,6 @@ SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuu
 -- Current behavior is it will clear previous compact phase num_dead_tuples in post-cleanup
 -- phase (at injecting point vacuum_ao_post_cleanup_end), which is different from above case
 -- in which vacuum worker isn't changed.
-ALTER SYSTEM SET gp_fts_mark_mirror_down_grace_period to 10;
-ALTER SYSTEM SET gp_fts_probe_interval to 10;
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');
-
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 CREATE TABLE vacuum_progress_ao_row(i int, j int);
 CREATE INDEX on vacuum_progress_ao_row(i);
@@ -180,6 +176,3 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;
 reset Debug_appendonly_print_compaction;
 reset default_table_access_method;
-ALTER SYSTEM RESET gp_fts_mark_mirror_down_grace_period;
-ALTER SYSTEM RESET gp_fts_probe_interval;
-SELECT gp_segment_id, pg_reload_conf() FROM gp_id UNION SELECT gp_segment_id, pg_reload_conf() FROM gp_dist_random('gp_id');


### PR DESCRIPTION
If injecting a fault to all segments but waiting for only one segment
fault trigger, it could lead to flakiness because the moment of that
fault trigger is variable, resulting in different summary results of
segments in vacuum progress report.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/hw-7X-vac-prog-flaky

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
