### PR TITLE
[7X] ORCA initialization refactoring

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -265,13 +265,32 @@ InitGPOPT()
 {
 	GPOS_TRY
 	{
-		return CGPOptimizer::InitGPOPT();
+		try
+		{
+			CGPOptimizer::InitGPOPT();
+		}
+		catch (CException ex)
+		{
+			throw ex;
+		}
+		catch (...)
+		{
+			// unexpected failure
+			GPOS_RAISE(CException::ExmaUnhandled, CException::ExmiUnhandled);
+		}
 	}
 	GPOS_CATCH_EX(ex)
 	{
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
 			PG_RE_THROW();
+		}
+
+		if (errstart(ERROR, TEXTDOMAIN))
+		{
+			errcode(ERRCODE_INTERNAL_ERROR);
+			errmsg("optimizer failed to init");
+			errfinish(ex.Filename(), ex.Line(), nullptr);
 		}
 	}
 	GPOS_CATCH_END;

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -50,11 +50,11 @@ CMemoryPoolPallocManager::UserSizeOfAlloc(const void *ptr)
 	return CMemoryPoolPalloc::UserSizeOfAlloc(ptr);
 }
 
-GPOS_RESULT
+void
 CMemoryPoolPallocManager::Init()
 {
-	return CMemoryPoolManager::SetupGlobalMemoryPoolManager<
-		CMemoryPoolPallocManager, CMemoryPoolPalloc>();
+	CMemoryPoolManager::SetupGlobalMemoryPoolManager<CMemoryPoolPallocManager,
+													 CMemoryPoolPalloc>();
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/exception.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/exception.h
@@ -43,7 +43,7 @@ enum ExMinor
 };
 
 // message initialization for GPOS exceptions
-gpos::GPOS_RESULT EresExceptionInit(gpos::CMemoryPool *mp);
+void EresExceptionInit(gpos::CMemoryPool *mp);
 
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -110,7 +110,7 @@ public:
 	}
 
 	// initialize global factory instance
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// destroy global factory instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpopt/src/exception.cpp
+++ b/src/backend/gporca/libgpopt/src/exception.cpp
@@ -24,7 +24,7 @@ using namespace gpos;
 //		Message initialization for GPOPT exceptions
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 gpopt::EresExceptionInit(CMemoryPool *mp)
 {
 	//---------------------------------------------------------------------------
@@ -113,30 +113,15 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 				 GPOS_WSZ_WSZLEN("Missing group stats")),
 	};
 
-	GPOS_RESULT eres = GPOS_FAILED;
+	// copy exception array into heap
+	CMessage *rgpmsg[gpopt::ExmiSentinel];
+	CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
 
-	GPOS_TRY
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
 	{
-		// copy exception array into heap
-		CMessage *rgpmsg[gpopt::ExmiSentinel];
-		CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
-
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
-		{
-			rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
-			pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
-		}
-
-		eres = GPOS_OK;
+		rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
+		pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
 	}
-	GPOS_CATCH_EX(ex)
-	{
-		return GPOS_FAILED;
-	}
-
-	GPOS_CATCH_END;
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -13,7 +13,6 @@
 #include "gpopt/init.h"
 
 #include "gpos/_api.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 #include "gpos/task/CWorker.h"
 
 #include "gpopt/exception.h"
