### PR TITLE
use shutil.which to get cmd path in Popen

### DIFF
--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -29,7 +29,7 @@ def _getPlatformInfo():
 def _getFileInfo(coreFile):
     file_cmd = which('file')
     if file_cmd is None:
-        file_cmd = '/usr/bin/file'
+        return False
 
     cmd = Popen([file_cmd, '--version'], stdout=PIPE, stderr=STDOUT)
     fileVersion = cmd.communicate()[0].split()[0].strip().decode()

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -17,7 +17,7 @@ def _getPlatformInfo():
         for file in glob.glob('/etc/*release'):
             shutil.copy(file, '.')
     else:
-        Popen('/usr/bin/lsb_release -a > ./lsb_release.out',
+        Popen('{} -a > ./lsb_release.out'.format(which('lsb_release')),
               shell=True, stderr=PIPE)
 
     if os.path.exists('/etc/gpdb-appliance-version'):
@@ -27,13 +27,17 @@ def _getPlatformInfo():
 
 
 def _getFileInfo(coreFile):
-    cmd = Popen(['/usr/bin/file', '--version'], stdout=PIPE, stderr=STDOUT)
+    file_cmd = which('file')
+    if file_cmd is None:
+        file_cmd = '/usr/bin/file'
+
+    cmd = Popen([file_cmd, '--version'], stdout=PIPE, stderr=STDOUT)
     fileVersion = cmd.communicate()[0].split()[0].strip().decode()
     # file allow setting parameters from command line from version 5.21, refer:
     # https://github.com/file/file/commit/6ce24f35cd4a43c4bdd249e8e0c4952c1f8eac67
     # Set ELF program sections processed for core files to suppres "too many
     # program headers" output
-    opts = ['/usr/bin/file']
+    opts = [file_cmd]
     if fileVersion >= 'file-5.21':
         opts += ['-P', 'elf_phnum=2048']
     opts += [coreFile]

--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -29,7 +29,7 @@ def _getPlatformInfo():
 def _getFileInfo(coreFile):
     file_cmd = which('file')
     if file_cmd is None:
-        return False
+        raise Exception("cannot find file command")
 
     cmd = Popen([file_cmd, '--version'], stdout=PIPE, stderr=STDOUT)
     fileVersion = cmd.communicate()[0].split()[0].strip().decode()

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -105,7 +105,7 @@ class GlobalShellExecutor(object):
 
         bash_cmd = shutil.which('bash')
         if bash_cmd is None:
-            bash_cmd = '/bin/bash'
+            raise GlobalShellExecutor.ExecutionError("cannot find bash command")
 
         self.sh_proc = subprocess.Popen([bash_cmd, '--noprofile', '--norc', '--noediting', '-i'],
                                         stdin=self.subsidiary_fd,

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -30,6 +30,7 @@ import traceback
 import select
 import psycopg2
 import io
+import shutil
 
 ## FIXME: When converting 'INTERVAL' typed value to Python Object, psycopg2 doesn't
 ## recognize the literal string '@ 0'. It's probably caused by the 'DateStyle' GUC
@@ -101,7 +102,12 @@ class GlobalShellExecutor(object):
         self.v_cnt = 0
         # open pseudo-terminal to interact with subprocess
         self.primary_fd, self.subsidiary_fd = pty.openpty()
-        self.sh_proc = subprocess.Popen(['/bin/bash', '--noprofile', '--norc', '--noediting', '-i'],
+
+        bash_cmd = shutil.which('bash')
+        if bash_cmd is None:
+            bash_cmd = '/bin/bash'
+
+        self.sh_proc = subprocess.Popen([bash_cmd, '--noprofile', '--norc', '--noediting', '-i'],
                                         stdin=self.subsidiary_fd,
                                         stdout=self.subsidiary_fd,
                                         stderr=self.subsidiary_fd,


### PR DESCRIPTION
For more reliability, use python `shutil.which` in Popen, it's also a recommended way in python document. 

Use `/bin/bash` in `src/test/isolation2/sql_isolation_testcase.py` will block the isolation2 on some environments, like `nix`.
reference:
https://docs.python.org/3/library/subprocess.html#popen-constructor