### PR TITLE
Fix test case resgroup_views

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_views.source
+++ b/src/test/isolation2/input/resgroup/resgroup_views.source
@@ -28,9 +28,9 @@ select groupname
  where groupname='default_group'
  order by segment_id;
 
-select *
+select rrrsgname
   from gp_toolkit.gp_resgroup_role
- where rrrolname='gpadmin';
+ where rrrolname='@curusername@';
 
 -- also log the raw output of the views, if any of above tests failed it is
 -- easier to find out the causes with these logs.

--- a/src/test/isolation2/output/resgroup/resgroup_views.source
+++ b/src/test/isolation2/output/resgroup/resgroup_views.source
@@ -21,10 +21,10 @@ select groupname , groupid , segment_id , vmem_usage from gp_toolkit.gp_resgroup
 -----------+---------+------------+------------
 (0 rows)
 
-select * from gp_toolkit.gp_resgroup_role where rrrolname='gpadmin';
- rrrolname | rrrsgname   
------------+-------------
- gpadmin   | admin_group 
+select rrrsgname from gp_toolkit.gp_resgroup_role where rrrolname='@curusername@';
+ rrrsgname   
+-------------
+ admin_group 
 (1 row)
 
 -- also log the raw output of the views, if any of above tests failed it is


### PR DESCRIPTION
Make test case 'resgroup_views' environmental independent.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
