### PR TITLE
[6X Backport]Enable ORCA to generate IndexScan plans with ScalarArrayOp quals

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -959,8 +959,10 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 					 IsA(index_cond_expr, ScalarArrayOpExpr)) &&
 					"expected OpExpr or ScalarArrayOpExpr in index qual");
 
+		// allow Index quals with scalar array only for bitmap and btree indexes
 		if (!is_bitmap_index_probe && IsA(index_cond_expr, ScalarArrayOpExpr) &&
-			IMDIndex::EmdindBitmap != index->IndexType())
+			!(IMDIndex::EmdindBitmap == index->IndexType() ||
+			  IMDIndex::EmdindBtree == index->IndexType()))
 		{
 			GPOS_RAISE(
 				gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -302,10 +302,10 @@ SELECT * FROM test WHERE a in (1, 47);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="387.964368" Rows="2.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000228" Rows="2.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -314,9 +314,9 @@ SELECT * FROM test WHERE a in (1, 47);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:BitmapTableScan>
+        <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="387.964333" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000193" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@ SELECT * FROM test WHERE a in (1, 47);
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:RecheckCond>
+          <dxl:IndexCondList>
             <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
@@ -332,19 +332,8 @@ SELECT * FROM test WHERE a in (1, 47);
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="47"/>
               </dxl:Array>
             </dxl:ArrayComp>
-          </dxl:RecheckCond>
-          <dxl:BitmapIndexProbe>
-            <dxl:IndexCondList>
-              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="47"/>
-                </dxl:Array>
-              </dxl:ArrayComp>
-            </dxl:IndexCondList>
-            <dxl:IndexDescriptor Mdid="0.41692.1.0" IndexName="test_index"/>
-          </dxl:BitmapIndexProbe>
+          </dxl:IndexCondList>
+          <dxl:IndexDescriptor Mdid="0.41692.1.0" IndexName="test_index"/>
           <dxl:TableDescriptor Mdid="6.41665.1.1" TableName="test">
             <dxl:Columns>
               <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -357,7 +346,7 @@ SELECT * FROM test WHERE a in (1, 47);
               <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
-        </dxl:BitmapTableScan>
+        </dxl:IndexScan>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
@@ -68,20 +68,16 @@ private:
 								  CColRefSetArray *pdrgpcrsEquivClasses);
 
 	// helper to create index lookup comparison predicate with index key on left side
-	static CExpression *PexprIndexLookupKeyOnLeft(CMemoryPool *mp,
-												  CMDAccessor *md_accessor,
-												  CExpression *pexprScalar,
-												  const IMDIndex *pmdindex,
-												  CColRefArray *pdrgpcrIndex,
-												  CColRefSet *outer_refs);
+	static CExpression *PexprIndexLookupKeyOnLeft(
+		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprScalar,
+		const IMDIndex *pmdindex, CColRefArray *pdrgpcrIndex,
+		CColRefSet *outer_refs, BOOL allowArrayCmpIndexQual);
 
 	// helper to create index lookup comparison predicate with index key on right side
-	static CExpression *PexprIndexLookupKeyOnRight(CMemoryPool *mp,
-												   CMDAccessor *md_accessor,
-												   CExpression *pexprScalar,
-												   const IMDIndex *pmdindex,
-												   CColRefArray *pdrgpcrIndex,
-												   CColRefSet *outer_refs);
+	static CExpression *PexprIndexLookupKeyOnRight(
+		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprScalar,
+		const IMDIndex *pmdindex, CColRefArray *pdrgpcrIndex,
+		CColRefSet *outer_refs, BOOL allowArrayCmpIndexQual);
 
 	// for all columns that appear in the given expression and are members
 	// of the given set, replace these columns with NULL constants
@@ -206,6 +202,10 @@ public:
 
 	// is the given expression a comparison between a scalar ident and a constant array
 	static BOOL FCompareIdentToConstArray(CExpression *pexpr);
+
+	// is the given ScalarArrayCmp a valid index qual
+	static BOOL IsScalarArrayCmpValidIndexQual(CExpression *pexpr,
+											   CColRefArray *pdrgpcrIndex);
 
 	// is the given expression an AND
 	static BOOL
@@ -396,7 +396,7 @@ public:
 		CExpressionArray *pdrgpexprResidual,
 		CColRefSet *pcrsAcceptedOuterRefs =
 			NULL,  // outer refs that are acceptable in an index predicate
-		BOOL allowArrayCmpForBTreeIndexes = false);
+		BOOL allowArrayCmpIndexQual = false);
 
 	// return the inverse of given comparison expression
 	static CExpression *PexprInverseComparison(CMemoryPool *mp,
@@ -426,7 +426,7 @@ public:
 	static CExpression *PexprIndexLookup(
 		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexpPred,
 		const IMDIndex *pmdindex, CColRefArray *pdrgpcrIndex,
-		CColRefSet *outer_refs, BOOL allowArrayCmpForBTreeIndexes);
+		CColRefSet *outer_refs, BOOL allowArrayCmpIndexQual);
 
 	// split given scalar expression into two conjunctions; without and with outer references
 	static void SeparateOuterRefs(CMemoryPool *mp, CExpression *pexprScalar,

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -853,6 +853,128 @@ SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
   3 |              3 |             3
 (1 row)
 
+--
+-- Test ORCA considers ScalarArrayOp in indexqual for partitioned table
+-- with multikey indexes only when predicate key is the first index key
+-- (similar test for non-partitioned tables in create_index)
+--
+CREATE TABLE pt_with_multikey_index (a int, key1 char(6), key2 char(1))
+PARTITION BY list(key2)
+(PARTITION p1 VALUES ('R'), PARTITION p2 VALUES ('G'), DEFAULT PARTITION other);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX multikey_idx on pt_with_multikey_index (key1, key2);
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'R' from generate_series(1,500)i;
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'G' from generate_series(1,500)i;
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'B' from generate_series(1,500)i;
+explain (costs off)
+SELECT key1 FROM pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65', 'KEY5')
+ORDER BY key1;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: pt_with_multikey_index_1_prt_p1.key1
+   ->  Sort
+         Sort Key: pt_with_multikey_index_1_prt_p1.key1
+         ->  Append
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_p1
+                     Recheck Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_p1_key1_key2_idx
+                           Index Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_p2
+                     Recheck Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_p2_key1_key2_idx
+                           Index Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_other
+                     Recheck Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_other_key1_key2_idx
+                           Index Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+SELECT key1 FROM pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65', 'KEY5')
+ORDER BY key1;
+  key1  
+--------
+ KEY5  
+ KEY5  
+ KEY5  
+ KEY55 
+ KEY55 
+ KEY55 
+ KEY65 
+ KEY65 
+ KEY65 
+(9 rows)
+
+EXPLAIN (costs off)
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 = 'KEY55' AND key2 IN ('R', 'G')
+ORDER BY key2;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: pt_with_multikey_index_1_prt_p1.key2
+   ->  Sort
+         Sort Key: pt_with_multikey_index_1_prt_p1.key2
+         ->  Append
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_p1
+                     Recheck Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_p1_key1_key2_idx
+                           Index Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_p2
+                     Recheck Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_p2_key1_key2_idx
+                           Index Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_other
+                     Recheck Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_other_key1_key2_idx
+                           Index Cond: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 = 'KEY55' AND key2 IN ('R', 'G')
+ORDER BY key2;
+ a  |  key1  | key2 
+----+--------+------
+ 55 | KEY55  | G
+ 55 | KEY55  | R
+(2 rows)
+
+EXPLAIN (costs off)
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65') AND key2 = 'R'
+ORDER BY key1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: pt_with_multikey_index_1_prt_p1.key1
+   ->  Sort
+         Sort Key: pt_with_multikey_index_1_prt_p1.key1
+         ->  Append
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_p1
+                     Recheck Cond: ((key1 = ANY ('{KEY55,KEY65}'::bpchar[])) AND (key2 = 'R'::bpchar))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_p1_key1_key2_idx
+                           Index Cond: ((key1 = ANY ('{KEY55,KEY65}'::bpchar[])) AND (key2 = 'R'::bpchar))
+               ->  Bitmap Heap Scan on pt_with_multikey_index_1_prt_other
+                     Recheck Cond: ((key1 = ANY ('{KEY55,KEY65}'::bpchar[])) AND (key2 = 'R'::bpchar))
+                     ->  Bitmap Index Scan on pt_with_multikey_index_1_prt_other_key1_key2_idx
+                           Index Cond: ((key1 = ANY ('{KEY55,KEY65}'::bpchar[])) AND (key2 = 'R'::bpchar))
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65') AND key2 = 'R'
+ORDER BY key1;
+ a  |  key1  | key2 
+----+--------+------
+ 55 | KEY55  | R
+ 65 | KEY65  | R
+(2 rows)
+
 -- The following tests are to verify a fix that allows ORCA to
 -- choose the bitmap index scan alternative when the predicate
 -- is in the form of `value operator cast(column)`. The fix

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -702,10 +702,10 @@ SET optimizer_enable_tablescan=off;
 SET optimizer_enable_indexscan=off;
 SET optimizer_enable_indexonlyscan=on;
 EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.10 rows=1 width=7)
