### PR TITLE
Docs gppkg

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -65,7 +65,7 @@ sync [<command_options>]
 :   Use this option when Greenplum Database is not running. The input file `<cluster_info>` contains information about the database cluster. You may generate the file by running the following command:
 
     ```
-    psql postgres -Xc 'select dbid, content, role, preferred_role, mode, status, hostname, address, port, datadir from gp_segment_configuration order by content, preferred_role desc;' | sed -n '3,7p' | tr -d " " > cluster_info
+    psql postgres -Xc 'select dbid, content, role, preferred_role, mode, status, hostname, address, port, datadir from gp_segment_configuration order by content, preferred_role desc;' | head -n-2 | tail -n+3 | tr -d " " > cluster_info
     ```
 
 -a | --accept 

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -1,6 +1,6 @@
 # gppkg 
 
-Installs Greenplum Database extensions in `.gppkg` format, such as PL/Java, PL/R, PostGIS, and MADlib, along with their dependencies, across an entire cluster.
+Greenplum Package Manager installs, upgrades, migrates, and removes Greenplum Database extensions in `.gppkg` format, such as PL/Java, PL/R, PostGIS, and MADlib, along with their dependencies, across an entire cluster.
 
 ## <a id="synopsis"></a>Synopsis 
 
@@ -29,36 +29,37 @@ Examples of database extensions and packages software that are delivered using t
 -   PostGIS
 -   MADlib
 
+> **Note** Be sure that `/usr/local/greenplum*` is owned by `gpadmin` user and group.
+
 ## <a id="commands"></a>Commands
 
 help 
-:   Displays the help for the command.
+:   Display the help for the command.
 
 install <package-name> [<global_options>]
-:   Installs or upgrades the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
+:   Install or upgrade the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
 
-migrate --source <source> --destination <destination> [--pkglibs <pkglibs>] [global_options]
-:   Migrates all packages from one minor version of Greenplum Database to another. The option `--source <source>` specifies the path of the source `$GPHOME`, the option `--destination <destination>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs>` allows you to point to a location where you may place newer version packages to install in the destination Greenplum version, `gppkg` will upgrade these packages automatically. 
+migrate --source <source_path> --destination <destination-path> [--pkglibs <pkglibs_path>] [<global_options>]
+:   Migrate all packages from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
 
-query [<query>] [<query_option>]
-:   Displays information about the extensions installed in the cluster. <query> is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
+query [<query_text>] [<query_option>] [<global_options>]
+:   Display information about the extensions installed in the cluster. <query_text> is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
 
     |query_option|Returns|
     |-------------|-------|
-    |`--exact`|The provided <query> must match exactly a package name|
+    |`--exact`|The provided <query_text> must match exactly a package name|
     |`--detail`|Provide detailed information about the package|
     |`--verify`|Verify the package installation|
     |`--local`|Do not query at cluster level|
 
-remove <package-name> [<global_options>]
-:    Uninstalls the specified package from the cluster. 
+remove <package_name> [<global_options>]
+:    Uninstall the specified package from the cluster. 
 
-upgrade
-:    Upgrades an existing package. Does a fresh install if the package does not exist.
-gppkg upgrade pkg-name.gppkg
+upgrade <package-name> [<global_options>]
+:    Upgrade an existing package. Do a fresh install if the package does not exist.
 
-sync [global_options]
-:    Reconciles the package state of the cluster to match the state of the master host. Running this option after a failed or partial install/uninstall ensures that the package installation state is consistent across the cluster.
+sync [<global_options>]
+:    Reconcile the package state of the cluster to match the state of the master host. Running this option after a failed or partial install/uninstall ensures that the package installation state is consistent across the cluster.
 
 ## <a id="options"></a>Global Options 
 
@@ -83,10 +84,10 @@ ing command:
 :   Display the online help.
 
 -V | --version
-:   Displays the version of this utility.
+:   Display the version of this utility.
 
 -v | --verbose
-:   Sets the logging level to verbose.
+:   Set the logging level to verbose.
 
 ## <a id="examples"></a>Examples
 

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -29,25 +29,23 @@ Examples of database extensions and packages software that are delivered using t
 -   PostGIS
 -   MADlib
 
-> **Note** Be sure that `/usr/local/greenplum*` is owned by `gpadmin` user and group.
-
 ## <a id="commands"></a>Commands
 
 help 
 :   Display the help for the command.
 