@@ -41,21 +40,11 @@ static CMemoryPool *mp = nullptr;
 void
 gpopt_init()
 {
-	{
-		CAutoMemoryPool amp;
-		mp = amp.Pmp();
+	mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-		// add standard exception messages
-		(void) gpopt::EresExceptionInit(mp);
+	gpopt::EresExceptionInit(mp);
 
-		// detach safety
-		(void) amp.Detach();
-	}
-
-	if (GPOS_OK != gpopt::CXformFactory::Init())
-	{
-		return;
-	}
+	CXformFactory::Init();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -352,44 +352,20 @@ CXformFactory::IsXformIdUsed(CXform::EXformId exfid)
 //		Initializes global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CXformFactory::Init()
 {
 	GPOS_ASSERT(nullptr == Pxff() && "Xform factory was already initialized");
 
-	GPOS_RESULT eres = GPOS_OK;
-
 	// create xform factory memory pool
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
-	GPOS_TRY
-	{
-		// create xform factory instance
-		m_pxff = GPOS_NEW(mp) CXformFactory(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
-		m_pxff = nullptr;
 
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			eres = GPOS_OOM;
-		}
-		else
-		{
-			eres = GPOS_FAILED;
-		}
-
-		return eres;
-	}
-	GPOS_CATCH_END;
+	// create xform factory instance
+	m_pxff = GPOS_NEW(mp) CXformFactory(mp);
 
 	// instantiating the factory
 	m_pxff->Instantiate();
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -64,7 +64,7 @@ public:
 	void AddMessage(ELocale locale, CMessage *msg);
 
 	// initializer for global singleton
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -64,7 +64,7 @@ public:
 	}
 
 	// initialize global memory pool
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// destroy global instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -96,7 +96,7 @@ protected:
 
 	// Initialize global memory pool manager using given types
 	template <typename ManagerType, typename PoolType>
-	static GPOS_RESULT
+	static void
 	SetupGlobalMemoryPoolManager()
 	{
 		// raw allocation of memory for internal memory pools
@@ -104,22 +104,12 @@ protected:
 
 		GPOS_OOM_CHECK(alloc_internal);
 
-		GPOS_TRY
-		{
-			// create internal memory pool
-			CMemoryPool *internal = ::new (alloc_internal) PoolType();
+		// create internal memory pool
+		CMemoryPool *internal = ::new (alloc_internal) PoolType();
 
-			// instantiate manager
-			m_memory_pool_mgr = ::new ManagerType(internal, EMemoryPoolTracker);
-			m_memory_pool_mgr->Setup();
-		}
-		GPOS_CATCH_EX(ex)
-		{
-			gpos::clib::Free(alloc_internal);
-			GPOS_RETHROW(ex);
-		}
-		GPOS_CATCH_END;
-		return GPOS_OK;
+		// instantiate manager
+		m_memory_pool_mgr = ::new ManagerType(internal, EMemoryPoolTracker);
+		m_memory_pool_mgr->Setup();
 	}
 
 public:
@@ -161,7 +151,7 @@ public:
 	virtual ULONG UserSizeOfAlloc(const void *ptr);
 
 	// initialize global instance
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// global accessor
 	static CMemoryPoolManager *

--- a/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
@@ -135,7 +135,7 @@ public:
 	}
 
 	// initialize worker pool manager
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// de-init global instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -130,28 +130,10 @@ gpos_init(struct gpos_init_params *params)
 {
 	CWorker::abort_requested_by_system = params->abort_requested;
 
-	if (GPOS_OK != gpos::CMemoryPoolManager::Init())
-	{
-		return;
-	}
-
-	if (GPOS_OK != gpos::CWorkerPoolManager::Init())
-	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CMessageRepository::Init())
-	{
-		CWorkerPoolManager::Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CCacheFactory::Init())
-	{
-		return;
-	}
+	CMemoryPoolManager::Init();
+	CWorkerPoolManager::Init();
+	CMessageRepository::Init();
+	CCacheFactory::Init();
 
 #ifdef GPOS_DEBUG_COUNTERS
 	CDebugCounter::Init();

--- a/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
+++ b/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
@@ -13,7 +13,6 @@
 #include "gpos/common/CDebugCounter.h"
 
 #include "gpos/error/CAutoTrace.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 
 using namespace gpos;
 
