### PR TITLE
fix gpload insert mode not included in transaction

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2879,7 +2879,7 @@ class gpload:
         truncate = False
         self.reuse_tables = False
 
-        if not self.options.no_auto_trans and not method=='insert':
+        if not self.options.no_auto_trans:
             with self.conn.cursor() as cur:
                 cur.execute("BEGIN")
 
@@ -2947,9 +2947,10 @@ class gpload:
                     self.log(self.ERROR, 'could not execute SQL in sql:after "%s": %s' %
                              (after, str(e)))
 
-        if not self.options.no_auto_trans and not method=='insert':
+        if not self.options.no_auto_trans:
             with self.conn.cursor() as cur:
                 cur.execute("COMMIT")
+
 
     def stop_gpfdists(self):
         if self.subprocesses:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -487,7 +487,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [46,51,57,65,76,260,402,609]
+Modify_Output_Case = [46,51,57,65,76,260,402]
 
 
 def doTest(num):
@@ -507,9 +507,7 @@ def doTest(num):
         newpat3 = ''
         pat4 = r'LINE 1: ...[a-zA-Z0-9\_]*\('
         newpat4 = 'LINE 1: ...('
-        pat5 = r'ext_gpload_[a-zA-Z0-9\_]*'
-        newpat5 = 'ext_gpload'
-        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4, pat5], [newpat1,newpat2,newpat3,newpat4, newpat5])  # some strings in outfile are different each time, such as host and file location
+        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4], [newpat1,newpat2,newpat3,newpat4])  # some strings in outfile are different each time, such as host and file location
         # we modify the out file here to make it match the ans file
 
     check_result(file,num=num)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -487,7 +487,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [46,51,57,65,76,260,402]
+Modify_Output_Case = [46,51,57,65,76,260,402,609]
 
 
 def doTest(num):
@@ -507,7 +507,9 @@ def doTest(num):
         newpat3 = ''
         pat4 = r'LINE 1: ...[a-zA-Z0-9\_]*\('
         newpat4 = 'LINE 1: ...('
-        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4], [newpat1,newpat2,newpat3,newpat4])  # some strings in outfile are different each time, such as host and file location
+        pat5 = r'ext_gpload_[a-zA-Z0-9\_]*'
+        newpat5 = 'ext_gpload'
+        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4, pat5], [newpat1,newpat2,newpat3,newpat4, newpat5])  # some strings in outfile are different each time, such as host and file location
         # we modify the out file here to make it match the ans file
 
     check_result(file,num=num)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
@@ -74,9 +74,8 @@ def test_609_gpload_fail_preload_truncate_rollback():
     "609T gpload set preload truncate, but gpload fail, truncate should rollback together"
     file = mkpath('setup.sql')
     runfile(file)
-    f = open(mkpath('query609.sql'), 'w')
-    f.write("\\!  gpload -f "+mkpath('config/config_file')+"\n")
-    f.write("\\!  psql -d reuse_gptest -c \"SELECT count(*) from  testtruncate;\"\n")
-    f.close()
+    with open(mkpath('query609.sql'), 'w') as f:
+        f.write("\\!  gpload -f "+mkpath('config/config_file')+"\n")
+        f.write("\\!  psql -d reuse_gptest -c \"SELECT count(*) from  testtruncate;\"\n")
     copy_data('external_file_13.csv','data_file.csv')
     write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='testtruncate', delimiter="';'", truncate=True )

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
@@ -68,3 +68,15 @@ def test_608_gpload_ext_staging_table():
     runfile(file)
     copy_data('external_file_13.csv','data_file.csv')
     write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='csvtable', delimiter="','", log_errors=True,error_limit=10,staging_table='"Staging_table"')
+
+@prepare_before_test(num=609, times=2)
+def test_609_gpload_fail_preload_truncate_rollback():
+    "609T gpload set preload truncate, but gpload fail, truncate should rollback together"
+    file = mkpath('setup.sql')
+    runfile(file)
+    f = open(mkpath('query609.sql'), 'w')
+    f.write("\\!  gpload -f "+mkpath('config/config_file')+"\n")
+    f.write("\\!  psql -d reuse_gptest -c \"SELECT count(*) from  testtruncate;\"\n")
+    f.close()
+    copy_data('external_file_13.csv','data_file.csv')
+    write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='testtruncate', delimiter="';'", truncate=True )

--- a/gpMgmt/bin/gpload_test/gpload2/init_file
+++ b/gpMgmt/bin/gpload_test/gpload2/init_file
@@ -18,6 +18,8 @@ m/^HINT:  Use the escape string syntax for backslashes.*/
 -- s/ext_gpload_reusable_db\d*b\d_created_\d*_\d*_\d*/EXT_GPLOAD_REUSABLE/
 -- m/ext_gpload_reusable/
 -- s/ext_gpload_reusable_\w*_\w*_\w*_\w*_\w*/EXT_GPLOAD_REUSABLE/
+-- m/ext_gpload/
+-- s/ext_gpload_\w*_\w*_\w*_\w*_\w*/EXT_GPLOAD/
 -- m/staging_gpload_reusable/
 -- s/staging_gpload_reusable_\w+/STAGING_GPLOAD_REUSABLE/
 -- m/started gpfdist/

