### PR TITLE
Change Query Parameter fallback message in Orca to notice type

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -288,7 +288,7 @@ CTranslatorScalarToDXL::TranslateScalarToDXL(
 			CHAR *str = (CHAR *) gpdb::NodeToString(const_cast<Expr *>(expr));
 			CWStringDynamic *wcstr =
 				CDXLUtils::CreateDynamicStringFromCharArray(m_mp, str);
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   wcstr->GetBuffer());
 		}
 		case T_Param:
@@ -296,7 +296,7 @@ CTranslatorScalarToDXL::TranslateScalarToDXL(
 			// Note: The choose_custom_plan() function in plancache.c
 			// knows that GPORCA doesn't support Params. If you lift this
 			// limitation, adjust choose_custom_plan() accordingly!
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   GPOS_WSZ_LIT("Query Parameter"));
 		}
 		case T_Var:


### PR DESCRIPTION
Previously a fallback to planner for query parameters would be logged as an error instead of a notice, which is misleading as this is an intentional fallback. Now, it will display as a notice.

THD000,ERROR,""GPDB Expression type: Query Parameter not supported in DXL"",

will change to:

THD000,NOTICE,""GPDB Expression type: Query Parameter not supported in DXL"",