### PR TITLE
Consider LIMIT pushdown when there are multiple remote postgres servers for postgres_fdw.

### DIFF
--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -905,8 +905,64 @@ SELECT count(c1), sum(c3), avg(c4), min(c5), max(c6), count(c1) * (random() <= 1
 (10 rows)
 
 ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
--- limit is not pushed down when there are multiple remote servers
--- limit with agg functions
+-- ===================================================================
+-- Queries with LIMIT/OFFSET clauses
+-- ===================================================================
+-- Simple query with LIMIT clause is pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 3::bigint
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+(3 rows)
+
+-- Simple query with OFFSET and LIMIT clause together is NOT pushed down.
+-- Because it's unsafe to do offset and limit in multiple remote servers.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Limit
+               Output: c1, c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c1, c2
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres query optimizer
+ Settings: gp_enable_minmax_optimization = 'off'
+(12 rows)
+
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
+ c1 | c2 
+----+----
+  3 |  3
+  4 |  4
+  5 |  5
+(3 rows)
+
+-- Query with aggregates and limit clause together is NOT pushed down.
+-- Because it's unsafe to do partial aggregate and limit in multiple remote servers.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
                                                QUERY PLAN                                                
@@ -926,7 +982,7 @@ SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
                            Output: c1, c2, c3, c4, c5, c6, c7
                            Remote SQL: SELECT c1, c2, c6 FROM "MPP_S 1"."T 2" ORDER BY c2 ASC NULLS LAST
  Optimizer: Postgres query optimizer
- Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
+ Settings: gp_enable_minmax_optimization = 'off'
 (16 rows)
 
 SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
@@ -937,33 +993,9 @@ SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
    100 | 0.992
 (3 rows)
 
--- limit with normal scan without agg functions
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Limit
-   Output: c1, c2
-   ->  Gather Motion 2:1  (slice1; segments: 2)
-         Output: c1, c2
-         Merge Key: c1
-         ->  Limit
-               Output: c1, c2
-               ->  Foreign Scan on public.mpp_ft2
-                     Output: c1, c2
-                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres query optimizer
- Settings: gp_enable_minmax_optimization = 'off', optimizer = 'off'
-(12 rows)
-
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
- c1 | c2 
-----+----
-  1 |  1
-  2 |  2
-  3 |  3
-(3 rows)
-
+-- ===================================================================
+-- Queries with JOIN
+-- ===================================================================
 -- join is not safe to pushed down when there are multiple remote servers
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -6765,6 +6765,12 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
 		return;
 
 	/*
+	 * It's unsafe to pushdown OFFSET/LIMIT when mpp_execute = 'all segments' and the OFFSET is specified.
+	 */
+	if (final_rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS && parse->limitOffset)
+		return;
+
+	/*
 	 * Also, the LIMIT/OFFSET cannot be pushed down, if their expressions are
 	 * not safe to remote.
 	 */


### PR DESCRIPTION
### 1. Scenario using this feature
We consider such scenario -- foreign table f_tbl is distributed randomly across multiple remote postgres server.
```
CREATE EXTENSION postgres_fdw;

CREATE SERVER multi_pg_servers
FOREIGN DATA WRAPPER postgres_fdw
OPTIONS (mpp_execute 'all segments', num_segments '4', multi_hosts '127.0.0.1 127.0.0.1 127.0.0.1 127.0.0.1', multi_ports '5432 5555 6666 7777', dbname 'postgres');

CREATE USER MAPPING FOR gpadmin 
SERVER multi_pg_servers OPTIONS (user 'postgres');

CREATE FOREIGN TABLE f_tbl(a int, b int) 
SERVER multi_pg_servers
OPTIONS(table_name 'demo_local_tbl');
```
- We set option `mpp_execute` to `all segments` for server `multi_pg_servers`. So when select something from postgres_fdw foreign table, the scan will be executed in a distributed way.
- The number of executors is controlled by the server option `num_segments`. If this option is not set, the number of executors will be the default number of segments in GPDB. 
- Options `multi_hosts` and `multi_ports` can specify multiple remote postgres server. The number of remote postgres server **MUST** be same as the option `num_segments`.

By doing so, we build the scenario that the foreign table is a distributed foreign table which data stored on multiple remote servers.

### 2. Results
In this PR, we will consider LIMIT pushdown when there are multiple remote postgres servers for postgres_fdw.

The plan without changes of this PR is:
```
testdb=# explain verbose select * from f_tbl order by c1 limit 1;
                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------
 Limit  (cost=387.52..387.54 rows=1 width=8)
   Output: c1, c2
   ->  Gather Motion 4:1  (slice1; segments: 4)  (cost=387.52..387.60 rows=4 width=8)
         Output: c1, c2
         Merge Key: c1
         ->  Limit  (cost=387.52..387.55 rows=1 width=8)
               Output: c1, c2
               ->  Foreign Scan on public.f_tbl  (cost=100.00..2975.20 rows=86100 width=8)
                     Output: c1, c2
                     Remote SQL: SELECT c1, c2 FROM public.demo_local_table ORDER BY c1 ASC NULLS LAST
 Optimizer: Postgres query optimizer
(11 rows)
```

The plan with changes of this PR will be:
```
testdb=# explain verbose select * from f_tbl order by c1 limit 1;
                                                   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------
 Limit  (cost=100.00..100.02 rows=1 width=8)
   Output: c1, c2
   ->  Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..100.08 rows=4 width=8)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.f_tbl  (cost=100.00..100.03 rows=1 width=8)
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM public.demo_local_table ORDER BY c1 ASC NULLS LAST LIMIT 1::bigint
 Optimizer: Postgres query optimizer
(9 rows)
```
