### PR TITLE
DOCS: Add example for collecting logs with timestamps that specify hour and minute

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gpsupport-gp_log_collector.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpsupport-gp_log_collector.html.md
@@ -130,6 +130,12 @@ Collect logs from host `sdw2.gpdb.local` between 2016-03-21 and 2016-03-23:
 gpsupport gp_log_collector -failed-segs -start 2016-03-21 -end 2016-03-21
 ```
 
+Collect logs from host `sdw2.gpdb.local` between 2023-06-07 07:21 and 2023-06-07 07:24:
+
+```
+ gpsupport gp_log_collector -start 2023-06-07 07:21 -end 2023-06-07 07:24
+```
+
 Collect only GPText logs for all segments, without any Greenplum logs:
 
 ```


### PR DESCRIPTION
Also, here is the text of the GPDB 7 Beta.5 release note:

"`gpsupport gp_log_collector` can now filter logs based on timestamps at the level of hours and minutes (YYYY-MM-DD-HH:MM); previously, filter granularity was limited to days (YYYY-MM-DD)."