### PR TITLE
Fix gpfdist7 data overwriting

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3660,19 +3660,19 @@ static void handle_post_request(request_t *r, int header_end)
 
 done_processing_request:
 
+	/* 
+	 * To ensure that retry works well,
+	 * there are two cases where seq_segs will be updated.
+	 * 1. Data has been written successfully.
+	 * 2. Request is OPEN_SEQ.
+	 */
+	session->seq_segs[r->segid] = r->seq;
+
 	/* send our success response and end the request */
 	if (0 != http_ok(r))
 		request_end(r, ERROR_CODE_GENERIC, 0);
 	else
-	{
 		request_end(r, ERROR_CODE_SUCCESS, 0); /* we're done! */
-		/* 
-		 * Only when send http_ok successfully will we set
-		 * OPEN_SEQ and normal seq, we just add 1.
-		 * For duplicate case, we set it unchanged.
-		 */
-		session->seq_segs[r->segid] = r->seq;
-	}
 }
 
 static int request_set_path(request_t *r, const char* d, char* p, char* pp, char* path)


### PR DESCRIPTION
Current gpfdist will update the corresponding sequence number when it responses a HTTP request successfully. However, the network may be unstable when gpfdist processes a HTTP request. In rare conditions, a connection could be aborted when gpfdist finishes receiving and writing data, which would lead to a data-sending retry.

Since gpfdist wouldn't update the sequence number despite finishing data writing when the response failed, data will be written again when gpdb retries sending the same data.

The PR is to handle the rare case. Gpfdist updates the sequence number when data writing ends or the request is OPEN_SEQ. The adaptation will avoid data overwriting.
