### PR TITLE
Add "+io" to cgroup.subtree_control

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup_v2.bash
+++ b/concourse/scripts/ic_gpdb_resgroup_v2.bash
@@ -22,6 +22,7 @@ enable_cgroup_subtree_control() {
         echo "+cpu" >> $basedir/cgroup.subtree_control
         echo "+cpuset" >> $basedir/cgroup.subtree_control
         echo "+memory" >> $basedir/cgroup.subtree_control
+        echo "+io" >> $basedir/cgroup.subtree_control
         mkdir $basedir/gpdb
         chmod -R 777 $basedir/gpdb
 EOF


### PR DESCRIPTION
Because some OS could not contain "io" in `cgroup.subtree_control` by
default, so add it to fix the broken CI