### PR TITLE
[6X] Try to terminate mpp backends during dtx recovery

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8124,6 +8124,8 @@ StartupXLOG(void)
 	 */
 	if (fast_promoted)
 		RequestCheckpoint(CHECKPOINT_FORCE);
+
+	*shmCleanupBackends = true;
 }
 
 /*

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -63,6 +63,7 @@ typedef struct TmControlBlock
 	DistributedTransactionId	seqno;
 	bool						DtmStarted;
 	pid_t						DtxRecoveryPid;
+	bool						CleanupBackends;
 	uint32						NextSnapshotId;
 	int							num_committed_xacts;
 	slock_t						gxidGenLock;
@@ -1155,6 +1156,7 @@ tmShmemInit(void)
 	}
 	shmDtmStarted = &shared->DtmStarted;
 	shmDtxRecoveryPid = &shared->DtxRecoveryPid;
+	shmCleanupBackends = &shared->CleanupBackends;
 	shmNextSnapshotId = &shared->NextSnapshotId;
 	shmNumCommittedGxacts = &shared->num_committed_xacts;
 	shmGxidGenLock = &shared->gxidGenLock;
@@ -1166,6 +1168,7 @@ tmShmemInit(void)
 		*shmNextSnapshotId = 0;
 		*shmDtmStarted = false;
 		*shmDtxRecoveryPid = 0;
+		*shmCleanupBackends = false;
 		*shmNumCommittedGxacts = 0;
 	}
 }

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -264,6 +264,7 @@ extern DtxContext DistributedTransactionContext;
 /* state variables for how much of the log file has been flushed */
 extern volatile bool *shmDtmStarted;
 extern volatile pid_t *shmDtxRecoveryPid;
+extern volatile bool *shmCleanupBackends;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
 extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;

--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -109,6 +109,14 @@ select pg_ctl(datadir, 'stop', 'immediate') from gp_segment_configuration where 
 -- by gpinitstandby needs access exclusive lock and the backend for
 -- this isolation spec is already holding an access share lock on
 -- gp_segment_configuration.
+-- NOTE: the select query should fail since the gang for master has been
+-- terminated by the dtx recovery process on standby during standby promote. We
+-- do not test the result of the select query; just expect it fail so that the
+-- next mpp query could recreate the gang and succeed.
+-- start_ignore
+select count(*) from committed_by_standby;
+ERROR:  terminating connection due to administrator command  (seg0 slice1 192.168.235.128:7002 pid=24473)
+-- end_ignore
 create table standby_config as (select hostname, datadir, port, role from gp_segment_configuration where content = -1) distributed by (hostname);
 CREATE 2
 

--- a/src/test/isolation2/input/orphaned_gang_cleaner.source
+++ b/src/test/isolation2/input/orphaned_gang_cleaner.source
@@ -1,0 +1,29 @@
+-- restart cluster
+!\retcode gpstop -afr;
+-- save session id into table
+1: CREATE TABLE session (id int) DISTRIBUTED REPLICATED;
+1: INSERT INTO session SELECT current_setting('gp_session_id')::int;
+-- create table for long query
+1: CREATE TABLE test(i int) DISTRIBUTED BY (i);
+1: INSERT INTO test SELECT i FROM generate_series(1, 100) i;
+-- run long query
+1&: SELECT pg_sleep(10) FROM test;
+-- panic on next query should restart coordinator
+SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::int);
+SELECT 1;
+-- got error after restarting
+1<:
+1q:
+-- ensure first session id is less than saved
+1: SELECT current_setting('gp_session_id')::int < id FROM session;
+-- these should not raise snapshot collision error
+2: SELECT id > 0 FROM session;
+3: SELECT id > 0 FROM session;
+4: SELECT id > 0 FROM session;
+5: SELECT id > 0 FROM session;
+6: SELECT id > 0 FROM session;
+7: SELECT id > 0 FROM session;
+8: SELECT id > 0 FROM session;
+9: SELECT id > 0 FROM session;
+-- ensure last session id is greater than saved
+10: SELECT current_setting('gp_session_id')::int > id FROM session;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -167,6 +167,7 @@ test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop ma
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_xlog_switch
 test: idle_gang_cleaner
+test: orphaned_gang_cleaner
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/isolation2/output/orphaned_gang_cleaner.source
+++ b/src/test/isolation2/output/orphaned_gang_cleaner.source
@@ -1,0 +1,85 @@
+-- restart cluster
+!\retcode gpstop -afr;
+(exited with code 0)
+-- save session id into table
+1: CREATE TABLE session (id int) DISTRIBUTED REPLICATED;
+CREATE
+1: INSERT INTO session SELECT current_setting('gp_session_id')::int;
+INSERT 1
+-- create table for long query
+1: CREATE TABLE test(i int) DISTRIBUTED BY (i);
+CREATE
+1: INSERT INTO test SELECT i FROM generate_series(1, 100) i;
+INSERT 100
+-- run long query
+1&: SELECT pg_sleep(10) FROM test;  <waiting ...>
+-- panic on next query should restart coordinator
+SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT 1;
+PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- got error after restarting
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1q: ... <quitting>
+-- ensure first session id is less than saved
+1: SELECT current_setting('gp_session_id')::int < id FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+-- these should not raise snapshot collision error
+2: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+3: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+4: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+5: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+6: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+7: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+8: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+9: SELECT id > 0 FROM session;
+ ?column? 
+----------
+ t        
+(1 row)
+-- ensure last session id is greater than saved
+10: SELECT current_setting('gp_session_id')::int > id FROM session;
+ ?column? 
+----------
+ t        
+(1 row)

--- a/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
@@ -70,6 +70,13 @@ where content = -1 and role = 'm';
 -- by gpinitstandby needs access exclusive lock and the backend for
 -- this isolation spec is already holding an access share lock on
 -- gp_segment_configuration.
+-- NOTE: the select query should fail since the gang for master has been
+-- terminated by the dtx recovery process on standby during standby promote. We
+-- do not test the result of the select query; just expect it fail so that the
+-- next mpp query could recreate the gang and succeed.
+-- start_ignore
+select count(*) from committed_by_standby;
+-- end_ignore
 create table standby_config as (select hostname, datadir, port, role
 from gp_segment_configuration where content = -1) distributed by (hostname);
 


### PR DESCRIPTION
When master reset or master failover happens, orphaned prepared transactions may be generated.  Normally dtx recovery process collects all in-doubted prepared transactions and aborts them after master reset/failover, however it is possible at that time the segment process is slowly doing prepare, and finishes before the collection in the dtx recovery process thus finally leave the prepared transaction orphaned.

There might be other issues due to conflict of old QE processes with new QE processes. One real scenario is the elog(FATAL, "writer segworker group shared snapshot collision on id XXX") issue when creating a new QE backend. This could happen if the old QE backend hangs due to e.g. wal replication waiting during prepare if mirror is down but has not been detected by fts yet, and dtx recovery keep retrying. If the previous gp_session_id is small soon we will encounter this.

Let's try to terminate all mpp backends before dtx recovery for such scenarios. We do not do hard-terminate since we do not want to block dtx recovery too much time so it's not 100% sure that we could resolve various related issues by this but it's better than doing nothing. We need other solutions to resolve the rest issues if this solution can not resolve them all, typically after dtm starts.

This is backport of first commit of https://github.com/greenplum-db/gpdb/pull/10393 with additional test