### PR TITLE
Fix io_limit_gram.y doesn't compatible with bison version older than 3.0

### DIFF
--- a/src/backend/utils/resgroup/Makefile
+++ b/src/backend/utils/resgroup/Makefile
@@ -19,7 +19,6 @@ ifeq ($(PORTNAME),linux)
 OBJS += cgroup.o
 OBJS += cgroup-ops-linux-v1.o
 OBJS += cgroup-ops-linux-v2.o
-OBJS += io_limit_scanner.o
 OBJS += io_limit_gram.o
 OBJS += cgroup_io_limit.o
 
@@ -34,7 +33,7 @@ io_limit_scanner.c: FLEXFLAGS = -CF -p -p
 io_limit_scanner.c: FLEX_NO_BACKUP=yes
 io_limit_scanner.c: FLEX_FIX_WARNING=yes
 
-io_limit_gram.o io_limit_scanner.o cgroup-ops-linux-v2.o: io_limit_gram.h
+io_limit_gram.o cgroup-ops-linux-v2.o: io_limit_scanner.c
 else
 OBJS += cgroup-ops-dummy.o
 

--- a/src/backend/utils/resgroup/io_limit_scanner.l
+++ b/src/backend/utils/resgroup/io_limit_scanner.l
@@ -1,15 +1,19 @@
 %{
 #include "postgres.h"
-#include "io_limit_gram.h"
-
-#define YYSTYPE IO_LIMIT_YYSTYPE
 %}
 
-%option noinput nounput noyywrap
-%option noyyalloc noyyfree noyyrealloc
+%option never-interactive
+%option nodefault
+%option noinput
+%option nounput
+%option noyywrap
+%option warn
 %option prefix="io_limit_yy"
-%option reentrant bison-bridge
-%option warn never-interactive nodefault
+%option bison-bridge
+%option reentrant
+%option noyyalloc
+%option noyyrealloc
+%option noyyfree
 
 id  [a-zA-Z_][a-zA-Z0-9_]*
 wildcard \*


### PR DESCRIPTION
Note that, GPDB and upstream(PG12) requires bison version newer than 1.875 in configure file, but io_limit_gram.y introduced by ce3e3523dae1f2d2776e01eb79e01be89995e10e can only work in the version later than 3.0.

This commit makes it compatible with the version that older than 3.0.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
