### PR TITLE
Flag persistent WalSndError on repslot invalidation

### DIFF
--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -45,6 +45,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "replication/slot.h"
+#include "replication/walsender_private.h"
 #include "storage/fd.h"
 #include "storage/proc.h"
 #include "storage/procarray.h"
@@ -1344,6 +1345,9 @@ restart:
 	 */
 	if (invalidated)
 	{
+		/* GPDB: Set WalSndCtl state to indicate persistent sync error state */
+		WalSndCtl->error = WALSNDERROR_WALREAD;
+
 		ReplicationSlotsComputeRequiredXmin(false);
 		ReplicationSlotsComputeRequiredLSN();
 	}

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -108,7 +108,12 @@ typedef struct WalSnd
 
 extern WalSnd *MyWalSnd;
 
+/*
+ * GPDB: Meant to hold persistent state about a walsender<->walreceiver
+ * connection, on the walsender side, even if the walsender has died.
+ */
 typedef enum
+
 {
 	WALSNDERROR_NONE = 0,
 	WALSNDERROR_WALREAD


### PR DESCRIPTION
67d4843a149 introduced WalSndError as a means for having a persistent
error state, exposed through the sync_error field in
gp_stat_replication. This state was meant to signal
walsender<->walreceiver connection failures, even when the walsender
died (the traditional upstream mechanism depends on the walsender being
alive to report issues).

We should set this state when the replication slot is invalidated as
well. This was done correctly in 6X_STABLE commit: ea69506b407.

This would prevent flakes in the associated max_slot_wal_keep_size test
such as:

```diff
--- expected/segwalrep/max_slot_wal_keep_size.out
+++ results/segwalrep/max_slot_wal_keep_size.out
@@ -289,7 +450,7 @@
 1: SELECT sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
  sync_error
 ------------
- walread
+ none
 (1 row)
```

PS: The max_slot_wal_keep_size GUC was first backported to 6X and then
later backported to 7X from PG13.

Co-authored-by: Alexandra Wang <walexandra@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_max_slot_flake
