### PR TITLE
Docs: new option -x for gpcheckcat

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
@@ -22,7 +22,7 @@ gpcheckcat [ <options<] [ <dbname>]
      -B <parallel_processes>
      -v
      -A
-     -x "<parameter_name>=value"
+     -x "<parameter_name>=<value>"
 
 gpcheckcat  -l 
 
@@ -126,7 +126,7 @@ Catalog inconsistencies are inconsistencies that occur between Greenplum Databas
 -v \(verbose\)
 :   Displays detailed information about the tests that are performed.
 
--x "<parameter_name>=value"
+-x "<parameter_name>=<value>"
 :   Set a server configuration parameter, such as `log_min_messages`, at a session level. To set multiple configuration parameters, use the `-x` option multiple times. 
 
 ## <a id="notes"></a>Notes 

--- a/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
@@ -22,6 +22,7 @@ gpcheckcat [ <options<] [ <dbname>]
      -B <parallel_processes>
      -v
      -A
+     -x "<parameter_name>=value"
 
 gpcheckcat  -l 
 
@@ -124,6 +125,9 @@ Catalog inconsistencies are inconsistencies that occur between Greenplum Databas
 
 -v \(verbose\)
 :   Displays detailed information about the tests that are performed.
+
+-x "<parameter_name>=value"
+:   Set a server configuration parameter, such as `log_min_messages`, at a session level. To set multiple configuration parameters, use the `-x` option multiple times. 
 
 ## <a id="notes"></a>Notes 
 


### PR DESCRIPTION
Documents https://github.com/greenplum-db/gpdb/pull/15962 which adds a new option `-x` to `gpcheckcat`.