### PR TITLE
Fix gpcheckcat error against pg_description

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2422,6 +2422,7 @@ TableMainColumn['pg_proc_callback'] = ['profnoid', 'pg_proc']
 TableMainColumn['pg_statistic_ext_data'] = ['stxoid', 'pg_statistic_ext']
 TableMainColumn['pg_type_encoding'] = ['typid', 'pg_type']
 TableMainColumn['pg_window'] = ['winfnoid', 'pg_proc']
+TableMainColumn['pg_description'] = ['objoid', 'pg_description']
 
 # Table with OID (special case), these OIDs are known to be inconsistent
 TableMainColumn['pg_attrdef'] = ['adrelid', 'pg_class']

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -705,8 +705,8 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         When the user runs "gpcheckcat miss_attr_db3"
         Then gpcheckcat should print "Missing" to stdout
-	And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_foreign_table" to stdout
-	And gpcheckcat should print "Table miss_attr_db3.public.part_external_1_prt_p_2.-1" to stdout
+        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_foreign_table" to stdout
+        And gpcheckcat should print "Table miss_attr_db3.public.part_external_1_prt_p_2.-1" to stdout
         Examples:
             | attrname   | tablename          |
             | ftrelid    | pg_foreign_table   |
@@ -725,10 +725,22 @@ Feature: gpcheckcat tests
         When the user runs "gpcheckcat miss_attr_db3"
         Then gpcheckcat should print "Missing" to stdout
         And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_class" to stdout
-	And gpcheckcat should print "Relation name: part_external_1_prt_p_2" to stdout
+        And gpcheckcat should print "Relation name: part_external_1_prt_p_2" to stdout
         Examples:
             | attrname   | tablename          |
             | relname    | pg_class           |
+
+    Scenario: gpcheckcat should discover missing attributes of pg_description catalogue table
+        Given there is a "heap" table "public.heap_table" in "miss_attr_db5" with data and description
+        When the user runs "gpcheckcat -v miss_attr_db5"
+        And gpcheckcat should return a return code of 0
+        Then gpcheckcat should not print "Missing" to stdout
+        And the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_description where objoid='heap_table'::regclass::oid;""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -v miss_attr_db5"
+        Then gpcheckcat should print "Missing description metadata of {.*} on content -1" to stdout
+        And gpcheckcat should not print "Execution error:" to stdout
+        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_description" to stdout
 
 
     Scenario: set multiple GUC at session level in gpcheckcat

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2244,14 +2244,20 @@ def impl(context):
 
 @given('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
 def impl(context, tabletype, tablename, dbname, numrows):
-    populate_regular_table_data(context, tabletype, tablename, 'None', dbname, with_data=True, rowcount=int(numrows))
+    populate_regular_table_data(context, tabletype, tablename, dbname, compression_type=None, with_data=True, rowcount=int(numrows))
 
 
 @given('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data')
 @then('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data')
 @when('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data')
 def impl(context, tabletype, tablename, dbname):
-    populate_regular_table_data(context, tabletype, tablename, 'None', dbname, with_data=True)
+    populate_regular_table_data(context, tabletype, tablename, dbname, compression_type=None, with_data=True)
+
+@given('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data and description')
+@then('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data and description')
+@when('there is a "{tabletype}" table "{tablename}" in "{dbname}" with data and description')
+def impl(context, tabletype, tablename, dbname):
+	populate_regular_table_data(context, tabletype, tablename, dbname, compression_type=None, with_data=True, with_desc=True)
 
 
 @given('there is a "{tabletype}" partition table "{table_name}" in "{dbname}" with data')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -430,7 +430,7 @@ def create_external_partition(context, tablename, dbname, port, filename):
 
 
 def create_partition(context, tablename, storage_type, dbname, compression_type=None, partition=True, rowcount=1094,
-                     with_data=True, host=None, port=0, user=None):
+                     with_data=True, with_desc=False, host=None, port=0, user=None):
     interval = '1 year'
 
     table_definition = 'Column1 int, Column2 varchar(20), Column3 date'
@@ -460,6 +460,11 @@ def create_partition(context, tablename, storage_type, dbname, compression_type=
 
     with closing(dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False)) as conn:
         dbconn.execSQL(conn, create_table_str)
+
+    if with_desc:
+	    comment_table_str = "Comment on table " + tablename + " is 'This is a table.';"
+	    with closing(dbconn.connect(dbconn.DbURL(hostname=host, port=port, username=user, dbname=dbname), unsetSearchPath=False)) as conn:
+		    dbconn.execSQL(conn, comment_table_str)
 
     if with_data:
         populate_partition(tablename, PARTITION_START_DATE, dbname, 0, rowcount, host, port, user)
@@ -728,16 +733,12 @@ def validate_local_path(path):
     return len(list)
 
 