-install <package-name> [<global_options>]
+install <package_name> [<global_options>]
 :   Install or upgrade the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
 
-migrate --source <source_path> --destination <destination-path> [--pkglibs <pkglibs_path>] [<global_options>]
+migrate --source <source_path> --destination <destination_path> [--pkglibs <pkglibs_path>] [<global_options>]
 :   Migrate all packages from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
 
 query [<query_text>] [<query_option>] [<global_options>]
-:   Display information about the extensions installed in the cluster. <query_text> is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
+:   Display information about the extensions installed in the cluster. `<query_text>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
 
     |query_option|Returns|
     |-------------|-------|
-    |`--exact`|The provided <query_text> must match exactly a package name|
+    |`--exact`|The provided `<query_text>` must match exactly a package name|
     |`--detail`|Provide detailed information about the package|
     |`--verify`|Verify the package installation|
     |`--local`|Do not query at cluster level|
@@ -55,7 +53,7 @@ query [<query_text>] [<query_option>] [<global_options>]
 remove <package_name> [<global_options>]
 :    Uninstall the specified package from the cluster. 
 
-upgrade <package-name> [<global_options>]
+upgrade <package_name> [<global_options>]
 :    Upgrade an existing package. Do a fresh install if the package does not exist.
 
 sync [<global_options>]
@@ -64,8 +62,7 @@ sync [<global_options>]
 ## <a id="options"></a>Global Options 
 
 --cluster_info <cluster_info>
-:   Use this option when Greenplum Database is not running. The input file `<cluster_info>` contains information about the database cluster. You may generate the file by running the follow
-ing command:
+:   Use this option when Greenplum Database is not running. The input file `<cluster_info>` contains information about the database cluster. You may generate the file by running the following command:
 
     ```
     psql postgres -Xc 'select dbid, content, role, preferred_role, mode, status, hostname, address, port, datadir from gp_segment_configuration order by content, preferred_role desc;' | sed -n '3,7p' | tr -d " " > cluster_info
@@ -97,13 +94,13 @@ Install the Greenplum Database PL/Java extension:
 gppkg install /tmp/pljava-2.0.7-gp7-rhel8_x86_64.gppkg 
 ```
 
-Migrate packages installed from Greenplum Database version 7.0.0 to Greenplum Database version 7.1.0 while the cluster is not running.
+Migrate all installed packages from Greenplum Database version 7.0.0 to Greenplum Database version 7.1.0 while the cluster is not running.
 
 ```
 gppkg migrate --cluster-info /tmp/cluster_info --source /usr/local/greenplum-db-7.0.0 --destination /usr/local/greenplum-db-7.1.0
 ```
 
-Where the file `/tmp/cluster_info` contains the following information:
+where the file `/tmp/cluster_info` contains the following information:
 
 ```
 1|-1|p|p|n|u|cdw|cdw|5432|/data/coordinator/gpseg-1