-   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=0.00..0.10 rows=1 width=7)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=7)
+   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=0.00..6.00 rows=1 width=7)
          Index Cond: (a > 5)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
@@ -790,15 +790,13 @@ SELECT * FROM bitmap_alt WHERE bitmap_idx_col IN (3, 5);
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on bitmap_alt
-         Recheck Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
-         ->  Bitmap Index Scan on bitmap_alt_idx2
-               Index Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
+   ->  Index Scan using bitmap_alt_idx2 on bitmap_alt
+         Index Cond: (btree_idx_col = ANY ('{3,5}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(4 rows)
 
 SELECT * FROM bitmap_alt WHERE btree_idx_col IN (3, 5);
  id | bitmap_idx_col | btree_idx_col 
@@ -839,6 +837,109 @@ SELECT * FROM bitmap_alt WHERE btree_idx_col=ALL(ARRAY[3]);
 ----+----------------+---------------
   3 |              3 |             3
 (1 row)
+
+--
+-- Test ORCA considers ScalarArrayOp in indexqual for partitioned table
+-- with multikey indexes only when predicate key is the first index key
+-- (similar test for non-partitioned tables in create_index)
+--
+CREATE TABLE pt_with_multikey_index (a int, key1 char(6), key2 char(1))
+PARTITION BY list(key2)
+(PARTITION p1 VALUES ('R'), PARTITION p2 VALUES ('G'), DEFAULT PARTITION other);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX multikey_idx on pt_with_multikey_index (key1, key2);
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'R' from generate_series(1,500)i;
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'G' from generate_series(1,500)i;
+INSERT INTO pt_with_multikey_index SELECT i, 'KEY'||i, 'B' from generate_series(1,500)i;
+explain (costs off)
+SELECT key1 FROM pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65', 'KEY5')
+ORDER BY key1;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: key1
+   ->  Sort
+         Sort Key: key1
+         ->  Sequence
+               ->  Partition Selector for pt_with_multikey_index (dynamic scan id: 1)
+                     Partitions selected: 3 (out of 3)
+               ->  Dynamic Index Scan on pt_with_multikey_index (dynamic scan id: 1)
+                     Index Cond: (key1 = ANY ('{KEY55,KEY65,KEY5}'::bpchar[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+SELECT key1 FROM pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65', 'KEY5')
+ORDER BY key1;
+  key1  
+--------
+ KEY5  
+ KEY5  
+ KEY5  
+ KEY55 
+ KEY55 
+ KEY55 
+ KEY65 
+ KEY65 
+ KEY65 
+(9 rows)
+
+EXPLAIN (costs off)
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 = 'KEY55' AND key2 IN ('R', 'G')
+ORDER BY key2;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: key2
+   ->  Sort
+         Sort Key: key2
+         ->  Sequence
+               ->  Partition Selector for pt_with_multikey_index (dynamic scan id: 1)
+                     Partitions selected: 2 (out of 3)
+               ->  Dynamic Index Scan on pt_with_multikey_index (dynamic scan id: 1)
+                     Index Cond: (key1 = 'KEY55'::bpchar)
+                     Filter: ((key1 = 'KEY55'::bpchar) AND (key2 = ANY ('{R,G}'::bpchar[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 = 'KEY55' AND key2 IN ('R', 'G')
+ORDER BY key2;
+ a  |  key1  | key2 
+----+--------+------
+ 55 | KEY55  | G
+ 55 | KEY55  | R
+(2 rows)
+
+EXPLAIN (costs off)
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65') AND key2 = 'R'
+ORDER BY key1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: key1
+   ->  Sort
+         Sort Key: key1
+         ->  Sequence
+               ->  Partition Selector for pt_with_multikey_index (dynamic scan id: 1)
+                     Partitions selected: 1 (out of 3)
+               ->  Dynamic Index Scan on pt_with_multikey_index (dynamic scan id: 1)
+                     Index Cond: ((key1 = ANY ('{KEY55,KEY65}'::bpchar[])) AND (key2 = 'R'::bpchar))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+SELECT * FROM  pt_with_multikey_index
+WHERE key1 IN ('KEY55', 'KEY65') AND key2 = 'R'
+ORDER BY key1;
+ a  |  key1  | key2 
+----+--------+------
+ 55 | KEY55  | R
+ 65 | KEY65  | R
+(2 rows)
 
 -- The following tests are to verify a fix that allows ORCA to
 -- choose the bitmap index scan alternative when the predicate

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3106,18 +3106,14 @@ explain (costs off)
 SELECT unique1 FROM tenk1
 WHERE unique1 IN (1,42,7)
 ORDER BY unique1;
-                               QUERY PLAN
--------------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: unique1
-   ->  Sort
-         Sort Key: unique1
-         ->  Bitmap Heap Scan on tenk1
-               Recheck Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
-               ->  Bitmap Index Scan on tenk1_unique1
-                     Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
-(9 rows)
+   ->  Index Only Scan using tenk1_unique1 on tenk1
+         Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 SELECT unique1 FROM tenk1
 WHERE unique1 IN (1,42,7)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13520,6 +13520,7 @@ select * from sqall_t1 where a not in (
 
 reset optimizer_join_order;
 -- Make sure materialize projects child's tlist, not what is requested
+set optimizer_enable_indexscan to off;
 create table material_test(first_id int, second_id int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -13590,6 +13591,7 @@ and first_id in (select first_id from mat_w);
         1
 (8 rows)
 
+reset optimizer_enable_indexscan;
 -- Test to ensure bitmapscan doesn't project recheck/scalar filter columns
 create table material_bitmapscan(i int, j int, k timestamp, l timestamp) with(appendonly=true) distributed replicated;
 create index material_bitmapscan_idx on material_bitmapscan using btree(k);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13688,6 +13688,7 @@ select * from sqall_t1 where a not in (
 
 reset optimizer_join_order;
 -- Make sure materialize projects child's tlist, not what is requested
+set optimizer_enable_indexscan to off;
 create table material_test(first_id int, second_id int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'first_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -13766,6 +13767,7 @@ and first_id in (select first_id from mat_w);
         1
 (8 rows)
 
+reset optimizer_enable_indexscan;
 -- Test to ensure bitmapscan doesn't project recheck/scalar filter columns
 create table material_bitmapscan(i int, j int, k timestamp, l timestamp) with(appendonly=true) distributed replicated;
 create index material_bitmapscan_idx on material_bitmapscan using btree(k);

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2915,6 +2915,7 @@ select * from sqall_t1 where a not in (
 reset optimizer_join_order;
 
 -- Make sure materialize projects child's tlist, not what is requested
+set optimizer_enable_indexscan to off;
 create table material_test(first_id int, second_id int);
 create index material_test_idx on material_test using btree (second_id);
 create table material_test2(first_id int, second_id int);
@@ -2946,6 +2947,7 @@ select first_id
 from material_test2
 where first_id in (select first_id from mat_w)
 and first_id in (select first_id from mat_w);
+reset optimizer_enable_indexscan;
 
 -- Test to ensure bitmapscan doesn't project recheck/scalar filter columns
 create table material_bitmapscan(i int, j int, k timestamp, l timestamp) with(appendonly=true) distributed replicated;


### PR DESCRIPTION
For older versions of GPDB(and PG) the executor supported ScalarArrayCmp with BitmapIndexScans only. As part of the PG 92 merge (commit: 9e8da0f) support was added to IndexScans aswell but wasn't updated in ORCA. This commit adds support in ORCA to consider IndexScan plans for Btree indexes with indexquals on ScalarArrayOp.  Similar to planner for multikey indexes, a scalararrayop qual will only be considered as an index qual if the predicate column is the first index key else it will be added as a filter on top. This ensures we do not assume scan results are ordered. (ref commit: 807a40c) This commit also renames the boolean flag and pass it further down in the function call.

(backport of PR https://github.com/greenplum-db/gpdb/pull/16055)
Note: the test in gporca.sql for testing `materialize projects child's tlist` was picking an IndexScan(costed lower) plan instead of Bitmap Heap Scan. Updated test to generate the same plan as before. This test isn't in main branch thus this change is specific to 6X only.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
