### PR TITLE
[Pipeline] Fix gsutil command failed due to wrong dependency location

### DIFF
--- a/concourse/scripts/combine_cli_coverage.bash
+++ b/concourse/scripts/combine_cli_coverage.bash
@@ -30,6 +30,7 @@ time install_gpdb
 # Set PIP Download cache directory
 export PIP_CACHE_DIR=${PWD}/pip-cache-dir
 
+pip3 uninstall -y urllib3
 pip3 --retries 10 install -r ./gpdb_src/gpMgmt/requirements-dev.txt
 
 # Save the JSON_KEY to a file, for later use by gsutil.


### PR DESCRIPTION
in job: combine_cli_coverage job

Same with prevous commit: bd2c707df2e3fe40025beacd7dd7129a43effe30

[GPR-1433]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
