### PR TITLE
Fix gpload insert mode not included in transaction 

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2965,7 +2965,7 @@ class gpload:
         truncate = False
         self.reuse_tables = False
 
-        if not self.options.no_auto_trans and not method=='insert':
+        if not self.options.no_auto_trans:
             self.db.query("BEGIN")
 
         self.extSchemaName = self.getconfig('gpload:external:schema', unicode, None)
@@ -3031,7 +3031,7 @@ class gpload:
                     self.log(self.ERROR, 'could not execute SQL in sql:after "%s": %s' %
                              (after, str(e)))
 
-        if not self.options.no_auto_trans and not method=='insert':
+        if not self.options.no_auto_trans:
             self.db.query("COMMIT")
 
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -545,7 +545,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [44,46,51,57,65,219,260,259]
+Modify_Output_Case = [44,46,51,57,65,219,260,259,609]
 
 
 def doTest(num):
@@ -564,7 +564,7 @@ def doTest(num):
         newpat2 = 'pathto/data_file'
         pat3 = r', SSL off$'
         newpat3 = ''
-        pat4 = r'ext_gpload_.*'
+        pat4 = r'ext_gpload_.*' # external table name
         newpat4='ext_gpload_table'
         pat5 = r'[a-zA-Z0-9/\_-]*/gpload.py'  # file location
         newpat5 = 'pathto/gpload.py'

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
@@ -84,3 +84,17 @@ def test_608_gpload_ext_staging_table():
     copy_data('external_file_13.csv','data_file.csv')
     write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='csvtable', delimiter="','", log_errors=True,error_limit=10,staging_table='"Staging_table"')
     write_config_file(reuse_tables=False, config='config/config_file1', format='csv', file='data_file.csv', table='csvtable', delimiter="','", log_errors=True,error_limit=10,staging_table='staging_table')
+
+
+@pytest.mark.order(609)
+@prepare_before_test(num=609, times=2)
+def test_609_gpload_fail_preload_truncate_rollback():
+    "609T gpload set preload truncate, but gpload fail, truncate should rollback together"
+    file = mkpath('setup.sql')
+    runfile(file)
+    f = open(mkpath('query609.sql'), 'w')
+    f.write("\\!  gpload -f "+mkpath('config/config_file')+"\n")
+    f.write("\\!  psql -d reuse_gptest -c \"SELECT count(*) from  testtruncate;\"\n")
+    f.close()
+    copy_data('external_file_13.csv','data_file.csv')
+    write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='testtruncate', delimiter="';'", truncate=True )

--- a/gpMgmt/bin/gpload_test/gpload2/query205.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query205.ans
@@ -3,6 +3,8 @@
 2021-06-01 15:56:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
 2021-06-01 15:56:30|INFO|did not find an external table to reuse. creating ext_gpload_reusable_e041fa16_c2ae_11eb_abd4_0050569ea4ff
 2021-06-01 15:56:30|ERROR|could not run SQL "create external table ext_gpload_reusable_e041fa16_c2ae_11eb_abd4_0050569ea4ff("s1" text,"s2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '' null '\N' escape '\') encoding'UTF8' ": ERROR:  COPY delimiter must be a single one-byte character, or 'off'
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
 2021-06-01 15:56:30|INFO|rows Inserted          = 0
 2021-06-01 15:56:30|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query233.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query233.ans
@@ -5,6 +5,8 @@
 2021-06-01 15:56:51|ERROR|could not run SQL "create external table ext_gpload_reusable_ecd5c1b8_c2ae_11eb_848f_0050569ea4ff("s1" text,"s2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter '|' null 'E''\x08E'\'' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "\"
 LINE 1: ...txt') format 'text' (delimiter '|' null 'E''\x08E'\'' escape...
                                                              ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
 2021-06-01 15:56:51|INFO|rows Inserted          = 0
 2021-06-01 15:56:51|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query259.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query259.ans
@@ -4,6 +4,8 @@
 2021-11-25 16:14:24|INFO|did not find an external table to reuse. creating ext_gpload_table
 2021-11-25 16:14:24|ERROR|could not run SQL "create external table ext_gpload_table
 HINT:  valid options are: 'LF', 'CRLF', 'CR'
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
 2021-11-25 16:14:24|INFO|rows Inserted          = 0
 2021-11-25 16:14:24|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query260.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query260.ans