@@ -116,7 +113,7 @@ Where the file `/tmp/cluster_info` contains the following information:
 Query all packages that are installed in a cluster:
 
 ```
-$gppkg query 
+gppkg query 
 
 Detecting network topology:    [=========================================] [OK] 
 Detect result 

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -41,7 +41,7 @@ migrate --source <source_path> --destination <destination_path> [--pkglibs <pkgl
 :   Migrate all packages from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
 
 query [<package_name_string>] [<query_option>] [<command_options>]
-:   Display information about the extensions installed in the cluster. `<package_name_string>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
+:   Display information about the extensions installed in the cluster. `<package_name_string>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages with the word included in the name. Use `–-exact` to specify the exact package name.
 
     |query_option|Returns|
     |-------------|-------|

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -34,29 +34,29 @@ Examples of database extensions and packages software that are delivered using t
 help 
 :   Display the help for the command.
 
-install <package_name> [<global_options>]
+install <package_name> [<command_options>]
 :   Install or upgrade the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
 
-migrate --source <source_path> --destination <destination_path> [--pkglibs <pkglibs_path>] [<global_options>]
+migrate --source <source_path> --destination <destination_path> [--pkglibs <pkglibs_path>] [<command_options>]
 :   Migrate all packages from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
 
-query [<query_text>] [<query_option>] [<global_options>]
-:   Display information about the extensions installed in the cluster. `<query_text>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
+query [<package_name_string>] [<query_option>] [<command_options>]
+:   Display information about the extensions installed in the cluster. `<package_name_string>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages which the word included in the name. Use `–-exact` to specify the exact package name.
 
     |query_option|Returns|
     |-------------|-------|
-    |`--exact`|The provided `<query_text>` must match exactly a package name|
+    |`--exact`|The provided `<package_name_string>` must match exactly a package name|
     |`--detail`|Provide detailed information about the package|
     |`--verify`|Verify the package installation|
     |`--local`|Do not query at cluster level|
 
-remove <package_name> [<global_options>]
+remove <package_name> [<command_options>]
 :    Uninstall the specified package from the cluster. 
 
-upgrade <package_name> [<global_options>]
+upgrade <package_name> [<command_options>]
 :    Upgrade an existing package. Do a fresh install if the package does not exist.
 
-sync [<global_options>]
+sync [<command_options>]
 :    Reconcile the package state of the cluster to match the state of the master host. Running this option after a failed or partial install/uninstall ensures that the package installation state is consistent across the cluster.
 
 ## <a id="options"></a>Global Options 

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -91,16 +91,16 @@ sync [<command_options>]
 Install the Greenplum Database PL/Java extension:
 
 ```
-gppkg install /tmp/pljava-2.0.7-gp7-rhel8_x86_64.gppkg 
+gppkg install ./pljava-2.0.7-gp7-rhel8_x86_64.gppkg
 ```
 
 Migrate all installed packages from Greenplum Database version 7.0.0 to Greenplum Database version 7.1.0 while the cluster is not running.
 
 ```
-gppkg migrate --cluster-info /tmp/cluster_info --source /usr/local/greenplum-db-7.0.0 --destination /usr/local/greenplum-db-7.1.0
+gppkg migrate --cluster-info ./cluster_info --source /usr/local/greenplum-db-7.0.0 --destination /usr/local/greenplum-db-7.1.0
 ```
 
-where the file `/tmp/cluster_info` contains the following information:
+where the file `./cluster_info` contains the following information:
 
 ```
 1|-1|p|p|n|u|cdw|cdw|5432|/data/coordinator/gpseg-1

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -18,7 +18,7 @@ gppkg -v | --verbose
 
 The Greenplum Package Manager -- `gppkg` -- utility installs Greenplum Database extensions, along with any dependencies, on all hosts across a cluster. It will also automatically install extensions on new hosts in the case of system expansion and segment recovery.
 
-The `gppkg` utility does not require that a Greenplum Database be running in order to install packages.
+The `gppkg` utility does not require that Greenplum Database is running in order to install packages.
 
 > **Note** After a major upgrade to Greenplum Database, you must download and install all `gppkg` extensions again.
 
@@ -37,18 +37,39 @@ help
 install [--tmpdir] <package-name>
 :   Installs the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
 
+migrate [options] --source <SOURCE> --destination <DESTINATION> 
+
+:   Migrates packages from a separate $GPHOME. Carries over packages from one version of Greenplum Database to another.
+
+For example: `gppkg --migrate /usr/local/greenplum-db-<old-version> /usr/local/greenplum-db-<new-version>`.
+
+> **Note** In general, it is best to avoid using the --migrate option, you should reinstall packages instead of migrating them.
+
 query
 :   Displays which extensions are installed in the cluster.
 
 remove <package-name>
 :    Uninstalls the specified package from the cluster. 
 
+upgrade
+:    Upgrades an existing package. Does a fresh install if the package does not exist.
+gppkg upgrade pkg-name.gppkg
+
 ## <a id="options"></a>Options 
 
 -a | --accept 
 :   Do not prompt the user for confirmation.
 
---version
+-d | --dryrun     
+:   Run a simulation for the command, without modifying anything.
+
+-f | --force
+:   Skip all requirement checks and overwrite existing files.
+
+-h | --help
+:   Display the online help.
+
+-V | --version
 :   Displays the version of this utility.
 
 -v | --verbose


### PR DESCRIPTION
This PR documents the changes in `gppkg` utility introduced for GP 7 beta 5.
Test site: https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-gppkg/greenplum-database/utility_guide-ref-gppkg.html
