### PR TITLE
Use custom allocator and deallocator for zstd

### DIFF
--- a/configure
+++ b/configure
@@ -9679,18 +9679,19 @@ fi
 #
 # zstd
 #
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build with ZSTD support" >&5
-$as_echo_n "checking whether to build with ZSTD support... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to build with ZSTD support" >&5
+printf %s "checking whether to build with ZSTD support... " >&6; }
 
 
 
 # Check whether --with-zstd was given.
-if test "${with_zstd+set}" = set; then :
+if test ${with_zstd+y}
+then :
   withval=$with_zstd;
   case $withval in
     yes)
 
-$as_echo "#define USE_ZSTD 1" >>confdefs.h
+printf "%s\n" "#define USE_ZSTD 1" >>confdefs.h
 
       ;;
     no)
@@ -9701,110 +9702,67 @@ $as_echo "#define USE_ZSTD 1" >>confdefs.h
       ;;
   esac
 
-else
+else $as_nop
   with_zstd=yes
 
-$as_echo "#define USE_ZSTD 1" >>confdefs.h
+printf "%s\n" "#define USE_ZSTD 1" >>confdefs.h
 
 fi
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_zstd" >&5
-$as_echo "$with_zstd" >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_zstd" >&5
+printf "%s\n" "$with_zstd" >&6; }
 
 
 if test "$with_zstd" = yes; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
+printf %s "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
+if test ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-l:libzstd.a  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.4.0" >&5
-$as_echo_n "checking for libzstd >= 1.4.0... " >&6; }
-
-if test -n "$ZSTD_CFLAGS"; then
-    pkg_cv_ZSTD_CFLAGS="$ZSTD_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.4.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char ZSTD_compressCCtx ();
+int
+main (void)
+{
+return ZSTD_compressCCtx ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib__libzstd_a_ZSTD_compressCCtx=yes
+else $as_nop
+  ac_cv_lib__libzstd_a_ZSTD_compressCCtx=no
 fi
- else
-    pkg_failed=untried
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
 fi
-if test -n "$ZSTD_LIBS"; then
-    pkg_cv_ZSTD_LIBS="$ZSTD_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.4.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
+printf "%s\n" "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
+if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIB_LIBZSTD_A 1" >>confdefs.h
+
+  LIBS="-l:libzstd.a $LIBS"
+
+else $as_nop
+  as_fn_error $? "zstd library not found
+If you have libzstd already installed, see config.log for details on the
+failure.  It is possible the compiler isn't looking in the proper directory.
+Use --without-zstd to disable zstd support." "$LINENO" 5
 fi
 
-
-
-if test $pkg_failed = yes; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
-        else
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$ZSTD_PKG_ERRORS" >&5
-
-	as_fn_error $? "Package requirements (libzstd >= 1.4.0) were not met:
-
-$ZSTD_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables ZSTD_CFLAGS
-and ZSTD_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
-elif test $pkg_failed = untried; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables ZSTD_CFLAGS
-and ZSTD_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
-else
-	ZSTD_CFLAGS=$pkg_cv_ZSTD_CFLAGS
-	ZSTD_LIBS=$pkg_cv_ZSTD_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-fi
 fi
 
 #
@@ -15435,6 +15393,26 @@ if test "x$ac_cv_header_bzlib_h" = xyes; then :
 
 else
   as_fn_error $? "header file <bzlib.h> is required for bzip2 support" "$LINENO" 5
+fi
+
+
+fi
+
+# Check for zstd.h and zstd_errors.h
+if test "$with_zstd" = yes; then
+  ac_fn_c_check_header_mongrel "$LINENO" "zstd.h" "ac_cv_header_zstd_h" "$ac_includes_default"
+if test "x$ac_cv_header_zstd_h" = xyes; then :
+
+else
+  as_fn_error $? "header file <zstd.h> is required for zstd support" "$LINENO" 5
+fi
+
+
+  ac_fn_c_check_header_mongrel "$LINENO" "zstd_errors.h" "ac_cv_header_zstd_errors_h" "$ac_includes_default"
+if test "x$ac_cv_header_zstd_errors_h" = xyes; then :
+
+else
+  as_fn_error $? "header file <zstd_errors.h> is required for zstd support" "$LINENO" 5
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -1154,8 +1154,11 @@ AC_MSG_RESULT([$with_zstd])
 AC_SUBST(with_zstd)
 
 if test "$with_zstd" = yes; then
-  dnl zstd_errors.h was renamed from error_public.h in v1.1.1
-  PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.0])
+  AC_CHECK_LIB(:libzstd.a, ZSTD_compressCCtx, [],
+               [AC_MSG_ERROR([zstd library not found
+If you have libzstd already installed, see config.log for details on the
+failure.  It is possible the compiler isn't looking in the proper directory.
+Use --without-zstd to disable zstd support.])])
 fi
 
 #
@@ -1721,6 +1724,12 @@ fi
 # Check for bzlib.h
 if test "$with_libbz2" = yes ; then
   AC_CHECK_HEADER(bzlib.h, [], [AC_MSG_ERROR([header file <bzlib.h> is required for bzip2 support])], [])
