### PR TITLE
gprecoverseg differential: Data integrity scenario

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -644,7 +644,7 @@ class CommandNotFoundException(Exception):
 
 def findCmdInPath(cmd):
     # ---------------command path--------------------
-    CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
+    CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/usr/local/bin', '/bin',
                '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
     CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -11,6 +11,7 @@ from steps.gpconfig_mgmt_utils import GpConfigContext
 from steps.gpssh_exkeys_mgmt_utils import GpsshExkeysMgmtContext
 from steps.mgmt_utils import backup_bashrc, restore_bashrc
 from gppylib.db import dbconn
+from gppylib.commands.base import Command, REMOTE
 
 def before_all(context):
     if list(map(int, behave.__version__.split('.'))) < [1,2,6]:
@@ -183,3 +184,10 @@ def after_scenario(context, scenario):
 
     if os.getenv('SUSPEND_PG_REWIND') is not None:
         del os.environ['SUSPEND_PG_REWIND']
+
+    if "remove_rsync_bash" in scenario.effective_tags:
+        for host in context.hosts_with_rsync_bash:
+            cmd = Command(name='remove /usr/local/bin/rsync', cmdStr="sudo rm /usr/local/bin/rsync", remoteHost=host,
+                          ctxt=REMOTE)
+            cmd.run(validateAfter=True)
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -24,6 +24,7 @@ from psycopg2 import extras
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from gppylib.commands.gp import SegmentStart, GpStandbyStart, CoordinatorStop
 from gppylib.commands import gp, unix
+from gppylib.commands.unix import CMD_CACHE
 from gppylib.commands.pg import PgBaseBackup
 from gppylib.operations.startSegments import MIRROR_MODE_MIRRORLESS
 from gppylib.operations.buildMirrorSegments import get_recovery_progress_pattern
@@ -4105,4 +4106,73 @@ def impl(context, command):
     context.ret_code = p.returncode
     context.stdout_message = stdout.decode()
     context.error_message = stderr.decode()
+
+
+@given('user creates a new executable rsync script which inserts data into table and runs checkpoint along with doing '
+       'rsync')
+def impl(context):
+
+    rsync_script = """
+cat >/usr/local/bin/rsync <<EOL
+#!/usr/bin/env bash
+
+arguments="\$@"
+
+# Insert data into table and run checkpoint just before syncing pg_control
+if [[ "\$arguments" == *"pg_wal"* ]]
+then
+    ssh cdw "psql -c 'INSERT INTO test_recoverseg SELECT generate_series(1, 1000)' -d postgres -p 5432 -h cdw"
+
+    # run checkpoint
+    ssh cdw "psql -c "CHECKPOINT" -d postgres -p 5432 -h cdw"
+fi
+
+/usr/bin/rsync \$arguments
+EOL
+"""
+    clear_cmd_cache_script = """
+cat >/tmp/clear_cmd_cache.py <<EOL
+#!/usr/bin/env python3
+
+# clear the cmd cache
+global CMD_CACHE
+CMD_CACHE = {}
+EOL
+"""
+
+    with closing(dbconn.connect(dbconn.DbURL(port=os.environ.get("PGPORT")), unsetSearchPath=False)) as conn:
+        query = "select distinct hostname from gp_segment_configuration where status='d';"
+        result = dbconn.query(conn, query).fetchall()
+        host_list = [result[s][0] for s in range(len(result))]
+        context.hosts_with_rsync_bash = host_list
+
+    cmd = Command(name='create a file for new rsync script',
+                  cmdStr="sudo touch /usr/local/bin/rsync;sudo chmod 777 /usr/local/bin/rsync")
+    cmd.run(validateAfter=True)
+
+    cmd = Command(name='update rsync bash script', cmdStr=rsync_script)
+    cmd.run(validateAfter=True)
+
+    for host in host_list:
+        cmd = Command(name='create a file for new rsync script', cmdStr="sudo touch /usr/local/bin/rsync;sudo chmod 777 /usr/local/bin/rsync", remoteHost=host, ctxt=REMOTE)
+        cmd.run(validateAfter=True)
+
+        cmd = Command(name='update rsync bash script', cmdStr="scp /usr/local/bin/rsync {}:/usr/local/bin/rsync".format(host))
+        cmd.run(validateAfter=True)
+
+        cmd = Command(name='create script to clear cmd_cache', cmdStr=clear_cmd_cache_script,
+                      remoteHost=host, ctxt=REMOTE)
+        cmd.run(validateAfter=True)
+
+        cmd = Command(name='run script to clear cmd_cache', cmdStr="chmod +x /tmp/clear_cmd_cache.py;/tmp/clear_cmd_cache.py",
+                      remoteHost=host, ctxt=REMOTE)
+        cmd.run(validateAfter=True)
+
+
+@then('the row count of table {table} in "{dbname}" should be {count}')
+def impl(context, table, dbname, count):
+    current_row_count = _get_row_count_per_segment(table, dbname)
+    if int(count) != sum(current_row_count):
+        raise Exception(
+            "%s table in %s has %d rows, expected %d rows." % (table, dbname, sum(current_row_count), int(count)))
 


### PR DESCRIPTION
Added a behave test scenario which tests the data integrity property of differential recovery. In this scenario we assert that any data inserted in database during the execution of recovery can be seen even after the completion of recovery and no data loss happens.

Steps:

- Create a table test_recoverseg with 1000 rows
- Stop one primary segment and wait for it to marked down in gp_segment_configuration
- Create a rsync bash script which will (1st and 2nd steps will be performed only if pg_wal is being synced)
                    1. insert 1000 extra rows in test_recoverseg
                    2. execute a checkpoint (just to make sure the latest_checkpoint is updated in pg_control file)
                    3. executes actual (/usr/bin/rsync) rsync to sync the source and target provided

- Run differential recovery and make sure it uses new rsync script whenever rsync is called during recovery
- After recovery is completed, check if number of rows in test_recoverseg are 2000
- Stop the primary segment with same content id which was stopped previously and wait for it to be marked down
- number of rows in test_recoverseg should be 2000, this means the rows inserted during recovery are not lost

Reason for no data loss:

- When more rows were inserted during recovery, the wal files were present on primary which were synced to mirror during pg_wal sync step.
- Also in differential recovery the starting point for wal replay is determined by backup_label file not pg_control file. As pg_control has no role here so updating the latest_checkpoint in pg_control will not impact anything.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
