### PR TITLE
Make gpcontrib extensions use schema param

### DIFF
--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments--1.0.sql
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments--1.0.sql
@@ -3,8 +3,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_debug_numsegments" to load this file. \quit
 
-SET search_path = public;
-
 -- This function set the default numsegments when creating tables.
 -- This form accepts a text argument: 'full', 'minimal', 'random'.
 CREATE OR REPLACE FUNCTION gp_debug_set_create_table_default_numsegments(text) RETURNS text

--- a/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.control
+++ b/gpcontrib/gp_debug_numsegments/gp_debug_numsegments.control
@@ -2,4 +2,4 @@
 comment = 'get / set default numsegments when creating tables'
 default_version = '1.0'
 module_pathname = '$libdir/gp_debug_numsegments'
-relocatable = true
+schema = public

--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy--1.0.sql
@@ -3,8 +3,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_distribution_policy" to load this file. \quit
 
-SET search_path = public;
-
 -- This function validates the data distribution in a table in a segment.
 CREATE OR REPLACE FUNCTION gp_distribution_policy_table_check(relid regclass)
 RETURNS boolean

--- a/gpcontrib/gp_distribution_policy/gp_distribution_policy.control
+++ b/gpcontrib/gp_distribution_policy/gp_distribution_policy.control
@@ -2,4 +2,4 @@
 comment = 'check distribution policy in a GPDB cluster'
 default_version = '1.0'
 module_pathname = '$libdir/gp_distribution_policy'
-relocatable = true
+schema = public


### PR DESCRIPTION
This is preferred over setting and referencing search_path directly in
the extension install script - which leads to issues such as #15912. Also
take out 'relocatable=true' as these extensions were never relocatable
to begin with due to their explicit need to create everything under
public (and besides relocatable and schema are conflicting options).

This fixes #15912.