### PR TITLE
Show planner error for CTAS queries containing modifying CTE

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -405,6 +405,10 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path,
 
 	if (query->commandType == CMD_SELECT && query->parentStmtType == PARENTSTMTTYPE_CTAS)
 	{
+		if (query->hasModifyingCTE)
+			ereport(ERROR,
+					(errcode(ERRCODE_GP_FEATURE_NOT_YET),
+					 errmsg("cannot create plan with several writing gangs")));
 		/* CREATE TABLE AS or SELECT INTO */
 		if (query->intoPolicy != NULL)
 		{

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2359,3 +2359,46 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
+-- queries contain modifying CTEs, because Greenplum cannot have two writer
+-- segworker groups, and during execution an error is thrown. Showing
+-- the error during planning stage would be more effective, therefore this test
+-- checks this behaviour.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+drop table if exists t_new;
+NOTICE:  table "t_new" does not exist, skipping
+--end_ignore
+create table with_dml(i int, j int) distributed by (i);
+explain (costs off)
+with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(update with_dml set j = j + 1 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(delete from with_dml where i > 0 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(update with_dml set j = j + 1 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(delete from with_dml where i > 0 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2373,3 +2373,46 @@ UNION ALL
  c      | 1
 (7 rows)
 
+-- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
+-- queries contain modifying CTEs, because Greenplum cannot have two writer
+-- segworker groups, and during execution an error is thrown. Showing
+-- the error during planning stage would be more effective, therefore this test
+-- checks this behaviour.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+drop table if exists t_new;
+NOTICE:  table "t_new" does not exist, skipping
+--end_ignore
+create table with_dml(i int, j int) distributed by (i);
+explain (costs off)
+with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(update with_dml set j = j + 1 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(delete from with_dml where i > 0 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(update with_dml set j = j + 1 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(delete from with_dml where i > 0 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -461,3 +461,39 @@ UNION ALL
   SELECT 'sleep', 1 where pg_sleep(1) is not null
 UNION ALL
   SELECT 'c', j FROM cte;
+
+-- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
+-- queries contain modifying CTEs, because Greenplum cannot have two writer
+-- segworker groups, and during execution an error is thrown. Showing
+-- the error during planning stage would be more effective, therefore this test
+-- checks this behaviour.
+--start_ignore
+drop table if exists with_dml;
+drop table if exists t_new;
+--end_ignore
+create table with_dml(i int, j int) distributed by (i);
+explain (costs off)
+with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select into t_new from cte;
+explain (costs off)
+with cte as
+(update with_dml set j = j + 1 returning *)
+select into t_new from cte;
+explain (costs off)
+with cte as
+(delete from with_dml where i > 0 returning *)
+select into t_new from cte;
+explain (costs off)
+create table t_new as (with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select * from cte);
+explain (costs off)
+create table t_new as (with cte as
+(update with_dml set j = j + 1 returning *)
+select * from cte);
+explain (costs off)
+create table t_new as (with cte as
+(delete from with_dml where i > 0 returning *)
+select * from cte);
+drop table with_dml;


### PR DESCRIPTION
Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose queries contain modifying CTEs, because Greenplum cannot have two writer segworker groups for one query. In current implementation all the plans with modifying CTE contain motion nodes, which separate slice with modifying DML operation from the slice, where the new table is created. And during execution stage an error is thrown, telling that node with modifying DML operation cannot be executed by a reader gang. However, showing the error during planning stage would be more effective, therefore this commit proposes the display of the error during planning. The if-clause, that checks whether query contains modifying CTEs, was added. Is is used in block dedicated to SELECT INTO or CREATE TABLE AS case inside the `cdbllize_adjust_top_path` function. If the condition is true, the proper error is shown.

Without patch, the following error is thrown (at execution stage):
```
create table with_dml (i int,j int) distributed by (i);
with cte as                                                
(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
select into t_new from cte;
ERROR:  Reader Gang execute ModifyTable node, some bugs must happen (nodeModifyTable.c:2406)  (seg1 slice1 127.0.0.1:7003 pid=1330245) (nodeModifyTable.c:2406)
```
And this patch proposed the planner failure:
```
explain (costs off)
with cte as                                                
(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
select into t_new from cte;
ERROR:  cannot create plan with several writing gangs
```