--- a/gpMgmt/bin/gpload_test/gpload2/query609.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query609.ans
@@ -1,13 +1,13 @@
-2023-08-04 15:04:39|INFO|gpload session started 2023-08-04 15:04:39
-2023-08-04 15:04:39|INFO|setting schema 'public' for table 'testtruncate'
-2023-08-04 15:04:39|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
-2023-08-04 15:04:39|ERROR|missing data for column "s2"  (seg0 slice1 10.117.190.142:7002 pid=13474)
-CONTEXT:  External table ext_gpload, line 1 of gpfdist://*:pathto/data_file.csv: "123,abc,abc,abc,1.23"
- encountered while running INSERT INTO public."testtruncate" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload
-2023-08-04 15:04:39|INFO|rows Inserted          = 0
-2023-08-04 15:04:39|INFO|rows Updated           = 0
-2023-08-04 15:04:39|INFO|data formatting errors = 0
-2023-08-04 15:04:39|INFO|gpload failed
+2023-08-08 11:16:55|INFO|gpload session started 2023-08-08 11:16:55
+2023-08-08 11:16:55|INFO|setting schema 'public' for table 'testtruncate'
+2023-08-08 11:16:55|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
+2023-08-08 11:16:56|ERROR|missing data for column "s2"  (seg1 slice1 10.117.190.142:7003 pid=1678)
+CONTEXT:  External table ext_gpload_07382f0e_359a_11ee_87d2_0050569ea4ff, line 1 of gpfdist://*:pathto/data_file.csv: "123,abc,abc,abc,1.23"
+ encountered while running INSERT INTO public."testtruncate" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_07382f0e_359a_11ee_87d2_0050569ea4ff
+2023-08-08 11:16:56|INFO|rows Inserted          = 0
+2023-08-08 11:16:56|INFO|rows Updated           = 0
+2023-08-08 11:16:56|INFO|data formatting errors = 0
+2023-08-08 11:16:56|INFO|gpload failed
  count 
 -------
      1

--- a/gpMgmt/bin/gpload_test/gpload2/query609.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query609.ans
@@ -1,0 +1,15 @@
+2023-08-04 15:04:39|INFO|gpload session started 2023-08-04 15:04:39
+2023-08-04 15:04:39|INFO|setting schema 'public' for table 'testtruncate'
+2023-08-04 15:04:39|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
+2023-08-04 15:04:39|ERROR|missing data for column "s2"  (seg0 slice1 10.117.190.142:7002 pid=13474)
+CONTEXT:  External table ext_gpload, line 1 of gpfdist://*:pathto/data_file.csv: "123,abc,abc,abc,1.23"
+ encountered while running INSERT INTO public."testtruncate" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload
+2023-08-04 15:04:39|INFO|rows Inserted          = 0
+2023-08-04 15:04:39|INFO|rows Updated           = 0
+2023-08-04 15:04:39|INFO|data formatting errors = 0
+2023-08-04 15:04:39|INFO|gpload failed
+ count 
+-------
+     1
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query665.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query665.ans
@@ -12,8 +12,7 @@ LINE 1: INSERT INTO test_665_after VALUES('a')
 2021-01-11 18:56:59|INFO|gpload failed
  c1 
 ----
-  1
-(1 row)
+(0 rows)
 
  c1 
 ----
@@ -21,6 +20,6 @@ LINE 1: INSERT INTO test_665_after VALUES('a')
 
  count 
 -------
-    16
+     0
 (1 row)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -73,13 +73,13 @@ class GpLoadTestCase(unittest.TestCase):
 
     def test_case_insert_transaction(self):
         self.help_test_with_config(['-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],
-                              False,
-                              False)
+                              True,
+                              True)
 
     def test_case_insert_transaction_t(self):
         self.help_test_with_config(['-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],
-                              False,
-                              False)
+                              True,
+                              True)
 
     def test_case_insert_without_transaction(self):
         self.help_test_with_config(['--no_auto_trans', '-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],


### PR DESCRIPTION
This pr backport [pr](https://github.com/greenplum-db/gpdb/pull/16146) in 6X_STABLE

Gpload usually starts a transaction for preload, before sql, gpload sql, and after sql. But in insert mode, no transaction is started. So if gpload insert fails, the sqls in preload, before and after will still be executed.
In this pr, we will start a transaction for insert mode to avoid this behavior.

### NOTE:
* The behavior of the insert mode will change: when the insert fails and rollback, the [preload](https://docs.vmware.com/en/VMware-Greenplum/5/greenplum-database/utility_guide-admin_utilities-gpload.html#:~:text=and%20so%20on.-,PRELOAD,-Optional.%20Specifies%20operations) and [SQL](https://docs.vmware.com/en/VMware-Greenplum/5/greenplum-database/utility_guide-admin_utilities-gpload.html#:~:text=a%20warning%20message.-,SQL,-Optional.%20Defines%20SQL) In YAML file will also rollback.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
