### PR TITLE
Introduce Non-Replicated Distribution Spec

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -1396,19 +1396,13 @@ explain (costs false) update t1 set b = b + 1 where b in (select a from gp_any w
                                QUERY PLAN
 ------------------------------------------------------------------------
  Update on t1
-   ->  Result
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: t1.a
-               ->  Hash Semi Join
-                     Hash Cond: (t1.b = a)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: t1.b
-                           ->  Seq Scan on t1
-                     ->  Hash
-                           ->  Result
-                                 ->  Foreign Scan on gp_any
+   ->  Hash Semi Join
+         Hash Cond: (t1.b = a)
+         ->  Seq Scan on t1
+         ->  Hash
+               ->  Foreign Scan on gp_any
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(7 rows)
 
 explain (costs false) update t1 set b = b + 1 where b in (select a from gp_coord where gp_coord.a > 10);
                                           QUERY PLAN                                           

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
@@ -395,7 +395,7 @@
         </dxl:UnionAll>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:DMLInsert Columns="0,1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765376.357180" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -304,7 +304,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="19">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000126" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -699,7 +699,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="10" VarTypeModList="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.394467" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -404,7 +404,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="152896745104">
+    <dxl:Plan Id="0" SpaceSize="155744591272">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250698.553699" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
@@ -450,10 +450,10 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1377.995318" Rows="1000000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1377.961011" Rows="1000000.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -471,9 +471,9 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1318.368651" Rows="1000000.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1318.334344" Rows="1000000.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -495,7 +495,7 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.258519" Rows="3000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.224212" Rows="3000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -509,7 +509,7 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
             <dxl:SortingColumnList/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.115319" Rows="1000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.081012" Rows="1000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -523,39 +523,10 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
               <dxl:JoinFilter/>
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="18" ColName="column1" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="18" ColName="column1" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="18" Alias="column1">
-                    <dxl:Ident ColId="18" ColName="column1" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="18" ColName="column1" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="column1">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:RedistributeMotion>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.006967" Rows="1000.000000" Width="8"/>
@@ -583,6 +554,18 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="column1">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:HashJoin>
           </dxl:BroadcastMotion>
           <dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -692,10 +692,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalDelete>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="156">
+    <dxl:Plan Id="0" SpaceSize="432">
       <dxl:DMLDelete Columns="0" ActionCol="23" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.570616" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.436468" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -717,7 +717,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.547178" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.413030" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -737,7 +737,7 @@
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.547172" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.413024" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -785,46 +785,42 @@
             </dxl:TableScan>
             <dxl:Materialize Eager="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000499" Rows="3.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000368" Rows="3.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000498" Rows="3.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="3.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000445" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000314" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000444" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                    <dxl:SortingColumnList/>
+                    <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="9" Alias="b">
-                          <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
+                      <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
                       <dxl:TableScan>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
@@ -854,49 +850,49 @@
                           </dxl:Columns>
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
-                    </dxl:GatherMotion>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="g">
-                          <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="18" Alias="g">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="18" ColName="g" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="17" Alias="">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            <dxl:ProjElem ColId="18" Alias="g">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="17" Alias="">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                          </dxl:Result>
                         </dxl:Result>
                       </dxl:Result>
-                    </dxl:Result>
-                  </dxl:HashJoin>
+                    </dxl:HashJoin>
+                  </dxl:GatherMotion>
                   <dxl:LimitCount>
                     <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
                   </dxl:LimitCount>

--- a/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
@@ -415,7 +415,7 @@ Physical plan:
         </dxl:Union>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22212">
+    <dxl:Plan Id="0" SpaceSize="18808">
       <dxl:DMLInsert Columns="0,1" ActionCol="22" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765376.357389" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
@@ -371,7 +371,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.004168" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
@@ -276,7 +276,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -329,7 +329,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="560">
+    <dxl:Plan Id="0" SpaceSize="644">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888832.304151" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -366,7 +366,7 @@ Table X (int i, int j) is distributed by i, column i has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="19">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000265" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
@@ -262,7 +262,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="229">
+    <dxl:Plan Id="0" SpaceSize="223">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000327" Rows="3.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -420,10 +420,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
-      <dxl:HashJoin JoinType="Left">
+    <dxl:Plan Id="0" SpaceSize="4">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.002764" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.001498" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -440,16 +440,10 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000417" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000902" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -458,9 +452,21 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="10.000000" Width="8"/>
@@ -488,46 +494,46 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:GatherMotion>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="9" Alias="a">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="b">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ctid">
-              <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="xmin">
-              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="13" Alias="cmin">
-              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="14" Alias="xmax">
-              <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="15" Alias="cmax">
-              <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="tableoid">
-              <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="gp_segment_id">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-          </dxl:OneTimeFilter>
-        </dxl:Result>
-      </dxl:HashJoin>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="ctid">
+                <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="xmin">
+                <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="cmin">
+                <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="xmax">
+                <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="cmax">
+                <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="tableoid">
+                <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="gp_segment_id">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+            </dxl:OneTimeFilter>
+          </dxl:Result>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -568,7 +568,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="69802500">
+    <dxl:Plan Id="0" SpaceSize="62291300">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
@@ -443,7 +443,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="84">
+    <dxl:Plan Id="0" SpaceSize="88">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="20" VarTypeModList="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324033.549169" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
@@ -423,10 +423,10 @@ WHERE buyer_name = 'ABC'
         </dxl:LogicalWindow>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.008986" Rows="1.000000" Width="25"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.008731" Rows="1.000000" Width="25"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="buyer_name">
@@ -447,7 +447,7 @@ WHERE buyer_name = 'ABC'
         <dxl:OneTimeFilter/>
         <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000012" Width="25"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.008698" Rows="1.000012" Width="25"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="curr_bidrate">
@@ -460,9 +460,9 @@ WHERE buyer_name = 'ABC'
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.008953" Rows="1.000012" Width="21"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.008698" Rows="1.000012" Width="21"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
@@ -473,27 +473,27 @@ WHERE buyer_name = 'ABC'
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="3" ColName="network_id" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="-1">
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.008369" Rows="1.000012" Width="21"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.008650" Rows="1.000012" Width="21"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="3" Alias="network_id">
-                  <dxl:Ident ColId="3" ColName="network_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
+                  <dxl:Ident ColId="2" ColName="curr_bidcnt" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="4" Alias="network_name">
                   <dxl:Ident ColId="4" ColName="network_name" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="3" ColName="network_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.008321" Rows="1.000012" Width="21"/>
@@ -526,55 +526,55 @@ WHERE buyer_name = 'ABC'
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:GatherMotion>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000042" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="network_id">
-                  <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
-                  <dxl:Ident ColId="2" ColName="curr_bidcnt" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000042" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="network_id">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                    <dxl:Ident ColId="2" ColName="curr_bidcnt" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="1" ColName="network_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    <dxl:ProjElem ColId="1" Alias="network_id">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="curr_bidcnt">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="">
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                  </dxl:Result>
                 </dxl:Result>
               </dxl:Result>
-            </dxl:Result>
-          </dxl:HashJoin>
+            </dxl:HashJoin>
+          </dxl:GatherMotion>
           <dxl:WindowKeyList>
             <dxl:WindowKey>
               <dxl:SortingColumnList/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -2164,10 +2164,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="261">
+    <dxl:Plan Id="0" SpaceSize="187">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="23478.203110" Rows="12277684.984527" Width="246"/>
+          <dxl:Cost StartupCost="0" TotalCost="23460.637588" Rows="12277684.984527" Width="246"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -2328,7 +2328,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9917.008937" Rows="12277684.984527" Width="246"/>
+            <dxl:Cost StartupCost="0" TotalCost="9899.443415" Rows="12277684.984527" Width="246"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -2613,7 +2613,7 @@
           </dxl:DynamicTableScan>
           <dxl:PartitionSelector RelationMdid="6.904881.1.1" SelectorId="0" ScanId="1" Partitions="0,1,2,3,4">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="456.101758" Rows="24.329392" Width="107"/>
+              <dxl:Cost StartupCost="0" TotalCost="438.536236" Rows="24.329392" Width="107"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2707,9 +2707,9 @@
                 <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:PartFilterExpr>
-            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="456.101758" Rows="24.329392" Width="107"/>
+                <dxl:Cost StartupCost="0" TotalCost="438.536236" Rows="24.329392" Width="107"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2801,7 +2801,7 @@
               <dxl:SortingColumnList/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="456.033618" Rows="12.164696" Width="107"/>
+                  <dxl:Cost StartupCost="0" TotalCost="438.502166" Rows="12.164696" Width="107"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2897,9 +2897,9 @@
                     <dxl:Ident ColId="66" ColName="bla" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
-                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="449.046463" Rows="29219.600000" Width="107"/>
+                    <dxl:Cost StartupCost="0" TotalCost="432.100848" Rows="29219.600000" Width="107"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="30" Alias="d_date_sk">
@@ -2988,146 +2988,53 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:DynamicTableScan SelectorIds="">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="432.100848" Rows="29219.600000" Width="107"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="30" Alias="d_date_sk">
-                        <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="31" Alias="d_date_id">
-                        <dxl:Ident ColId="31" ColName="d_date_id" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="32" Alias="d_date">
-                        <dxl:Ident ColId="32" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="33" Alias="d_month_seq">
-                        <dxl:Ident ColId="33" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="34" Alias="d_week_seq">
-                        <dxl:Ident ColId="34" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="35" Alias="d_quarter_seq">
-                        <dxl:Ident ColId="35" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="36" Alias="d_year">
-                        <dxl:Ident ColId="36" ColName="d_year" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="37" Alias="d_dow">
-                        <dxl:Ident ColId="37" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="38" Alias="d_moy">
-                        <dxl:Ident ColId="38" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="39" Alias="d_dom">
-                        <dxl:Ident ColId="39" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="40" Alias="d_qoy">
-                        <dxl:Ident ColId="40" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="d_fy_year">
-                        <dxl:Ident ColId="41" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="42" Alias="d_fy_quarter_seq">
-                        <dxl:Ident ColId="42" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="43" Alias="d_fy_week_seq">
-                        <dxl:Ident ColId="43" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="44" Alias="d_day_name">
-                        <dxl:Ident ColId="44" ColName="d_day_name" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="45" Alias="d_quarter_name">
-                        <dxl:Ident ColId="45" ColName="d_quarter_name" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="46" Alias="d_holiday">
-                        <dxl:Ident ColId="46" ColName="d_holiday" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="47" Alias="d_weekend">
-                        <dxl:Ident ColId="47" ColName="d_weekend" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="48" Alias="d_following_holiday">
-                        <dxl:Ident ColId="48" ColName="d_following_holiday" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="49" Alias="d_first_dom">
-                        <dxl:Ident ColId="49" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="50" Alias="d_last_dom">
-                        <dxl:Ident ColId="50" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="51" Alias="d_same_day_ly">
-                        <dxl:Ident ColId="51" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="52" Alias="d_same_day_lq">
-                        <dxl:Ident ColId="52" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="53" Alias="d_current_day">
-                        <dxl:Ident ColId="53" ColName="d_current_day" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="54" Alias="d_current_week">
-                        <dxl:Ident ColId="54" ColName="d_current_week" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="55" Alias="d_current_month">
-                        <dxl:Ident ColId="55" ColName="d_current_month" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="56" Alias="d_current_quarter">
-                        <dxl:Ident ColId="56" ColName="d_current_quarter" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="57" Alias="d_current_year">
-                        <dxl:Ident ColId="57" ColName="d_current_year" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Partitions>
-                      <dxl:Partition Mdid="6.897052001.1.1"/>
-                      <dxl:Partition Mdid="6.897052002.1.1"/>
-                      <dxl:Partition Mdid="6.897052003.1.1"/>
-                      <dxl:Partition Mdid="6.897052004.1.1"/>
-                      <dxl:Partition Mdid="6.897052005.1.1"/>
-                    </dxl:Partitions>
-                    <dxl:TableDescriptor Mdid="6.897052.1.1" TableName="date_dim">
-                      <dxl:Columns>
-                        <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="31" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                        <dxl:Column ColId="32" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                        <dxl:Column ColId="33" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="34" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="35" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="37" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="38" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="39" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="40" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="41" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="42" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="43" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="44" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
-                        <dxl:Column ColId="45" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="46" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="47" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="48" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="49" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="50" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="51" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="52" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="53" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="54" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="55" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="56" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="57" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                        <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:GatherMotion>
+                  <dxl:Partitions>
+                    <dxl:Partition Mdid="6.897052001.1.1"/>
+                    <dxl:Partition Mdid="6.897052002.1.1"/>
+                    <dxl:Partition Mdid="6.897052003.1.1"/>
+                    <dxl:Partition Mdid="6.897052004.1.1"/>
+                    <dxl:Partition Mdid="6.897052005.1.1"/>
+                  </dxl:Partitions>
+                  <dxl:TableDescriptor Mdid="6.897052.1.1" TableName="date_dim">
+                    <dxl:Columns>
+                      <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="31" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                      <dxl:Column ColId="32" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+                      <dxl:Column ColId="33" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="34" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="35" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="37" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="38" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="39" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="40" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="41" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="42" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="43" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="44" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
+                      <dxl:Column ColId="45" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="46" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="47" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="48" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="49" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="50" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="51" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="52" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="53" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="54" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="55" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="56" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="57" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
                 <dxl:Result>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -392,10 +392,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8760">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="56680">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.003050" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.002889" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="c9596">
@@ -403,46 +403,38 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:SortingColumnList/>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.003050" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.002871" Rows="1.000000" Width="4"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="20"/>
-            <dxl:GroupingColumn ColId="17"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="?column?">
               <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="max">
-              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3017.003040" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="3017.002871" Rows="1.000000" Width="4"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="20"/>
+              <dxl:GroupingColumn ColId="17"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="17" Alias="max">
-                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="20" Alias="?column?">
                 <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="max">
+                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3017.002949" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="3017.002862" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="17" Alias="max">
@@ -453,116 +445,125 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
-                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                    <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0" FuncVariadic="false">
-                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                    </dxl:FuncExpr>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:And>
-              </dxl:JoinFilter>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000360" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3017.002771" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="c504">
-                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="16" Alias="avg">
-                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="17" Alias="max">
                     <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="?column?">
+                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:Result>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000181" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3017.002756" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="c504">
-                      <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="avg">
-                      <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="17" Alias="max">
                       <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="20" Alias="?column?">
+                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
+                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                        <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0" FuncVariadic="false">
+                          <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:FuncExpr>
+                      </dxl:Comparison>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:And>
+                  </dxl:JoinFilter>
+                  <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  </dxl:HashCondList>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000148" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000181" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="8"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="16" Alias="avg">
-                        <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="17" Alias="max">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="8" Alias="c504">
                         <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="avg">
+                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="17" Alias="max">
+                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000129" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000148" Rows="1.000000" Width="20"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="8"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="16" Alias="avg">
+                          <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="max">
+                          <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="8" Alias="c504">
                           <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000129" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="8" Alias="c504">
@@ -570,15 +571,14 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="8" Alias="c504">
@@ -586,227 +586,244 @@
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.131046.1.1" TableName="t39">
-                            <dxl:Columns>
-                              <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Result>
-              </dxl:GatherMotion>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2586.001683" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="2" Alias="min">
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="?column?">
-                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000231" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="2" Alias="min">
-                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Limit>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="8" Alias="c504">
+                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.131046.1.1" TableName="t39">
+                              <dxl:Columns>
+                                <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2586.001683" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="1" Alias="?column?">
-                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="2" Alias="min">
                         <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000158" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000231" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="?column?">
-                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="2" Alias="min">
                           <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
                       </dxl:Filter>
                       <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Limit>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000092" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="1"/>
-                        </dxl:GroupingColumns>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="min">
-                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="1" Alias="?column?">
                             <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="min">
+                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000083" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000158" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1" Alias="?column?">
                               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="min">
+                              <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:LimitCount/>
-                          <dxl:LimitOffset/>
-                          <dxl:Result>
+                          <dxl:Filter>
+                            <dxl:And>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              </dxl:Comparison>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:And>
+                          </dxl:Filter>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000092" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="1"/>
+                            </dxl:GroupingColumns>
                             <dxl:ProjList>
+                              <dxl:ProjElem ColId="2" Alias="min">
+                                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="1" Alias="?column?">
                                 <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:Comparison>
-                            </dxl:Filter>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Result>
+                            <dxl:Filter/>
+                            <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000083" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="1" Alias="?column?">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="0" Alias="">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:ProjElem ColId="1" Alias="?column?">
+                                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
-                                <dxl:Filter/>
+                                <dxl:Filter>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  </dxl:Comparison>
+                                </dxl:Filter>
                                 <dxl:OneTimeFilter/>
+                                <dxl:Result>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="1" Alias="?column?">
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="0" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
+                                </dxl:Result>
                               </dxl:Result>
-                            </dxl:Result>
-                          </dxl:Result>
-                        </dxl:Sort>
-                      </dxl:Aggregate>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
                     </dxl:Result>
-                    <dxl:LimitCount>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
-                    </dxl:LimitCount>
-                    <dxl:LimitOffset>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:LimitOffset>
-                  </dxl:Limit>
-                </dxl:Result>
-                <dxl:Materialize Eager="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="?column?">
-                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
+                    <dxl:Materialize Eager="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:Materialize>
-              </dxl:NestedLoopJoin>
-            </dxl:HashJoin>
-          </dxl:Sort>
-        </dxl:Aggregate>
-      </dxl:Result>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="">
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                        </dxl:Result>
+                      </dxl:Result>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:HashJoin>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Result>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlTvf.mdp
@@ -286,7 +286,7 @@ LIMIT 999
         </dxl:LogicalLimit>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="882720.643838" Rows="999.000000" Width="8"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
@@ -34,6 +34,30 @@ using namespace gpos;
 class CDistributionSpec : public CPropSpec
 {
 public:
+	/*
+	 * A required distribution spec is a property that we can
+	 * enforce the input data to satisfy. A derived dist spec
+	 * is a property that the input data can possess.
+	 *
+	 * Universal, hashed, randomly distributed, replicated,
+	 * and singleton (together with their sub-types) are
+	 * properties that the input data can possess. Those are
+	 * intrinsic distribution properties.
+	 *
+	 * Non-singleton and non-replicated aren't properties
+	 * that the input data can possess. They are required-only
+	 * specs. We cannot say the input is a non-singleton, or
+	 * is non-replicated. We can only enforce the input to
+	 * comply with the non-singleton, or non-replicated
+	 * requirement.
+	 *
+	 * Based on the logic above, a derived-only spec cannot
+	 * be required. Therefore, it shouldn't have an enforcer.
+	 *
+	 * Correspondingly, a required-only spec cannot be derived.
+	 * Therefore, it shouldn't have a `Satisfies` function.
+	 */
+
 	enum EDistributionType
 	{
 		EdtHashed,		// data is hashed across all segments
@@ -50,6 +74,7 @@ public:
 		EdtRouted,	// data is routed to a segment explicitly specified in the tuple,
 		EdtUniversal,  // data is available everywhere (derived only)
 		EdtNonSingleton,  // data can have any distribution except singleton (required only)
+		EdtNonReplicated,  // data cannot be duplicated (required only)
 
 		EdtSentinel
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonReplicated.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonReplicated.h
@@ -1,0 +1,81 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CDistributionSpecNonReplicated.h
+//
+//	@doc:
+//		Description of a distribution that allows no duplicates;
+//		Can be used only as a required property;
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CDistributionSpecNonReplicated_H
+#define GPOPT_CDistributionSpecNonReplicated_H
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CDistributionSpec.h"
+#include "gpopt/base/CDistributionSpecSingleton.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CDistributionSpecNonReplicated
+//
+//	@doc:
+//		Class for representing distribution that allows no duplicates
+//---------------------------------------------------------------------------
+class CDistributionSpecNonReplicated : public CDistributionSpecSingleton
+{
+private:
+public:
+	//ctor
+	CDistributionSpecNonReplicated() = default;
+
+	// accessor
+	EDistributionType
+	Edt() const override
+	{
+		return CDistributionSpec::EdtNonReplicated;
+	}
+
+	// does current distribution satisfy the given one
+	BOOL
+	FSatisfies(const CDistributionSpec *pds GPOS_UNUSED) const override
+	{
+		GPOS_ASSERT(!"Non-Replicated distribution cannot be derived");
+
+		return false;
+	}
+
+	// return true if distribution spec can be derived
+	BOOL
+	FDerivable() const override
+	{
+		return false;
+	}
+
+	// print
+	IOstream &
+	OsPrint(IOstream &os) const override
+	{
+		return os << "NON-REPLICATED";
+	}
+
+	// return distribution partitioning type
+	EDistributionPartitioningType
+	Edpt() const override
+	{
+		return EdptUnknown;
+	}
+
+};	// class CDistributionSpecNonReplicated
+
+}  // namespace gpopt
+
+#endif	// !GPOPT_CDistributionSpecNonReplicated_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -195,9 +195,10 @@ CDistributionSpecHashed::FSatisfies(const CDistributionSpec *pds) const
 		return true;
 	}
 
-	if (EdtAny == pds->Edt() || EdtNonSingleton == pds->Edt())
+	if (EdtAny == pds->Edt() || EdtNonSingleton == pds->Edt() ||
+		EdtNonReplicated == pds->Edt())
 	{
-		// hashed distribution satisfies the "any" and "non-singleton" distribution requirement
+		// hashed distribution satisfies the "any", "non-singleton", and "non-replicated" distribution requirement
 		return true;
 	}
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
@@ -123,7 +123,8 @@ CDistributionSpecRandom::FSatisfies(const CDistributionSpec *pds) const
 		return true;
 	}
 
