### PR TITLE
Fix gpfdist data overwriting

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3216,19 +3216,19 @@ static void handle_post_request(request_t *r, int header_end)
 
 done_processing_request:
 
+	/* 
+	 * To ensure that retry works well,
+	 * there are two cases where seq_segs will be updated.
+	 * 1. Data has been written successfully.
+	 * 2. Request is OPEN_SEQ.
+	 */
+	session->seq_segs[r->segid] = r->seq;
+
 	/* send our success response and end the request */
 	if (0 != http_ok(r))
 		request_end(r, 1, 0);
 	else
-	{
 		request_end(r, 0, 0); /* we're done! */
-		/* 
-		 * Only when send http_ok successfully will we set
-		 * OPEN_SEQ and normal seq, we just add 1.
-		 * For duplicate case, we set it unchanged.
-		 */
-		session->seq_segs[r->segid] = r->seq;
-	}
 }
 
 static int request_set_path(request_t *r, const char* d, char* p, char* pp, char* path)


### PR DESCRIPTION
Current gpfdist will update the corresponding sequence number when it responds a HTTP request successfully.  However, the network may be unstable when gpfdist processes a HTTP request. In rare conditions, a connection could be aborted when gpfdist finishes receiving and writing data, which would lead to a data-sending retry.  

Since gpfdist wouldn't update the sequence number despite finishing data writing when the response failed, gpdb will retry to send the same data which will be written again. 

The PR is to handle the rare case. Gpfdist updates the sequence number when data writing ends or the request is OPEN_SEQ. This will avoid the unexpected network abortion when gpfdist responds 'OK' to gpdb. After the sequence number is updated for the segment, even if the same data is sent to gpfdist, The data will be discarded. The adaptation will avoid data overwriting.

If you want to reproduce the error, I suggest you do the following steps on gpfdist v6.24.5:
   1. Change the return value of `http_ok` to 1 when `request_id` in `request_t` is odd.
   2. Recompile the gpfdist and run it.
   3. Start any task that writes to a writable external table. Note that the data size should be bigger than 256MB.
   4. The actually written data is bigger the size of the expected value.

The core objective of the above steps is to simulate the specific network error in a hardcoded way. 

We have tested the correctness of the modification by simulating the network error using the way of reproducing the error.