### PR TITLE
Backpatch trusted extensions

### DIFF
--- a/contrib/btree_gin/btree_gin.control
+++ b/contrib/btree_gin/btree_gin.control
@@ -3,3 +3,4 @@ comment = 'support for indexing common datatypes in GIN'
 default_version = '1.0'
 module_pathname = '$libdir/btree_gin'
 relocatable = true
+trusted = true

--- a/contrib/btree_gist/btree_gist.control
+++ b/contrib/btree_gist/btree_gist.control
@@ -3,3 +3,4 @@ comment = 'support for indexing common datatypes in GiST'
 default_version = '1.0'
 module_pathname = '$libdir/btree_gist'
 relocatable = true
+trusted = true

--- a/contrib/citext/citext.control
+++ b/contrib/citext/citext.control
@@ -3,3 +3,4 @@ comment = 'data type for case-insensitive character strings'
 default_version = '1.0'
 module_pathname = '$libdir/citext'
 relocatable = true
+trusted = true

--- a/contrib/cube/cube.control
+++ b/contrib/cube/cube.control
@@ -3,3 +3,4 @@ comment = 'data type for multidimensional cubes'
 default_version = '1.0'
 module_pathname = '$libdir/cube'
 relocatable = true
+trusted = true

--- a/contrib/dblink/dblink.control
+++ b/contrib/dblink/dblink.control
@@ -3,3 +3,4 @@ comment = 'connect to other PostgreSQL databases from within a database'
 default_version = '1.1'
 module_pathname = '$libdir/dblink'
 relocatable = true
+trusted = true

--- a/contrib/dict_int/dict_int.control
+++ b/contrib/dict_int/dict_int.control
@@ -3,3 +3,4 @@ comment = 'text search dictionary template for integers'
 default_version = '1.0'
 module_pathname = '$libdir/dict_int'
 relocatable = true
+trusted = true

--- a/contrib/earthdistance/earthdistance.control
+++ b/contrib/earthdistance/earthdistance.control
@@ -3,4 +3,5 @@ comment = 'calculate great-circle distances on the surface of the Earth'
 default_version = '1.0'
 module_pathname = '$libdir/earthdistance'
 relocatable = true
+trusted = true
 requires = 'cube'

--- a/contrib/fuzzystrmatch/fuzzystrmatch.control
+++ b/contrib/fuzzystrmatch/fuzzystrmatch.control
@@ -3,3 +3,4 @@ comment = 'determine similarities and distance between strings'
 default_version = '1.0'
 module_pathname = '$libdir/fuzzystrmatch'
 relocatable = true
+trusted = true

--- a/contrib/hstore/hstore.control
+++ b/contrib/hstore/hstore.control
@@ -3,3 +3,4 @@ comment = 'data type for storing sets of (key, value) pairs'
 default_version = '1.3'
 module_pathname = '$libdir/hstore'
 relocatable = true
+trusted = true

--- a/contrib/intarray/intarray.control
+++ b/contrib/intarray/intarray.control
@@ -3,3 +3,4 @@ comment = 'functions, operators, and index support for 1-D arrays of integers'
 default_version = '1.0'
 module_pathname = '$libdir/_int'
 relocatable = true
+trusted = true

--- a/contrib/isn/isn.control
+++ b/contrib/isn/isn.control
@@ -3,3 +3,4 @@ comment = 'data types for international product numbering standards'
 default_version = '1.0'
 module_pathname = '$libdir/isn'
 relocatable = true
+trusted = true

--- a/contrib/lo/lo.control
+++ b/contrib/lo/lo.control
@@ -3,3 +3,4 @@ comment = 'Large Object maintenance'
 default_version = '1.0'
 module_pathname = '$libdir/lo'
 relocatable = true
+trusted = true

--- a/contrib/ltree/ltree.control
+++ b/contrib/ltree/ltree.control
@@ -3,3 +3,4 @@ comment = 'data type for hierarchical tree-like structures'
 default_version = '1.0'
 module_pathname = '$libdir/ltree'
 relocatable = true
+trusted = true

--- a/contrib/pg_trgm/pg_trgm.control
+++ b/contrib/pg_trgm/pg_trgm.control
@@ -3,3 +3,4 @@ comment = 'text similarity measurement and index searching based on trigrams'
 default_version = '1.1'
 module_pathname = '$libdir/pg_trgm'
 relocatable = true
+trusted = true

--- a/contrib/pgcrypto/pgcrypto.control
+++ b/contrib/pgcrypto/pgcrypto.control
@@ -3,3 +3,4 @@ comment = 'cryptographic functions'
 default_version = '1.1'
 module_pathname = '$libdir/pgcrypto'
 relocatable = true
+trusted = true

--- a/contrib/postgres_fdw/postgres_fdw.control
+++ b/contrib/postgres_fdw/postgres_fdw.control
@@ -3,3 +3,4 @@ comment = 'foreign-data wrapper for remote PostgreSQL servers'
 default_version = '1.0'
 module_pathname = '$libdir/postgres_fdw'
 relocatable = true
+trusted = true

--- a/contrib/seg/seg.control
+++ b/contrib/seg/seg.control
@@ -3,3 +3,4 @@ comment = 'data type for representing line segments or floating-point intervals'
 default_version = '1.0'
 module_pathname = '$libdir/seg'
 relocatable = true
+trusted = true