-def populate_regular_table_data(context, tabletype, table_name, compression_type, dbname, rowcount=1094,
-                                with_data=False, host=None, port=0, user=None):
+def populate_regular_table_data(context, tabletype, table_name, dbname, compression_type=None, rowcount=1094,
+                                with_data=False, with_desc=False, host=None, port=0, user=None):
     create_database_if_not_exists(context, dbname, host=host, port=port, user=user)
     drop_table_if_exists(context, table_name=table_name, dbname=dbname, host=host, port=port, user=user)
-    if compression_type == "None":
-        create_partition(context, table_name, tabletype, dbname, compression_type=None, partition=False,
-                         rowcount=rowcount, with_data=with_data, host=host, port=port, user=user)
-    else:
-        create_partition(context, table_name, tabletype, dbname, compression_type, partition=False,
-                         rowcount=rowcount, with_data=with_data, host=host, port=port, user=user)
+    create_partition(context, table_name, tabletype, dbname, compression_type=compression_type, partition=False,
+                     rowcount=rowcount, with_data=with_data, with_desc=with_desc, host=host, port=port, user=user)
 
 
 def is_process_running(proc_name, host=None):


### PR DESCRIPTION
**Issue:**
gpcheckcat is reporting error  while running ‘missing_extraneous’ test on pg_description catalogue table

```
[~/workspace/gpdb6/gpAux/gpdemo/datadirs: {6X_STABLE} ?]$ gpcheckcat postgres
Truncated batch size to number of primaries: 4Connected as user 'sshirisha' to database 'postgres', port '6000', gpdb version '6.24'
-------------------------------------------------------------------
Batch size: 4
Performing test 'unique_index_violation'
Total runtime for test 'unique_index_violation': 0:00:02.08
Performing test 'duplicate'
Total runtime for test 'duplicate': 0:00:03.11
Performing test 'missing_extraneous'
  Execution error: ERROR:  column "oid" does not exist
LINE 4:                 SELECT oid FROM pg_description
                               ^
          SELECT oid
          FROM (
                SELECT oid FROM pg_description
                WHERE classoid='1259' and objsubid='0' and objoid='16436'
                UNION ALL
                SELECT oid FROM gp_dist_random('pg_description')
                WHERE classoid='1259' and objsubid='0' and objoid='16436'
          ) alloids
          GROUP BY oid
          ORDER BY count(*) desc, oidTotal runtime for test 'missing_extraneous': 0:00:00.83
Performing test 'inconsistent'
Total runtime for test 'inconsistent': 0:00:03.48
Performing test 'foreign_key'
Total runtime for test 'foreign_key': 0:00:02.44
Performing test 'pgclass'
Total runtime for test 'pgclass': 0:00:00.20
Performing test 'namespace'
Total runtime for test 'namespace': 0:00:00.09
Performing test 'distribution_policy'
Total runtime for test 'distribution_policy': 0:00:00.01
Performing test 'dependency'
Total runtime for test 'dependency': 0:00:00.68
Performing test 'part_integrity'
Total runtime for test 'part_integrity': 0:00:00.16
Performing test 'part_constraint'
Total runtime for test 'part_constraint': 0:00:00.00
Performing test 'orphaned_toast_tables'
Total runtime for test 'orphaned_toast_tables': 0:00:00.37
Performing test 'aoseg_table'
Total runtime for test 'aoseg_table': 0:00:00.01SUMMARY REPORT
===================================================================
Completed 13 test(s) on database 'postgres' at 2023-07-26 12:30:13 with elapsed time 0:00:13
Found a total of 1 issue(s)----------------------------------------------------
Object oid: None
Table name: pg_description    Name of test which found this issue: missing_extraneous_pg_description
        Missing description metadata of {'oid': None} on content 0
```
This issue is seen in both 6x and 7x.

**RCA:**
Internally missing_extraneous test of gpcheckcat tries to fetch the oid from all the catalogue tables present in the database. For pg_description table, the oid is changed to objoid in 6x and 7x. As there is no column as oid currently in pg_description table, hence an error is reported.

```
sshirisha=# \d+ pg_description;
                               Table "pg_catalog.pg_description"
   Column    |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description
-------------+---------+-----------+----------+---------+----------+--------------+-------------
 objoid      | oid     |           | not null |         | plain    |              |
 classoid    | oid     |           | not null |         | plain    |              |
 objsubid    | integer |           | not null |         | plain    |              |
 description | text    | C         | not null |         | extended |              |
Indexes:
    "pg_description_o_c_o_index" UNIQUE, btree (objoid, classoid, objsubid)
Access method: heap

```
**Fix:**
Catalogue tables which do not have a OID column are stored in a dictionary 'TableMainColumn' and are mapped an existing OID type attribute. For fixing this issue an entry is added to dictionary so that objoid is used instead of oid while running SQL queries.

Additionally, a behave test is also to catch any further inconsistencies with pg_description table.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
