### PR TITLE
(6x) fix unknown var coerce

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -644,9 +644,12 @@ coerce_unknown_var(ParseState *pstate, Var *var,
             cell = list_nth_cell(rte->joinaliasvars, var->varattno - 1);
             joinvar = (Var *)lfirst(cell);
 
-            /* If still untyped, try to replace it with a properly typed Var */
-            if (joinvar->vartype == UNKNOWNOID &&
-                targetTypeId != UNKNOWNOID)
+			/*
+			 * If still untyped, try to replace it with a properly typed Var.
+			 * Don't need to consider targetTypeId here, the joinvar must refs
+			 * to a leaf RTE, always descend through leaf RTEs.
+			 */
+            if (joinvar->vartype == UNKNOWNOID)
             {
                 joinvar = coerce_unknown_var(pstate, joinvar,
                                              targetTypeId, targetTypeMod,

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -4096,3 +4096,7 @@ SELECT * FROM dml_heap_int;
  1
 (4 rows)
 
+-- Insert with constant columns from join
+CREATE TABLE dml_insert_t1(a int, b varchar(10));
+CREATE TABLE dml_select_t2(a int);
+INSERT INTO dml_insert_t1 SELECT col1,col2 FROM (SELECT x.a AS col1, '100' AS col2 FROM dml_select_t2 x LEFT JOIN dml_select_t2 y ON x.a<y.a) AS t LEFT JOIN dml_select_t2 ON 1=1 WHERE t.col2::int<20;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -4114,3 +4114,7 @@ SELECT * FROM dml_heap_int;
  1
 (4 rows)
 
+-- Insert with constant columns from join
+CREATE TABLE dml_insert_t1(a int, b varchar(10));
+CREATE TABLE dml_select_t2(a int);
+INSERT INTO dml_insert_t1 SELECT col1,col2 FROM (SELECT x.a AS col1, '100' AS col2 FROM dml_select_t2 x LEFT JOIN dml_select_t2 y ON x.a<y.a) AS t LEFT JOIN dml_select_t2 ON 1=1 WHERE t.col2::int<20;

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1765,3 +1765,8 @@ FROM dml_heap_int t1
 		SELECT a+1
 		FROM dml_heap_int)) t2 ON (t1.a = t2.a);
 SELECT * FROM dml_heap_int;
+
+-- Insert with constant columns from join
+CREATE TABLE dml_insert_t1(a int, b varchar(10));
+CREATE TABLE dml_select_t2(a int);
+INSERT INTO dml_insert_t1 SELECT col1,col2 FROM (SELECT x.a AS col1, '100' AS col2 FROM dml_select_t2 x LEFT JOIN dml_select_t2 y ON x.a<y.a) AS t LEFT JOIN dml_select_t2 ON 1=1 WHERE t.col2::int<20;


### PR DESCRIPTION
An UNKNOWN var refered to the targetlist of a join's subquery in the insert statement can't coerce to a proper type lead to error. When coerce qury targetlist's tpe to the insert column's type, the fixed unknown var can be coerce to other type which isn't equal to target type. Do unknownout(Var) for a non-UNKNOWN is dangerous.

When transforms a Select Statement, Untyped Const or Param nodes in a subquery in the FROM clause might have been assigned proper types when we transformed the WHERE clause. So after that, when coerce UNKNOWN var in targetlist to the assigned type, don't need to specify target type. Now we simply pass UNKNOWNOID to the tartgettypeId, then if the var refs to a join, it will still keep unchanged.

If the unknown var is refered to a join, the joinvar must refs to a leaf RTE of the join, descend through leaf RTEs regardless of the targetType will always bring targetlist Var types up to date. And when coerce qury target's type to insert column, type of upper level keeps same as refer vars.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