+fi
+
+# Check for zstd.h and zstd_errors.h
+if test "$with_zstd" = yes; then
+  AC_CHECK_HEADER(zstd.h, [], [AC_MSG_ERROR([header file <zstd.h> is required for zstd support])])
+  AC_CHECK_HEADER(zstd_errors.h, [], [AC_MSG_ERROR([header file <zstd_errors.h> is required for zstd support])])
 fi
 
 if test "$with_gssapi" = yes ; then

--- a/gpcontrib/zstd/Makefile
+++ b/gpcontrib/zstd/Makefile
@@ -2,8 +2,6 @@ PG_CONFIG = pg_config
 
 MODULE_big = gp_zstd_compression
 OBJS = zstd_compression.o
-CFLAGS_SL += -lzstd
-LDFLAGS_SL += -lzstd
 
 REGRESS = zstd_column_compression compression_zstd zstd_abort_leak AOCO_zstd AORO_zstd
 

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -42,6 +42,7 @@
 #include "postgres.h"
 
 #ifdef USE_ZSTD
+#define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #endif
 
@@ -55,6 +56,7 @@
 #include "utils/resowner.h"
 
 #include "storage/gp_compress.h"
+#include "utils/gp_alloc.h"
 #include "utils/faultinjector.h"
 #include "utils/workfile_mgr.h"
 
@@ -165,6 +167,9 @@ static void BufFileStartCompression(BufFile *file);
 static void BufFileDumpCompressedBuffer(BufFile *file, const void *buffer, Size nbytes);
 static void BufFileEndCompression(BufFile *file);
 static int BufFileLoadCompressedBuffer(BufFile *file, void *buffer, size_t bufsize);
+
+void *customAlloc(void *opaque, size_t size);
+void customFree(void *opaque, void *address);
 
 /*
  * Create BufFile and perform the common initialization.
@@ -1255,6 +1260,18 @@ BufFilePledgeSequential(BufFile *buffile)
 
 #define BUFFILE_ZSTD_COMPRESSION_LEVEL 1
 
+void *
+customAlloc(void *opaque, size_t size)
+{
+	return MemoryContextAlloc(TopMemoryContext, size);
+}
+
+void
+customFree(void *opaque, void *address)
+{
+	pfree(address);
+}
+
 /*
  * Temporary buffer used during compression. It's used only within the
  * functions, so we can allocate this once and reuse it for all files.
@@ -1269,6 +1286,10 @@ BufFileStartCompression(BufFile *file)
 {
 	ResourceOwner oldowner;
 	size_t ret;
+	ZSTD_customMem customMem;
+
+	customMem.customAlloc = customAlloc;
+	customMem.customFree = customFree;
 
 	/*
 	 * When working with compressed files, we rely on libzstd's buffer,
@@ -1295,7 +1316,7 @@ BufFileStartCompression(BufFile *file)
 	CurrentResourceOwner = file->resowner;
 
 	file->zstd_context = zstd_alloc_context();
-	file->zstd_context->cctx = ZSTD_createCStream();
+	file->zstd_context->cctx = ZSTD_createCStream_advanced(customMem);
 	if (!file->zstd_context->cctx)
 		elog(ERROR, "out of memory");
 	ret = ZSTD_initCStream(file->zstd_context->cctx, BUFFILE_ZSTD_COMPRESSION_LEVEL);
@@ -1357,6 +1378,10 @@ BufFileEndCompression(BufFile *file)
 	size_t		ret;
 	int			wrote;
 	off_t		pos = 0;
+	ZSTD_customMem customMem;
+
+	customMem.customAlloc = customAlloc;
+	customMem.customFree = customFree;
 
 	Assert(file->state == BFS_COMPRESSED_WRITING);
 
@@ -1382,7 +1407,7 @@ BufFileEndCompression(BufFile *file)
 		 file->uncompressed_bytes, BufFileSize(file));
 
 	/* Done writing. Initialize for reading */
-	file->zstd_context->dctx = ZSTD_createDStream();
+	file->zstd_context->dctx = ZSTD_createDStream_advanced(customMem);
 	if (!file->zstd_context->dctx)
 		elog(ERROR, "out of memory");
 	ret = ZSTD_initDStream(file->zstd_context->dctx);


### PR DESCRIPTION
gpdb uses zstd to compress workfiles, but it can't control memory allocation within zstd. Meanwhile zstd allocates as much memory as it needs, which results in ambiguous error message in a case of memory exhaustion and can make OOM killer stop gpdb processes with force. In this patch we pass our custom allocator to zstd which can keep track of allocated memory.

Since this zstd feature is experimental and its api can change, we also had to link zstd statically. Well... we had to change autoconf script as well and apply an approach that we had used in 6x. We changed `PKG_CHECK_MODULES` back to `AC_CHECK_LIB` because, as far as I understand, we need an individual .pc file for a static library so that pkg-config can use it, but zstd doesn't provide it. Actually, I don't know a graceful way to link statically using autoconf, so feel free to suggest more proper ways to do it.