### PR TITLE
Rewrite test interrupt_holdoff_count

### DIFF
--- a/src/test/regress/expected/interrupt_holdoff_count.out
+++ b/src/test/regress/expected/interrupt_holdoff_count.out
@@ -1,13 +1,19 @@
 -- test for Github Issue 15278
 -- QD should reset InterruptHoldoffCount
+-- start_ignore
+create extension if not exists gp_inject_fault;
+-- end_ignore
+select gp_inject_fault('start_prepare', 'error', dbid, current_setting('gp_session_id')::int)
+	from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 create table t_15278(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into t_15278 values (-1,1);
-begin;
-declare c1 cursor for select count(*) from t_15278 group by sqrt(a);
-abort;
-ERROR:  cannot take square root of a negative number  (seg2 slice2 127.0.1.1:7004 pid=489428)
+ERROR:  fault triggered, fault name:'start_prepare' fault type:'error'  (seg0 127.0.1.1:6002 pid=764409)
 -- Without fix, the above transaction will lead
 -- QD's global var InterruptHoldoffCount not reset to 0
 -- thus the below SQL will return t. After fixing, now
@@ -15,4 +21,10 @@ ERROR:  cannot take square root of a negative number  (seg2 slice2 127.0.1.1:700
 -- the correct behavior.
 select pg_cancel_backend(pg_backend_pid());
 ERROR:  canceling statement due to user request
-drop table t_15278;
+select gp_inject_fault('start_prepare', 'reset', dbid, current_setting('gp_session_id')::int)
+	from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -179,7 +179,8 @@ test: resource_group_gucs
 test: trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression
 
 # direct dispatch tests
-test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types interrupt_holdoff_count
+test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types
+test: interrupt_holdoff_count
 
 test: bfv_catalog bfv_index bfv_olap bfv_aggregate DML_over_joins bfv_statistic nested_case_null sort bb_mpph aggregate_with_groupingsets gporca gpsd catcache part_external_table
 # Run minirepro separately to avoid concurrent deletes erroring out the internal pg_dump call


### PR DESCRIPTION
This commit fixes test, which was added at [commit](https://github.com/greenplum-db/gpdb/commit/50e66c76acf19d09ac7f0fc05cca01e014bb0ab8)

This test checks that error, which generated at critical place (where `InterruptHoldoffCount` is more than zero) leads to resetting counter `InterruptHoldoffCount` at QD. Operation, which generates created commit, is used for the test.
This operation:

1. Dispatches to segments and can lead to error on segments (as already done at the test).
2. Does not process interruptions while dispatching to the segments.

At first version of this test there was declare cursor. QD does not wait result of declare cursor, but on segments there is work, which ends with error. This error is processed when abort is called. At some cases abort is called before error is generated on segment. It led to situation, when there is not any errors on segments and abort is executed with success result. This test requires error to check `InterruptHoldoffCount` after query which ended with error.
This test failed with diff:
```
[2023-07-21T09:06:28.980Z] --- \/home\/gpadmin\/gpdb_src\/src\/test\/regress\/expected\/interrupt_holdoff_count\.out	2023-07-21 07:04:43.297869548 +0000
[2023-07-21T09:06:28.980Z] +++ \/home\/gpadmin\/gpdb_src\/src\/test\/regress\/results\/interrupt_holdoff_count\.out	2023-07-21 07:04:43.301869547 +0000
[2023-07-21T09:06:28.980Z] @@ -6,7 +6,6 @@
[2023-07-21T09:06:28.980Z]  begin;
[2023-07-21T09:06:28.980Z]  declare c1 cursor for select count(*) from t_15278 group by sqrt(a);
[2023-07-21T09:06:28.980Z]  abort;
[2023-07-21T09:06:28.980Z] -ERROR:  cannot take square root of a negative number
[2023-07-21T09:06:28.980Z]  -- Without fix, the above transaction will lead
[2023-07-21T09:06:28.980Z]  -- QD's global var InterruptHoldoffCount not reset to 0
[2023-07-21T09:06:28.980Z]  -- thus the below SQL will return t. After fixing, now
```

New version of the test uses existing inject fault, which generate error at create table. create table ends with error and `InterruptHoldoffCount` can be checked correctly.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
