### PR TITLE
[6x Backport] analyzedb should be skipped on Temp tables (#16095)

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -123,6 +123,12 @@ GET_COLUMN_NAMES_SQL = """
 SELECT attname FROM pg_attribute WHERE attrelid = %s AND attnum > 0 AND NOT attisdropped
 """
 
+GET_SCHEMA_WITH_TEMP_TABLE_SQL = """
+SELECT n.nspname
+FROM pg_class c, pg_namespace n
+WHERE c.relnamespace = n.oid AND c.relpersistence = 't';
+"""
+
 GET_INCLUDED_COLUMNS_FROM_EXCLUDE_SQL = """
 SELECT attname FROM pg_attribute WHERE attrelid = %s AND attname NOT IN (%s) AND attnum > 0 AND NOT attisdropped
 """
@@ -635,10 +641,15 @@ class AnalyzeDb(Operation):
             tup = (schema_tbl[0], schema_tbl[1])
             mid_level_partitions.append(tup)
 
+        qresult = run_sql(self.conn, GET_SCHEMA_WITH_TEMP_TABLE_SQL)
+        temp_schema_set = set([x[0] for x in qresult])
+
         ret = set()
         for can in candidates:
             schema = can[0]
             table = can[1]
+            if schema in temp_schema_set:
+                continue
             if '\n' in schema or ',' in schema or ':' in schema:
                 raise Exception('Schema name has an invalid character "\\n", ":", "," : "%s"' % schema)
             if '\n' in table or ',' in table or ':' in table:
@@ -1334,7 +1345,6 @@ def create_parser():
     parser.add_option('-v', '--verbose', action='store_true', dest='verbose', help='Print debug messages.')
     parser.add_option('-a', action='store_true', dest='silent', default=False,
                       help="Quiet mode. Do not prompt for user confirmation.")
-
     return parser
 
 

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1767,3 +1767,13 @@ Feature: Incrementally analyze the database
         When the user runs "analyzedb -a -d incr_analyze -t public.jazz"
         Then analyzedb should print "There are no tables or partitions to be analyzed" to stdout
         And the user runs "psql -d incr_analyze -c 'drop table jazz'"
+
+    Scenario: analyzedb ignores temp table
+        Given database "schema_with_temp_table" is dropped and recreated
+        And the user connects to "schema_with_temp_table" with named connection "default"
+        And the user executes "CREATE TEMP TABLE temp_t1 (c1 int) DISTRIBUTED BY (c1)" with named connection "default"
+        When the user runs "analyzedb -a -d schema_with_temp_table"
+        Then output should not contain "temp_t1"
+        And the user runs "dropdb schema_with_temp_table"
+        And the user drops the named connection "default"
+


### PR DESCRIPTION
Problem: analyzedb reports many errors saying that "schema XXX does not exist", because by the time the process starts analyzing the temp table, the session with the temp tables is already gone.

Solution: skip the temporary schemas from being analyzed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