@@ -4,6 +4,8 @@
 2021-11-25 16:14:25|INFO|did not find an external table to reuse. creating ext_gpload_table
 2021-11-25 16:14:25|ERROR|could not run SQL "create external table ext_gpload_table
 HINT:  valid options are: 'LF', 'CRLF', 'CR'
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
 2021-11-25 16:14:25|INFO|rows Inserted          = 0
 2021-11-25 16:14:25|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query261.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query261.ans
@@ -13,7 +13,7 @@ CONTEXT:  External table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b
 2021-11-09 09:42:31|INFO|gpload session started 2021-11-09 09:42:31
 2021-11-09 09:42:31|INFO|setting schema 'public' for table 'texttable2'
 2021-11-09 09:42:31|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-11-09 09:42:31|INFO|reusing external table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
+2021-11-09 09:42:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
 2021-11-09 09:42:31|ERROR|ERROR:  segment reject limit reached, aborting operation  (seg2 slice1 127.0.0.1:6004 pid=22383)
 DETAIL:  Last error was: missing data for column "s2"
 CONTEXT:  External table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2, line 2 of gpfdist://127.0.0.1:8081//home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt: "est1"

--- a/gpMgmt/bin/gpload_test/gpload2/query609.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query609.ans
@@ -1,0 +1,15 @@
+2023-08-04 14:31:51|INFO|gpload session started 2023-08-04 14:31:51
+2023-08-04 14:31:51|INFO|setting schema 'public' for table 'testtruncate'
+2023-08-04 14:31:51|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
+2023-08-04 14:31:51|ERROR|ERROR:  missing data for column "s2"  (seg0 slice1 *:6002 pid=4857)
+CONTEXT:  External table ext_gpload_table
+ encountered while running INSERT INTO public."testtruncate" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_table
+2023-08-04 14:31:51|INFO|rows Inserted          = 0
+2023-08-04 14:31:51|INFO|rows Updated           = 0
+2023-08-04 14:31:51|INFO|data formatting errors = 0
+2023-08-04 14:31:51|INFO|gpload failed
+ count 
+-------
+     1
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query665.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query665.ans
@@ -10,17 +10,16 @@ LINE 1: INSERT INTO test_665_after VALUES('a')
 2021-06-02 16:22:07|INFO|rows Updated           = 0
 2021-06-02 16:22:07|INFO|data formatting errors = 0
 2021-06-02 16:22:07|INFO|gpload failed
- c1 
-----
-  1
-(1 row)
-
- c1 
+ c1
 ----
 (0 rows)
 
- count 
+ c1
+----
+(0 rows)
+
+ count
 -------
-    16
+     0
 (1 row)
 

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -5,7 +5,8 @@
 2021-07-30 11:44:08|ERROR|could not run SQL "create external table ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
- standard_conforming_strings is set to 'off', please set it to 'on' and try again 
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
 2021-07-30 11:44:08|INFO|rows Inserted          = 0
 2021-07-30 11:44:08|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -5,7 +5,8 @@
 2021-07-29 21:08:35|ERROR|could not run SQL "create external table ext_gpload_reusable_15099ac8_f06e_11eb_abc1_0050569ea4ff("Field1" text,"Field#2" text)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
- standard_conforming_strings is set to 'off', please set it to 'on' and try again 
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again
 
 2021-07-29 21:08:35|INFO|rows Inserted          = 0
 2021-07-29 21:08:35|INFO|rows Updated           = 0


### PR DESCRIPTION
gpload usually starts a transaction for preload, before sql, gpload sql, and after sql. But in insert mode, no transaction is started. So if gpload insert fails, the sqls in preload, before and after will still be executed.
In this pr, we will start a transaction for insert mode to avoid this behavior.

### NOTE: 
* The behavior of the insert mode will change: when the insert fails and rollback, the [preload](https://docs.vmware.com/en/VMware-Greenplum/5/greenplum-database/utility_guide-admin_utilities-gpload.html#:~:text=and%20so%20on.-,PRELOAD,-Optional.%20Specifies%20operations) and [SQL](https://docs.vmware.com/en/VMware-Greenplum/5/greenplum-database/utility_guide-admin_utilities-gpload.html#:~:text=a%20warning%20message.-,SQL,-Optional.%20Defines%20SQL) In YAML file will also rollback.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