-	return EdtAny == pds->Edt() || EdtNonSingleton == pds->Edt();
+	return EdtAny == pds->Edt() || EdtNonSingleton == pds->Edt() ||
+		   EdtNonReplicated == pds->Edt();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecReplicated.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecReplicated.cpp
@@ -35,11 +35,17 @@ using namespace gpopt;
 //	| singleton & segment     | T                | T                 |
 //	| ANY                     | T                | T                 |
 //	| others not Singleton    | T                |(default) F        |
+//	| Non-Replicated          | F                | F                 |
 //	+-------------------------+------------------+-------------------+
 BOOL
 CDistributionSpecReplicated::FSatisfies(const CDistributionSpec *pdss) const
 {
 	GPOS_ASSERT(Edt() != CDistributionSpec::EdtReplicated);
+
+	if (CDistributionSpec::EdtNonReplicated == pdss->Edt())
+	{
+		return false;
+	}
 
 	if (Edt() == CDistributionSpec::EdtTaintedReplicated)
 	{

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecSingleton.cpp
@@ -72,9 +72,9 @@ CDistributionSpecSingleton::FSatisfies(const CDistributionSpec *pds) const
 		return false;
 	}
 
-	if (EdtAny == pds->Edt())
+	if (EdtAny == pds->Edt() || EdtNonReplicated == pds->Edt())
 	{
-		// a singleton distribution satisfies "any" distributions
+		// a singleton distribution satisfies "any" and "non-replicated" distributions
 		return true;
 	}
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictRandom.cpp
@@ -17,5 +17,5 @@ BOOL
 CDistributionSpecStrictRandom::FSatisfies(const CDistributionSpec *pds) const
 {
 	return Matches(pds) || EdtAny == pds->Edt() || EdtRandom == pds->Edt() ||
-		   EdtNonSingleton == pds->Edt();
+		   EdtNonSingleton == pds->Edt() || EdtNonReplicated == pds->Edt();
 }

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecStrictSingleton.cpp
@@ -53,9 +53,9 @@ CDistributionSpecStrictSingleton::FSatisfies(
 		return false;
 	}
 
-	if (EdtAny == pdss->Edt())
+	if (EdtAny == pdss->Edt() || EdtNonReplicated == pdss->Edt())
 	{
-		// a singleton distribution satisfies "any"
+		// a singleton distribution satisfies "any" and "non-replicated" distribution
 		return true;
 	}
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
@@ -15,6 +15,7 @@
 
 #include "gpopt/base/CCastUtils.h"
 #include "gpopt/base/CDistributionSpecHashed.h"
+#include "gpopt/base/CDistributionSpecNonReplicated.h"
 #include "gpopt/base/CDistributionSpecNonSingleton.h"
 #include "gpopt/base/CDistributionSpecReplicated.h"
 #include "gpopt/base/CUtils.h"
@@ -152,9 +153,10 @@ CPhysicalInnerNLJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CDrvdPropPlan::Pdpplan((*pdrgpdpCtxt)[0])->Pds();
 	if (CDistributionSpec::EdtUniversal == pdsOuter->Edt())
 	{
-		// first child is universal, request second child to execute on a single host to avoid duplicates
+		// Outer child is universal, request the inner child to be non-replicated.
+		// It doesn't have to be a singleton, because inner join is deduplicated.
 		return GPOS_NEW(mp) CEnfdDistribution(
-			GPOS_NEW(mp) CDistributionSpecSingleton(), dmatch);
+			GPOS_NEW(mp) CDistributionSpecNonReplicated(), dmatch);
 	}
 
 	return GPOS_NEW(mp)

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -548,15 +548,14 @@ explain (costs off) select * from t_hashdist cross join (select a, count(1) as s
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
+         ->  Result
+               Filter: (((count(1)))::double precision > random())
+               ->  HashAggregate
+                     Group Key: generate_series.generate_series
+                     ->  Function Scan on generate_series
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Result
-                     Filter: (((count(1)))::double precision > random())
-                     ->  HashAggregate
-                           Group Key: generate_series.generate_series
-                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(10 rows)
 
 -- limit
 explain (costs off) select * from t_hashdist cross join (select * from generate_series(1, 10) limit random()) x;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -12189,29 +12189,25 @@ WHERE L1.lid = int4in(textout(meta.load_id));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..431.22 rows=1 width=8)
