### PR TITLE
docs - default value of optimizer_force_multistage_agg is false

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2460,7 +2460,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|coordinator, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 ## <a id="optimizer_force_three_stage_scalar_dqa"></a>optimizer\_force\_three\_stage\_scalar\_dqa 
 


### PR DESCRIPTION
doc updates for https://github.com/greenplum-db/gpdb/pull/15992.

text is mismatched - description indicates the default is false, but the table says true.
