### PR TITLE
Fix test test_HandleFtsWalRepPromoteMirror variable reference

### DIFF
--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -174,7 +174,7 @@ test_HandleFtsWalRepPromoteMirror(void **state)
 	expect_value(ReplicationSlotCreate, db_specific, false);
 	expect_value(ReplicationSlotCreate, persistency, RS_PERSISTENT);
 	will_be_called_with_sideeffect(ReplicationSlotCreate,
-								   set_replication_slot, &ReplicationSlotCtl);
+								   set_replication_slot, ReplicationSlotCtl);
 
 	/* expect SignalPromote() */
 	expectSendFtsResponse(FTS_MSG_PROMOTE, &mockresponse);


### PR DESCRIPTION
Test case test_HandleFtsWalRepPromoteMirror had undefined behavior. On
CI using Rocky9 non-asserts build this triggered a segfault against an
unrelated commit.

In the test ReplicationSlotCtl is already a pointer. And so referencing
it passes a pointer to a pointer to will_be_called_with_sideeffect().
But that is not what the method set_replication_slot() expects. That
leads to undefined behavior.