+ Result  (cost=0.00..431.09 rows=1 width=8)
    Output: c, lid
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.20 rows=1 width=8)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.07 rows=1 width=8)
          Output: c, lid
-         ->  HashAggregate  (cost=0.00..431.20 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..431.07 rows=1 width=8)
                Output: c, lid
                Group Key: t55.c, t55.lid
-               ->  Hash Join  (cost=0.00..431.20 rows=1 width=8)
+               ->  Sort  (cost=0.00..431.07 rows=1 width=8)
                      Output: c, lid
-                     Hash Cond: (t55.lid = int4in(textout(('99'::text))))
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8)
+                     Sort Key: t55.c, t55.lid
+                     ->  Hash Join  (cost=0.00..431.07 rows=1 width=8)
                            Output: c, lid
-                           Hash Key: lid
+                           Hash Cond: (t55.lid = int4in(textout(('99'::text))))
                            ->  Seq Scan on orca.t55  (cost=0.00..431.01 rows=334 width=8)
                                  Output: c, lid
-                     ->  Hash  (cost=0.00..0.00 rows=1 width=8)
-                           Output: ('99'::text)
-                           ->  Result  (cost=0.00..0.00 rows=1 width=8)
-                                 Output: ('99'::text)
-                                 ->  Result  (cost=0.00..0.00 rows=1 width=8)
-                                       Output: ('99'::text), int4in(textout(('99'::text)))
-                                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
-                                             Output: '99'::text
+                           ->  Hash  (cost=0.00..0.00 rows=1 width=8)
+                                 Output: ('2020-01-01'::text), ('99'::text)
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                       Output: '2020-01-01'::text, '99'::text
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer_enable_coordinator_only_queries = 'on', optimizer_enable_master_only_queries = 'on', optimizer_join_order = 'query', optimizer_segments = '3'
 (25 rows)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2262,26 +2262,30 @@ explain (costs off)
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
 order by 1, 2;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Sort
