### PR TITLE
Re-used index after ALTER COLUMN TYPE shouldn't change relfilenode

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13734,9 +13734,68 @@ ATPostAlterTypeParse(Oid oldId, Oid oldRelId, Oid refRelId, char *cmd,
 	/*
 	 * In the QE, don't add items to the work queues. They were already
 	 * added in the QD, and we don't want to do them twice.
+	 *
+	 * However, we need to check if we are to reuse the relfilenode of an
+	 * existing index. This information is unique to QD and each QE. If so,
+	 * we need to replace that with QE's own relfilenode. Note that this is
+	 * not a problem for foreign key operator oids (see TryReuseForeignKey)
+	 * since those are the same among QD/QEs.
 	 */
 	if (Gp_role == GP_ROLE_EXECUTE)
+	{
+		ListCell 		*lc;
+		Relation 		rel;
+		Relation 		irel = NULL;
+		AlteredTableInfo 	*tab;
+
+		/* Caller should already have acquired whatever lock we need. */
+		rel = relation_open(oldRelId, NoLock);
+		tab = ATGetQueueEntry(wqueue, rel);
+
+		/* Check the commands I got from QD for any re-used index. */
+		foreach (lc, tab->subcmds[AT_PASS_OLD_INDEX])
+		{
+			AlterTableCmd 	*cmd = castNode(AlterTableCmd, lfirst(lc));
+			IndexStmt 	*stmt;
+
+			Assert(cmd->subtype == AT_ReAddIndex);
+
+			stmt = (IndexStmt *) cmd->def;
+
+			/* if we are not reusing this index, continue */
+			if (!OidIsValid(stmt->oldNode))
+				continue;
+
+			if (irel == NULL)
+			{
+				Oid 		indoid = InvalidOid;
+				HeapTuple 	tup;
+
+				tup = SearchSysCache1(INDEXRELID, ObjectIdGetDatum(oldId));
+				if (HeapTupleIsValid(tup))
+					indoid = oldId;
+				else
+					/* not an index, them it must be a constraint */
+					indoid = get_constraint_index(oldId);
+
+				if (HeapTupleIsValid(tup))
+					ReleaseSysCache(tup);
+
+				Assert(OidIsValid(indoid));
+
+				/* We might not open index on QE, so acquire a valid lock */
+				irel = index_open(indoid, AccessShareLock);
+			}
+
+			/* replace it with my own */
+			stmt->oldNode = irel->rd_node.relNode;
+		}
+
+		if (irel != NULL)
+			index_close(irel, AccessShareLock);
+		relation_close(rel, NoLock);
 		return;
+	}
 
 	/*
 	 * We expect that we will get only ALTER TABLE and CREATE INDEX

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -309,3 +309,88 @@ SELECT * FROM issue_14279_taptest_table_p3000000100;
 
 DROP TABLE issue_14279_taptest_table;
 DROP TABLE issue_14279_fk_reference;
+-- alter indexed column to the same type shouldn't change the index' relfilenode on QD and QEs.
+-- helper utilities to check compare relfilenodes
+drop table if exists relfilenodecheck;
+create table relfilenodecheck(segid int, relname text, relfilenodebefore int, relfilenodeafter int, casename text);
+prepare capturerelfilenodebefore as
+insert into relfilenodecheck select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename from pg_class where relname like $2
+union select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename  from gp_dist_random('pg_class')
+where relname like $2 order by segid;
+prepare checkrelfilenodediff as
+select a.segid, b.casename, b.relname, (relfilenodebefore != a.relfilenode) rewritten
+from
+    (
+        select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from pg_class
+        where relname like $2
+        union
+        select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from gp_dist_random('pg_class')
+        where relname like $2 order by segid
+    )a, relfilenodecheck b
+where b.casename like $1 and b.relname like $2 and a.segid = b.segid;
+create table attype_indexed(a int, b int);
+create index attype_indexed_i on attype_indexed(b);
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+-- alter to same type.
+-- check relfilenode before AT
+execute capturerelfilenodebefore('alter column type same', 'attype_indexed_i');
+alter table attype_indexed alter column b type int;
+-- relfilenode stay same as before
+execute checkrelfilenodediff('alter column type same', 'attype_indexed_i');
+ segid |        casename        |     relname      | rewritten 
+-------+------------------------+------------------+-----------
+     0 | alter column type same | attype_indexed_i | f
+     1 | alter column type same | attype_indexed_i | f
+     2 | alter column type same | attype_indexed_i | f
+    -1 | alter column type same | attype_indexed_i | f
+(4 rows)
+
+-- insert works fine
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+select count(*) from attype_indexed;
+ count 
+-------
+   200
+(1 row)
+
+-- alter to different type, relfilenode should change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_i');
+alter table attype_indexed alter column b type text;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_i');
+ segid |        casename        |     relname      | rewritten 
+-------+------------------------+------------------+-----------
+     0 | alter column diff type | attype_indexed_i | t
+     1 | alter column diff type | attype_indexed_i | t
+     2 | alter column diff type | attype_indexed_i | t
+    -1 | alter column diff type | attype_indexed_i | t
+(4 rows)
+
+--insert works fine
+insert into attype_indexed select i, 'abc'::text from generate_series(1, 100) i;
+select count(*) from attype_indexed;
+ count 
+-------
+   300
+(1 row)
+
+-- alter column with exclusion constraint
+create table attype_indexed_constr(
+    c circle,
+    dkey inet,
+    exclude using gist (dkey inet_ops with =, c with &&)
+);
+-- not change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+alter table attype_indexed_constr alter column c type circle;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+ segid |        casename        |              relname              | rewritten 
+-------+------------------------+-----------------------------------+-----------
+     0 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+     1 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+     2 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+    -1 | alter column diff type | attype_indexed_constr_dkey_c_excl | f
+(4 rows)
+
+drop table relfilenodecheck;

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -246,3 +246,67 @@ SELECT * FROM issue_14279_taptest_table_p3000000000;
 SELECT * FROM issue_14279_taptest_table_p3000000100;
 DROP TABLE issue_14279_taptest_table;
 DROP TABLE issue_14279_fk_reference;
+
+-- alter indexed column to the same type shouldn't change the index' relfilenode on QD and QEs.
+
+-- helper utilities to check compare relfilenodes
+drop table if exists relfilenodecheck;
+create table relfilenodecheck(segid int, relname text, relfilenodebefore int, relfilenodeafter int, casename text);
+
+prepare capturerelfilenodebefore as
+insert into relfilenodecheck select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename from pg_class where relname like $2
+union select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename  from gp_dist_random('pg_class')
+where relname like $2 order by segid;
+
+prepare checkrelfilenodediff as
+select a.segid, b.casename, b.relname, (relfilenodebefore != a.relfilenode) rewritten
+from
+    (
+        select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from pg_class
+        where relname like $2
+        union
+        select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from gp_dist_random('pg_class')
+        where relname like $2 order by segid
+    )a, relfilenodecheck b
+where b.casename like $1 and b.relname like $2 and a.segid = b.segid;
+
+create table attype_indexed(a int, b int);
+create index attype_indexed_i on attype_indexed(b);
+
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+
+-- alter to same type.
+-- check relfilenode before AT
+execute capturerelfilenodebefore('alter column type same', 'attype_indexed_i');
+alter table attype_indexed alter column b type int;
+-- relfilenode stay same as before
+execute checkrelfilenodediff('alter column type same', 'attype_indexed_i');
+
+-- insert works fine
+insert into attype_indexed select i,i from generate_series(1, 100)i;
+select count(*) from attype_indexed;
+
+-- alter to different type, relfilenode should change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_i');
+alter table attype_indexed alter column b type text;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_i');
+
+--insert works fine
+insert into attype_indexed select i, 'abc'::text from generate_series(1, 100) i;
+select count(*) from attype_indexed;
+
+-- alter column with exclusion constraint
+create table attype_indexed_constr(
+    c circle,
+    dkey inet,
+    exclude using gist (dkey inet_ops with =, c with &&)
+);
+
+-- not change
+execute capturerelfilenodebefore('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+alter table attype_indexed_constr alter column c type circle;
+execute checkrelfilenodediff('alter column diff type', 'attype_indexed_constr_dkey_c_excl');
+
+drop table relfilenodecheck;


### PR DESCRIPTION
During ALTER COLUMN TYPE of an indexed column, we check if the index can be re-used. If so, we preserve the existing relfilenode instead of removing it. However, in GPDB the preservation is done on QD and the relfilenode is packaged in another ALTER TABLE subcommand to be handled later. So QE might make its index to have QD's relfilenode, which could cause data missing/corruption errors.

The fix is for QE to go through the generated index command, and replace QD's relfilenode with its own.

It's not an issue for 6X as we don't allow altering type of indexed column in 6X.

P.S. this should help resolve two flaky tests `vacuum_gp` and `gp_check_files` for diff like this:
```
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/vacuum_gp.out	2023-08-07 17:31:36.674940540 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/vacuum_gp.out	2023-08-07 17:31:36.694942596 +0000
@@ -438,6 +446,7 @@
 LANGUAGE plpgsql;
 -- start off cleanly
 vacuum freeze;
+ERROR:  could not open file "base/17073/21866": No such file or directory

--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/gp_check_files.out	2023-08-07 18:01:52.749627092 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/gp_check_files.out	2023-08-07 18:01:52.753627503 +0000
@@ -55,7 +55,8 @@
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------
              1 | x              | checkmissing_heap
-(1 row)
+             1 | x              | rc_test
+(2 rows)
```
The reasoning between the flakiness and the PR is this: in some tests prior to `vacuum_gp`, we had some case that alter column type and reuse the index. Because of the bug, we incorrectly re-use the QD's relfilenode and set it in pg_class. Then, we drop the altered table and removed the file. When that bad relfilenode wasn't used by any existing table, all good. But if it's the same as an existing table (`rc_test` in this case), then that table is essentially missing its file. So both VACUUM and gp_check_missing_files would immediately complain about it.

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/at-type-relfile

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
