### PR TITLE
Docs: Added gprecoverseg -x option for 6X_STABLE

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpcheckcat.html.md
@@ -22,6 +22,7 @@ gpcheckcat [ <options<] [ <dbname>]
      -B <parallel_processes>
      -v
      -A
+     -x "<parameter_name>=<value>"
 
 gpcheckcat  -l 
 
@@ -126,6 +127,9 @@ Catalog inconsistencies are inconsistencies that occur between Greenplum Databas
 
 -v \(verbose\)
 :   Displays detailed information about the tests that are performed.
+
+-x "<parameter_name>=<value>"
+:   Set a server configuration parameter, such as `log_min_messages`, at a session level. To set multiple configuration parameters, use the `-x` option multiple times. 
 
 ## <a id="notes"></a>Notes 
 


### PR DESCRIPTION
This PR ports https://github.com/greenplum-db/gpdb/pull/16111 to 6X_STABLE.