### PR TITLE
[7X] Fix Differential recovery tablespace issue

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -346,12 +346,12 @@ class PgBaseBackup(Command):
         cmd_tokens.append(source_host)
         cmd_tokens.append('-p')
         cmd_tokens.append(source_port)
+        cmd_tokens.extend(self._xlog_arguments(replication_slot_name))
 
         # In case of differential recovery, this flag is used to only write recovery.conf
         # and internal.auto.conf files to target data directory.
         if writeconffilesonly:
             cmd_tokens.append('--write-conf-files-only')
-            cmd_tokens.extend(self._xlog_arguments(replication_slot_name))
         else:
 
             # if there is already slot present and create-slot arg is true it will give error,
@@ -367,8 +367,6 @@ class PgBaseBackup(Command):
                         cmd_tokens.append('--create-slot')
                 else:
                     cmd_tokens.append('--create-slot')
-
-            cmd_tokens.extend(self._xlog_arguments(replication_slot_name))
 
             # GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: avoid checking checksum
             # for heap tables till we code logic to skip/verify checksum

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -167,6 +167,20 @@ def terminate_proc_tree(pid, sig=signal.SIGTERM, include_parent=True, timeout=No
         process.kill()
 
 
+def get_remote_link_path(path, host):
+    """
+      Function to get symlink target path for a given path on given host.
+      :param  path: path for which symlink has to be found
+      :param  host: host on which the given path is available
+      :return: returns symlink target path
+    """
+
+    cmdStr = """python3 -c 'import os; print(os.readlink("%s"))'""" % path
+    cmd = Command('get remote link path', cmdStr=cmdStr, ctxt=REMOTE,
+                       remoteHost=host)
+    cmd.run(validateAfter=True)
+    return cmd.get_stdout()
+
 # ---------------Platform Framework--------------------
 
 """ The following platform framework is used to handle any differences between

--- a/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
@@ -48,7 +48,7 @@ def get_tablespace_locations(all_hosts, mirror_data_directory):
     return tablespace_locations
 
 
-def get_segment_tablespace_locations(primary_hostname, primary_port):
+def get_segment_tablespace_oid_locations(primary_hostname, primary_port):
     """
         to get user defined tablespace locations for a specific primary segment. This function is called by
         gprecoverseg --differential to get the tablespace locations by connecting to primary while mirror is down.
@@ -57,9 +57,9 @@ def get_segment_tablespace_locations(primary_hostname, primary_port):
 
         :param primary_hostname: string type primary hostname
         :param primary_port: int type primary segment port
-        :return: list of tablespace locations
+        :return: list of tablespace oids and locations
         """
-    sql = "SELECT distinct(tblspc_loc) FROM ( SELECT oid FROM pg_tablespace WHERE spcname NOT IN " \
+    sql = "SELECT distinct(oid),tblspc_loc FROM ( SELECT oid FROM pg_tablespace WHERE spcname NOT IN " \
           "('pg_default', 'pg_global')) AS q,LATERAL gp_tablespace_location(q.oid);"
     try:
         query = RemoteQueryCommand("Get segment tablespace locations", sql, primary_hostname, primary_port)

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
@@ -2,7 +2,7 @@
 
 
 from mock import Mock, patch, call
-from gppylib.operations.segment_tablespace_locations import get_tablespace_locations, get_segment_tablespace_locations
+from gppylib.operations.segment_tablespace_locations import get_tablespace_locations, get_segment_tablespace_oid_locations
 from test.unit.gp_unittest import GpTestCase
 
 
@@ -41,9 +41,9 @@ class GetTablespaceDirTestCase(GpTestCase):
         self.assertEqual(expected, get_tablespace_locations(False, mirror_data_directory))
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.run', side_effect=Exception())
-    def test_get_segment_tablespace_locations_exception(self, mock1):
+    def test_get_segment_tablespace_oid_locations_exception(self, mock1):
         with self.assertRaises(Exception) as ex:
-            get_segment_tablespace_locations('sdw1', 40000)
+            get_segment_tablespace_oid_locations('sdw1', 40000)
         self.assertEqual(0, self.mock_logger.debug.call_count)
         self.assertTrue('Failed to get segment tablespace locations for segment with host sdw1 and port 40000'
                         in str(ex.exception))
@@ -51,8 +51,8 @@ class GetTablespaceDirTestCase(GpTestCase):
     @patch('gppylib.db.catalog.RemoteQueryCommand.__init__', return_value=None)
     @patch('gppylib.db.catalog.RemoteQueryCommand.run')
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results')
-    def test_get_segment_tablespace_locations_success(self, mock1, mock2, mock3):
-        get_segment_tablespace_locations('sdw1', 40000)
+    def test_get_segment_tablespace_oid_locations_success(self, mock1, mock2, mock3):
+        get_segment_tablespace_oid_locations('sdw1', 40000)
         self.assertEqual(1, self.mock_logger.debug.call_count)
         self.assertEqual([call('Successfully got tablespace locations for segment with host sdw1, port 40000')],
                          self.mock_logger.debug.call_args_list)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -484,8 +484,12 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mytblspace1'], ['/data/mytblspace2']])
-    def test_sync_tablespaces_outside_data_dir(self, mock):
+           return_value=[['1111','/data/mytblspace1'], ['2222','/data/mytblspace2']])
+    @patch('gpsegrecovery.get_remote_link_path',
+           return_value='/data/mytblspace1/2')
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_outside_data_dir(self, mock1,mock2,mock3,mock4):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(2, self.mock_rsync_init.call_count)
         self.assertEqual(2, self.mock_rsync_run.call_count)
@@ -494,8 +498,10 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mirror0']])
-    def test_sync_tablespaces_within_data_dir(self, mock):
+           return_value=[['1234','/data/primary0']])
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_within_data_dir(self, mock, mock2,mock3):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(0, self.mock_rsync_init.call_count)
         self.assertEqual(0, self.mock_rsync_run.call_count)
@@ -503,8 +509,12 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mirror0'], ['/data/mytblspace1']])
-    def test_sync_tablespaces_mix_data_dir(self, mock):
+           return_value=[['1111','/data/primary0'], ['2222','/data/mytblspace1']])
+    @patch('gpsegrecovery.get_remote_link_path',
+           return_value='/data/mytblspace1/2')
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_mix_data_dir(self, mock1, mock2, mock3,mock4):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(1, self.mock_rsync_init.call_count)
         self.assertEqual(1, self.mock_rsync_run.call_count)
@@ -635,10 +645,10 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
         expected_exclude_list = {'/log', 'pgsql_tmp',
                                  'postgresql.auto.conf.tmp',
                                  'current_logfiles.tmp', 'postmaster.pid',
-                                 'postmaster.opts', 'pg_dynshmem',
+                                 'postmaster.opts', 'pg_dynshmem','tablespace_map',
                                  'pg_notify/*', 'pg_replslot/*', 'pg_serial/*',
                                  'pg_stat_tmp/*', 'pg_snapshots/*',
-                                 'pg_subtrans/*', 'backups/*', '/db_dumps',
+                                 'pg_subtrans/*', 'pg_tblspc/*', 'backups/*', '/db_dumps',
                                  '/promote', '/some_log'}
         self.assertEqual(expected_exclude_list, self.mock_rsync_init.call_args_list[0][1]['exclude_list'])
 
@@ -655,10 +665,10 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
         expected_exclude_list = {'/log', 'pgsql_tmp',
                                  'postgresql.auto.conf.tmp',
                                  'current_logfiles.tmp', 'postmaster.pid',
-                                 'postmaster.opts', 'pg_dynshmem',
+                                 'postmaster.opts', 'pg_dynshmem', 'tablespace_map',
                                  'pg_notify/*', 'pg_replslot/*', 'pg_serial/*',
                                  'pg_stat_tmp/*', 'pg_snapshots/*',
-                                 'pg_subtrans/*', 'backups/*', '/db_dumps',
+                                 'pg_subtrans/*', 'pg_tblspc/*', 'backups/*', '/db_dumps',
                                  '/promote'}
         self.assertEqual(expected_exclude_list, self.mock_rsync_init.call_args_list[0][1]['exclude_list'])
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -3,14 +3,15 @@ Feature: gprecoverseg tests
 
     Scenario Outline: <scenario> recovery works with tablespaces
         Given the database is running
-          And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
+          And a tablespace is created with data
          When the user runs "gprecoverseg <args>"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
+          And the tablespace has valid symlink
           And the database segments are in execute mode
 
         Given another tablespace is created with data
@@ -19,6 +20,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
+          And the tablespace has valid symlink
           And the other tablespace is valid
           And the database segments are in execute mode
       Examples:
@@ -517,13 +519,14 @@ Feature: gprecoverseg tests
   @concourse_cluster
   Scenario Outline: <scenario> recovery works with tablespaces on a multi-host environment
     Given the database is running
-    And a tablespace is created with data
     And user stops all primary processes
     And user can start transactions
+    And a tablespace is created with data
     When the user runs "gprecoverseg <args>"
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the database segments are in execute mode
 
     Given another tablespace is created with data
@@ -532,6 +535,7 @@ Feature: gprecoverseg tests
     And the segments are synchronized
     And verify replication slot internal_wal_replication_slot is available on all the segments
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the other tablespace is valid
     And the database segments are in execute mode
 
@@ -580,6 +584,7 @@ Feature: gprecoverseg tests
 
         # verify the data
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the row count from table "public.before_host_is_down" in "gptest" is verified against the saved data
     And the row count from table "public.after_host_is_down" in "gptest" is verified against the saved data
 


### PR DESCRIPTION
### Issue 1: 
 **Post differential recovery more tablespace directory is created on the target segment.**
```
[gpadmin@cdw ~]$ gpssh -f segment_host_list -v
[WARN] Reference default values as $COORDINATOR_DATA_DIRECTORY/gpssh.conf could not be found Using delaybeforesend 0.05 and prompt_validation_timeout 1.0 [Reset ...]
[INFO] login sdw2
[INFO] login sdw1
=> ls /tmp/mytblespace/
ls /tmp/mytblespace/
[sdw2] 4 5 6 7
[sdw1] 2 3 8 9
=> exit

[gpadmin@cdw ~]$ gpssh -f segment_host_list -v
[WARN] Reference default values as $COORDINATOR_DATA_DIRECTORY/gpssh.conf could not be found Using delaybeforesend 0.05 and prompt_validation_timeout 1.0 [Reset ...]
[INFO] login sdw1
[INFO] login sdw2
=> ls /tmp/mytblespace/
ls /tmp/mytblespace/
[sdw1] 2 3 4 5 6 7 8 9
[sdw2] 4 5 6 7
=> exit
```

#### Steps to reproduce ( tested on multi-node cluster):

1. make sure that the cluster is up and running in a balanced state.
2. create a tablespace to a location outside of the data directory, add some tables just to have some data.
3. check the content of tablespace location(/tmp/mytblespace/) for all host.
4. pick any of the segments and make primary down and wait until mirror gets promoted.
5. run differential recovery.
6. post recover check the content of tablespace location(/tmp/mytblespace/) for all host. you will find that source tablespace data also getting populated in the target data-dir.

#### RCA:
In differential recovery when we perform the step of sync_tablespaces() there is a bug because of that we are copying all the directories under the tablespace location.
which was not intended as the get_segment_tablespace returning only base tablespace location, not the segment-specific target link location.

#### Fix: 
Updated algorithm to copy tablespaces data directory and update the symlink. following are the steps
1. First get the tablespace location using get_segment_tablespace_oid_locations()
2. clean all the symlink files available in $DATADIR/pg_tblspc/ for target data directory.
3. Loop through all oid, location for the segment, and do rsync from source to target tablespace dir.
4. create a symlink for the target tablespace directory under $DATADIR/pg_tblspc.

### Issue 2:
Post differential recovery tablespace symlink is pointing to the wrong target path(source). 
```
for dbid 3: 17270 -> /tmp/testtblspc/3 (primary)
for dbid 6: 17270 -> /tmp/testtblspc/3 (mirror)

```
#### Steps to reproduce:
1. make sure that the cluster is up and running in a balanced state.
2. create a tablespace to a location outside of the data directory, add some tables just to have some data.
3. pick any one segment pair and check the symlink for primary and mirror at location $PG_DATA/pg_tblspc/{oid}. you will find that both are pointing to different locations, such as tablespace_location/{dbid}.
4. now make primary down and wait until mirror gets promoted.
5. run differential recovery.
6. post recovery check tablespace symlink for the current primary and mirror, you will find that mirror is pointing to the source tablespace location (tablespace_location/{primary_dbid}), or in other words both are pointing to same location.

#### RCA: 
From the code when we are doing sync_pgdata we are copying all data from $PG_DATA/pg_tblspc/ to the target data directory, which is an overwriting symlink in the target data directory. 

#### Fix: 
recreated the symlink in sync_tablespaces() step. Some observation: when we create checkpoint before recovery via pg_start_backup() it creates tablespace_map file along with backup_label that also holds the entries for tablespace symlink. on segment_start it reads symlink from the tablespace_map file and creates the same. As we wanted the fix to be consistent with gp_expand and gpupgrade instead of updating tablespaace_map file we have updated the symlink and that is the reason for this fix, we have excluded tablespace_map file from the file list.  we have also excluded pg_tblspc dir in sync_pg_data(), this will help us to run rsync for pg_data and tablespace in parallel. 

### Unit Test:
Updated the unit test impacted by the changes.

### Behave test:
extended the current tablespace verification step to verify tablespace to check for the symlink duplication and wrong entry.
also updated tablespace to make it a little more complex scenario.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
