### PR TITLE
Fix bug: resgroup total wait during always 0.

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1366,7 +1366,7 @@ addTotalQueueDuration(ResGroupData *group)
 	if (group == NULL)
 		return;
 
-	group->totalQueuedTimeMs += (groupWaitEnd - groupWaitEnd);
+	group->totalQueuedTimeMs += (groupWaitEnd - groupWaitStart);
 }
 
 /*
@@ -1857,6 +1857,7 @@ waitOnGroup(ResGroupData *group, bool isMoveQuery)
 	PG_END_TRY();
 
 	groupAwaited = NULL;
+	groupWaitEnd = GetCurrentTimestamp();
 
 	/* reset ps status */
 	if (update_process_title)

--- a/src/test/isolation2/expected/resgroup/resgroup_wait_time.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_wait_time.out
@@ -1,0 +1,104 @@
+create resource group rg_wait_time_test with (concurrency=2, cpu_max_percent=20);
+CREATE RESOURCE GROUP
+create role role_wait_time_test resource group rg_wait_time_test;
+CREATE ROLE
+
+1: set role role_wait_time_test;
+SET
+1: begin;
+BEGIN
+
+2: set role role_wait_time_test;
+SET
+2: begin;
+BEGIN
+
+3: set role role_wait_time_test;
+SET
+-- this group only has two concurrency, the below SQL will be put in wait queue
+3&: begin;  <waiting ...>
+
+select pg_sleep(2);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- commit the 1st transaction to unblock 3
+-- so 3 will record its wait time
+1: end;
+COMMIT
+2: end;
+COMMIT
+3<:  <... completed>
+BEGIN
+
+select total_queue_duration > '00:00:00' waited from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+ waited 
+--------
+ t      
+(1 row)
+
+3:end;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+drop role role_wait_time_test;
+DROP ROLE
+drop resource group rg_wait_time_test;
+DROP RESOURCE GROUP
+
+create resource group rg_wait_time_test with (concurrency=2, cpu_max_percent=20);
+CREATE RESOURCE GROUP
+create role role_wait_time_test resource group rg_wait_time_test;
+CREATE ROLE
+
+1: set role role_wait_time_test;
+SET
+1: begin;
+BEGIN
+
+2: set role role_wait_time_test;
+SET
+2: begin;
+BEGIN
+
+3: set role role_wait_time_test;
+SET
+-- this group only has two concurrency, the below SQL will be put in wait queue
+3&: begin;  <waiting ...>
+
+select pg_sleep(2);
+ pg_sleep 
+----------
+          
+(1 row)
+
+select pg_terminate_backend(pid) from pg_stat_activity where rsgname = 'rg_wait_time_test' and wait_event_type = 'ResourceGroup';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+1q: ... <quitting>
+2q: ... <quitting>
+3<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3q: ... <quitting>
+
+select total_queue_duration > '00:00:00' waited from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+ waited 
+--------
+ t      
+(1 row)
+
+-- clean up
+drop role role_wait_time_test;
+DROP ROLE
+drop resource group rg_wait_time_test;
+DROP RESOURCE GROUP

--- a/src/test/isolation2/isolation2_resgroup_v1_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v1_schedule
@@ -21,6 +21,7 @@ test: resgroup/resgroup_seg_down_2pc
 
 # functions
 test: resgroup/resgroup_concurrency
+test: resgroup/resgroup_wait_time
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_cpu_max_percent
 test: resgroup/resgroup_cpuset

--- a/src/test/isolation2/isolation2_resgroup_v2_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v2_schedule
@@ -21,6 +21,7 @@ test: resgroup/resgroup_seg_down_2pc
 
 # functions
 test: resgroup/resgroup_concurrency
+test: resgroup/resgroup_wait_time
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_cpu_max_percent
 test: resgroup/resgroup_cpuset

--- a/src/test/isolation2/sql/resgroup/resgroup_wait_time.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_wait_time.sql
@@ -1,0 +1,62 @@
+create resource group rg_wait_time_test with (concurrency=2, cpu_max_percent=20);
+create role role_wait_time_test resource group rg_wait_time_test;
+
+1: set role role_wait_time_test;
+1: begin;
+
+2: set role role_wait_time_test;
+2: begin;
+
+3: set role role_wait_time_test;
+-- this group only has two concurrency, the below SQL will be put in wait queue
+3&: begin;
+
+select pg_sleep(2);
+
+-- commit the 1st transaction to unblock 3
+-- so 3 will record its wait time
+1: end;
+2: end;
+3<:
+
+select total_queue_duration > '00:00:00' waited
+from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+
+3:end;
+1q:
+2q:
+3q:
+
+drop role role_wait_time_test;
+drop resource group rg_wait_time_test;
+
+create resource group rg_wait_time_test with (concurrency=2, cpu_max_percent=20);
+create role role_wait_time_test resource group rg_wait_time_test;
+
+1: set role role_wait_time_test;
+1: begin;
+
+2: set role role_wait_time_test;
+2: begin;
+
+3: set role role_wait_time_test;
+-- this group only has two concurrency, the below SQL will be put in wait queue
+3&: begin;
+
+select pg_sleep(2);
+
+select pg_terminate_backend(pid)
+from pg_stat_activity
+where rsgname = 'rg_wait_time_test' and wait_event_type = 'ResourceGroup';
+
+1q:
+2q:
+3<:
+3q:
+
+select total_queue_duration > '00:00:00' waited
+from gp_toolkit.gp_resgroup_status where groupname = 'rg_wait_time_test';
+
+-- clean up
+drop role role_wait_time_test;
+drop resource group rg_wait_time_test;


### PR DESCRIPTION
DEV CI https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/zlv_test_rg_wait_time