### PR TITLE
gprecoverseg: Fix CI flakiness after #15700

### DIFF
--- a/gpMgmt/sbin/recovery_base.py
+++ b/gpMgmt/sbin/recovery_base.py
@@ -20,6 +20,7 @@ class RecoveryBase(object):
         self.seg_recovery_info_list = None
         self.options = None
         self.pool = None
+        self.termination_requested = False
         try:
             self.parseargs()
         except Exception as e:
@@ -101,6 +102,9 @@ class RecoveryBase(object):
                 errors.append(error_obj)
         if not errors:
             sys.exit(0)
+
+        if self.termination_requested:
+            logger.warning("Recieved termination signal, stopping gpsegrecovery")
 
         str_error = recoveryinfo.serialize_list(errors)
         print(str_error, file=sys.stderr)

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -601,7 +601,7 @@ Feature: gprecoverseg tests
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And verify that mirror on content 0,1,2 is up
+    And the user waits until mirror on content 0,1,2 is up
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And a sample recovery_progress.file is created from saved lines
@@ -713,7 +713,7 @@ Feature: gprecoverseg tests
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
-    And verify that mirror on content 0,1,2 is up
+    And the user waits until mirror on content 0,1,2 is up
     And the old data directories are cleaned up for content 0
     And user can start transactions
     And check segment conf: postgresql.conf

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -177,7 +177,7 @@ Feature: gprecoverseg tests involving migrating to a new host
     And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
     And the cluster configuration is saved for "before_recoverseg"
     And datadirs from "before_recoverseg" configuration for "sdw1" are created on "sdw5" with mode 700
-    When the user would run "gprecoverseg -a -p sdw5 --hba-hostnames" and terminate the process with SIGTERM
+    When the user would run "gprecoverseg -a -p sdw5 --hba-hostnames" and terminate the process for host "sdw5" with SIGTERM
     Then gprecoverseg should return a return code of 1
     And check if moving the mirrors from sdw1 to sdw5 failed with user termination
     And gprecoverseg should print "[WARNING]:-Recieved SIGTERM signal, terminating gprecoverseg" escaped to stdout

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4095,11 +4095,14 @@ def impl(context, command, input, delay):
     context.error_message = stderr.decode()
 
 
-@when('the user would run "{command}" and terminate the process with SIGTERM')
-def impl(context, command):
+@when('the user would run "{command}" and terminate the process for host "{hostname}" with SIGTERM')
+def impl(context, command, hostname):
     p = Popen(command.split(), stdout=PIPE, stdin=PIPE, stderr=PIPE)
 
-    context.execute_steps('''Then the user just waits until recovery_progress.file is created in gpAdminLogs''')
+    context.execute_steps('''
+        Then the user just waits until recovery_progress.file is created in gpAdminLogs
+        Then verify that pg_basebackup is running for host {}
+        '''.format(hostname))
     p.send_signal(signal.SIGTERM)
 
     stdout, stderr = p.communicate()


### PR DESCRIPTION
After the merging of https://github.com/greenplum-db/gpdb/pull/15700, there were some intermittent `gprecoverseg` and `gprecoverseg_new_hosts` job failures. They were happening for a couple of reasons -
- The `signal_handler` in the `gpsegrecovery` process would be called multiple times and sometimes the logger would close the buffer for writing leading to a logging error. Fixed this by moving the logging outside the handler and ignoring the signal once inside the function so that it cannot be called multiple times.
- The timeout for waiting for the `pg_basebackup/pg_rewind` process was less (around 1 min) so increase it.
- Sometimes the mirror might take some time to come up, so changed it to wait instead of just checking once and erroring out.