--- a/contrib/tablefunc/tablefunc.control
+++ b/contrib/tablefunc/tablefunc.control
@@ -3,3 +3,4 @@ comment = 'functions that manipulate whole tables, including crosstab'
 default_version = '1.0'
 module_pathname = '$libdir/tablefunc'
 relocatable = true
+trusted = true

--- a/contrib/tcn/tcn.control
+++ b/contrib/tcn/tcn.control
@@ -3,3 +3,4 @@ comment = 'Triggered change notifications'
 default_version = '1.0'
 module_pathname = '$libdir/tcn'
 relocatable = true
+trusted = true

--- a/contrib/unaccent/unaccent.control
+++ b/contrib/unaccent/unaccent.control
@@ -3,3 +3,4 @@ comment = 'text search dictionary that removes accents'
 default_version = '1.0'
 module_pathname = '$libdir/unaccent'
 relocatable = true
+trusted = true

--- a/contrib/uuid-ossp/uuid-ossp.control
+++ b/contrib/uuid-ossp/uuid-ossp.control
@@ -3,3 +3,4 @@ comment = 'generate universally unique identifiers (UUIDs)'
 default_version = '1.0'
 module_pathname = '$libdir/uuid-ossp'
 relocatable = true
+trusted = true

--- a/doc/src/sgml/btree-gist.sgml
+++ b/doc/src/sgml/btree-gist.sgml
@@ -51,6 +51,12 @@
   <type>oid</>, and <type>money</>.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Example Usage</title>
 

--- a/doc/src/sgml/citext.sgml
+++ b/doc/src/sgml/citext.sgml
@@ -14,6 +14,12 @@
   exactly like <type>text</>.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Rationale</title>
 

--- a/doc/src/sgml/earthdistance.sgml
+++ b/doc/src/sgml/earthdistance.sgml
@@ -23,6 +23,12 @@
   project.)
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Cube-based Earth Distances</title>
 

--- a/doc/src/sgml/hstore.sgml
+++ b/doc/src/sgml/hstore.sgml
@@ -15,6 +15,12 @@
   simply text strings.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title><type>hstore</> External Representation</title>
 
@@ -630,6 +636,11 @@ ALTER TABLE tablename ALTER hstorecol TYPE hstore USING hstorecol || '';
   <para>
    Additional enhancements by Andrew Gierth <email>andrew@tao11.riddles.org.uk</email>,
    United Kingdom
+  </para>
+
+  <para>
+   Of these additional extensions, <literal>hstore_plperl</literal> is
+   considered trusted; the rest are not.
   </para>
  </sect2>
 

--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -21,6 +21,12 @@
   dropped from a future version of this module.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Data Types</title>
 

--- a/doc/src/sgml/json.sgml
+++ b/doc/src/sgml/json.sgml
@@ -564,5 +564,12 @@ SELECT jdoc-&gt;'guid', jdoc-&gt;'name' FROM api WHERE jdoc @&gt; '{"tags": ["qu
       <productname>PostgreSQL</productname> data type.  Strings are
       compared using the default database collation.
   </para>
+
+  <para>
+   Of these extensions, <literal>jsonb_plperl</literal> is
+   considered <quote>trusted</quote>, that is, it can be installed by
+   non-superusers who have <literal>CREATE</literal> privilege on the
+   current database.  The rest require superuser privilege to install.
+  </para>
  </sect2>
 </sect1>

--- a/doc/src/sgml/ltree.sgml
+++ b/doc/src/sgml/ltree.sgml
@@ -13,6 +13,12 @@
   Extensive facilities for searching through label trees are provided.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Definitions</title>
 

--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -17,6 +17,12 @@
   <productname>PostgreSQL</>.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>General Hashing Functions</title>
 

--- a/doc/src/sgml/tcn.sgml
+++ b/doc/src/sgml/tcn.sgml
@@ -18,6 +18,12 @@
  </para>
 
  <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
+ <para>
   Only one parameter may be supplied to the function in a
   <literal>CREATE TRIGGER</> statement, and that is optional.  If supplied
   it will be used for the channel name for the notifications.  If omitted

--- a/doc/src/sgml/unaccent.sgml
+++ b/doc/src/sgml/unaccent.sgml
@@ -21,6 +21,12 @@
   normalizing dictionary for the <filename>thesaurus</filename> dictionary.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title>Configuration</title>
 

--- a/doc/src/sgml/uuid-ossp.sgml
+++ b/doc/src/sgml/uuid-ossp.sgml
@@ -13,6 +13,12 @@
   are also functions to produce certain special UUID constants.
  </para>
 
+ <para>
+  This module is considered <quote>trusted</quote>, that is, it can be
+  installed by non-superusers who have <literal>CREATE</literal> privilege
+  on the current database.
+ </para>
+
  <sect2>
   <title><literal>uuid-ossp</literal> Functions</title>
 

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -42,6 +42,7 @@ extern Oid	ExecAlterExtensionContentsStmt(AlterExtensionContentsStmt *stmt);
 
 extern Oid	get_extension_oid(const char *extname, bool missing_ok);
 extern char *get_extension_name(Oid ext_oid);
+extern bool extension_file_exists(const char *extensionName);
 
 extern Oid	AlterExtensionNamespace(List *names, const char *newschema);
 


### PR DESCRIPTION
This pr backpathes `trusted extension` infrastructure from PostgreSQL to Greenplum 6 branch. Trusted extensions 
is really helpful to allow `CREATE EXTENSION` to be executed without superuser privilege and comes in handy for Cloud based greenplum solutions, which does not provide superuser privilege for customers, bur provides various extensions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