-   Sort Key: int8_tbl.q1, int8_tbl.q2
-   ->  Hash Left Join
-         Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on int8_tbl
-         ->  Hash
-               ->  Hash Join
-                     Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
-                     ->  Gather Motion 3:1  (slice2; segments: 3)
-                           ->  Seq Scan on int8_tbl int8_tbl_1
-                                 Filter: (q1 = 123)
-                     ->  Hash
-                           ->  Result
-                                 Filter: ((123) = 123)
-                                 ->  Result
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: int8_tbl.q1, int8_tbl.q2
+   ->  Sort
+         Sort Key: int8_tbl.q1, int8_tbl.q2
+         ->  Hash Left Join
+               Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int8_tbl.q2
+                     ->  Seq Scan on int8_tbl
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: int8_tbl_1.q2
+                           ->  Hash Join
+                                 Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: (q1 = 123)
+                                 ->  Hash
+                                       ->  Result
+                                             Filter: ((123) = 123)
+                                             ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(21 rows)
 
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2

--- a/src/test/regress/expected/misc_functions_optimizer.out
+++ b/src/test/regress/expected/misc_functions_optimizer.out
@@ -291,27 +291,27 @@ CREATE FUNCTION my_gen_series(int, int) RETURNS SETOF integer
   SUPPORT test_support_func;
 EXPLAIN (COSTS OFF)
 SELECT * FROM tenk1 a JOIN my_gen_series(1,1000) g ON a.unique1 = g;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Hash Join
-   Hash Cond: (tenk1.unique1 = my_gen_series.my_gen_series)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (tenk1.unique1 = my_gen_series.my_gen_series)
          ->  Seq Scan on tenk1
-   ->  Hash
-         ->  Function Scan on my_gen_series
+         ->  Hash
+               ->  Function Scan on my_gen_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM tenk1 a JOIN my_gen_series(1,10) g ON a.unique1 = g;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Hash Join
-   Hash Cond: (tenk1.unique1 = my_gen_series.my_gen_series)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (tenk1.unique1 = my_gen_series.my_gen_series)
          ->  Seq Scan on tenk1
-   ->  Hash
-         ->  Function Scan on my_gen_series
+         ->  Hash
+               ->  Function Scan on my_gen_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -2774,19 +2774,17 @@ update ab_a1 set b = 3 from ab_a2 where ab_a2.b = (select 1);
                      ->  Materialize (actual rows=1 loops=4)
                            ->  Broadcast Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
                                  ->  Hash Join (actual rows=1 loops=1)
-                                       Hash Cond: ((1) = ab_a2.b)
-                                       Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-                                       ->  Result (actual rows=1 loops=1)
-                                             One-Time Filter: (gp_execution_segment() = 2)
-                                             ->  Result (actual rows=1 loops=1)
+                                       Hash Cond: (ab_a2.b = (1))
+                                       Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+                                       ->  Dynamic Seq Scan on ab_a2 (actual rows=1 loops=1)
+                                             Number of partitions to scan: 3 (out of 3)
+                                             Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                                        ->  Hash (actual rows=1 loops=1)
                                              Buckets: 262144  Batches: 1  Memory Usage: 2049kB