@@ -59,14 +58,12 @@ CDebugCounter::~CDebugCounter()
 void
 CDebugCounter::Init()
 {
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
-
 	GPOS_RTL_ASSERT(NULL == m_instance);
-	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 
-	// detach safety
-	(void) amp.Detach();
+	CMemoryPool *mp =
+		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+
+	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 }
 
 void

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -12,7 +12,6 @@
 #include "gpos/error/CMessageRepository.h"
 
 #include "gpos/common/CSyncHashtableAccessByKey.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 #include "gpos/utils.h"
 
 
@@ -88,24 +87,17 @@ CMessageRepository::LookupMessage(CException exc, ELocale locale)
 //		Initialize global instance of message repository
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CMessageRepository::Init()
 {
 	GPOS_ASSERT(nullptr == m_repository);
 
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
+	CMemoryPool *mp =
+		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	CMessageRepository *repository = GPOS_NEW(mp) CMessageRepository(mp);
-	repository->InitDirectory(mp);
-	repository->LoadStandardMessages();
-
-	CMessageRepository::m_repository = repository;
-
-	// detach safety
-	(void) amp.Detach();
-
-	return GPOS_OK;
+	m_repository = GPOS_NEW(mp) CMessageRepository(mp);
+	m_repository->InitDirectory(mp);
+	m_repository->LoadStandardMessages();
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -57,40 +57,18 @@ CCacheFactory::Pmp() const
 //		Initializes global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CCacheFactory::Init()
 {
 	GPOS_ASSERT(nullptr == GetFactory() &&
 				"Cache factory was already initialized");
 
-	GPOS_RESULT res = GPOS_OK;
-
 	// create cache factory memory pool
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
-	GPOS_TRY
-	{
-		// create cache factory instance
-		CCacheFactory::m_factory = GPOS_NEW(mp) CCacheFactory(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
 
-		CCacheFactory::m_factory = nullptr;
-
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			res = GPOS_OOM;
-		}
-		else
-		{
-			res = GPOS_FAILED;
-		}
-	}
-	GPOS_CATCH_END;
-	return res;
+	// create cache factory instance
+	m_factory = GPOS_NEW(mp) CCacheFactory(mp);
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -64,16 +64,13 @@ CMemoryPoolManager::Setup()
 }
 
 // Initialize global memory pool manager using CMemoryPoolTracker
-GPOS_RESULT
+void
 CMemoryPoolManager::Init()
 {
 	if (nullptr == CMemoryPoolManager::m_memory_pool_mgr)
 	{
-		return SetupGlobalMemoryPoolManager<CMemoryPoolManager,
-											CMemoryPoolTracker>();
+		SetupGlobalMemoryPoolManager<CMemoryPoolManager, CMemoryPoolTracker>();
 	}
-
-	return GPOS_OK;
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -59,7 +59,7 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 //		Initializer for global worker pool manager
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CWorkerPoolManager::Init()
 {
 	GPOS_ASSERT(nullptr == WorkerPoolManager());
@@ -67,29 +67,8 @@ CWorkerPoolManager::Init()
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	GPOS_TRY
-	{
-		// create worker pool
-		CWorkerPoolManager::m_worker_pool_manager =
-			GPOS_NEW(mp) CWorkerPoolManager(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// turn in memory pool in case of failure
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
-
-		CWorkerPoolManager::m_worker_pool_manager = nullptr;
-
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			return GPOS_OOM;
-		}
-
-		return GPOS_FAILED;
-	}
-	GPOS_CATCH_END;
-
-	return GPOS_OK;
+	// create worker pool
+	m_worker_pool_manager = GPOS_NEW(mp) CWorkerPoolManager(mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/exception.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/exception.h
@@ -80,7 +80,7 @@ enum ExMinor
 };
 
 // message initialization for GPOS exceptions
-gpos::GPOS_RESULT EresExceptionInit(gpos::CMemoryPool *mp);
+void EresExceptionInit(gpos::CMemoryPool *mp);
 
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -26,7 +26,7 @@ using namespace gpdxl;
 //		Message initialization for DXL exceptions
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 gpdxl::EresExceptionInit(CMemoryPool *mp)
 {
 	//---------------------------------------------------------------------------
@@ -279,32 +279,19 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 
 	};
 
-	GPOS_RESULT eres = GPOS_FAILED;
-
-	GPOS_TRY
+	// copy exception array into heap
+	CMessage *rgpmsg[ExmiDXLSentinel];
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
 	{
-		// copy exception array into heap
-		CMessage *rgpmsg[ExmiDXLSentinel];
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
-		{
-			rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
-		}
-
-		CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
-
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgmsg); i++)
-		{
-			pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
-		}
-
-		eres = GPOS_OK;
+		rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
 	}
-	GPOS_CATCH_EX(ex)
+
+	CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
+
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgmsg); i++)
 	{
+		pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
 	}
