### PR TITLE
Fall back to planner for queries on relations with pgvector index

### DIFF
--- a/src/backend/access/index/amapi.c
+++ b/src/backend/access/index/amapi.c
@@ -141,3 +141,22 @@ amvalidate(PG_FUNCTION_ARGS)
 
 	PG_RETURN_BOOL(result);
 }
+
+/*
+ * GetAmName
+ *		Retrieve the name of a relation's access method
+ */
+char *
+GetAmName(Oid amoid)
+{
+	Form_pg_am	amform;
+	HeapTuple	tuple;
+
+	tuple = SearchSysCache1(AMOID, ObjectIdGetDatum(amoid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for relam object %u", amoid);
+
+	amform = (Form_pg_am) GETSTRUCT(tuple);
+	ReleaseSysCache(tuple);
+	return NameStr(amform->amname);
+}

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -33,6 +33,7 @@
 
 #include "catalog/pg_collation.h"
 extern "C" {
+#include "access/amapi.h"
 #include "access/external.h"
 #include "catalog/pg_inherits.h"
 #include "foreign/fdwapi.h"
@@ -2688,4 +2689,14 @@ gpdb::IsTypeRange(Oid typid)
 	return false;
 }
 
+char *
+gpdb::GetRelAmName(Oid reloid)
+{
+	GP_WRAP_START;
+	{
+		return GetAmName(reloid);
+	}
+	GP_WRAP_END;
+	return nullptr;
+}
 // EOF

--- a/src/include/access/amapi.h
+++ b/src/include/access/amapi.h
@@ -236,5 +236,6 @@ typedef struct IndexAmRoutine
 /* Functions in access/index/amapi.c */
 extern IndexAmRoutine *GetIndexAmRoutine(Oid amhandler);
 extern IndexAmRoutine *GetIndexAmRoutineByAmId(Oid amoid, bool noerror);
+extern char *GetAmName(Oid amoid);
 
 #endif							/* AMAPI_H */

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -668,6 +668,8 @@ TargetEntry *FlatCopyTargetEntry(TargetEntry *src_tle);
 
 bool IsTypeRange(Oid typid);
 
+char *GetRelAmName(Oid reloid);
+
 }  //namespace gpdb
 
 #define ForEach(cell, l) \


### PR DESCRIPTION
When querying a relation with an `ivfflat` index from pgvector, Orca won't currently generate this index alternative. This will take a bit of work to support in Orca for a few reasons: generating index scans for this particular plan shape, creating the correct checks to ensure we generate a valid index plan, and proper costing for ivfflat indexes.

For now, fall back to planner to ensure users can still generate plans with index scans. Note that Orca will not fall back if no index is present--Orca can generate those plans without any issues.

No test is included since pgvector isn't part of this repo. Test case:
```
CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3)); 
INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]'); 
CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100);


explain SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 5; NOTICE,"Feature not supported: Queries on relations with pgvector indexes (ivfflat) are not supported"
                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------
 Limit  (cost=23.65..23.74 rows=5 width=48)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=23.65..23.91 rows=15 width=48)
         Merge Key: ((embedding <-> '[3,1,2]'::vector))
         ->  Limit  (cost=23.65..23.71 rows=5 width=48)
               ->  Index Scan using items_embedding_idx on items  (cost=6.00..182.48 rows=15567 width=48)
                     Order By: (embedding <-> '[3,1,2]'::vector)
 Optimizer: Postgres query optimizer
(7 rows)
```