-                                             ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
-                                                   ->  Dynamic Seq Scan on ab_a2 (actual rows=1 loops=1)
-                                                         Number of partitions to scan: 3 (out of 3)
-                                                         Partitions scanned:  Avg 3.0 x 3 workers.  Max 3 parts (seg0).
+                                             ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
+                                                   ->  Result (actual rows=1 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(21 rows)
 
 select tableoid::regclass, * from ab;
  tableoid | a | b 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -721,36 +721,31 @@ select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not 
 (10 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1356692465.22 rows=4 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356692465.22 rows=10 width=12)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1356692053.43 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356692053.43 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
-         ->  Limit  (cost=0.00..1356692465.22 rows=4 width=12)
-               ->  Sort  (cost=0.00..1356692465.22 rows=18 width=12)
+         ->  Limit  (cost=0.00..1356692053.43 rows=4 width=12)
+               ->  Sort  (cost=0.00..1356692053.43 rows=18 width=12)
                      Sort Key: a.i, b.i, c.j
-                     ->  Nested Loop  (cost=0.00..1356692465.22 rows=18 width=12)
+                     ->  Nested Loop  (cost=0.00..1356692053.42 rows=18 width=12)
                            Join Filter: true
-                           ->  Nested Loop  (cost=0.00..1324032.98 rows=2 width=8)
+                           ->  Nested Loop  (cost=0.00..1324032.58 rows=2 width=8)
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Hash Join  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Cond: ((NULL::integer) = a.j)
-                                             ->  Result  (cost=0.00..0.00 rows=0 width=4)
-                                                   ->  HashAggregate  (cost=0.00..0.00 rows=0 width=4)
-                                                         Group Key: NULL::integer
-                                                         ->  Result  (cost=0.00..0.00 rows=0 width=4)
-                                                               One-Time Filter: false
-                                             ->  Hash  (cost=431.00..431.00 rows=2 width=8)
-                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
-                                                         Hash Key: a.j
-                                                         ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                       ->  Hash Semi Join  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Cond: (a.j = (NULL::integer))
+                                             ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
+                                             ->  Hash  (cost=0.00..0.00 rows=0 width=4)
+                                                   ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                                                         One-Time Filter: false
                                  ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(27 rows)
+(22 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 

--- a/src/test/regress/expected/qp_join_universal.out
+++ b/src/test/regress/expected/qp_join_universal.out
@@ -1,0 +1,470 @@
+-- This test verifies ORCA plans when one side of join is
+-- of universal spec. Historically, we enforce universal
+-- to be joined with singleton to avoid duplicates. This is
+-- overly conservative. Instead, we should be able to join
+-- universal with any deduplicated input, as far as the join
+-- doesn't return all records from the universal side.
+-- start_matchsubs
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: \(seg#\)/
+-- end_matchsubs
+-- start_ignore
+drop schema if exists join_universal cascade;
+NOTICE:  schema "join_universal" does not exist, skipping
+-- end_ignore
+-- greenplum
+create schema join_universal;
+set search_path=join_universal;
+set optimizer_trace_fallback=on;
+-- distributed
+create table dist (c1 int) distributed by (c1);
+insert into dist select i from generate_series(1,999) i;
+-- randomly distributed
+create table rand (c1 int) distributed randomly;
+insert into rand select i from generate_series(1,999) i;
+-- replicated
+create table rep (c1 int) distributed replicated; 
+insert into rep select i from generate_series(1,999) i;
+-- partitioned
+create table part (c1 int, c2 int) partition by list(c2) (
+partition part1 values (1, 2, 3, 4), 
+partition part2 values (5, 6, 7), 
+partition part3 values (8, 9, 0));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part select i, i%10 from generate_series(1, 999) i;
+-- const tvf (universal)
+-- This tvf is defined as volatile, but since it's not
+-- used as a scan operator, it's distribution spec is
+-- still universal instead of singleton.
+-- We avoid the "immutable" keyword so that the tvf
+-- execution doesn't fall back due to lack of support
+-- for Query Parameter.
+create function const_tvf(a int) returns int as $$ select $1 $$ language sql;
+-- unnested array (universal)
+create view unnest_arr as (select unnest(string_to_array('-3,-2,-1,0,1,2,3',','))::int c1);
+-- generate_series (universal)
+create view gen_series as (select generate_series(-10,10) c1);
+analyze dist;
+analyze rand;
+analyze rep;
+analyze part;
+-- Testing hash join
+set optimizer_enable_hashjoin = on;
+-- distributed ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows us to
+-- hash the much smaller universal table, instead of
+-- the much larger distributed table.
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: (dist.c1 = ct.c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Function Scan on ct (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+   ->  Hash Join (actual rows=2 loops=1)
+         Hash Cond: (dist.c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=10 loops=1)
+   ->  Hash Join (actual rows=5 loops=1)
+         Hash Cond: (dist.c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- randomly distributed ⋈ universal 
+-- We get the same plans as above, since no motion is
+-- needed when joining with a universal table
+-- (We don't flag row count diffs in the following tests.
+-- This is because the row count of intermediate physical
+-- operations are expected to fluctuate in randomly 
+-- distributed tables.)
+explain (analyze, timing off, summary off) select * from rand join const_tvf(1) ct(c1) on rand.c1 = ct.c1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.02..5.35 rows=10 width=8) (actual rows=1 loops=1)
+   ->  Hash Join  (cost=0.02..5.22 rows=3 width=8) (actual rows=1 loops=1)
+         Hash Cond: (rand.c1 = ct.c1)
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Seq Scan on rand  (cost=0.00..4.33 rows=333 width=4) (actual rows=346 loops=1)
+         ->  Hash  (cost=0.01..0.01 rows=1 width=4) (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Function Scan on ct  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+explain (analyze, timing off, summary off) select * from rand join unnest_arr on rand.c1 = unnest_arr.c1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.33..5.66 rows=10 width=8) (actual rows=3 loops=1)
+   ->  Hash Join  (cost=0.33..5.53 rows=3 width=8) (actual rows=2 loops=1)
+         Hash Cond: (rand.c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on rand  (cost=0.00..4.33 rows=333 width=4) (actual rows=346 loops=1)
+         ->  Hash  (cost=0.25..0.25 rows=7 width=4) (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result  (cost=0.00..0.18 rows=7 width=4) (actual rows=7 loops=1)
+                     ->  ProjectSet  (cost=0.00..0.05 rows=7 width=32) (actual rows=7 loops=1)
+                           ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+explain (analyze, timing off, summary off) select * from rand join gen_series on rand.c1 = gen_series.c1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.59..6.12 rows=21 width=8) (actual rows=10 loops=1)
+   ->  Hash Join  (cost=0.59..5.84 rows=7 width=8) (actual rows=4 loops=1)
+         Hash Cond: (rand.c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on rand  (cost=0.00..4.33 rows=333 width=4) (actual rows=346 loops=1)
+         ->  Hash  (cost=0.33..0.33 rows=21 width=4) (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet  (cost=0.00..0.12 rows=21 width=4) (actual rows=21 loops=1)
+                     ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- replicated ⋈ universal
+-- Replicated joined with universal needs to be deduplicated.
+-- This is achieved by a one-time segment filter
+-- (duplicate-sensitive random motion).
+explain (analyze, costs off, timing off, summary off) select * from rep join const_tvf(1) ct(c1) on rep.c1 = ct.c1;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: (rep.c1 = ct.c1)
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Seq Scan on rep (actual rows=999 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Function Scan on ct (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from rep join unnest_arr on rep.c1 = unnest_arr.c1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
+   ->  Hash Join (actual rows=3 loops=1)
+         Hash Cond: (rep.c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on rep (actual rows=999 loops=1)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from rep join gen_series on rep.c1 = gen_series.c1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=10 loops=1)
+   ->  Hash Join (actual rows=10 loops=1)
+         Hash Cond: (rep.c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on rep (actual rows=999 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- partitioned ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows the
+-- propagation of the partition selector, and enables DPE. 
+explain (analyze, costs off, timing off, summary off) select * from part join const_tvf(1) ct(c1) on part.c2 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=100 loops=1)
+   ->  Hash Join (actual rows=43 loops=1)
+         Hash Cond: (part_1_prt_part3.c2 = ct.c1)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Append (actual rows=150 loops=1)
+               Partition Selectors: $0
+               ->  Seq Scan on part_1_prt_part3 (never executed)
+               ->  Seq Scan on part_1_prt_part1 (actual rows=150 loops=1)
+               ->  Seq Scan on part_1_prt_part2 (never executed)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
+                     ->  Function Scan on ct (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from part join unnest_arr on part.c2 = unnest_arr.c1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=399 loops=1)
+   ->  Hash Join (actual rows=150 loops=1)
+         Hash Cond: (part_1_prt_part3.c2 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Append (actual rows=245 loops=1)
+               Partition Selectors: $0
+               ->  Seq Scan on part_1_prt_part3 (actual rows=106 loops=1)
+               ->  Seq Scan on part_1_prt_part1 (actual rows=150 loops=1)
+               ->  Seq Scan on part_1_prt_part2 (never executed)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=7 loops=1)
+                     ->  Result (actual rows=7 loops=1)
+                           ->  ProjectSet (actual rows=7 loops=1)
+                                 ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from part join gen_series on part.c2 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Join (actual rows=340 loops=1)
+         Hash Cond: (part_1_prt_part3.c2 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Append (actual rows=340 loops=1)
+               Partition Selectors: $0
+               ->  Seq Scan on part_1_prt_part3 (actual rows=106 loops=1)
+               ->  Seq Scan on part_1_prt_part1 (actual rows=150 loops=1)
+               ->  Seq Scan on part_1_prt_part2 (actual rows=113 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=21 loops=1)
+                     ->  ProjectSet (actual rows=21 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+-- distributed ⟕ universal 
+-- We get the same plans as those of the inner join, 
+-- since the outer table is deduplicated.
+explain (analyze, costs off, timing off, summary off) select * from dist left join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (dist.c1 = ct.c1)
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Function Scan on ct (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist left join unnest_arr on dist.c1 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (dist.c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist left join gen_series on dist.c1 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (dist.c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- universal ⟕ distributed
+-- Since left join returns all the records from the universal
+-- side, it needs to be deduplicated. This is achieved by a
+-- hash filter (duplicate-sensitive hash motion).
+-- (Test of const TVF left join distributed table is flaky
+-- and is turned off. ORCA generates two alternatives, left 
+-- join and right join, that happen to have the same cost.)  
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr left join dist on dist.c1 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=7 loops=1)
+   ->  Hash Right Join (actual rows=4 loops=1)
+         Hash Cond: (dist.c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 4 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=4 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=4 loops=1)
+                     Hash Key: (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer)
+                     ->  Result (actual rows=7 loops=1)
+                           ->  ProjectSet (actual rows=7 loops=1)
+                                 ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from gen_series left join dist on dist.c1 = gen_series.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=21 loops=1)
+   ->  Hash Right Join (actual rows=8 loops=1)
+         Hash Cond: (dist.c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 8 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=8 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=8 loops=1)
+                     Hash Key: (generate_series('-10'::integer, 10))
+                     ->  ProjectSet (actual rows=21 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+-- universal ▷ distributed
+-- Since anti join returns all the records from the universal
+-- side where no matches are found in the deduplicated side,
+-- it needs to be deduplicated. This is achieved by a hash
+-- filter (duplicate-sensitive hash motion).
+explain (analyze, costs off, timing off, summary off) select * from const_tvf(1) ct(c1) where not exists (select 1 from dist where dist.c1 = ct.c1);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Hash Anti Join (actual rows=0 loops=1)
+         Hash Cond: (($0) = dist.c1)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=1 loops=1)
+               Hash Key: ($0)
+               ->  Result (actual rows=1 loops=1)
+                     InitPlan 1 (returns $0)  (slice3)
+                       ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4108kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr where not exists (select 1 from dist where dist.c1 = unnest_arr.c1);
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Hash Anti Join (actual rows=3 loops=1)
+         Hash Cond: ((((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer) = dist.c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 322 of 524288 buckets.
+         ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=4 loops=1)
+               Hash Key: (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer)
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4108kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from gen_series where not exists (select 1 from dist where dist.c1 = gen_series.c1);
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=11 loops=1)
+   ->  Hash Anti Join (actual rows=6 loops=1)
+         Hash Cond: ((generate_series('-10'::integer, 10)) = dist.c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 322 of 524288 buckets.
+         ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=8 loops=1)
+               Hash Key: (generate_series('-10'::integer, 10))
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4108kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+-- Testing inner nested loop join
+set optimizer_enable_hashjoin = off;
+-- We no more enforce the inner side to be a singleton
+-- when the outer side is universal. It just needs to
+-- be non-replicated since inner join is deduplicated. 
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 < ct.c1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         Join Filter: (dist.c1 < ct.c1)
+         ->  Function Scan on ct (actual rows=1 loops=1)
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 < unnest_arr.c1;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         Join Filter: (dist.c1 < (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Rows Removed by Join Filter: 2252
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Materialize (actual rows=7 loops=340)
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 < gen_series.c1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=45 loops=1)
+   ->  Nested Loop (actual rows=26 loops=1)
+         Join Filter: (dist.c1 < (generate_series('-10'::integer, 10)))
+         Rows Removed by Join Filter: 7051
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Materialize (actual rows=21 loops=340)
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+

--- a/src/test/regress/expected/qp_join_universal_optimizer.out
+++ b/src/test/regress/expected/qp_join_universal_optimizer.out
@@ -1,0 +1,479 @@
+-- This test verifies ORCA plans when one side of join is
+-- of universal spec. Historically, we enforce universal
+-- to be joined with singleton to avoid duplicates. This is
+-- overly conservative. Instead, we should be able to join
+-- universal with any deduplicated input, as far as the join
+-- doesn't return all records from the universal side.
+-- start_matchsubs
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: \(seg#\)/
+-- end_matchsubs
+-- start_ignore
+drop schema if exists join_universal cascade;
+NOTICE:  schema "join_universal" does not exist, skipping
+-- end_ignore
+-- greenplum
+create schema join_universal;
+set search_path=join_universal;
+set optimizer_trace_fallback=on;
+-- distributed
+create table dist (c1 int) distributed by (c1);
+insert into dist select i from generate_series(1,999) i;
+-- randomly distributed
+create table rand (c1 int) distributed randomly;
+insert into rand select i from generate_series(1,999) i;
+-- replicated
+create table rep (c1 int) distributed replicated; 
+insert into rep select i from generate_series(1,999) i;
+-- partitioned
+create table part (c1 int, c2 int) partition by list(c2) (
+partition part1 values (1, 2, 3, 4), 
+partition part2 values (5, 6, 7), 
+partition part3 values (8, 9, 0));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part select i, i%10 from generate_series(1, 999) i;
+-- const tvf (universal)
+-- This tvf is defined as volatile, but since it's not
+-- used as a scan operator, it's distribution spec is
+-- still universal instead of singleton.
+-- We avoid the "immutable" keyword so that the tvf
+-- execution doesn't fall back due to lack of support
+-- for Query Parameter.
+create function const_tvf(a int) returns int as $$ select $1 $$ language sql;
+-- unnested array (universal)
+create view unnest_arr as (select unnest(string_to_array('-3,-2,-1,0,1,2,3',','))::int c1);
+-- generate_series (universal)
+create view gen_series as (select generate_series(-10,10) c1);
+analyze dist;
+analyze rand;
+analyze rep;
+analyze part;
+-- Testing hash join
+set optimizer_enable_hashjoin = on;
+-- distributed ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows us to
+-- hash the much smaller universal table, instead of
+-- the much larger distributed table.
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: (c1 = (1))
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=1 loops=1)
+               Filter: (c1 = 1)
+               Rows Removed by Filter: 321
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=1 loops=1)
+                     Filter: ((1) = 1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+   ->  Hash Join (actual rows=2 loops=1)
+         Hash Cond: (c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=10 loops=1)
+   ->  Hash Join (actual rows=5 loops=1)
+         Hash Cond: (c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- randomly distributed ⋈ universal 
+-- We get the same plans as above, since no motion is
+-- needed when joining with a universal table
+-- (We don't flag row count diffs in the following tests.
+-- This is because the row count of intermediate physical
+-- operations are expected to fluctuate in randomly 
+-- distributed tables.)
+explain (analyze, timing off, summary off) select * from rand join const_tvf(1) ct(c1) on rand.c1 = ct.c1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.02 rows=1 width=8) (actual rows=1 loops=1)
+   ->  Hash Join  (cost=0.00..431.02 rows=1 width=8) (actual rows=1 loops=1)
+         Hash Cond: (c1 = (1))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Seq Scan on rand  (cost=0.00..431.02 rows=1 width=4) (actual rows=1 loops=1)
+               Filter: (c1 = 1)
+               Rows Removed by Filter: 322
+         ->  Hash  (cost=0.00..0.00 rows=1 width=4) (actual rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result  (cost=0.00..0.00 rows=1 width=4) (actual rows=1 loops=1)
+                     Filter: ((1) = 1)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=1) (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+explain (analyze, timing off, summary off) select * from rand join unnest_arr on rand.c1 = unnest_arr.c1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.11 rows=999 width=8) (actual rows=3 loops=1)
+   ->  Hash Join  (cost=0.00..431.08 rows=333 width=8) (actual rows=2 loops=1)
+         Hash Cond: (c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on rand  (cost=0.00..431.01 rows=333 width=4) (actual rows=338 loops=1)
+         ->  Hash  (cost=0.00..0.00 rows=1 width=4) (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result  (cost=0.00..0.00 rows=1 width=4) (actual rows=7 loops=1)
+                     ->  ProjectSet  (cost=0.00..0.00 rows=1 width=4) (actual rows=7 loops=1)
+                           ->  Result  (cost=0.00..0.00 rows=1 width=1) (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+explain (analyze, timing off, summary off) select * from rand join gen_series on rand.c1 = gen_series.c1;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.11 rows=999 width=8) (actual rows=10 loops=1)
+   ->  Hash Join  (cost=0.00..431.08 rows=333 width=8) (actual rows=7 loops=1)
+         Hash Cond: (c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on rand  (cost=0.00..431.01 rows=333 width=4) (actual rows=338 loops=1)
+         ->  Hash  (cost=0.00..0.00 rows=1 width=4) (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet  (cost=0.00..0.00 rows=1 width=4) (actual rows=21 loops=1)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=1) (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- replicated ⋈ universal
+-- Replicated joined with universal needs to be deduplicated.
+-- This is achieved by a one-time segment filter
+-- (duplicate-sensitive random motion).
+explain (analyze, costs off, timing off, summary off) select * from rep join const_tvf(1) ct(c1) on rep.c1 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: ((1) = c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Result (actual rows=1 loops=1)
+               One-Time Filter: (gp_execution_segment() = 1)
+               ->  Result (actual rows=1 loops=1)
+                     Filter: ((1) = 1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Seq Scan on rep (actual rows=1 loops=1)
+                     Filter: (c1 = 1)
+                     Rows Removed by Filter: 998
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from rep join unnest_arr on rep.c1 = unnest_arr.c1;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+   ->  Hash Join (actual rows=3 loops=1)
+         Hash Cond: ((((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer) = c1)
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 999 of 524288 buckets.
+         ->  Result (actual rows=7 loops=1)
+               One-Time Filter: (gp_execution_segment() = 2)
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=999 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4132kB
+               ->  Seq Scan on rep (actual rows=999 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from rep join gen_series on rep.c1 = gen_series.c1;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=10 loops=1)
+   ->  Hash Join (actual rows=10 loops=1)
+         Hash Cond: ((generate_series('-10'::integer, 10)) = c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 999 of 524288 buckets.
+         ->  Result (actual rows=21 loops=1)
+               One-Time Filter: (gp_execution_segment() = 1)
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=999 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4132kB
+               ->  Seq Scan on rep (actual rows=999 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- partitioned ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows the
+-- propagation of the partition selector, and enables DPE. 
+explain (analyze, costs off, timing off, summary off) select * from part join const_tvf(1) ct(c1) on part.c2 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=100 loops=1)
+   ->  Hash Join (actual rows=43 loops=1)
+         Hash Cond: (c2 = (1))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Dynamic Seq Scan on part (actual rows=43 loops=1)
+               Number of partitions to scan: 1 (out of 3)
+               Filter: (c2 = 1)
+               Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+                           Filter: ((1) = 1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from part join unnest_arr on part.c2 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=399 loops=1)
+   ->  Hash Join (actual rows=150 loops=1)
+         Hash Cond: (c2 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Dynamic Seq Scan on part (actual rows=245 loops=1)
+               Number of partitions to scan: 3 (out of 3)
+               Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=7 loops=1)
+                     ->  Result (actual rows=7 loops=1)
+                           ->  ProjectSet (actual rows=7 loops=1)
+                                 ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from part join gen_series on part.c2 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Join (actual rows=340 loops=1)
+         Hash Cond: (c2 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Dynamic Seq Scan on part (actual rows=340 loops=1)
+               Number of partitions to scan: 3 (out of 3)
+               Partitions scanned:  Avg 3.0 x 3 workers.  Max 3 parts (seg0).
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=21 loops=1)
+                     ->  ProjectSet (actual rows=21 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+-- distributed ⟕ universal 
+-- We get the same plans as those of the inner join, 
+-- since the outer table is deduplicated.
+explain (analyze, costs off, timing off, summary off) select * from dist left join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (c1 = (1))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist left join unnest_arr on dist.c1 = unnest_arr.c1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (c1 = (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 7 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist left join gen_series on dist.c1 = gen_series.c1;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=999 loops=1)
+   ->  Hash Left Join (actual rows=340 loops=1)
+         Hash Cond: (c1 = (generate_series('-10'::integer, 10)))
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 21 of 524288 buckets.
+         ->  Seq Scan on dist (actual rows=340 loops=1)
+         ->  Hash (actual rows=21 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- universal ⟕ distributed
+-- Since left join returns all the records from the universal
+-- side, it needs to be deduplicated. This is achieved by a
+-- hash filter (duplicate-sensitive hash motion).
+-- (Test of const TVF left join distributed table is flaky
+-- and is turned off. ORCA generates two alternatives, left 
+-- join and right join, that happen to have the same cost.)  
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr left join dist on dist.c1 = unnest_arr.c1;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=7 loops=1)
+   ->  Hash Left Join (actual rows=4 loops=1)
+         Hash Cond: ((((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer) = c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 322 of 524288 buckets.
+         ->  Result (actual rows=4 loops=1)
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4108kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from gen_series left join dist on dist.c1 = gen_series.c1;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=21 loops=1)
+   ->  Hash Left Join (actual rows=8 loops=1)
+         Hash Cond: ((generate_series('-10'::integer, 10)) = c1)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 337 of 524288 buckets.
+         ->  Result (actual rows=8 loops=1)
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4108kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+-- universal ▷ distributed
+-- Since anti join returns all the records from the universal
+-- side where no matches are found in the deduplicated side,
+-- it needs to be deduplicated. This is achieved by a hash
+-- filter (duplicate-sensitive hash motion).
+explain (analyze, costs off, timing off, summary off) select * from const_tvf(1) ct(c1) where not exists (select 1 from dist where dist.c1 = ct.c1);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Hash Anti Join (actual rows=0 loops=1)
+   Hash Cond: ((1) = c1)
+   Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+   ->  Result (actual rows=1 loops=1)
+   ->  Hash (actual rows=1 loops=1)
+         Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+         ->  Result (actual rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
+                     ->  Seq Scan on dist (actual rows=1 loops=1)
+                           Filter: (c1 = 1)
+                           Rows Removed by Filter: 321
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr where not exists (select 1 from dist where dist.c1 = unnest_arr.c1);
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Hash Anti Join (actual rows=3 loops=1)
+         Hash Cond: ((((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer) = c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 322 of 524288 buckets.
+         ->  Result (actual rows=4 loops=1)
+               ->  Result (actual rows=7 loops=1)
+                     ->  ProjectSet (actual rows=7 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4110kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from gen_series where not exists (select 1 from dist where dist.c1 = gen_series.c1);
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=11 loops=1)
+   ->  Hash Anti Join (actual rows=6 loops=1)
+         Hash Cond: ((generate_series('-10'::integer, 10)) = c1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 322 of 524288 buckets.
+         ->  Result (actual rows=8 loops=1)
+               ->  ProjectSet (actual rows=21 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Hash (actual rows=340 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4110kB
+               ->  Seq Scan on dist (actual rows=340 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+-- Testing inner nested loop join
+set optimizer_enable_hashjoin = off;
+-- We no more enforce the inner side to be a singleton
+-- when the outer side is universal. It just needs to
+-- be non-replicated since inner join is deduplicated. 
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 < ct.c1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         Join Filter: (c1 < (1))
+         ->  Result (actual rows=1 loops=1)
+         ->  Seq Scan on dist (actual rows=170 loops=2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 < unnest_arr.c1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         Join Filter: (c1 < (((unnest('{-3,-2,-1,0,1,2,3}'::text[])))::integer))
+         Rows Removed by Join Filter: 2252
+         ->  Result (actual rows=7 loops=1)
+               ->  ProjectSet (actual rows=7 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+         ->  Seq Scan on dist (actual rows=298 loops=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 < gen_series.c1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=45 loops=1)
+   ->  Nested Loop (actual rows=26 loops=1)
+         Join Filter: (c1 < (generate_series('-10'::integer, 10)))
+         Rows Removed by Join Filter: 7051
+         ->  ProjectSet (actual rows=21 loops=1)
+               ->  Result (actual rows=1 loops=1)
+         ->  Seq Scan on dist (actual rows=325 loops=22)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1899,36 +1899,36 @@ SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.09 rows=1 width=20)
-   ->  Nested Loop  (cost=0.00..882688.09 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.08 rows=1 width=20)
+   ->  Nested Loop  (cost=0.00..882688.08 rows=1 width=20)
          Join Filter: true
-         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
          ->  Result  (cost=0.00..0.00 rows=0 width=12)
                One-Time Filter: false
+         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.09 rows=1 width=20)
-   ->  Nested Loop  (cost=0.00..882688.09 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.08 rows=1 width=20)
+   ->  Nested Loop  (cost=0.00..882688.08 rows=1 width=20)
          Join Filter: true
-         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
          ->  Result  (cost=0.00..0.00 rows=0 width=12)
                One-Time Filter: false
+         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.09 rows=1 width=20)
-   ->  Nested Loop  (cost=0.00..882688.09 rows=1 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.08 rows=1 width=20)
+   ->  Nested Loop  (cost=0.00..882688.08 rows=1 width=20)
          Join Filter: true
-         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
          ->  Result  (cost=0.00..0.00 rows=0 width=12)
                One-Time Filter: false
+         ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -2083,16 +2083,22 @@ create function dedup_func_volatile() RETURNS int AS $$
 $$ LANGUAGE SQL VOLATILE;
 explain (costs off)
 select * from dedup_func() r(a) where r.a in (select t.a/10 from dedup_tab t);
-                      QUERY PLAN                      
-------------------------------------------------------
- Hash Semi Join
-   Hash Cond: ((5) = ((a / 10)))
-   ->  Result
-   ->  Hash
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on dedup_tab
- Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0
-(7 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (((a / 10)) = (5))
+         ->  GroupAggregate
+               Group Key: ((a / 10))
+               ->  Sort
+                     Sort Key: ((a / 10))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((a / 10))
+                           ->  Seq Scan on dedup_tab
+         ->  Hash
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select * from dedup_func() r(a) where r.a in (select t.a/10 from dedup_tab t);
  a 
@@ -2102,16 +2108,22 @@ select * from dedup_func() r(a) where r.a in (select t.a/10 from dedup_tab t);
 
 explain (costs off)
 select * from dedup_func_stable() r(a) where r.a in (select t.a/10 from dedup_tab t);
-                      QUERY PLAN                      
-------------------------------------------------------
- Hash Semi Join
-   Hash Cond: ((5) = ((a / 10)))
-   ->  Result
-   ->  Hash
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on dedup_tab
- Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0
-(7 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (((a / 10)) = (5))
+         ->  GroupAggregate
+               Group Key: ((a / 10))
+               ->  Sort
+                     Sort Key: ((a / 10))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((a / 10))
+                           ->  Seq Scan on dedup_tab
+         ->  Hash
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select * from dedup_func_stable() r(a) where r.a in (select t.a/10 from dedup_tab t);
  a 
@@ -2121,16 +2133,22 @@ select * from dedup_func_stable() r(a) where r.a in (select t.a/10 from dedup_ta
 
 explain (costs off)
 select * from dedup_func_volatile() r(a) where r.a in (select t.a/10 from dedup_tab t);
-                      QUERY PLAN                      
-------------------------------------------------------
- Hash Semi Join
-   Hash Cond: ((5) = ((a / 10)))
-   ->  Result
-   ->  Hash
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on dedup_tab
- Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0
-(7 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (((a / 10)) = (5))
+         ->  GroupAggregate
+               Group Key: ((a / 10))
+               ->  Sort
+                     Sort Key: ((a / 10))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((a / 10))
+                           ->  Seq Scan on dedup_tab
+         ->  Hash
+               ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select * from dedup_func_volatile() r(a) where r.a in (select t.a/10 from dedup_tab t);
  a 

--- a/src/test/regress/expected/tsrf_optimizer.out
+++ b/src/test/regress/expected/tsrf_optimizer.out
@@ -115,17 +115,15 @@ SELECT * FROM few f1,
    ->  Nested Loop
          Output: id, dataa, datab, (unnest('{1,2}'::integer[]))
          Join Filter: true
+         ->  ProjectSet
+               Output: unnest('{1,2}'::integer[])
+               ->  Result
+                     Output: NULL::integer, NULL::tid, NULL::xid, NULL::cid, NULL::xid, NULL::cid, NULL::oid, NULL::integer
+                     One-Time Filter: false
          ->  Seq Scan on public.few
                Output: id, dataa, datab
-         ->  Materialize
-               Output: (unnest('{1,2}'::integer[]))
-               ->  ProjectSet
-                     Output: unnest('{1,2}'::integer[])
-                     ->  Result
-                           Output: NULL::integer, NULL::tid, NULL::xid, NULL::cid, NULL::xid, NULL::cid, NULL::oid, NULL::integer
-                           One-Time Filter: false
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(13 rows)
 
 SELECT * FROM few f1,
   (SELECT unnest(ARRAY[1,2]) FROM few f2 WHERE false OFFSET 0) ss;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -197,7 +197,7 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # temp tables
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
 
-test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew qp_select partition_prune_opfamily gp_tsrf qp_join_union_all
+test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew qp_select partition_prune_opfamily gp_tsrf qp_join_union_all qp_join_universal
 
 test: qp_misc_jiras qp_with_clause qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan qp_dropped_cols
 test: qp_with_functional_inlining qp_with_functional_noinlining

--- a/src/test/regress/sql/qp_join_universal.sql
+++ b/src/test/regress/sql/qp_join_universal.sql
@@ -1,0 +1,144 @@
+-- This test verifies ORCA plans when one side of join is
+-- of universal spec. Historically, we enforce universal
+-- to be joined with singleton to avoid duplicates. This is
+-- overly conservative. Instead, we should be able to join
+-- universal with any deduplicated input, as far as the join
+-- doesn't return all records from the universal side.
+
+-- start_matchsubs
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: \(seg#\)/
+-- end_matchsubs
+
+-- start_ignore
+drop schema if exists join_universal cascade;
+-- end_ignore
+
+-- greenplum
+create schema join_universal;
+set search_path=join_universal;
+set optimizer_trace_fallback=on;
+
+-- distributed
+create table dist (c1 int) distributed by (c1);
+insert into dist select i from generate_series(1,999) i;
+
+-- randomly distributed
+create table rand (c1 int) distributed randomly;
+insert into rand select i from generate_series(1,999) i;
+
+-- replicated
+create table rep (c1 int) distributed replicated; 
+insert into rep select i from generate_series(1,999) i;
+
+-- partitioned
+create table part (c1 int, c2 int) partition by list(c2) (
+partition part1 values (1, 2, 3, 4), 
+partition part2 values (5, 6, 7), 
+partition part3 values (8, 9, 0));
+insert into part select i, i%10 from generate_series(1, 999) i;
+
+-- const tvf (universal)
+-- This tvf is defined as volatile, but since it's not
+-- used as a scan operator, it's distribution spec is
+-- still universal instead of singleton.
+-- We avoid the "immutable" keyword so that the tvf
+-- execution doesn't fall back due to lack of support
+-- for Query Parameter.
+create function const_tvf(a int) returns int as $$ select $1 $$ language sql;
+
+-- unnested array (universal)
+create view unnest_arr as (select unnest(string_to_array('-3,-2,-1,0,1,2,3',','))::int c1);
+
+-- generate_series (universal)
+create view gen_series as (select generate_series(-10,10) c1);
+
+analyze dist;
+analyze rand;
+analyze rep;
+analyze part;
+
+-- Testing hash join
+set optimizer_enable_hashjoin = on;
+
+-- distributed ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows us to
+-- hash the much smaller universal table, instead of
+-- the much larger distributed table.
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 = unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 = gen_series.c1;
+
+-- randomly distributed ⋈ universal 
+-- We get the same plans as above, since no motion is
+-- needed when joining with a universal table
+-- (We don't flag row count diffs in the following tests.
+-- This is because the row count of intermediate physical
+-- operations are expected to fluctuate in randomly 
+-- distributed tables.)
+explain (analyze, timing off, summary off) select * from rand join const_tvf(1) ct(c1) on rand.c1 = ct.c1;
+explain (analyze, timing off, summary off) select * from rand join unnest_arr on rand.c1 = unnest_arr.c1;
+explain (analyze, timing off, summary off) select * from rand join gen_series on rand.c1 = gen_series.c1;
+
+-- replicated ⋈ universal
+-- Replicated joined with universal needs to be deduplicated.
+-- This is achieved by a one-time segment filter
+-- (duplicate-sensitive random motion).
+explain (analyze, costs off, timing off, summary off) select * from rep join const_tvf(1) ct(c1) on rep.c1 = ct.c1;
+explain (analyze, costs off, timing off, summary off) select * from rep join unnest_arr on rep.c1 = unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from rep join gen_series on rep.c1 = gen_series.c1;
+
+-- partitioned ⋈ universal 
+-- We no more enforce the outer side to be a singleton
+-- when the inner side is universal. This allows the
+-- propagation of the partition selector, and enables DPE. 
+explain (analyze, costs off, timing off, summary off) select * from part join const_tvf(1) ct(c1) on part.c2 = ct.c1;
+explain (analyze, costs off, timing off, summary off) select * from part join unnest_arr on part.c2 = unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from part join gen_series on part.c2 = gen_series.c1;
+
+-- distributed ⟕ universal 
+-- We get the same plans as those of the inner join, 
+-- since the outer table is deduplicated.
+explain (analyze, costs off, timing off, summary off) select * from dist left join const_tvf(1) ct(c1) on dist.c1 = ct.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist left join unnest_arr on dist.c1 = unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist left join gen_series on dist.c1 = gen_series.c1;
+
+-- universal ⟕ distributed
+-- Since left join returns all the records from the universal
+-- side, it needs to be deduplicated. This is achieved by a
+-- hash filter (duplicate-sensitive hash motion).
+-- (Test of const TVF left join distributed table is flaky
+-- and is turned off. ORCA generates two alternatives, left 
+-- join and right join, that happen to have the same cost.)  
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr left join dist on dist.c1 = unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from gen_series left join dist on dist.c1 = gen_series.c1;
+
+-- universal ▷ distributed
+-- Since anti join returns all the records from the universal
+-- side where no matches are found in the deduplicated side,
+-- it needs to be deduplicated. This is achieved by a hash
+-- filter (duplicate-sensitive hash motion).
+explain (analyze, costs off, timing off, summary off) select * from const_tvf(1) ct(c1) where not exists (select 1 from dist where dist.c1 = ct.c1);
+explain (analyze, costs off, timing off, summary off) select * from unnest_arr where not exists (select 1 from dist where dist.c1 = unnest_arr.c1);
+explain (analyze, costs off, timing off, summary off) select * from gen_series where not exists (select 1 from dist where dist.c1 = gen_series.c1);
+
+-- Testing inner nested loop join
+set optimizer_enable_hashjoin = off;
+
+-- We no more enforce the inner side to be a singleton
+-- when the outer side is universal. It just needs to
+-- be non-replicated since inner join is deduplicated. 
+explain (analyze, costs off, timing off, summary off) select * from dist join const_tvf(1) ct(c1) on dist.c1 < ct.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist join unnest_arr on dist.c1 < unnest_arr.c1;
+explain (analyze, costs off, timing off, summary off) select * from dist join gen_series on dist.c1 < gen_series.c1;


### PR DESCRIPTION
**Motivation**

Currently, we don't support DPE when joining a partition table with data universally available. Such data could be an unnested array or a TVF. To allow DPE, hash join places the partition table as the outer child, and the partition selector as the inner child. A common scenario is where the partition table is randomly distributed on the join key (partition key is usually not the distribution key), and the non-partitioned table is broadcasted. However, if the inner child is universal, we enforce the outer child into a singleton to avoid duplicates. Forcing a partition table into a singleton means gathering all the data into the coordinator. As a result, the join order for DPE to happen is not further explored.

Apparently, enforcing the outer table into a singleton when the inner side is universal is overly conservative. `Universal` distribution spec is very much like `Replicated`, and it should be joinable with `Non-Singleton` as well. This PR relaxes the enforcement. This way, we avoid unnecessary Gather or duplicate sensitive motions and generate better plans (including propagating DPE).

**Implementation**

`Non-Singleton` distribution spec is satisfiable by both `Hash` and `Random`. As the name suggests, `Non-Singleton` excludes `Singleton`. Since the idea is to allow `Universal` to be joinable with `Non-Singleton` and `Singleton`, we introduce a new distribution spec `Non-Replicated`, satisfiable by `Hash`, `Random`, and `Singleton`. This PR applies the `Non-Replicated` spec to hash join and inner nested loop join.

We use `Non-Replicated` for two types of hash join optimization requests: (1) hash distribute both sides, and (2) broadcast the inner side. In the first type of optimization, if hash distributing both sides isn't doable (eg. columns not hashable), we request a matching spec for one child given the other's distribution spec. In the second type of optimization, we request the inner child to be replicated. In both cases, if one child is `Universal`, we request the other child to be `Non-Replicated` only if there's no duplicate concern. Otherwise, we still request a `Singleton`.

Similarly in inner nested loop join, we request `Non-Replicated` for one child if the other is `Universal`. Since inner join doesn't generate duplicates as far as one child is deduplicated, it's safe to always pair `Non-Replicated` with `Universal`.

The following two examples illustrates the "duplicate concern".

**_Eg.1_**
Inner join of `Universal` and `Non-Replicated` doesn't generate duplicates, because the `Non-Replicated` side deduplicates the join output.

**_Eg.2_**
Left outer join of `Universal` and `Non-Replicated` generates duplicates, because it outputs all the tuples from the outer table. Therefore, we request the inner side to be a `Singleton` if the `Universal` table is on the outer side of the left outer join.

**Discussions**

Distribution specs can be best understood by their enforcers. For example, `Random` and `Non-Singleton` have very similar enforcers. Therefore, even though `Non-Singleton` can be satisfied by `Random`, `Hash`, and even `Replicated` by default, it bears more similarity to `Random` than to the other two specs. Interestingly, we inherit `Hash` from `Random`, possibly because they share some features such as handling duplicates. But since they have completely different enforces, they should really be perceived as very different specs.

We build `Non-Replicated` as an inherited class of `Singleton` so it shares the same enforcer -- Gather. There are two reasons for this implementation.

1. As the naming suggests, `Non-Replicated` is anything but `Replicated`. What this means is `Non-Replicated` doesn't have duplicates. Correspondingly, its enforcer's job is to deduplicate any given data distribution.

Both `Hash` and `Random` enforcers have mechanisms to handle duplicates by using a filter that's not actually a physical motion. But that mechanism is more of an add-on feature in case the given spec is `Universal`. The enforcers' main jobs are to hash distribute or randomize the data, which would be an overkill for our purpose. Comparatively, `Singleton` enforcer actually gets rid of the duplicates by gathering the data into the coordinator.

2. `Non-Replicated` is introduced to replace existing usages of `Singleton` when appropriate. If the given distribution spec doesn't satisfy what we request, it would be ideal for the updated logic to behave like the original. `Non-Replicated` offers more leeway to avoid enforcement. But in case we have to enforce, `Non-Replicated` being an inheritance of `Singleton` will likely get us the same plan as before.

**Tests**
This PR updated a lot of ORCA plans. Here are a few catagories --

1. Partition selector propagated to enable DPE
2. Gather motion enforced after join to benefit from MPP
3. Join order of nested loop join swapped as a result of added alternatives