### PR TITLE
Fix race condition in autovacuum root partition check

### DIFF
--- a/src/backend/catalog/partition.c
+++ b/src/backend/catalog/partition.c
@@ -150,7 +150,7 @@ get_partition_ancestors_worker(Relation inhRel, Oid relid, List **ancestors)
  * wrapper around get_partition_ancestors.
  *
  * This assumes that the given relation is a partition (i.e. relispartition is
- * true)
+ * true). If no parent partition is found, returns InvalidOid.
  *
  * Note: we depend on the order of results returned by get_partition_ancestors
  */
@@ -161,7 +161,7 @@ get_top_level_partition_root(Oid relid)
 
 	Assert(OidIsValid(relid));
 	ancestors = get_partition_ancestors(relid);
-	return llast_oid(ancestors);
+	return list_length(ancestors) > 0 ? llast_oid(ancestors) : InvalidOid;
 }
 
 /*

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2234,8 +2234,14 @@ do_autovacuum(void)
 		/* Get oid of top level partition root and add to separate set */
 		if (doanalyze && classForm->relispartition)
 		{
+			/*
+			 * If partition is detached/exchanged between the relispartition
+			 * check and getting the root partition, the root relid will be
+			 * invalid and we skip merging this root
+			 */
 			Oid root_parent_relid = get_top_level_partition_root(relid);
-			(void) hash_search(top_level_partition_roots, (void *) &root_parent_relid, HASH_ENTER, NULL);
+			if (OidIsValid(root_parent_relid))
+				(void) hash_search(top_level_partition_roots, (void *) &root_parent_relid, HASH_ENTER, NULL);
 		}
 		/*
 		 * Remember TOAST associations for the second pass.  Note: we must do


### PR DESCRIPTION
When checking the root partition during autoanalyze, we found that get_partition_ancestors() returned an empty list, indicating that no parent partition was found. This is likely due to the root partition being detached, either through an exchange or detach operation. In this case autoanalyze should skip merging root stats for this partition, since it isn't part of a partition hierarchy anymore. We don't want to take additional locks if possible.