### PR TITLE
[6X] Fix flaky case resource_queue_stat

### DIFF
--- a/src/test/regress/expected/resource_queue_stat.out
+++ b/src/test/regress/expected/resource_queue_stat.out
@@ -1,9 +1,7 @@
 set stats_queue_level=on;
 -- start_ignore
 drop role resqueuetest;
-ERROR:  role "resqueuetest" does not exist
 drop resource queue q;
-ERROR:  resource queue "q" does not exist
 -- end_ignore
 create resource queue q with (active_statements = 10);
 create user resqueuetest with resource queue q;
@@ -26,17 +24,19 @@ select 1;
         1
 (1 row)
 
-select pg_sleep(1);
+select pg_sleep(0.1);
  pg_sleep 
 ----------
  
 (1 row)
 
 -- will display q.n_queries_exec=4, and after the query it becomes 5
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
- queuename | n_queries_exec 
------------+----------------
- q         |              4
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+ pg_sleep | queuename | n_queries_exec 
+----------+-----------+----------------
+          | q         |              4
 (1 row)
 
 -- drop the queue
@@ -66,17 +66,19 @@ select 1;
         1
 (1 row)
 
-select pg_sleep(1);
+select pg_sleep(0.1);
  pg_sleep 
 ----------
  
 (1 row)
 
 -- will display q.n_queries_exec=4, and after the query it becomes 5
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
- queuename | n_queries_exec 
------------+----------------
- q         |              4
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+ pg_sleep | queuename | n_queries_exec 
+----------+-----------+----------------
+          | q         |              4
 (1 row)
 
 -- create another queue, do switch test
@@ -110,23 +112,25 @@ select 1;
         1
 (1 row)
 
-select pg_sleep(1);
+select pg_sleep(0.1);
  pg_sleep 
 ----------
  
 (1 row)
 
 -- will display q.n_queries_exec=5, q1.n_queries_exec=4
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q1';
- queuename | n_queries_exec 
------------+----------------
- q1        |              4
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q1';
+ pg_sleep | queuename | n_queries_exec 
+----------+-----------+----------------
+          | q1        |              4
 (1 row)
 
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
- queuename | n_queries_exec 
------------+----------------
- q         |              5
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+ pg_sleep | queuename | n_queries_exec 
+----------+-----------+----------------
+          | q         |              5
 (1 row)
 
 -- clean

--- a/src/test/regress/sql/resource_queue_stat.sql
+++ b/src/test/regress/sql/resource_queue_stat.sql
@@ -14,9 +14,11 @@ select 1;
 select 1;
 select 1;
 
-select pg_sleep(1);
+select pg_sleep(0.1);
 -- will display q.n_queries_exec=4, and after the query it becomes 5
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
 
 -- drop the queue
 reset role;
@@ -35,9 +37,11 @@ select 1;
 select 1;
 select 1;
 
-select pg_sleep(1);
+select pg_sleep(0.1);
 -- will display q.n_queries_exec=4, and after the query it becomes 5
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
 
 -- create another queue, do switch test
 reset role;
@@ -57,10 +61,12 @@ select 1;
 select 1;
 select 1;
 
-select pg_sleep(1);
+select pg_sleep(0.1);
 -- will display q.n_queries_exec=5, q1.n_queries_exec=4
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q1';
-select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
+-- The query should sleep more than PGSTAT_STAT_INTERVAL first to ensure
+-- the fresh resource queue stats are synced to stat files. 
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q1';
+select pg_sleep(0.6), queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
 
 -- clean
 reset role;


### PR DESCRIPTION
This is a backport of main PR: https://github.com/greenplum-db/gpdb/pull/15967

When getting the number of n_queries_exec of a resource queue, we must wait more than PGSTAT_STAT_INTERVAL in current query, or we might not be able to aquire fresh resource queue stats.

Without this fix, we would get flakes like:

```diff
--- expected/resource_queue_stat.out
+++ results/resource_queue_stat.out
@@ -77,7 +77,7 @@
 select queuename, n_queries_exec from pg_stat_resqueues where queuename = 'q';
  queuename | n_queries_exec
 -----------+----------------
- q         |              4
+ q         |              3
 (1 row)
```

(cherry picked from commit f3cf4ae096ceb1435b13784cfeaf7155b8af2b3a)

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_fix_resource_queue_stat_flake