### PR TITLE
5X: Convert disallow_unique_rowid_path to a GUC

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -470,6 +470,7 @@ bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte_prototype = false;
+bool		gp_disallow_unique_rowid_path = false;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -2538,6 +2539,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_recursive_cte_prototype,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_disallow_unique_rowid_path", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Disable planner path that uses unique rowid."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_disallow_unique_rowid_path,
 		false, NULL, NULL
 	},
 

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -265,7 +265,6 @@ typedef struct PlannerInfo
 	List	   *dynamicScans;	/* DynamicScanInfos */
 
 	bool		is_correlated_subplan; /* true for correlated subqueries nested within subplans */
-	bool		disallow_unique_rowid_path; /* true if we decide not to generate unique rowid path */
 } PlannerInfo;
 
 /*----------

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -185,6 +185,7 @@ extern bool gp_appendonly_verify_block_checksums;
 extern bool gp_appendonly_verify_write_block;
 extern bool gp_appendonly_verify_eof;
 extern bool gp_appendonly_compaction;
+extern bool gp_disallow_unique_rowid_path;
 
 /*
  * Threshold of the ratio of dirty data in a segment file

--- a/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
+++ b/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
@@ -78,4 +78,4 @@ SET
 -- Ensure that we ERROR out if gp_disable_dtx_visibility_check is set in
 -- non-utility mode.
 3: set gp_disable_dtx_visibility_check to on;
-ERROR:  gp_disable_dtx_visibility_check can only be set in utility mode (guc_gp.c:6347)
+ERROR:  gp_disable_dtx_visibility_check can only be set in utility mode (guc_gp.c:6358)

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -424,9 +424,11 @@ SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (selec
 -- end equivalent
 
 -- Don't generate unique rowid path if there is a table function scan
+SET gp_disallow_unique_rowid_path = true;
 SELECT gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 SELECT count(*) FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (select a,b from example);
 SELECT gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+RESET gp_disallow_unique_rowid_path;
 
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -1550,6 +1550,7 @@ SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (selec
 
 -- end equivalent
 -- Don't generate unique rowid path if there is a table function scan
+SET gp_disallow_unique_rowid_path = true;
 SELECT gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 NOTICE:  Success:
  gp_inject_fault 
@@ -1570,6 +1571,7 @@ NOTICE:  Success:
  t
 (1 row)
 
+RESET gp_disallow_unique_rowid_path;
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
                               QUERY PLAN                               

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -1551,6 +1551,7 @@ SELECT * FROM multiset_5( TABLE(SELECT a, b from example)) where (a,b) in (selec
 
 -- end equivalent
 -- Don't generate unique rowid path if there is a table function scan
+SET gp_disallow_unique_rowid_path = true;
 SELECT gp_inject_fault('low_unique_rowid_path_cost', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 NOTICE:  Success:
  gp_inject_fault 
@@ -1571,6 +1572,7 @@ NOTICE:  Success:
  t
 (1 row)
 
+RESET gp_disallow_unique_rowid_path;
 -- Explain a couple interesting cases
 explain SELECT * FROM multiset_5( TABLE (SELECT dbid, gpname FROM gp_id) );
                               QUERY PLAN                               


### PR DESCRIPTION
Use a GUC to block the new behavior so it will be less likely to affect other customers.

	commit 5ad4db29600308504f569021cea159c6a01409b1
	Author: Adam Lee <adlee@vmware.com>
	Date:   Thu Jul 6 10:19:04 2023 +0800

	    5X: Don't create unique rowid paths if there is a table function scan (#15771)