-	GPOS_CATCH_END;
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -15,8 +15,6 @@
 #include <xercesc/framework/MemBufInputSource.hpp>
 #include <xercesc/util/XMLString.hpp>
 
-#include "gpos/memory/CAutoMemoryPool.h"
-
 #include "naucrates/dxl/parser/CParseHandlerFactory.h"
 #include "naucrates/dxl/xml/CDXLMemoryManager.h"
 #include "naucrates/dxl/xml/dxltokens.h"
@@ -123,23 +121,13 @@ void
 gpdxl_init()
 {
 	// create memory pool for Xerces global allocations
-	{
-		CAutoMemoryPool amp;
-
-		// detach safety
-		pmpXerces = amp.Detach();
-	}
+	pmpXerces = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
 	// create memory pool for DXL global allocations
-	{
-		CAutoMemoryPool amp;
-
-		// detach safety
-		pmpDXL = amp.Detach();
-	}
+	pmpDXL = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
 	// add standard exception messages
-	(void) EresExceptionInit(pmpDXL);
+	EresExceptionInit(pmpDXL);
 }
 
 

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -217,9 +217,7 @@ ConfigureTests()
 #ifdef GPOS_DEBUG
 	// reset xforms factory to exercise xforms ctors and dtors
 	CXformFactory::Shutdown();
-	GPOS_RESULT eres = CXformFactory::Init();
-
-	GPOS_ASSERT(GPOS_OK == eres);
+	CXformFactory::Init();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/include/gpopt/utils/CMemoryPoolPallocManager.h
+++ b/src/include/gpopt/utils/CMemoryPoolPallocManager.h
@@ -39,8 +39,7 @@ public:
 	// get user requested size of allocation
 	ULONG UserSizeOfAlloc(const void *ptr) override;
 
-
-	static GPOS_RESULT Init();
+	static void Init();
 };
 }  // namespace gpos
 


### PR DESCRIPTION
When initializing ORCA mixed a C approach (returning error codes and then checking them) and a C++ approach (throwing exceptions and then catching them). This mixing led to errors. For example, in case of low memory or any other exception, the CWorkerPoolManager::Init function did not return GPOS_OK, and then the gpos_init function called
the CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown function, which reset CMemoryPoolManager::m_memory_pool_mgr. In this case, all the exceptions that arose were not rethrown, so the execution continued, and the following gpdxl_init function was called, in which the CAutoMemoryPool class was initialized. In the constructor of this class, the static method CMemoryPoolManager::GetMemoryPoolMgr returned NULL, because we nullified m_memory_pool_mgr up the stack. Thus, a segfault could occur.

The patch replaces C approach with C++ approach in ORCA initialization and adds processing of standard C++ exceptions, which are thrown for example by the new operator in case of out of memory.

Now a backend terminates with error on any exception during ORCA initialization, because ORCA does not work correctly when initialization is not fully completed.

The gpdxl_init function has been changed, because the auto memory pool is used to automatically free memory when it goes out of scope, but here the pools were immediately removed, and in fact, they are not needed here at all.

This is extended version of https://github.com/greenplum-db/gpdb/pull/16085