### PR TITLE
Append to shared_preload_libraries instead of replace

### DIFF
--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),auto_explain"
 \! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
 \! gpconfig -c auto_explain.log_analyze -v true --skipvalidation;
 \! gpstop -raiq;
@@ -27,6 +27,6 @@ DROP TABLE t2;
 -- start_ignore
 \! gpconfig -r auto_explain.log_min_duration;
 \! gpconfig -r auto_explain.log_analyze;
-\! gpconfig -r shared_preload_libraries;
+\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}' | awk -F ',' -v OFS=, 'NF-=1')"
 \! gpstop -raiq;
 -- end_ignore

--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v "$(echo $(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),auto_explain | sed 's/^,//g')"
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'auto_explain'), ',')" postgres)"
 \! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
 \! gpconfig -c auto_explain.log_analyze -v true --skipvalidation;
 \! gpstop -raiq;
@@ -27,6 +27,6 @@ DROP TABLE t2;
 -- start_ignore
 \! gpconfig -r auto_explain.log_min_duration;
 \! gpconfig -r auto_explain.log_analyze;
-\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}' | awk -F ',' -v OFS=, 'NF-=1')"
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_remove(string_to_array(current_setting('shared_preload_libraries'), ','), 'auto_explain'), ',')" postgres)"
 \! gpstop -raiq;
 -- end_ignore

--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,5 +1,5 @@
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),auto_explain"
+\! gpconfig -c shared_preload_libraries -v "$(echo $(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),auto_explain | sed 's/^,//g')"
 \! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
 \! gpconfig -c auto_explain.log_analyze -v true --skipvalidation;
 \! gpstop -raiq;

--- a/contrib/pgcrypto/sql/setup_fips.sql
+++ b/contrib/pgcrypto/sql/setup_fips.sql
@@ -4,6 +4,6 @@
 -- 'pgcrypto.fips' immediately after creating the extension on master.
 
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v 'pgcrypto.so'
+\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),pgcrypto.so"
 \! gpstop -air
 -- end_ignore

--- a/contrib/pgcrypto/sql/setup_fips.sql
+++ b/contrib/pgcrypto/sql/setup_fips.sql
@@ -4,6 +4,6 @@
 -- 'pgcrypto.fips' immediately after creating the extension on master.
 
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v "$(echo $(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),pgcrypto.so | sed 's/^,//g')"
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'pgcrypto.so'), ',')" postgres)"
 \! gpstop -air
 -- end_ignore

--- a/contrib/pgcrypto/sql/setup_fips.sql
+++ b/contrib/pgcrypto/sql/setup_fips.sql
@@ -4,6 +4,6 @@
 -- 'pgcrypto.fips' immediately after creating the extension on master.
 
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v "$(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),pgcrypto.so"
+\! gpconfig -c shared_preload_libraries -v "$(echo $(gpconfig -s shared_preload_libraries | grep value: | head -n 1 | awk -F ': ' '{print $2}'),pgcrypto.so | sed 's/^,//g')"
 \! gpstop -air
 -- end_ignore


### PR DESCRIPTION
Previously in ICW tests, some extensions including auto_explain and pgcrypto set GUC `shared_preload_libraries` regardless of its original value. This will impact other extensions who also need to include themselves into `shared_preload_libraries`.

To fix this issue, this patch changes the `gpconfig` command to

- Before running the test, append new library names to the end, rather than replace the whole value.
- After running the test, instead of removing the GUC setting, only the newly appended library is removed.

As a result, extensions required to be in `shared_preload_libraries` can work nicely together throughout the whole ICW tests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
