### PR TITLE
Update Orca logging and fallback messages

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -1,6 +1,6 @@
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 CREATE SCHEMA auto_explain_test;
 CREATE TABLE auto_explain_test.t1(a int);
@@ -38,7 +38,7 @@ Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
   Index Cond: (relname = 'pg_class'::name)
   Heap Fetches: 1
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
   (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
@@ -58,7 +58,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                     ->  Materialize  (cost=0.00..68.06 rows=1001 width=0) (actual rows=1001 loops=340)
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
@@ -100,7 +100,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                           work_mem: 142kB  Segments: 3  Max: 48kB (segment 0)  Workfile: (0 spilling)
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 Settings: enable_nestloop = 'on', optimizer = 'off'
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -1,6 +1,6 @@
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 CREATE SCHEMA auto_explain_test;
 CREATE TABLE auto_explain_test.t1(a int);
@@ -33,13 +33,13 @@ SET auto_explain.log_verbose = FALSE;
 LOG:  statement: SET auto_explain.log_verbose = FALSE;
 SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
-"Feature not supported: Queries on coordinator-only tables",
+"Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables",
 LOG:  duration: 0.026 ms  plan:
 Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
   Index Cond: (relname = 'pg_class'::name)
   Heap Fetches: 1
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
   (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
@@ -59,7 +59,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
@@ -78,7 +78,7 @@ LOG:  statement: SET auto_explain.log_verbose = TRUE;
 -- this select should not dump execution plan
 SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
-"Feature not supported: Queries on coordinator-only tables",
+"Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables",
  relname  
 ----------
  pg_class
@@ -100,7 +100,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on auto_explain_test.t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on auto_explain_test.t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 Settings: enable_nestloop = 'on'
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain.out
@@ -44,7 +44,7 @@ Finalize Aggregate  (cost=475.67..475.68 rows=1 width=8) (actual time=3.018..3.0
                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (never executed)
                                             ->  Limit  (cost=35.50..35.61 rows=10 width=4) (never executed)
                                                   ->  Seq Scan on t1  (cost=0.00..355.00 rows=32100 width=4) (never executed)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
   (slice0)    Executor memory: 57K bytes.
   (slice1)    Executor memory: 4120K bytes avg x 3 workers, 4120K bytes max (seg0).  Work_mem: 4096K bytes max.
   (slice2)    Executor memory: 38K bytes (seg2).

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -43,7 +43,7 @@ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=10.250..10.256 rows=1
               ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.170 rows=0 loops=1)
                     Buckets: 524288  Batches: 1  Memory Usage: 4096kB
                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.166 rows=0 loops=1)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
   (slice0)    Executor memory: 45K bytes.
   (slice1)    Executor memory: 4116K bytes avg x 3 workers, 4116K bytes max (seg0).  Work_mem: 4096K bytes max.
   (slice2)    Executor memory: 38K bytes (entry db).

--- a/contrib/auto_explain/sql/auto_explain.sql
+++ b/contrib/auto_explain/sql/auto_explain.sql
@@ -1,6 +1,6 @@
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 
 CREATE SCHEMA auto_explain_test;

--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -173,7 +173,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv;
  Foreign Scan on public.agg_csv
    Output: a, b
    Foreign File: @abs_srcdir@/data/agg.csv
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Settings: optimizer=off
 
 \t off
@@ -225,7 +225,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0;
  Result
    Output: a, b
    One-Time Filter: false
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Settings: optimizer=off
 
 \t off
@@ -240,7 +240,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0;
  Result
    Output: a, b
    One-Time Filter: false
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Settings: constraint_exclusion=on, optimizer=off
 
 \t off
@@ -415,7 +415,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_text WHERE a > 0;
    Output: a, b
    Filter: (agg_text.a > 0)
    Foreign File: @abs_srcdir@/data/agg.data
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Settings: optimizer=off
 
 \t off

--- a/contrib/file_fdw/output/file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/file_fdw_optimizer.source
@@ -173,7 +173,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv;
  Foreign Scan on public.agg_csv
    Output: a, b
    Foreign File: @abs_srcdir@/data/agg.csv
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 
 \t off
 PREPARE st(int) AS SELECT * FROM agg_csv WHERE a = $1;
@@ -201,21 +201,21 @@ SELECT tableoid::regclass, b FROM agg_csv;
 
 -- updates aren't supported
 INSERT INTO agg_csv VALUES(1,2.0);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 ERROR:  cannot insert into foreign table "agg_csv"
 UPDATE agg_csv SET a = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 ERROR:  cannot update foreign table "agg_csv"
 DELETE FROM agg_csv WHERE a = 100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 ERROR:  cannot delete from foreign table "agg_csv"
 -- but this should be allowed
 SELECT * FROM agg_csv FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
   a  |    b    
 -----+---------
  100 |  99.097
@@ -232,7 +232,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0;
  Result
    Output: NULL::smallint, NULL::real
    One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 
 \t off
 SELECT * FROM agg_csv WHERE a < 0;
@@ -246,7 +246,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_csv WHERE a < 0;
  Result
    Output: NULL::smallint, NULL::real
    One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 
 \t off
 SELECT * FROM agg_csv WHERE a < 0;
@@ -259,8 +259,8 @@ RESET constraint_exclusion;
 CREATE TABLE agg (a int2, b float4);
 ALTER FOREIGN TABLE agg_csv INHERIT agg;
 SELECT tableoid::regclass, * FROM agg;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid |  a  |    b    
 ----------+-----+---------
  agg_csv  | 100 |  99.097
@@ -277,25 +277,25 @@ SELECT tableoid::regclass, * FROM agg_csv;
 (3 rows)
 
 SELECT tableoid::regclass, * FROM ONLY agg;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  tableoid | a | b 
 ----------+---+---
 (0 rows)
 
 -- updates aren't supported
 UPDATE agg SET a = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 ERROR:  ModifyTable mixes distributed and entry-only tables
 DELETE FROM agg WHERE a = 100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 ERROR:  ModifyTable mixes distributed and entry-only tables
 -- but this should be allowed
 SELECT tableoid::regclass, * FROM agg FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid |  a  |    b    
 ----------+-----+---------
  agg_csv  | 100 |  99.097
@@ -358,15 +358,15 @@ SELECT tableoid::regclass, * FROM p2;
 (2 rows)
 
 INSERT INTO pt VALUES (1, 'xyzzy'); -- ERROR
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
 ERROR:  cannot insert into foreign table "p1"  (seg1 127.0.0.1:7008 pid=39425)
 INSERT INTO pt VALUES (2, 'xyzzy');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
 UPDATE pt set a = 1 where a = 2; -- ERROR
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Update with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Update with External/foreign partition storage types
 ERROR:  cannot insert into foreign table "p1"  (seg1 127.0.0.1:7008 pid=50091)
 SELECT tableoid::regclass, * FROM pt;
  tableoid | a |   b   
@@ -436,7 +436,7 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM agg_text WHERE a > 0;
    Output: a, b
    Filter: (agg_text.a > 0)
    Foreign File: @abs_srcdir@/data/agg.data
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 
 \t off
 -- file FDW allows foreign tables to be accessed without user mapping

--- a/contrib/file_fdw/output/gp_file_fdw.source
+++ b/contrib/file_fdw/output/gp_file_fdw.source
@@ -38,7 +38,7 @@ EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
          Sort Key: word1
          ->  Foreign Scan on text_csv_all  (cost=0.00..358.00 rows=3480 width=64)
                Foreign File: @abs_srcdir@/data/text<SEGID>.csv
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (7 rows)
 
 SELECT * FROM text_csv_all ORDER BY word1;
@@ -71,7 +71,7 @@ explain select word1 from text_csv_coordinator union all select word1 from text_
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..497.20 rows=10440 width=32)
          ->  Foreign Scan on text_csv_all  (cost=0.00..358.00 rows=3480 width=32)
                Foreign File: @abs_srcdir@/data/text<SEGID>.csv
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (8 rows)
 
 select word1 from text_csv_coordinator union all select word1 from text_csv_all;
@@ -97,7 +97,7 @@ explain select word1 from text_csv_all union all select word1 from text_csv_coor
    ->  Foreign Scan on text_csv_coordinator  (cost=0.00..1.15 rows=2 width=32)
          Foreign File: @abs_srcdir@/file_fdw/data/text.csv
          Foreign File Size: 86 b
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (8 rows)
 
 select word1 from text_csv_all union all select word1 from text_csv_coordinator;
@@ -132,7 +132,7 @@ explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a
                      Foreign File Size: 86 b
          ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                ->  Seq Scan on bar  (cost=0.00..1.01 rows=1 width=4)
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (11 rows)
 
 select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;

--- a/contrib/file_fdw/output/gp_file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/gp_file_fdw_optimizer.source
@@ -38,7 +38,7 @@ EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
          Sort Key: word1
          ->  Foreign Scan on text_csv_all  (cost=0.00..431.00 rows=1 width=16)
                Foreign File: @abs_srcdir@/data/text<SEGID>.csv
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (7 rows)
 
 SELECT * FROM text_csv_all ORDER BY word1;
@@ -71,7 +71,7 @@ explain select word1 from text_csv_coordinator union all select word1 from text_
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
          ->  Foreign Scan on text_csv_all  (cost=0.00..431.00 rows=1 width=8)
                Foreign File: @abs_srcdir@/data/text<SEGID>.csv
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (8 rows)
 
 select word1 from text_csv_coordinator union all select word1 from text_csv_all;
@@ -98,7 +98,7 @@ explain select word1 from text_csv_all union all select word1 from text_csv_coor
                ->  Foreign Scan on text_csv_coordinator  (cost=0.00..431.00 rows=1 width=8)
                      Foreign File: @abs_srcdir@/data/text.csv
                      Foreign File Size: 86 b
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (9 rows)
 
 select word1 from text_csv_all union all select word1 from text_csv_coordinator;
@@ -133,7 +133,7 @@ explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a
                      Foreign File Size: 86 b
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (11 rows)
 
 select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -228,8 +228,8 @@ ALTER FOREIGN TABLE ft2 OPTIONS (schema_name 'S 1', table_name 'T 1');
 ALTER FOREIGN TABLE ft1 ALTER COLUMN c1 OPTIONS (column_name 'C 1');
 ALTER FOREIGN TABLE ft2 ALTER COLUMN c1 OPTIONS (column_name 'C 1');
 \det+
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                               List of foreign tables
  Schema | Table |  Server   |              FDW options              | Description 
 --------+-------+-----------+---------------------------------------+-------------
@@ -258,7 +258,7 @@ DO $d$
             OPTIONS (SET dbname '$$||current_database()||$$')$$;
     END;
 $d$;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again
   c3   |              c4              
 -------+------------------------------
@@ -347,8 +347,8 @@ SELECT * FROM ft1 t1 ORDER BY t1.c3, t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 
 -- whole-row reference
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
@@ -358,8 +358,8 @@ DETAIL:  Feature not supported: Whole-row variable
 (4 rows)
 
 SELECT t1 FROM ft1 t1 ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                                              t1                                             
 --------------------------------------------------------------------------------------------
  (101,1,00101,"Fri Jan 02 00:00:00 1970 PST","Fri Jan 02 00:00:00 1970",1,"1         ",foo)
@@ -398,8 +398,8 @@ SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
 
 -- with FOR UPDATE/SHARE
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = 101 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
@@ -409,16 +409,16 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (4 rows)
 
 SELECT * FROM ft1 t1 WHERE c1 = 101 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
 -----+----+-------+------------------------------+--------------------------+----+------------+-----
  101 |  1 | 00101 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = 102 FOR SHARE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
@@ -428,8 +428,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (4 rows)
 
 SELECT * FROM ft1 t1 WHERE c1 = 102 FOR SHARE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
 -----+----+-------+------------------------------+--------------------------+----+------------+-----
  102 |  2 | 00102 | Sat Jan 03 00:00:00 1970 PST | Sat Jan 03 00:00:00 1970 | 2  | 2          | foo
@@ -1037,8 +1037,8 @@ WHERE a.c2 = 6 AND b.c1 = a.c1 AND a.c8 = 'foo' AND b.c7 = upper(a.c7);
 
 -- bug before 9.3.5 due to sloppy handling of remote-estimate parameters
 SELECT * FROM ft1 WHERE c1 = ANY (ARRAY(SELECT c1 FROM ft2 WHERE c1 < 5));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
 ----+----+-------+------------------------------+--------------------------+----+------------+-----
   1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
@@ -1048,8 +1048,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 (4 rows)
 
 SELECT * FROM ft2 WHERE c1 = ANY (ARRAY(SELECT c1 FROM ft1 WHERE c1 < 5));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  
 ----+----+-------+------------------------------+--------------------------+----+------------+-----
   1 |  1 | 00001 | Fri Jan 02 00:00:00 1970 PST | Fri Jan 02 00:00:00 1970 | 1  | 1          | foo
@@ -1077,8 +1077,8 @@ EXPLAIN (VERBOSE, COSTS OFF)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT * FROM ft2 ORDER BY ft2.c1, ft2.c3 collate "C";
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Sort
@@ -1154,8 +1154,8 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (7 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  count 
 -------
      9
@@ -1701,8 +1701,8 @@ SELECT t1.c1, t2.c1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT 1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (TRUE) OFFSET 10 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -1713,8 +1713,8 @@ DETAIL:  No plan has been computed for required properties
 (5 rows)
 
 SELECT 1 FROM (SELECT c1 FROM ft4 WHERE c1 between 50 and 60) t1 FULL JOIN (SELECT c1 FROM ft5 WHERE c1 between 50 and 60) t2 ON (TRUE) OFFSET 10 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  ?column? 
 ----------
         1
@@ -2381,8 +2381,8 @@ ALTER SERVER pgserver OPTIONS (ADD extensions 'postgres_fdw');
 -- tests whole-row reference for row marks
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -2393,8 +2393,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (5 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c1  
 -----+-----
  101 | 101
@@ -2411,8 +2411,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -2423,8 +2423,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (5 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c1  
 -----+-----
  101 | 101
@@ -2442,8 +2442,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 -- join two tables with FOR SHARE clause
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -2454,8 +2454,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (5 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c1  
 -----+-----
  101 | 101
@@ -2472,8 +2472,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                   
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -2484,8 +2484,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 (5 rows)
 
 SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10 FOR SHARE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1  | c1  
 -----+-----
  101 | 101
@@ -2547,8 +2547,8 @@ WITH t (c1_1, c1_3, c2_1) AS MATERIALIZED (SELECT t1.c1, t1.c3, t2.c1 FROM ft1 t
 -- ctid with whole-row reference
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1.ctid, t1, t2, t1.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) ORDER BY t1.c3, t1.c1 OFFSET 100 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -2900,8 +2900,8 @@ SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 
 -- join with lateral reference
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM ft1 t2, ft2 t3 WHERE t2.c1 = t3.c1 AND t2.c2 = t1.c2) q ORDER BY t1."C 1" OFFSET 10 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                                                                 QUERY PLAN                                                                                
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -2927,8 +2927,8 @@ DETAIL:  Feature not supported: LATERAL
 (20 rows)
 
 SELECT t1."C 1" FROM "S 1"."T 1" t1, LATERAL (SELECT DISTINCT t2.c1, t3.c1 FROM ft1 t2, ft2 t3 WHERE t2.c1 = t3.c1 AND t2.c2 = t1.c2) q ORDER BY t1."C 1" OFFSET 10 LIMIT 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  C 1 
 -----
    1
@@ -3016,12 +3016,12 @@ SELECT ft4.c1, q.* FROM ft4 LEFT JOIN (SELECT 13, ft1.c1, ft2.c1 FROM ft1 RIGHT 
 
 -- join with nullable side with some columns with null values
 UPDATE ft5 SET c3 = null where c1 % 9 = 0;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT ft5, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2 FROM ft5 left join ft4 on ft5.c1 = ft4.c1 WHERE ft4.c1 BETWEEN 10 and 30 ORDER BY ft5.c1, ft4.c1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                                                                                                                                                     QUERY PLAN                                                                                                                                                     
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -3032,8 +3032,8 @@ DETAIL:  Feature not supported: Whole-row variable
 (5 rows)
 
 SELECT ft5, ft5.c1, ft5.c2, ft5.c3, ft4.c1, ft4.c2 FROM ft5 left join ft4 on ft5.c1 = ft4.c1 WHERE ft4.c1 BETWEEN 10 and 30 ORDER BY ft5.c1, ft4.c1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
       ft5       | c1 | c2 |   c3   | c1 | c2 
 ----------------+----+----+--------+----+----
  (12,13,AAA012) | 12 | 13 | AAA012 | 12 | 13
@@ -3059,8 +3059,8 @@ SET enable_mergejoin TO true;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM ft1, ft2, ft4, ft5, local_tbl WHERE ft1.c1 = ft2.c1 AND ft1.c2 = ft4.c1
     AND ft1.c2 = ft5.c1 AND ft1.c2 = local_tbl.c1 AND ft1.c1 < 100 AND ft2.c1 < 100 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
                                                                                                                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3119,8 +3119,8 @@ DETAIL:  Feature not supported: Locking clause on foreign table
 
 SELECT * FROM ft1, ft2, ft4, ft5, local_tbl WHERE ft1.c1 = ft2.c1 AND ft1.c2 = ft4.c1
     AND ft1.c2 = ft5.c1 AND ft1.c2 = local_tbl.c1 AND ft1.c1 < 100 AND ft2.c1 < 100 FOR UPDATE;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Locking clause on foreign table
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Locking clause on foreign table
  c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1 | c2 |  c3   |              c4              |            c5            | c6 |     c7     | c8  | c1 | c2 |   c3   | c1 | c2 |   c3   | c1 | c2 |  c3  
 ----+----+-------+------------------------------+--------------------------+----+------------+-----+----+----+-------+------------------------------+--------------------------+----+------------+-----+----+----+--------+----+----+--------+----+----+------
   6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo |  6 |  6 | 00006 | Wed Jan 07 00:00:00 1970 PST | Wed Jan 07 00:00:00 1970 | 6  | 6          | foo |  6 |  7 | AAA006 |  6 |  7 | AAA006 |  6 |  6 | 0006
@@ -3681,8 +3681,8 @@ select sum(c1) from ft1 group by c2 having avg(c1 * (random() <= 1)::int) > 100 
 -- of an initplan) can be trouble, per bug #15781
 explain (verbose, costs off)
 select exists(select 1 from pg_enum), sum(c1) from ft1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                     QUERY PLAN                    
 --------------------------------------------------
  Foreign Scan
@@ -3696,8 +3696,8 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 (8 rows)
 
 select exists(select 1 from pg_enum), sum(c1) from ft1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  exists |  sum   
 --------+--------
  t      | 500500
@@ -3705,8 +3705,8 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 
 explain (verbose, costs off)
 select exists(select 1 from pg_enum), sum(c1) from ft1 group by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                     QUERY PLAN                     
 ---------------------------------------------------
  GroupAggregate
@@ -3722,8 +3722,8 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 (10 rows)
 
 select exists(select 1 from pg_enum), sum(c1) from ft1 group by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  exists |  sum   
 --------+--------
  t      | 500500
@@ -3733,8 +3733,8 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 -- ORDER BY within aggregate, same column used to order
 explain (verbose, costs off)
 select array_agg(c1 order by c1) from ft1 where c1 < 100 group by c2 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -3745,8 +3745,8 @@ DETAIL:  Feature not supported: Hash aggregation with ORDER BY
 (5 rows)
 
 select array_agg(c1 order by c1) from ft1 where c1 < 100 group by c2 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
            array_agg            
 --------------------------------
  {1,11,21,31,41,51,61,71,81,91}
@@ -3914,8 +3914,8 @@ select array_agg(distinct (t1.c1)%5 order by (t1.c1)%5 desc nulls last) from ft4
 -- FILTER within aggregate
 explain (verbose, costs off)
 select sum(c1) filter (where c1 < 100 and c2 > 5) from ft1 group by c2 order by 1 nulls last;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                                                          QUERY PLAN                                                                                         
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -3926,8 +3926,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (5 rows)
 
 select sum(c1) filter (where c1 < 100 and c2 > 5) from ft1 group by c2 order by 1 nulls last;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum 
 -----
  510
@@ -3945,8 +3945,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- DISTINCT, ORDER BY and FILTER within aggregate
 explain (verbose, costs off)
 select sum(c1%3), sum(distinct c1%3 order by c1%3) filter (where c1%3 < 2), c2 from ft1 where c2 = 6 group by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -3957,8 +3957,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (5 rows)
 
 select sum(c1%3), sum(distinct c1%3 order by c1%3) filter (where c1%3 < 2), c2 from ft1 where c2 = 6 group by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum | c2 
 -----+-----+----
   99 |   1 |  6
@@ -3967,8 +3967,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- Outer query is aggregation query
 explain (verbose, costs off)
 select distinct (select count(*) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Unique
@@ -3989,8 +3989,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (15 rows)
 
 select distinct (select count(*) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      1
@@ -3999,8 +3999,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- Inner query is aggregation query
 explain (verbose, costs off)
 select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                                       QUERY PLAN                                                                      
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique
@@ -4021,8 +4021,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (15 rows)
 
 select distinct (select count(t1.c1) filter (where t2.c2 = 6 and t2.c1 < 10) from ft1 t1 where t1.c1 = 6) from ft2 t2 where t2.c2 % 6 = 0 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      0
@@ -4032,8 +4032,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- Aggregate not pushed down as FILTER condition is not pushable
 explain (verbose, costs off)
 select sum(c1) filter (where (c1 / c1) * random() <= 1) from ft1 group by c2 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -4050,8 +4050,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 explain (verbose, costs off)
 select sum(c2) filter (where c2 in (select c2 from ft1 where c2 < 5)) from ft1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Aggregate
@@ -4172,8 +4172,8 @@ select c2, least_agg(c1) from ft1 where c2 < 100 group by c2 order by c2;
 (11 rows)
 
 select c2, least_agg(c1) from ft1 where c2 < 100 group by c2 order by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  c2 | least_agg 
 ----+-----------
   0 |        10
@@ -4287,8 +4287,8 @@ alter server pgserver options (set extensions 'postgres_fdw');
 -- Now this will be pushed as sort operator is part of the extension.
 explain (verbose, costs off)
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
@@ -4299,8 +4299,8 @@ DETAIL:  Feature not supported: Hash aggregation with ORDER BY
 (5 rows)
 
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
            array_agg            
 --------------------------------
  {6,16,26,36,46,56,66,76,86,96}
@@ -4331,8 +4331,8 @@ alter server pgserver options (set extensions 'postgres_fdw');
 -- This will not be pushed as sort operator is now removed from the extension.
 explain (verbose, costs off)
 select array_agg(c1 order by c1 using operator(public.<^)) from ft2 where c2 = 6 and c1 < 100 group by c2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  GroupAggregate
@@ -4515,8 +4515,8 @@ select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
 set enable_hashagg to false;
 explain (verbose, costs off)
 select c2, sum from "S 1"."T 1" t1, lateral (select sum(t2.c1 + t1."C 1") sum from ft2 t2 group by t2.c1) qry where t1.c2 * 2 = qry.sum and t1.c2 < 3 and t1."C 1" < 100 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Sort
@@ -4543,8 +4543,8 @@ DETAIL:  Feature not supported: LATERAL
 (21 rows)
 
 select c2, sum from "S 1"."T 1" t1, lateral (select sum(t2.c1 + t1."C 1") sum from ft2 t2 group by t2.c1) qry where t1.c2 * 2 = qry.sum and t1.c2 < 3 and t1."C 1" < 100 order by 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  c2 | sum 
 ----+-----
   1 |   2
@@ -4565,8 +4565,8 @@ FROM
     ) AS subq_1
 WHERE ref_0."C 1" < 10 AND subq_1.c3 = '00001'
 ORDER BY ref_0."C 1";
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Nested Loop
@@ -4603,8 +4603,8 @@ FROM
     ) AS subq_1
 WHERE ref_0."C 1" < 10 AND subq_1.c3 = '00001'
 ORDER BY ref_0."C 1";
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  c2 | c1 | c2 |  c3   
 ----+----+----+-------
   1 |  1 |  1 | 00001
@@ -5181,8 +5181,8 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft1
@@ -5219,8 +5219,8 @@ EXECUTE st6;
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft1
@@ -5359,8 +5359,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 SELECT f_test(100);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  f_test 
 --------
     100
@@ -5407,8 +5407,8 @@ ERROR:  invalid input syntax for type integer: "foo"
 CONTEXT:  column "c8" of foreign table "ft1"
 SELECT ftx.x1, ft2.c2, ftx FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8), ft2
   WHERE ftx.x1 = ft2.c1 AND ftx.x1 = 1; -- ERROR
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
 ERROR:  invalid input syntax for type integer: "foo"
 CONTEXT:  whole-row reference to foreign table "ftx"
 SELECT sum(c2), array_agg(c8) FROM ft1 GROUP BY c8; -- ERROR
@@ -5474,8 +5474,8 @@ create foreign table ft3 (f1 text collate "C", f2 text, f3 varchar(10))
 create table loct3 (f1 text collate "C", f2 text, f3 varchar(10)) DISTRIBUTED BY (f1);
 -- can be sent to remote
 explain (verbose, costs off) select * from ft3 where f1 = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Foreign Scan on public.ft3
@@ -5485,8 +5485,8 @@ DETAIL:  Feature not supported: Non-default collation
 (4 rows)
 
 explain (verbose, costs off) select * from ft3 where f1 COLLATE "C" = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Foreign Scan on public.ft3
@@ -5496,8 +5496,8 @@ DETAIL:  Feature not supported: Non-default collation
 (4 rows)
 
 explain (verbose, costs off) select * from ft3 where f2 = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Foreign Scan on public.ft3
@@ -5507,8 +5507,8 @@ DETAIL:  Feature not supported: Non-default collation
 (4 rows)
 
 explain (verbose, costs off) select * from ft3 where f3 = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Foreign Scan on public.ft3
@@ -5519,8 +5519,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 explain (verbose, costs off) select * from ft3 f, loct3 l
   where f.f3 = l.f3 and l.f1 = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -5544,8 +5544,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 -- can't be sent to remote
 explain (verbose, costs off) select * from ft3 where f1 COLLATE "POSIX" = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     QUERY PLAN                     
 ---------------------------------------------------
  Foreign Scan on public.ft3
@@ -5556,8 +5556,8 @@ DETAIL:  Feature not supported: Non-default collation
 (5 rows)
 
 explain (verbose, costs off) select * from ft3 where f1 = 'foo' COLLATE "C";
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     QUERY PLAN                     
 ---------------------------------------------------
  Foreign Scan on public.ft3
@@ -5568,8 +5568,8 @@ DETAIL:  Feature not supported: Non-default collation
 (5 rows)
 
 explain (verbose, costs off) select * from ft3 where f2 COLLATE "C" = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     QUERY PLAN                     
 ---------------------------------------------------
  Foreign Scan on public.ft3
@@ -5580,8 +5580,8 @@ DETAIL:  Feature not supported: Non-default collation
 (5 rows)
 
 explain (verbose, costs off) select * from ft3 where f2 = 'foo' COLLATE "C";
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     QUERY PLAN                     
 ---------------------------------------------------
  Foreign Scan on public.ft3
@@ -5593,8 +5593,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 explain (verbose, costs off) select * from ft3 f, loct3 l
   where f.f3 = l.f3 COLLATE "POSIX" and l.f1 = 'foo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -5621,8 +5621,8 @@ DETAIL:  Feature not supported: Non-default collation
 -- ===================================================================
 EXPLAIN (verbose, costs off)
 INSERT INTO ft2 (c1,c2,c3) SELECT c1+1000,c2+100, c3 || c3 FROM ft2 LIMIT 20;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
                                                                                                                     QUERY PLAN                                                                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft2
@@ -5636,12 +5636,12 @@ DETAIL:  Feature not supported: Inserts with foreign tables
 (8 rows)
 
 INSERT INTO ft2 (c1,c2,c3) SELECT c1+1000,c2+100, c3 || c3 FROM ft2 LIMIT 20;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 INSERT INTO ft2 (c1,c2,c3)
   VALUES (1101,201,'aaa'), (1102,202,'bbb'), (1103,203,'ccc') RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2  | c3  | c4 | c5 | c6 |     c7     | c8 
 ------+-----+-----+----+----+----+------------+----
  1101 | 201 | aaa |    |    |    | ft2        | 
@@ -5650,12 +5650,12 @@ DETAIL:  Feature not supported: RETURNING clause
 (3 rows)
 
 INSERT INTO ft2 (c1,c2,c3) VALUES (1104,204,'ddd'), (1105,205,'eee');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = c2 + 300, c3 = c3 || '_update3' WHERE c1 % 10 = 3;              -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -5665,12 +5665,12 @@ DETAIL:  Feature not supported: Updates with foreign tables
 (4 rows)
 
 UPDATE ft2 SET c2 = c2 + 300, c3 = c3 || '_update3' WHERE c1 % 10 = 3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = c2 + 400, c3 = c3 || '_update7' WHERE c1 % 10 = 7 RETURNING *;  -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -5681,8 +5681,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (5 rows)
 
 UPDATE ft2 SET c2 = c2 + 400, c3 = c3 || '_update7' WHERE c1 % 10 = 7 RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2  |         c3         |              c4              |            c5            | c6 |     c7     | c8  
 ------+-----+--------------------+------------------------------+--------------------------+----+------------+-----
     7 | 407 | 00007_update7      | Thu Jan 08 00:00:00 1970 PST | Thu Jan 08 00:00:00 1970 | 7  | 7          | foo
@@ -5792,8 +5792,8 @@ DETAIL:  Feature not supported: RETURNING clause
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c2 = ft2.c2 + 500, c3 = ft2.c3 || '_update9', c7 = DEFAULT
   FROM ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 9;                               -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                                                                                                    QUERY PLAN                                                                                                    
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -5804,12 +5804,12 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 UPDATE ft2 SET c2 = ft2.c2 + 500, c3 = ft2.c3 || '_update9', c7 = DEFAULT
   FROM ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 EXPLAIN (verbose, costs off)
   DELETE FROM ft2 WHERE c1 % 10 = 5 RETURNING c1, c4;                               -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Delete on public.ft2
@@ -5820,8 +5820,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (5 rows)
 
 DELETE FROM ft2 WHERE c1 % 10 = 5 RETURNING c1, c4;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  |              c4              
 ------+------------------------------
     5 | Tue Jan 06 00:00:00 1970 PST
@@ -5931,8 +5931,8 @@ DETAIL:  Feature not supported: RETURNING clause
 
 EXPLAIN (verbose, costs off)
 DELETE FROM ft2 USING ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 2;                -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Delete on public.ft2
@@ -5942,8 +5942,8 @@ DETAIL:  Feature not supported: Deletes with foreign tables
 (4 rows)
 
 DELETE FROM ft2 USING ft1 WHERE ft1.c1 = ft2.c2 AND ft1.c1 % 10 = 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 SELECT c1,c2,c3,c4 FROM ft2 ORDER BY c1;
   c1  | c2  |         c3         |              c4              
 ------+-----+--------------------+------------------------------
@@ -6770,8 +6770,8 @@ SELECT c1,c2,c3,c4 FROM ft2 ORDER BY c1;
 
 EXPLAIN (verbose, costs off)
 INSERT INTO ft2 (c1,c2,c3) VALUES (1200,999,'foo') RETURNING tableoid::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on public.ft2
@@ -6783,8 +6783,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (6 rows)
 
 INSERT INTO ft2 (c1,c2,c3) VALUES (1200,999,'foo') RETURNING tableoid::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  tableoid 
 ----------
  ft2
@@ -6792,8 +6792,8 @@ DETAIL:  Feature not supported: RETURNING clause
 
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c3 = 'bar' WHERE c1 = 1200 RETURNING tableoid::regclass;             -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Update on public.ft2
@@ -6804,8 +6804,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (5 rows)
 
 UPDATE ft2 SET c3 = 'bar' WHERE c1 = 1200 RETURNING tableoid::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  tableoid 
 ----------
  ft2
@@ -6813,8 +6813,8 @@ DETAIL:  Feature not supported: RETURNING clause
 
 EXPLAIN (verbose, costs off)
 DELETE FROM ft2 WHERE c1 = 1200 RETURNING tableoid::regclass;                       -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Delete on public.ft2
@@ -6825,8 +6825,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (5 rows)
 
 DELETE FROM ft2 WHERE c1 = 1200 RETURNING tableoid::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  tableoid 
 ----------
  ft2
@@ -6835,15 +6835,15 @@ DETAIL:  Feature not supported: RETURNING clause
 -- Test UPDATE/DELETE with RETURNING on a three-table join
 INSERT INTO ft2 (c1,c2,c3)
   SELECT id, id - 1200, to_char(id, 'FM00000') FROM generate_series(1201, 1300) id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c3 = 'foo'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c2 = ft4.c1
   RETURNING ft2, ft2.*, ft4, ft4.*;       -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                                                                                                                           QUERY PLAN                                                                                                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -6857,8 +6857,8 @@ UPDATE ft2 SET c3 = 'foo'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c2 = ft4.c1
   RETURNING ft2, ft2.*, ft4, ft4.*;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
               ft2               |  c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 |      ft4       | c1 | c2 |   c3   
 --------------------------------+------+----+-----+----+----+----+------------+----+----------------+----+----+--------
  (1206,6,foo,,,,"ft2       ",)  | 1206 |  6 | foo |    |    |    | ft2        |    | (6,7,AAA006)   |  6 |  7 | AAA006
@@ -6884,8 +6884,8 @@ DELETE FROM ft2
   USING ft4 LEFT JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c1 % 10 = 0 AND ft2.c2 = ft4.c1
   RETURNING 100;                          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                                             QUERY PLAN                                                                                             
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Delete on public.ft2
@@ -6899,8 +6899,8 @@ DELETE FROM ft2
   USING ft4 LEFT JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 1200 AND ft2.c1 % 10 = 0 AND ft2.c2 = ft4.c1
   RETURNING 100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  ?column? 
 ----------
       100
@@ -6916,8 +6916,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (10 rows)
 
 DELETE FROM ft2 WHERE ft2.c1 > 1200;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test UPDATE with a MULTIEXPR sub-select
 -- (maybe someday this'll be remotely executable, but not today)
 EXPLAIN (verbose, costs off)
@@ -6926,8 +6926,8 @@ UPDATE ft2 AS target SET (c2, c7) = (
         FROM ft2 AS src
         WHERE target.c1 = src.c1
 ) WHERE c1 > 1100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2 target
@@ -6947,26 +6947,26 @@ UPDATE ft2 AS target SET (c2, c7) = (
         FROM ft2 AS src
         WHERE target.c1 = src.c1
 ) WHERE c1 > 1100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 UPDATE ft2 AS target SET (c2) = (
     SELECT c2 / 10
         FROM ft2 AS src
         WHERE target.c1 = src.c1
 ) WHERE c1 > 1100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 -- Test UPDATE/DELETE with WHERE or JOIN/ON conditions containing
 -- user-defined operators/functions
 ALTER SERVER pgserver OPTIONS (DROP extensions);
 INSERT INTO ft2 (c1,c2,c3)
   SELECT id, id % 10, to_char(id, 'FM00000') FROM generate_series(2001, 2010) id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 EXPLAIN (verbose, costs off)
 UPDATE ft2 SET c3 = 'bar' WHERE postgres_fdw_abs(c1) > 2000 RETURNING *;            -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -6980,10 +6980,10 @@ DETAIL:  Feature not supported: RETURNING clause
 (8 rows)
 
 UPDATE ft2 SET c3 = 'bar' WHERE postgres_fdw_abs(c1) > 2000 RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
   c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 
 ------+----+-----+----+----+----+------------+----
  2001 |  1 | bar |    |    |    | ft2        | 
@@ -7003,8 +7003,8 @@ UPDATE ft2 SET c3 = 'baz'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 === ft4.c1
   RETURNING ft2.*, ft4.*, ft5.*;                                                    -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                                                                                     QUERY PLAN                                                                                                                                     
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.ft2
@@ -7040,8 +7040,8 @@ UPDATE ft2 SET c3 = 'baz'
   FROM ft4 INNER JOIN ft5 ON (ft4.c1 = ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 === ft4.c1
   RETURNING ft2.*, ft4.*, ft5.*;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2 | c3  | c4 | c5 | c6 |     c7     | c8 | c1 | c2 |   c3   | c1 | c2 |   c3   
 ------+----+-----+----+----+----+------------+----+----+----+--------+----+----+--------
  2006 |  6 | baz |    |    |    | ft2        |    |  6 |  7 | AAA006 |  6 |  7 | AAA006
@@ -7052,8 +7052,8 @@ DELETE FROM ft2
   USING ft4 INNER JOIN ft5 ON (ft4.c1 === ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 = ft4.c1
   RETURNING ft2.c1, ft2.c2, ft2.c3;       -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                                                                                                                                                                      QUERY PLAN                                                                                                                                                                     
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Delete on public.ft2
@@ -7089,16 +7089,16 @@ DELETE FROM ft2
   USING ft4 INNER JOIN ft5 ON (ft4.c1 === ft5.c1)
   WHERE ft2.c1 > 2000 AND ft2.c2 = ft4.c1
   RETURNING ft2.c1, ft2.c2, ft2.c3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2 | c3  
 ------+----+-----
  2006 |  6 | baz
 (1 row)
 
 DELETE FROM ft2 WHERE ft2.c1 > 2000;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 ALTER SERVER pgserver OPTIONS (ADD extensions 'postgres_fdw');
 -- Test that trigger on remote table works as expected
 -- CREATE OR REPLACE FUNCTION "S 1".F_BRTRIG() RETURNS trigger AS $$
@@ -7112,24 +7112,24 @@ CREATE TRIGGER
 -- CREATE TRIGGER t1_br_insert BEFORE INSERT OR UPDATE
 --    ON "S 1"."T 1" FOR EACH ROW EXECUTE PROCEDURE "S 1".F_BRTRIG();
 INSERT INTO ft2 (c1,c2,c3) VALUES (1208, 818, 'fff') RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2  |       c3        | c4 | c5 | c6 |     c7     | c8 
 ------+-----+-----------------+----+----+----+------------+----
  1208 | 818 | fff_trig_update |    |    |    | ft2        | 
 (1 row)
 
 INSERT INTO ft2 (c1,c2,c3,c6) VALUES (1218, 818, 'ggg', '(--;') RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2  |       c3        | c4 | c5 |  c6  |     c7     | c8 
 ------+-----+-----------------+----+----+------+------------+----
  1218 | 818 | ggg_trig_update |    |    | (--; | ft2        | 
 (1 row)
 
 UPDATE ft2 SET c2 = c2 + 600 WHERE c1 % 10 = 8 AND c1 < 1200 RETURNING *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
   c1  | c2  |           c3           |              c4              |            c5            | c6 |     c7     | c8  
 ------+-----+------------------------+------------------------------+--------------------------+----+------------+-----
     8 | 608 | 00008_trig_update      | Fri Jan 09 00:00:00 1970 PST | Fri Jan 09 00:00:00 1970 | 8  | 8          | foo
@@ -7241,31 +7241,31 @@ DETAIL:  Feature not supported: RETURNING clause
 ALTER TABLE
 -- ALTER TABLE "S 1"."T 1" ADD CONSTRAINT c2positive CHECK (c2 >= 0);
 INSERT INTO ft1(c1, c2) VALUES(11, 12);  -- duplicate key
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 ERROR:  duplicate key value violates unique constraint "t1_pkey"
 DETAIL:  Key ("C 1")=(11) already exists.
 CONTEXT:  remote SQL command: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 INSERT INTO ft1(c1, c2) VALUES(11, 12) ON CONFLICT DO NOTHING; -- works
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 INSERT INTO ft1(c1, c2) VALUES(11, 12) ON CONFLICT (c1, c2) DO NOTHING; -- unsupported
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 INSERT INTO ft1(c1, c2) VALUES(11, 12) ON CONFLICT (c1, c2) DO UPDATE SET c3 = 'ffg'; -- unsupported
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 INSERT INTO ft1(c1, c2) VALUES(1111, -2);  -- c2positive
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
 DETAIL:  Failing row contains (1111, -2, null, null, null, null, ft1       , null).
 CONTEXT:  remote SQL command: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 UPDATE ft1 SET c2 = -c2 WHERE c1 = 1;  -- c2positive
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
 DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00+00, 1970-01-02 00:00:00, 1, 1         , foo).
 CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (- c2) WHERE (("C 1" = 1))
@@ -7309,8 +7309,8 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 -- select c2, count(*) from "S 1"."T 1" where c2 < 500 group by 1 order by 1;
 begin;
 update ft2 set c2 = 42 where c2 = 0;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
@@ -7331,8 +7331,8 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 
 savepoint s1;
 update ft2 set c2 = 44 where c2 = 4;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
@@ -7372,8 +7372,8 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 
 savepoint s2;
 update ft2 set c2 = 46 where c2 = 6;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
  c2  | count 
 -----+-------
@@ -7432,8 +7432,8 @@ select c2, count(*) from ft2 where c2 < 500 group by 1 order by 1;
 
 savepoint s3;
 update ft2 set c2 = -2 where c2 = 42 and c1 = 10; -- fail on remote side
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
 DETAIL:  Failing row contains (10, -2, 00010_trig_update_trig_update, 1970-01-11 08:00:00+00, 1970-01-11 00:00:00, 0, 0         , foo).
 CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (-2) WHERE ((c2 = 42)) AND (("C 1" = 10))
@@ -7672,14 +7672,14 @@ SET constraint_exclusion = 'off';
 -- RESET constraint_exclusion;
 -- check constraint is enforced on the remote side, not locally
 INSERT INTO ft1(c1, c2) VALUES(1111, -2);  -- c2positive
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
 DETAIL:  Failing row contains (1111, -2, null, null, null, null, ft1       , null).
 CONTEXT:  remote SQL command: INSERT INTO "S 1"."T 1"("C 1", c2, c3, c4, c5, c6, c7, c8) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 UPDATE ft1 SET c2 = -c2 WHERE c1 = 1;  -- c2positive
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 ERROR:  new row for relation "T 1" violates check constraint "c2positive"
 DETAIL:  Failing row contains (1, -1, 00001_trig_update, 1970-01-02 08:00:00+00, 1970-01-02 00:00:00, 1, 1         , foo).
 CONTEXT:  remote SQL command: UPDATE "S 1"."T 1" SET c2 = (- c2) WHERE (("C 1" = 1))
@@ -7726,11 +7726,11 @@ SELECT count(*) FROM ft1 WHERE c2 >= 0;
 SET constraint_exclusion = 'off';
 -- local check constraint is not actually enforced
 INSERT INTO ft1(c1, c2) VALUES(1111, 2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 UPDATE ft1 SET c2 = c2 + 1 WHERE c1 = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 ALTER FOREIGN TABLE ft1 DROP CONSTRAINT ft1_c2negative;
 -- ===================================================================
 -- test WITH CHECK OPTION constraints
@@ -7752,20 +7752,20 @@ CREATE FOREIGN TABLE foreign_tbl (a int, b int)
 CREATE VIEW rw_view AS SELECT * FROM foreign_tbl
   WHERE a < b WITH CHECK OPTION;
 \d+ rw_view
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                            View "public.rw_view"
  Column |  Type   | Collation | Nullable | Default | Storage | Description 
 --------+---------+-----------+----------+---------+---------+-------------
@@ -7780,8 +7780,8 @@ Options: check_option=cascaded
 
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 5);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Insert on public.foreign_tbl
@@ -7793,14 +7793,14 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (6 rows)
 
 INSERT INTO rw_view VALUES (0, 5); -- should fail
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 ERROR:  new row violates check option for view "rw_view"
 DETAIL:  Failing row contains (10, 5).
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 15);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Insert on public.foreign_tbl
@@ -7812,8 +7812,8 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (6 rows)
 
 INSERT INTO rw_view VALUES (0, 15); -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 SELECT * FROM foreign_tbl;
  a  | b  
 ----+----
@@ -7822,8 +7822,8 @@ SELECT * FROM foreign_tbl;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Update on public.foreign_tbl
@@ -7836,14 +7836,14 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (7 rows)
 
 UPDATE rw_view SET b = b + 5; -- should fail
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 ERROR:  new row violates check option for view "rw_view"
 DETAIL:  Failing row contains (20, 20).
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 15;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Update on public.foreign_tbl
@@ -7856,8 +7856,8 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (7 rows)
 
 UPDATE rw_view SET b = b + 15; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 SELECT * FROM foreign_tbl;
  a  | b  
 ----+----
@@ -7891,20 +7891,20 @@ ALTER TABLE parent_tbl ATTACH PARTITION foreign_tbl FOR VALUES FROM (0) TO (100)
 CREATE VIEW rw_view AS SELECT * FROM parent_tbl
   WHERE a < b WITH CHECK OPTION;
 \d+ rw_view
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                            View "public.rw_view"
  Column |  Type   | Collation | Nullable | Default | Storage | Description 
 --------+---------+-----------+----------+---------+---------+-------------
@@ -7919,8 +7919,8 @@ Options: check_option=cascaded
 
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 5);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                QUERY PLAN               
 ----------------------------------------
  Insert on public.parent_tbl
@@ -7931,14 +7931,14 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (5 rows)
 
 INSERT INTO rw_view VALUES (0, 5); -- should fail
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 ERROR:  new row violates check option for view "rw_view"  (seg1 127.0.0.1:7008 pid=3386)
 DETAIL:  Failing row contains (10, 5).
 EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO rw_view VALUES (0, 15);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                QUERY PLAN               
 ----------------------------------------
  Insert on public.parent_tbl
@@ -7949,8 +7949,8 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (5 rows)
 
 INSERT INTO rw_view VALUES (0, 15); -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 SELECT * FROM foreign_tbl;
  a  | b  
 ----+----
@@ -7959,8 +7959,8 @@ SELECT * FROM foreign_tbl;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Update on public.parent_tbl
@@ -7974,14 +7974,14 @@ DETAIL:  Feature not supported: View with WITH CHECK OPTION
 (8 rows)
 
 UPDATE rw_view SET b = b + 5; -- should fail
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
 ERROR:  new row violates check option for view "rw_view"  (seg1 127.0.0.1:7008 pid=3386)
 DETAIL:  Failing row contains (20, 20).
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE rw_view SET b = b + 15;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: View with WITH CHECK OPTION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: View with WITH CHECK OPTION
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Update on public.parent_tbl
@@ -8027,8 +8027,8 @@ ALTER TABLE
 create foreign table rem1 (f1 serial, f2 text)
   server pgserver options(table_name 'loc1');
 select pg_catalog.setval('rem1_f1_seq', 10, false);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  setval 
 --------
      10
@@ -8038,14 +8038,14 @@ DETAIL:  Feature not supported: SIRV functions
 INSERT 0 1
 -- insert into loc1(f2) values('hi');
 insert into rem1(f2) values('hi remote');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c "insert into loc1(f2) values('bye');"
 INSERT 0 1
 -- insert into loc1(f2) values('bye');
 insert into rem1(f2) values('bye remote');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'select * from loc1;'
  f1 |     f2     
 ----+------------
@@ -8082,8 +8082,8 @@ create foreign table grem1 (
   server pgserver options(table_name 'gloc1');
 explain (verbose, costs off)
 insert into grem1 (a) values (1), (2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Insert on public.grem1
@@ -8095,12 +8095,12 @@ DETAIL:  Feature not supported: Inserts with foreign tables
 (6 rows)
 
 insert into grem1 (a) values (1), (2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 explain (verbose, costs off)
 update grem1 set a = 22 where a = 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Update on public.grem1
@@ -8113,8 +8113,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 (7 rows)
 
 update grem1 set a = 22 where a = 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'select * from gloc1;'
  a  | b  
 ----+----
@@ -8131,8 +8131,8 @@ select * from grem1;
 (2 rows)
 
 delete from grem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- ===================================================================
 -- test local triggers
 -- ===================================================================
@@ -8195,82 +8195,82 @@ CREATE TRIGGER trig_row_after
 AFTER INSERT OR UPDATE OR DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 delete from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW DELETE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (1,hi)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW DELETE ON rem1
 NOTICE:  OLD: (10,"hi remote")
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW DELETE ON rem1
 NOTICE:  OLD: (2,bye)
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW DELETE ON rem1
 NOTICE:  OLD: (11,"bye remote")
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW DELETE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (1,hi)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW DELETE ON rem1
 NOTICE:  OLD: (10,"hi remote")
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW DELETE ON rem1
@@ -8278,26 +8278,26 @@ NOTICE:  OLD: (2,bye)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW DELETE ON rem1
 NOTICE:  OLD: (11,"bye remote")
 insert into rem1 values(1,'insert');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,insert)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,insert)
 update rem1 set f2  = 'update' where f1 = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW UPDATE ON rem1
 NOTICE:  OLD: (1,insert),NEW: (1,update)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW UPDATE ON rem1
 NOTICE:  OLD: (1,insert),NEW: (1,update)
 update rem1 set f2 = f2 || f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW UPDATE ON rem1
 NOTICE:  OLD: (1,update),NEW: (1,updateupdate)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW UPDATE ON rem1
@@ -8310,8 +8310,8 @@ DROP TRIGGER trig_row_after ON rem1;
 -- DROP TRIGGER trig_stmt_before ON rem1;
 -- DROP TRIGGER trig_stmt_after ON rem1;
 DELETE from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test multiple AFTER ROW triggers on a foreign table
 CREATE TRIGGER trig_row_after1
 AFTER INSERT OR UPDATE OR DELETE ON rem1
@@ -8320,97 +8320,97 @@ CREATE TRIGGER trig_row_after2
 AFTER INSERT OR UPDATE OR DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 insert into rem1 values(1,'insert');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after1(23, skidoo) AFTER ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,insert)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after2(23, skidoo) AFTER ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,insert)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 update rem1 set f2  = 'update' where f1 = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_after1(23, skidoo) AFTER ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (1,insert),NEW: (1,update)
 NOTICE:  trig_row_after2(23, skidoo) AFTER ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (1,insert),NEW: (1,update)
 update rem1 set f2 = f2 || f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_after1(23, skidoo) AFTER ROW UPDATE ON rem1
 NOTICE:  OLD: (1,update),NEW: (1,updateupdate)
 NOTICE:  trig_row_after2(23, skidoo) AFTER ROW UPDATE ON rem1
 NOTICE:  OLD: (1,update),NEW: (1,updateupdate)
 delete from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 NOTICE:  trig_row_after1(23, skidoo) AFTER ROW DELETE ON rem1
 NOTICE:  OLD: (1,updateupdate)
 NOTICE:  trig_row_after2(23, skidoo) AFTER ROW DELETE ON rem1
@@ -8431,93 +8431,93 @@ WHEN (NEW.f2 like '%update%')
 EXECUTE PROCEDURE trigger_data(23,'skidoo');
 -- Insert or update not matching: nothing happens
 INSERT INTO rem1 values(1, 'insert');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 UPDATE rem1 set f2 = 'test';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 -- Insert or update matching: triggers are fired
 INSERT INTO rem1 values(2, 'update');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before_insupd(23, skidoo) BEFORE ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (2,update)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after_insupd(23, skidoo) AFTER ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (2,update)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 UPDATE rem1 set f2 = 'update update' where f1 = '2';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_before_insupd(23, skidoo) BEFORE ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (2,update),NEW: (2,"update update")
 NOTICE:  trig_row_after_insupd(23, skidoo) AFTER ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (2,update),NEW: (2,"update update")
 CREATE TRIGGER trig_row_before_delete
 BEFORE DELETE ON rem1
@@ -8531,76 +8531,76 @@ WHEN (OLD.f2 like '%update%')
 EXECUTE PROCEDURE trigger_data(23,'skidoo');
 -- Trigger is fired for f1=2, not for f1=1
 DELETE FROM rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before_delete(23, skidoo) BEFORE ROW DELETE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (2,"update update")
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after_delete(23, skidoo) AFTER ROW DELETE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (2,"update update")
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 -- cleanup
 DROP TRIGGER trig_row_before_insupd ON rem1;
 DROP TRIGGER trig_row_after_insupd ON rem1;
@@ -8618,10 +8618,10 @@ BEFORE INSERT OR UPDATE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
 -- The new values should have 'triggered' appended
 INSERT INTO rem1 values(1, 'insert');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;'
  f1 |         f2         
 ----+--------------------
@@ -8630,8 +8630,8 @@ DETAIL:  Feature not supported: Query Parameter
 
 -- SELECT * from loc1;
 INSERT INTO rem1 values(2, 'insert') RETURNING f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
          f2         
 --------------------
  insert triggered !
@@ -8646,8 +8646,8 @@ DETAIL:  Feature not supported: RETURNING clause
 
 -- SELECT * from loc1;
 UPDATE rem1 set f2 = '';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;'
  f1 |      f2      
 ----+--------------
@@ -8657,8 +8657,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 -- SELECT * from loc1;
 UPDATE rem1 set f2 = 'skidoo' RETURNING f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
          f2         
 --------------------
  skidoo triggered !
@@ -8675,8 +8675,8 @@ DETAIL:  Feature not supported: RETURNING clause
 -- SELECT * from loc1;
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f1 = 10;          -- all columns should be transmitted
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Update on public.rem1
@@ -8689,8 +8689,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 (7 rows)
 
 UPDATE rem1 set f1 = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |               f2               
 ----+--------------------------------
@@ -8700,18 +8700,18 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 -- SELECT * from loc1;
 DELETE FROM rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Add a second trigger, to check that the changes are propagated correctly
 -- from trigger to trigger
 CREATE TRIGGER trig_row_before_insupd2
 BEFORE INSERT OR UPDATE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
 INSERT INTO rem1 values(1, 'insert');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |               f2               
 ----+--------------------------------
@@ -8720,8 +8720,8 @@ DETAIL:  Feature not supported: Query Parameter
 
 -- SELECT * from loc1;
 INSERT INTO rem1 values(2, 'insert') RETURNING f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                f2               
 --------------------------------
  insert triggered ! triggered !
@@ -8736,8 +8736,8 @@ DETAIL:  Feature not supported: RETURNING clause
 
 -- SELECT * from loc1;
 UPDATE rem1 set f2 = '';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |            f2            
 ----+--------------------------
@@ -8747,8 +8747,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 -- SELECT * from loc1;
 UPDATE rem1 set f2 = 'skidoo' RETURNING f2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
                f2               
 --------------------------------
  skidoo triggered ! triggered !
@@ -8766,11 +8766,11 @@ DETAIL:  Feature not supported: RETURNING clause
 DROP TRIGGER trig_row_before_insupd ON rem1;
 DROP TRIGGER trig_row_before_insupd2 ON rem1;
 DELETE from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 INSERT INTO rem1 VALUES (1, 'test');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 -- Test with a trigger returning NULL
 CREATE FUNCTION trig_null() RETURNS TRIGGER AS $$
   BEGIN
@@ -8782,8 +8782,8 @@ BEFORE INSERT OR UPDATE OR DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trig_null();
 -- Nothing should have changed.
 INSERT INTO rem1 VALUES (2, 'test2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |  f2  
 ----+------
@@ -8792,8 +8792,8 @@ DETAIL:  Feature not supported: Inserts with foreign tables
 
 -- SELECT * from loc1;
 UPDATE rem1 SET f2 = 'test2';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |  f2  
 ----+------
@@ -8802,8 +8802,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 -- SELECT * from loc1;
 DELETE from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'SELECT * from loc1;' 
  f1 |  f2  
 ----+------
@@ -8813,8 +8813,8 @@ DETAIL:  Feature not supported: Deletes with foreign tables
 -- SELECT * from loc1;
 DROP TRIGGER trig_null ON rem1;
 DELETE from rem1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test a combination of local and remote triggers
 CREATE TRIGGER trig_row_before
 BEFORE INSERT OR UPDATE OR DELETE ON rem1
@@ -8827,91 +8827,91 @@ CREATE TRIGGER
 -- CREATE TRIGGER trig_local_before BEFORE INSERT OR UPDATE ON loc1
 -- FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
 INSERT INTO rem1(f2) VALUES ('test');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (12,test)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW INSERT ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (12,"test triggered !")
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 UPDATE rem1 SET f2 = 'testo';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (12,"test triggered !"),NEW: (12,testo)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW UPDATE ON rem1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  OLD: (12,"test triggered !"),NEW: (12,"testo triggered !")
 -- Test returning a system attribute
 INSERT INTO rem1(f2) VALUES ('test') RETURNING ctid;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem1
 NOTICE:  NEW: (13,test)
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW INSERT ON rem1
@@ -8936,8 +8936,8 @@ DROP TRIGGER
 --	FOR EACH STATEMENT EXECUTE PROCEDURE trigger_func();
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -8949,8 +8949,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -8968,8 +8968,8 @@ DETAIL:  Feature not supported: Deletes with foreign tables
 --	FOR EACH STATEMENT EXECUTE PROCEDURE trigger_func();
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -8981,8 +8981,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -8999,8 +8999,8 @@ BEFORE INSERT ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -9012,8 +9012,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -9029,8 +9029,8 @@ AFTER INSERT ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -9042,8 +9042,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -9060,8 +9060,8 @@ BEFORE UPDATE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Update on public.rem1
@@ -9075,8 +9075,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -9092,8 +9092,8 @@ AFTER UPDATE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Update on public.rem1
@@ -9107,8 +9107,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                  QUERY PLAN                  
 ---------------------------------------------
  Delete on public.rem1
@@ -9125,8 +9125,8 @@ BEFORE DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -9138,8 +9138,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                              QUERY PLAN                              
 ---------------------------------------------------------------------
  Delete on public.rem1
@@ -9157,8 +9157,8 @@ AFTER DELETE ON rem1
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 EXPLAIN (verbose, costs off)
 UPDATE rem1 set f2 = '';          -- can be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
                         QUERY PLAN                        
 ----------------------------------------------------------
  Update on public.rem1
@@ -9170,8 +9170,8 @@ DETAIL:  Feature not supported: Updates with foreign tables
 
 EXPLAIN (verbose, costs off)
 DELETE FROM rem1;                 -- can't be pushed down
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Delete on public.rem1
@@ -9201,26 +9201,26 @@ ALTER TABLE
 CREATE FOREIGN TABLE b (bb TEXT) INHERITS (a)
   SERVER pgserver OPTIONS (table_name 'loct');
 INSERT INTO a(aa) VALUES('aaa');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 INSERT INTO a(aa) VALUES('aaaa');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 INSERT INTO a(aa) VALUES('aaaaa');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 INSERT INTO b(aa) VALUES('bbb');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 INSERT INTO b(aa) VALUES('bbbb');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 INSERT INTO b(aa) VALUES('bbbbb');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 SELECT tableoid::regclass, * FROM a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid |  aa   
 ----------+-------
  a        | aaa
@@ -9240,8 +9240,8 @@ SELECT tableoid::regclass, * FROM b;
 (3 rows)
 
 SELECT tableoid::regclass, * FROM ONLY a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  tableoid |  aa   
 ----------+-------
  a        | aaa
@@ -9258,11 +9258,11 @@ SELECT tableoid::regclass, * FROM b;
 SELECT tableoid::regclass, * FROM ONLY a;
 */
 UPDATE b SET aa = 'new';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Updates with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Updates with foreign tables
 SELECT tableoid::regclass, * FROM a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid |  aa   
 ----------+-------
  a        | aaa
@@ -9282,8 +9282,8 @@ SELECT tableoid::regclass, * FROM b;
 (3 rows)
 
 SELECT tableoid::regclass, * FROM ONLY a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  tableoid |  aa   
 ----------+-------
  a        | aaa
@@ -9345,39 +9345,39 @@ WARNING:  autovacuum is not supported in Greenplum
 alter table bar set (autovacuum_enabled = 'false');
 WARNING:  autovacuum is not supported in Greenplum
 insert into foo values(1,1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into foo values(3,3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into foo2 values(2,2,2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into foo2 values(4,4,4);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into bar values(1,11);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into bar values(2,22);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into bar values(6,66);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into bar2 values(3,33,33);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into bar2 values(4,44,44);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into bar2 values(7,77,77);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 explain (verbose, costs off)
 select * from bar where f1 in (select f1 from foo) for update;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Hash Join
@@ -9410,8 +9410,8 @@ DETAIL:  Feature not supported: Inherited tables
 (27 rows)
 
 select * from bar where f1 in (select f1 from foo) for update;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  f1 | f2 
 ----+----
   2 | 22
@@ -9422,8 +9422,8 @@ DETAIL:  Feature not supported: Inherited tables
 
 explain (verbose, costs off)
 select * from bar where f1 in (select f1 from foo) for share;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Hash Join
@@ -9456,8 +9456,8 @@ DETAIL:  Feature not supported: Inherited tables
 (27 rows)
 
 select * from bar where f1 in (select f1 from foo) for share;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  f1 | f2 
 ----+----
   2 | 22
@@ -9523,8 +9523,8 @@ INSERT 0 1001
 \set num_rows_foo 2000
 insert into loct1 select generate_series(0, :num_rows_foo, 2), generate_series(0, :num_rows_foo, 2), generate_series(0, :num_rows_foo, 2);
 insert into foo select generate_series(1, :num_rows_foo, 2), generate_series(1, :num_rows_foo, 2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 SET enable_hashjoin to false;
 SET enable_nestloop to false;
 SET enable_mergejoin to true;
@@ -9538,8 +9538,8 @@ analyze loct1;
 -- inner join; expressions in the clauses appear in the equivalence class list
 explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit
@@ -9575,8 +9575,8 @@ DETAIL:  Feature not supported: Inherited tables
 (30 rows)
 
 select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  f1 | f1 
 ----+----
  20 | 20
@@ -9595,8 +9595,8 @@ DETAIL:  Feature not supported: Inherited tables
 -- list but no output change as compared to the previous query
 explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit
@@ -9632,8 +9632,8 @@ DETAIL:  Feature not supported: Inherited tables
 (30 rows)
 
 select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  f1 | f1 
 ----+----
  10 | 10
@@ -9719,17 +9719,17 @@ create foreign table remt2 (a int, b text)
   server pgserver options (table_name 'loct2');
 alter foreign table remt1 inherit parent;
 insert into remt1 values (1, 'foo');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into remt1 values (2, 'bar');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into remt2 values (1, 'foo');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 insert into remt2 values (2, 'bar');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inserts with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inserts with foreign tables
 analyze remt1;
 analyze remt2;
 -- Greenplum don't support that ModifyTable mixes distributed and entry-only tables.
@@ -9770,30 +9770,30 @@ create foreign table remp2 (b text, a int check (a in (2))) server pgserver opti
 alter table itrtest attach partition remp1 for values in (1);
 alter table itrtest attach partition remp2 for values in (2);
 insert into itrtest values (1, 'foo');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
 insert into itrtest values (1, 'bar') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |  b  
 ---+-----
  1 | bar
 (1 row)
 
 insert into itrtest values (2, 'baz');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
 insert into itrtest values (2, 'qux') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |  b  
 ---+-----
  2 | qux
 (1 row)
 
 insert into itrtest values (1, 'test1'), (2, 'test2') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |   b   
 ---+-------
  2 | test2
@@ -9840,28 +9840,28 @@ CREATE INDEX
 -- create unique index loct1_idx on loct1 (a);
 -- DO NOTHING without an inference specification is supported
 insert into itrtest values (1, 'foo') on conflict do nothing returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |  b  
 ---+-----
  1 | foo
 (1 row)
 
 insert into itrtest values (1, 'foo') on conflict do nothing returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a | b 
 ---+---
 (0 rows)
 
 -- But other cases are not supported
 insert into itrtest values (1, 'bar') on conflict (a) do nothing;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 insert into itrtest values (1, 'bar') on conflict (a) do update set b = excluded.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 select tableoid::regclass, * FROM itrtest;
  tableoid | a |  b  
@@ -9893,24 +9893,24 @@ CREATE TRIGGER
 -- 	for each row execute procedure br_insert_trigfunc();
 -- The new values are concatenated with ' triggered !'
 insert into itrtest values (1, 'foo') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |        b        
 ---+-----------------
  1 | foo triggered !
 (1 row)
 
 insert into itrtest values (2, 'qux') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |        b        
 ---+-----------------
  2 | qux triggered !
 (1 row)
 
 insert into itrtest values (1, 'test1'), (2, 'test2') returning *;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |         b         
 ---+-------------------
  2 | test2 triggered !
@@ -9918,8 +9918,8 @@ DETAIL:  Feature not supported: RETURNING clause
 (2 rows)
 
 with result as (insert into itrtest values (1, 'test1'), (2, 'test2') returning *) select * from result;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  a |         b         
 ---+-------------------
  2 | test2 triggered !
@@ -10117,8 +10117,8 @@ select * from rem2;
 (2 rows)
 
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test check constraints
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'alter table loc2 add constraint loc2_f1positive check (f1 >= 0);'
 ALTER TABLE
@@ -10143,8 +10143,8 @@ alter foreign table rem2 drop constraint rem2_f1positive;
 ALTER TABLE
 -- alter table loc2 drop constraint loc2_f1positive;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- In greenplum, Triggers for statements are not yet supported.
 -- So SQLs below are disable here.
 -- Test local triggers
@@ -10159,76 +10159,76 @@ create trigger trig_row_before before insert on rem2
 create trigger trig_row_after after insert on rem2
 	for each row execute procedure trigger_data(23,'skidoo');
 copy rem2 from stdin;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,foo)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem2
 NOTICE:  NEW: (2,bar)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW INSERT ON rem2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,foo)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  trig_row_after(23, skidoo) AFTER ROW INSERT ON rem2
 NOTICE:  NEW: (2,bar)
 select * from rem2;
@@ -10245,14 +10245,14 @@ drop trigger trig_stmt_before on rem2;
 drop trigger trig_stmt_after on rem2;
 */
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 create trigger trig_row_before_insert before insert on rem2
 	for each row execute procedure trig_row_before_insupdate();
 -- The new values are concatenated with ' triggered !'
 copy rem2 from stdin;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 select * from rem2;
  f1 |       f2        
 ----+-----------------
@@ -10262,8 +10262,8 @@ select * from rem2;
 
 drop trigger trig_row_before_insert on rem2;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 create trigger trig_null before insert on rem2
 	for each row execute procedure trig_null();
 -- Nothing happens
@@ -10275,8 +10275,8 @@ select * from rem2;
 
 drop trigger trig_null on rem2;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test remote triggers
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'create trigger trig_row_before_insert before insert on loc2 for each row execute procedure trig_row_before_insupdate();'
 CREATE TRIGGER
@@ -10295,8 +10295,8 @@ select * from rem2;
 DROP TRIGGER
 -- drop trigger trig_row_before_insert on loc2;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'create trigger trig_null before insert on loc2 for each row execute procedure trig_null();'
 CREATE TRIGGER
 -- create trigger trig_null before insert on loc2
@@ -10312,8 +10312,8 @@ select * from rem2;
 DROP TRIGGER
 -- drop trigger trig_null on loc2;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- Test a combination of local and remote triggers
 create trigger rem2_trig_row_before before insert on rem2
 	for each row execute procedure trigger_data(23,'skidoo');
@@ -10324,76 +10324,76 @@ CREATE TRIGGER
 -- create trigger loc2_trig_row_before_insert before insert on loc2
 --	for each row execute procedure trig_row_before_insupdate();
 copy rem2 from stdin;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  rem2_trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,foo)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  rem2_trig_row_before(23, skidoo) BEFORE ROW INSERT ON rem2
 NOTICE:  NEW: (2,bar)
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  rem2_trig_row_after(23, skidoo) AFTER ROW INSERT ON rem2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  NEW: (1,"foo triggered !")
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  rem2_trig_row_after(23, skidoo) AFTER ROW INSERT ON rem2
 NOTICE:  NEW: (2,"bar triggered !")
 select * from rem2;
@@ -10409,8 +10409,8 @@ drop trigger rem2_trig_row_after on rem2;
 DROP TRIGGER
 -- drop trigger loc2_trig_row_before_insert on loc2;
 delete from rem2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Deletes with foreign tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Deletes with foreign tables
 -- test COPY FROM with foreign table created in the same transaction
 \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -c 'create table loc3 (f1 int, f2 text);'
 CREATE TABLE
@@ -10472,8 +10472,8 @@ CREATE TYPE typ1 AS (m1 int, m2 varchar);
 CREATE SCHEMA import_dest1;
 IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO import_dest1;
 \det+ import_dest1.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      List of foreign tables
     Schema    | Table |  Server  |                   FDW options                   | Description 
 --------------+-------+----------+-------------------------------------------------+-------------
@@ -10487,26 +10487,26 @@ DETAIL:  Feature not supported: Non-default collation
 (7 rows)
 
 \d import_dest1.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest1.t1"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10515,24 +10515,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't1')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest1.t2"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10542,24 +10542,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't2')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                              Foreign table "import_dest1.t3"
  Column |           Type           | Collation | Nullable | Default |    FDW options     
 --------+--------------------------+-----------+----------+---------+--------------------
@@ -10568,24 +10568,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't3')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     Foreign table "import_dest1.t4"
  Column |  Type   | Collation | Nullable | Default |    FDW options     
 --------+---------+-----------+----------+---------+--------------------
@@ -10593,24 +10593,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Foreign table "import_dest1.x 4"
  Column |         Type          | Collation | Nullable | Default |     FDW options     
 --------+-----------------------+-----------+----------+---------+---------------------
@@ -10620,48 +10620,48 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                Foreign table "import_dest1.x 5"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   Foreign table "import_dest1.x 6"
  Column |  Type   | Collation | Nullable |               Default               |    FDW options     
 --------+---------+-----------+----------+-------------------------------------+--------------------
@@ -10675,8 +10675,8 @@ CREATE SCHEMA import_dest2;
 IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO import_dest2
   OPTIONS (import_default 'true');
 \det+ import_dest2.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      List of foreign tables
     Schema    | Table |  Server  |                   FDW options                   | Description 
 --------------+-------+----------+-------------------------------------------------+-------------
@@ -10690,26 +10690,26 @@ DETAIL:  Feature not supported: Non-default collation
 (7 rows)
 
 \d import_dest2.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest2.t1"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10718,24 +10718,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't1')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest2.t2"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10745,24 +10745,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't2')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                              Foreign table "import_dest2.t3"
  Column |           Type           | Collation | Nullable | Default |    FDW options     
 --------+--------------------------+-----------+----------+---------+--------------------
@@ -10771,24 +10771,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't3')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     Foreign table "import_dest2.t4"
  Column |  Type   | Collation | Nullable | Default |    FDW options     
 --------+---------+-----------+----------+---------+--------------------
@@ -10796,24 +10796,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Foreign table "import_dest2.x 4"
  Column |         Type          | Collation | Nullable | Default |     FDW options     
 --------+-----------------------+-----------+----------+---------+---------------------
@@ -10823,48 +10823,48 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                Foreign table "import_dest2.x 5"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                   Foreign table "import_dest2.x 6"
  Column |  Type   | Collation | Nullable |               Default               |    FDW options     
 --------+---------+-----------+----------+-------------------------------------+--------------------
@@ -10877,8 +10877,8 @@ CREATE SCHEMA import_dest3;
 IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO import_dest3
   OPTIONS (import_collate 'false', import_generated 'false', import_not_null 'false');
 \det+ import_dest3.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      List of foreign tables
     Schema    | Table |  Server  |                   FDW options                   | Description 
 --------------+-------+----------+-------------------------------------------------+-------------
@@ -10892,26 +10892,26 @@ DETAIL:  Feature not supported: Non-default collation
 (7 rows)
 
 \d import_dest3.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest3.t1"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10920,24 +10920,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't1')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                          Foreign table "import_dest3.t2"
  Column |       Type        | Collation | Nullable | Default |    FDW options     
 --------+-------------------+-----------+----------+---------+--------------------
@@ -10947,24 +10947,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't2')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                              Foreign table "import_dest3.t3"
  Column |           Type           | Collation | Nullable | Default |    FDW options     
 --------+--------------------------+-----------+----------+---------+--------------------
@@ -10973,24 +10973,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't3')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     Foreign table "import_dest3.t4"
  Column |  Type   | Collation | Nullable | Default |    FDW options     
 --------+---------+-----------+----------+---------+--------------------
@@ -10998,24 +10998,24 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 't4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Foreign table "import_dest3.x 4"
  Column |         Type          | Collation | Nullable | Default |     FDW options     
 --------+-----------------------+-----------+----------+---------+---------------------
@@ -11025,48 +11025,48 @@ DETAIL:  Feature not supported: Non-default collation
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 4')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                Foreign table "import_dest3.x 5"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
 Server: pgserver
 FDW options: (schema_name 'import_source', table_name 'x 5')
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                     Foreign table "import_dest3.x 6"
  Column |  Type   | Collation | Nullable | Default |    FDW options     
 --------+---------+-----------+----------+---------+--------------------
@@ -11080,8 +11080,8 @@ CREATE SCHEMA import_dest4;
 IMPORT FOREIGN SCHEMA import_source LIMIT TO (t1, nonesuch)
   FROM SERVER pgserver INTO import_dest4;
 \det+ import_dest4.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      List of foreign tables
     Schema    | Table |  Server  |                  FDW options                   | Description 
 --------------+-------+----------+------------------------------------------------+-------------
@@ -11091,8 +11091,8 @@ DETAIL:  Feature not supported: Non-default collation
 IMPORT FOREIGN SCHEMA import_source EXCEPT (t1, "x 4", nonesuch)
   FROM SERVER pgserver INTO import_dest4;
 \det+ import_dest4.*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      List of foreign tables
     Schema    | Table |  Server  |                   FDW options                   | Description 
 --------------+-------+----------+-------------------------------------------------+-------------
@@ -11144,8 +11144,8 @@ SELECT count(*)
 FROM pg_foreign_server
 WHERE srvname = 'fetch101'
 AND srvoptions @> array['fetch_size=101'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      1
@@ -11156,8 +11156,8 @@ SELECT count(*)
 FROM pg_foreign_server
 WHERE srvname = 'fetch101'
 AND srvoptions @> array['fetch_size=101'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      0
@@ -11167,8 +11167,8 @@ SELECT count(*)
 FROM pg_foreign_server
 WHERE srvname = 'fetch101'
 AND srvoptions @> array['fetch_size=202'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      1
@@ -11179,8 +11179,8 @@ SELECT COUNT(*)
 FROM pg_foreign_table
 WHERE ftrelid = 'table30000'::regclass
 AND ftoptions @> array['fetch_size=30000'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      1
@@ -11191,8 +11191,8 @@ SELECT COUNT(*)
 FROM pg_foreign_table
 WHERE ftrelid = 'table30000'::regclass
 AND ftoptions @> array['fetch_size=30000'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      0
@@ -11202,8 +11202,8 @@ SELECT COUNT(*)
 FROM pg_foreign_table
 WHERE ftrelid = 'table30000'::regclass
 AND ftoptions @> array['fetch_size=60000'];
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
      1
@@ -11290,8 +11290,8 @@ ANALYZE fprt2;
 -- inner join three tables
 EXPLAIN (COSTS OFF)
 SELECT t1.a,t2.b,t3.c FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) INNER JOIN fprt1 t3 ON (t2.b = t3.a) WHERE t1.a % 25 =0 ORDER BY 1,2,3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Sort
@@ -11305,8 +11305,8 @@ DETAIL:  No plan has been computed for required properties
 (8 rows)
 
 SELECT t1.a,t2.b,t3.c FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) INNER JOIN fprt1 t3 ON (t2.b = t3.a) WHERE t1.a % 25 =0 ORDER BY 1,2,3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
   a  |  b  |  c   
 -----+-----+------
    0 |   0 | 0000
@@ -11362,8 +11362,8 @@ SELECT t1.a,t2.b,t2.c FROM fprt1 t1 LEFT JOIN (SELECT * FROM fprt2 WHERE a < 10)
 -- with whole-row reference; partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.wr, t2.wr FROM (SELECT t1 wr, a FROM fprt1 t1 WHERE t1.a % 25 = 0) t1 FULL JOIN (SELECT t2 wr, b FROM fprt2 t2 WHERE t2.b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                        QUERY PLAN                       
 --------------------------------------------------------
  Sort
@@ -11381,8 +11381,8 @@ DETAIL:  Feature not supported: Whole-row variable
 (12 rows)
 
 SELECT t1.wr, t2.wr FROM (SELECT t1 wr, a FROM fprt1 t1 WHERE t1.a % 25 = 0) t1 FULL JOIN (SELECT t2 wr, b FROM fprt2 t2 WHERE t2.b % 25 = 0) t2 ON (t1.a = t2.b) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
        wr       |       wr       
 ----------------+----------------
  (0,0,0000)     | (0,0,0000)
@@ -11404,8 +11404,8 @@ DETAIL:  Feature not supported: Whole-row variable
 -- join with lateral reference
 EXPLAIN (COSTS OFF)
 SELECT t1.a,t1.b FROM fprt1 t1, LATERAL (SELECT t2.a, t2.b FROM fprt2 t2 WHERE t1.a = t2.b AND t1.b = t2.a) q WHERE t1.a%25 = 0 ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Sort
@@ -11419,8 +11419,8 @@ DETAIL:  Feature not supported: LATERAL
 (8 rows)
 
 SELECT t1.a,t1.b FROM fprt1 t1, LATERAL (SELECT t2.a, t2.b FROM fprt2 t2 WHERE t1.a = t2.b AND t1.b = t2.a) q WHERE t1.a%25 = 0 ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
   a  |  b  
 -----+-----
    0 |   0
@@ -11482,8 +11482,8 @@ SELECT t1.a, t1.phv, t2.b, t2.phv FROM (SELECT 't1_phv' phv, * FROM fprt1 WHERE 
 -- test FOR UPDATE; partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t2.b FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) WHERE t1.a % 25 = 0 ORDER BY 1,2 FOR UPDATE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                           QUERY PLAN                          
 --------------------------------------------------------------
  Sort
@@ -11503,8 +11503,8 @@ DETAIL:  No plan has been computed for required properties
 (14 rows)
 
 SELECT t1.a, t2.b FROM fprt1 t1 INNER JOIN fprt2 t2 ON (t1.a = t2.b) WHERE t1.a % 25 = 0 ORDER BY 1,2 FOR UPDATE OF t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
 WARNING:  partition selector was not fully executed
   a  |  b  
 -----+-----
@@ -11607,8 +11607,8 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
 -- Should have all the columns in the target list for the given relation
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Sort
@@ -11641,8 +11641,8 @@ DETAIL:  Feature not supported: Whole-row variable
 (27 rows)
 
 SELECT a, count(t1) FROM pagg_tab t1 GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
  a  | count 
 ----+-------
   0 |   100

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -982,10 +982,10 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	 * don't match the built-in defaults.
 	 */
 	if (queryDesc->plannedstmt->planGen == PLANGEN_PLANNER)
-		ExplainPropertyStringInfo("Optimizer", es, "Postgres query optimizer");
+		ExplainPropertyStringInfo("Optimizer", es, "Postgres-based planner");
 #ifdef USE_ORCA
 	else
-		ExplainPropertyStringInfo("Optimizer", es, "Pivotal Optimizer (GPORCA)");
+		ExplainPropertyStringInfo("Optimizer", es, "GPORCA");
 #endif
 
 	ExplainPrintSettings(es);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17343,7 +17343,7 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 
 		/* Step (a) */
 		/*
-		 * Force the use of Postgres query optimizer, since Pivotal Optimizer (GPORCA) will not
+		 * Force the use of Postgres based planner, since GPORCA will not
 		 * redistribute the tuples if the current and required distributions
 		 * are both RANDOM even when reorganize is set to "true"
 		 */
@@ -18066,7 +18066,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			/*
 			 * Make sure the redistribution happens for a randomly distributed table.
 			 *
-			 * Force the use of Postgres query optimizer, since Pivotal Optimizer (GPORCA) will not
+			 * Force the use of Postgres based planner, since GPORCA will not
 			 * redistribute the tuples if the current and required distributions
 			 * are both RANDOM even when reorganize is set to "true"
 			 * Also set gp_force_random_redistribution to true.

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -87,7 +87,7 @@ CGPOptimizer::GPOPTOptimizedPlan(
 			{
 				errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
 				errmsg(
-					"GPORCA failed to produce a plan, falling back to planner");
+					"GPORCA failed to produce a plan, falling back to Postgres-based planner");
 				if (serialized_error_msg)
 				{
 					errdetail("%s", serialized_error_msg);

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -69,55 +69,11 @@ CGPOptimizer::GPOPTOptimizedPlan(
 
 		// Special handler for a few common user-facing errors. In particular,
 		// we want to use the correct error code for these, in case an application
-		// tries to do something smart with them. Also, ERRCODE_INTERNAL_ERROR
-		// is handled specially in elog.c, and we don't want that for "normal"
-		// application errors.
-		if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
-						  gpdxl::ExmiQuery2DXLNotNullViolation))
-		{
-			if (errstart(ERROR, TEXTDOMAIN))
-			{
-				errcode(ERRCODE_NOT_NULL_VIOLATION);
-				errmsg("%s", serialized_error_msg);
-				errfinish(ex.Filename(), ex.Line(), nullptr);
-			}
-		}
+		// tries to do something smart with them.
 
-		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError) ||
-				 gpopt_context.m_should_error_out)
-		{
-			Assert(nullptr != serialized_error_msg);
-			if (errstart(ERROR, TEXTDOMAIN))
-			{
-				errcode(ERRCODE_INTERNAL_ERROR);
-				errmsg("%s", serialized_error_msg);
-				errfinish(ex.Filename(), ex.Line(), nullptr);
-			}
-		}
-		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
 			PG_RE_THROW();
-		}
-		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
-							   gpdxl::ExmiNoAvailableMemory))
-		{
-			if (errstart(ERROR, TEXTDOMAIN))
-			{
-				errcode(ERRCODE_INTERNAL_ERROR);
-				errmsg("no available memory to allocate string buffer");
-				errfinish(ex.Filename(), ex.Line(), nullptr);
-			}
-		}
-		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
-							   gpdxl::ExmiInvalidComparisonTypeCode))
-		{
-			if (errstart(ERROR, TEXTDOMAIN))
-			{
-				errcode(ERRCODE_INTERNAL_ERROR);
-				errmsg(
-					"invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq.");
-				errfinish(ex.Filename(), ex.Line(), nullptr);
-			}
 		}
 
 		// Failed to produce a plan, but it wasn't an error that should

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -455,7 +455,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarArrayCompToScalar(
 
 		default:
 			GPOS_RAISE(
-				gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+				gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
 				GPOS_WSZ_LIT(
 					"Scalar Array Comparison: Specified operator type is invalid"));
 	}
@@ -585,7 +585,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarAggrefToScalar(
 			break;
 		default:
 			GPOS_RAISE(
-				gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+				gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
 				GPOS_WSZ_LIT("AGGREF: Specified AggStage value is invalid"));
 	}
 

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -769,14 +769,14 @@ CTranslatorScalarToDXL::TranslateBoolExprToDXL(
 	if ((NOT_EXPR != bool_expr->boolop) && (2 > count))
 	{
 		GPOS_RAISE(
-			gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT(
 				"Boolean Expression (OR / AND): Incorrect Number of Children "));
 	}
 	else if ((NOT_EXPR == bool_expr->boolop) && (1 != count))
 	{
 		GPOS_RAISE(
-			gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT(
 				"Boolean Expression (NOT): Incorrect Number of Children "));
 	}
@@ -988,8 +988,8 @@ CTranslatorScalarToDXL::TranslateCaseExprToDXL(
 
 	if (nullptr == case_expr->args)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
-				   GPOS_WSZ_LIT("Do not support SIMPLE CASE STATEMENT"));
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+				   GPOS_WSZ_LIT("Case statement with no arguments"));
 		return nullptr;
 	}
 
@@ -1591,7 +1591,7 @@ CTranslatorScalarToDXL::TranslateWindowFrameToDXL(
 	}
 	else
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("Unrecognized window frame option"));
 	}
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -817,7 +817,7 @@ CTranslatorUtils::OidCmpOperator(Expr *expr)
 			return LInitialOID(((RowCompareExpr *) expr)->opnos);
 
 		default:
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion,
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
 					   GPOS_WSZ_LIT("Unsupported comparison"));
 			return InvalidOid;
 	}

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -619,7 +619,6 @@ COptTasks::OptimizeTask(void *ptr)
 
 		IErrorContext *errctxt = CTask::Self()->GetErrCtxt();
 
-		opt_ctxt->m_should_error_out = ShouldErrorOut(ex);
 		opt_ctxt->m_is_unexpected_failure = IsLoggableFailure(ex);
 		opt_ctxt->m_error_msg =
 			CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg());

--- a/src/backend/gporca/libgpopt/src/exception.cpp
+++ b/src/backend/gporca/libgpopt/src/exception.cpp
@@ -68,20 +68,20 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 					   gpopt::ExmiUnsupportedCompositePartKey),
 			CException::ExsevNotice,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by the Pivotal Query Optimizer: composite partitioning keys"),
+				"Feature not supported by GPORCA: composite partitioning keys"),
 			0,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by the Pivotal Query Optimizer: composite partitioning keys")),
+				"Feature not supported by GPORCA: composite partitioning keys")),
 
 		CMessage(
 			CException(gpopt::ExmaGPOPT,
 					   gpopt::ExmiUnsupportedNonDeterministicUpdate),
 			CException::ExsevNotice,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by the Pivotal Query Optimizer: non-deterministic DML statements"),
+				"Feature not supported by GPORCA: non-deterministic DML statements"),
 			0,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by the Pivotal Query Optimizer: non-deterministic DML statements")),
+				"Feature not supported by GPORCA: non-deterministic DML statements")),
 
 		CMessage(CException(gpopt::ExmaGPOPT,
 							gpopt::ExmiUnsatisfiedRequiredProperties),

--- a/src/backend/gporca/libgpopt/src/exception.cpp
+++ b/src/backend/gporca/libgpopt/src/exception.cpp
@@ -31,11 +31,12 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 	// Basic DXL messages in English
 	//---------------------------------------------------------------------------
 	CMessage rgmsg[ExmiSentinel] = {
-		CMessage(CException(gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound),
-				 CException::ExsevError,
-				 GPOS_WSZ_WSZLEN(
-					 "No plan has been computed for required properties"),
-				 0, GPOS_WSZ_WSZLEN("No plan found")),
+		CMessage(
+			CException(gpopt::ExmaGPOPT, gpopt::ExmiNoPlanFound),
+			CException::ExsevError,
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA"),
+			0, GPOS_WSZ_WSZLEN("No plan found")),
 
 		CMessage(
 			CException(gpopt::ExmaGPOPT, gpopt::ExmiInvalidPlanAlternative),
@@ -68,27 +69,30 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 					   gpopt::ExmiUnsupportedCompositePartKey),
 			CException::ExsevNotice,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by GPORCA: composite partitioning keys"),
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: composite partitioning keys"),
 			0,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by GPORCA: composite partitioning keys")),
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: composite partitioning keys")),
 
 		CMessage(
 			CException(gpopt::ExmaGPOPT,
 					   gpopt::ExmiUnsupportedNonDeterministicUpdate),
 			CException::ExsevNotice,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by GPORCA: non-deterministic DML statements"),
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: non-deterministic DML statements"),
 			0,
 			GPOS_WSZ_WSZLEN(
-				"Feature not supported by GPORCA: non-deterministic DML statements")),
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: non-deterministic DML statements")),
 
-		CMessage(CException(gpopt::ExmaGPOPT,
-							gpopt::ExmiUnsatisfiedRequiredProperties),
-				 CException::ExsevError,
-				 GPOS_WSZ_WSZLEN("Plan does not satisfy required properties"),
-				 0,
-				 GPOS_WSZ_WSZLEN("Plan does not satisfy required properties")),
+		CMessage(
+			CException(gpopt::ExmaGPOPT,
+					   gpopt::ExmiUnsatisfiedRequiredProperties),
+			CException::ExsevError,
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because plan does not satisfy required properties in GPORCA"),
+			0,
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because plan does not satisfy required properties in GPORCA")),
 
 		CMessage(
 			CException(gpopt::ExmaGPOPT, gpopt::ExmiEvalUnsupportedScalarExpr),

--- a/src/backend/gporca/libgpos/include/gpos/_api.h
+++ b/src/backend/gporca/libgpos/include/gpos/_api.h
@@ -32,9 +32,6 @@ gpos::BOOL FoundException(gpos::CException &exc, const gpos::ULONG *exceptions,
 // produce a plan
 gpos::BOOL IsLoggableFailure(gpos::CException &exc);
 
-// check if given exception should error out
-gpos::BOOL ShouldErrorOut(gpos::CException &exc);
-
 
 extern "C" {
 #include <stddef.h>

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -53,8 +53,6 @@ const ULONG expected_dxl_fallback[] = {
 	gpdxl::
 		ExmiQuery2DXLUnsupportedFeature,  // unsupported feature during algebrization
 	gpdxl::
-		ExmiPlStmt2DXLConversion,  // unsupported feature during plan freezing
-	gpdxl::
 		ExmiDXL2PlStmtConversion,  // unsupported feature during planned statement translation
 	gpdxl::ExmiDXL2ExprAttributeNotFound,
 	gpdxl::ExmiDXLMissingAttribute,

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -57,30 +57,12 @@ const ULONG expected_dxl_fallback[] = {
 	gpdxl::
 		ExmiDXL2PlStmtConversion,  // unsupported feature during planned statement translation
 	gpdxl::ExmiDXL2ExprAttributeNotFound,
-	gpdxl::ExmiOptimizerError,
 	gpdxl::ExmiDXLMissingAttribute,
 	gpdxl::ExmiDXLUnrecognizedOperator,
 	gpdxl::ExmiDXLUnrecognizedCompOperator,
 	gpdxl::ExmiDXLIncorrectNumberOfChildren,
-	gpdxl::ExmiQuery2DXLMissingValue,
-	gpdxl::ExmiQuery2DXLDuplicateRTE,
 	gpdxl::ExmiMDCacheEntryNotFound,
-	gpdxl::ExmiQuery2DXLError,
-	gpdxl::ExmiInvalidComparisonTypeCode};
-
-// array of DXL minor exception types that error out and NOT fallback to the planner
-const ULONG expected_dxl_errors[] = {
-	gpdxl::ExmiDXL2PlStmtForeignScanError,	// foreign table error
-	gpdxl::ExmiQuery2DXLNotNullViolation,	// not null violation
-};
-
-BOOL
-ShouldErrorOut(gpos::CException &exc)
-{
-	return gpdxl::ExmaDXL == exc.Major() &&
-		   FoundException(exc, expected_dxl_errors,
-						  GPOS_ARRAY_SIZE(expected_dxl_errors));
-}
+	gpdxl::ExmiQuery2DXLError};
 
 gpos::BOOL
 FoundException(gpos::CException &exc, const gpos::ULONG *exceptions,

--- a/src/backend/gporca/libnaucrates/include/naucrates/exception.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/exception.h
@@ -43,13 +43,8 @@ enum ExMinor
 	ExmiDXLIncorrectNumberOfChildren,
 	ExmiPlStmt2DXLConversion,
 	ExmiDXL2PlStmtConversion,
-	ExmiDXL2PlStmtForeignScanError,
-	ExmiDXL2PlStmtMissingPlanForSubPlanTranslation,
 	ExmiQuery2DXLAttributeNotFound,
 	ExmiQuery2DXLUnsupportedFeature,
-	ExmiQuery2DXLDuplicateRTE,
-	ExmiQuery2DXLMissingValue,
-	ExmiQuery2DXLNotNullViolation,
 	ExmiQuery2DXLError,
 	ExmiExpr2DXLUnsupportedFeature,
 	ExmiExpr2DXLAttributeNotFound,
@@ -61,20 +56,11 @@ enum ExMinor
 	ExmiMDCacheEntryNotFound,
 	ExmiMDObjUnsupported,
 
-	// communication related errors
-	ExmiCommPropagateError,
-	ExmiCommUnexpectedMessage,
-
 	// GPDB-related exceptions
 	ExmiGPDBError,
 
 	// exceptions related to constant expression evaluation
 	ExmiConstExprEvalNonConst,
-
-	// ORCA Exceptions that need to be reported as ERROR to GPDB
-	ExmiOptimizerError,
-	ExmiNoAvailableMemory,
-	ExmiInvalidComparisonTypeCode,
 
 	ExmiDXLSentinel
 };

--- a/src/backend/gporca/libnaucrates/include/naucrates/exception.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/exception.h
@@ -41,7 +41,6 @@ enum ExMinor
 	ExmiDXLValidationError,
 	ExmiDXLXercesParseError,
 	ExmiDXLIncorrectNumberOfChildren,
-	ExmiPlStmt2DXLConversion,
 	ExmiDXL2PlStmtConversion,
 	ExmiQuery2DXLAttributeNotFound,
 	ExmiQuery2DXLUnsupportedFeature,

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -153,7 +153,7 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiExpr2DXLUnsupportedFeature),
-			CException::ExsevError,
+			CException::ExsevNotice,
 			GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
 			1,	// feature name
 			GPOS_WSZ_WSZLEN("Feature not supported")),

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -94,11 +94,14 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			0,	//
 			GPOS_WSZ_WSZLEN("Incorrect Number of children")),
 
-		CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion),
-				 CException::ExsevNotice,
-				 GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
-				 1,	 //
-				 GPOS_WSZ_WSZLEN("Feature not supported")),
+		CMessage(
+			CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion),
+			CException::ExsevNotice,
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: %ls"),
+			1,	//
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support this feature")),
 
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound),
@@ -112,9 +115,11 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature),
 			CException::ExsevNotice,
-			GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: %ls"),
 			1,	//
-			GPOS_WSZ_WSZLEN("Feature not supported")),
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support this feature.")),
 
 		// MD related messages
 		CMessage(
@@ -131,11 +136,14 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 				 1,	 // mdid
 				 GPOS_WSZ_WSZLEN("Lookup of object in cache failed")),
 
-		CMessage(CException(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported),
-				 CException::ExsevNotice,
-				 GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
-				 1,	 // md obj
-				 GPOS_WSZ_WSZLEN("Feature not supported")),
+		CMessage(
+			CException(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported),
+			CException::ExsevNotice,
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: %ls"),
+			1,	// md obj
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support this feature")),
 
 		CMessage(CException(gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError),
 				 CException::ExsevError, GPOS_WSZ_WSZLEN("PG exception raised"),
@@ -154,9 +162,11 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiExpr2DXLUnsupportedFeature),
 			CException::ExsevNotice,
-			GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support the following feature: %ls"),
 			1,	// feature name
-			GPOS_WSZ_WSZLEN("Feature not supported")),
+			GPOS_WSZ_WSZLEN(
+				"Falling back to Postgres-based planner because GPORCA does not support this feature")),
 
 		CMessage(
 			CException(gpdxl::ExmaConstExprEval,

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -94,19 +94,11 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			0,	//
 			GPOS_WSZ_WSZLEN("Incorrect Number of children")),
 
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN("GPDB Expression type: %ls not supported in DXL"),
-			1,	//
-			GPOS_WSZ_WSZLEN("GPDB Expression type not supported in DXL")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN("DXL-to-PlStmt Translation: %ls not supported"),
-			1,	//
-			GPOS_WSZ_WSZLEN("DXL-to-PlStmt Translation not supported")),
+		CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion),
+				 CException::ExsevNotice,
+				 GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
+				 1,	 //
+				 GPOS_WSZ_WSZLEN("Feature not supported")),
 
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound),
@@ -164,7 +156,7 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			CException::ExsevError,
 			GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
 			1,	// feature name
-			GPOS_WSZ_WSZLEN("Feature not supported: %ls")),
+			GPOS_WSZ_WSZLEN("Feature not supported")),
 
 		CMessage(
 			CException(gpdxl::ExmaConstExprEval,

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -102,27 +102,11 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			GPOS_WSZ_WSZLEN("GPDB Expression type not supported in DXL")),
 
 		CMessage(
-			CException(gpdxl::ExmaDXL,
-					   gpdxl::ExmiDXL2PlStmtMissingPlanForSubPlanTranslation),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN(
-				"DXL-to-PlStmt: Missing Plan During SubPlan Translation"),
-			0,	//
-			GPOS_WSZ_WSZLEN(
-				"DXL-to-PlStmt: Missing Plan During SubPlan Translation")),
-
-		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion),
 			CException::ExsevError,
 			GPOS_WSZ_WSZLEN("DXL-to-PlStmt Translation: %ls not supported"),
 			1,	//
 			GPOS_WSZ_WSZLEN("DXL-to-PlStmt Translation not supported")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtForeignScanError),
-			CException::ExsevError, GPOS_WSZ_WSZLEN("Foreign scan error: %ls"),
-			1,	//
-			GPOS_WSZ_WSZLEN("Foreign scan error")),
 
 		CMessage(
 			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLAttributeNotFound),
@@ -139,29 +123,6 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
 			1,	//
 			GPOS_WSZ_WSZLEN("Feature not supported")),
-
-		CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLMissingValue),
-				 CException::ExsevError,
-				 GPOS_WSZ_WSZLEN("Query-to-DXL Translation: Missing %ls value"),
-				 1,	 //
-				 GPOS_WSZ_WSZLEN("Query-to-DXL Translation: Missing value")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN(
-				"null value in column \"%ls\" violates not-null constraint"),
-			1,	//
-			GPOS_WSZ_WSZLEN(
-				"null value in column violates not-null constraint")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLDuplicateRTE),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN(
-				"DXL-to-Query: Duplicate range table entry at query level %d at position %d"),
-			2,	// query level and var no
-			GPOS_WSZ_WSZLEN("DXL-to-Query: Duplicate range table entry")),
 
 		// MD related messages
 		CMessage(
@@ -183,18 +144,6 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 				 GPOS_WSZ_WSZLEN("Feature not supported: %ls"),
 				 1,	 // md obj
 				 GPOS_WSZ_WSZLEN("Feature not supported")),
-
-		CMessage(CException(gpdxl::ExmaComm, gpdxl::ExmiCommPropagateError),
-				 CException::ExsevError, GPOS_WSZ_WSZLEN("%S"),
-				 1,	 // message
-				 GPOS_WSZ_WSZLEN("Propagate remote exception")),
-
-		CMessage(
-			CException(gpdxl::ExmaComm, gpdxl::ExmiCommPropagateError),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN("Received unexpected message type from OPT: %d"),
-			1,	// type
-			GPOS_WSZ_WSZLEN("Received unexpected message type from OPT")),
 
 		CMessage(CException(gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError),
 				 CException::ExsevError, GPOS_WSZ_WSZLEN("PG exception raised"),
@@ -253,29 +202,6 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 			1,	// attno
 			GPOS_WSZ_WSZLEN(
 				"DXL-to-Expr Translation: Attribute number not found in project list")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError),
-			CException::ExsevError, GPOS_WSZ_WSZLEN("%s"),
-			1,	// attno
-			GPOS_WSZ_WSZLEN(
-				"PQO unable to generate a plan, please see the above message for details.")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiNoAvailableMemory),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN("No available memory to allocate string buffer."),
-			0,
-			GPOS_WSZ_WSZLEN("No available memory to allocate string buffer.")),
-
-		CMessage(
-			CException(gpdxl::ExmaDXL, gpdxl::ExmiInvalidComparisonTypeCode),
-			CException::ExsevError,
-			GPOS_WSZ_WSZLEN(
-				"Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq."),
-			0,
-			GPOS_WSZ_WSZLEN(
-				"Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq."))
 
 	};
 

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -71,11 +71,11 @@ log_optimizer(PlannedStmt *plan, bool fUnexpectedFailure)
 	{
 		if (fUnexpectedFailure)
 		{
-			elog(LOG, "Pivotal Optimizer (GPORCA) failed to produce plan (unexpected)");
+			elog(LOG, "GPORCA failed to produce plan (unexpected)");
 		}
 		else
 		{
-			elog(LOG, "Pivotal Optimizer (GPORCA) failed to produce plan");
+			elog(LOG, "GPORCA failed to produce plan");
 		}
 		return;
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2255,7 +2255,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"optimizer_enable_hashagg", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use hash aggregates."),
+			gettext_noop("Enables GPORCA to use hash aggregates."),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},
@@ -2266,7 +2266,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"optimizer_enable_groupagg", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use group aggregates."),
+			gettext_noop("Enables GPORCA to use group aggregates."),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},
@@ -2597,7 +2597,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"optimizer_enable_dml", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enable DML plans in Pivotal Optimizer (GPORCA)."),
+			gettext_noop("Enable DML plans in GPORCA."),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -88,10 +88,6 @@ struct SOptContext
 	// did the optimizer fail unexpectedly?
 	BOOL m_is_unexpected_failure{false};
 
-	// should the error be propagated to user, instead of falling back to the
-	// Postres planner?
-	BOOL m_should_error_out{false};
-
 	// buffer for optimizer error messages
 	CHAR *m_error_msg{nullptr};
 

--- a/src/test/isolation/expected/drop-index-concurrently-1.out
+++ b/src/test/isolation/expected/drop-index-concurrently-1.out
@@ -18,7 +18,7 @@ Sort
   Sort Key: id                                
   ->  Index Scan using test_dc_data on test_dc
         Index Cond: (data = 34)               
-Optimizer: Postgres query optimizer           
+Optimizer: Postgres-based planner             
 (5 rows)
 
 step explains: EXPLAIN (COSTS OFF) EXECUTE getrow_seq;
@@ -28,7 +28,7 @@ Sort
   Sort Key: id, data                       
   ->  Seq Scan on test_dc                  
         Filter: ((data)::text = '34'::text)
-Optimizer: Postgres query optimizer        
+Optimizer: Postgres-based planner          
 (5 rows)
 
 step select2: SELECT * FROM test_dc WHERE data=34 ORDER BY id,data;

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -992,8 +992,8 @@ END;
 $$ LANGUAGE plpgsql;
 --
 SELECT InsertManyIntoSales(20,'sales_par_CO');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1010,8 +1010,8 @@ delete from sales;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
 SELECT InsertManyIntoSales(40,'sales');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1135,8 +1135,8 @@ delete from sales_par;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
 SELECT InsertManyIntoSales(20,'sales_par');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1214,13 +1214,13 @@ select s.* from s, r,sales_par where s.a = r.b and s.b = sales_par.id;
 delete from r;
 delete from s;
 delete from sales_par2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
 SELECT InsertManyIntoSales(20,'sales_par2');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1228,8 +1228,8 @@ DETAIL:  Feature not supported: SIRV functions
 
 -- partition key
 select sales_par2.* from sales_par2,s,r where sales_par2.id = s.b and sales_par2.month = r.b+1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  id | year | month | day |  region   
 ----+------+-------+-----+-----------
   3 | 2005 |     4 |   4 | australia
@@ -1240,11 +1240,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (5 rows)
 
 update sales_par2 set month = month+1 from r,s where sales_par2.id = s.b and sales_par2.month = r.b+1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select sales_par2.* from sales_par2,s,r where sales_par2.id = s.b and sales_par2.month = r.b+2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  id | year | month | day |  region   
 ----+------+-------+-----+-----------
   9 | 2004 |    11 |  10 | europe
@@ -1256,11 +1256,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 
 PREPARE plan0 as update sales_par2 set month = month+1 from r,s where sales_par2.id = s.b and sales_par2.month = r.b+2;
 EXECUTE plan0;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select sales_par2.* from sales_par2,s,r where sales_par2.id = s.b and sales_par2.month = r.b+3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  id | year | month | day |  region   
 ----+------+-------+-----+-----------
   9 | 2004 |    12 |  10 | europe
@@ -1271,8 +1271,8 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (5 rows)
 
 select sales_par2.* from sales_par2 where id in (select s.b-1 from s,r where s.a = r.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  id | year | month | day | region 
 ----+------+-------+-----+--------
  17 | 2005 |     6 |  18 | europe
@@ -1280,19 +1280,19 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (2 rows)
 
 delete from sales_par2 where id in (select s.b-1 from s,r where s.a = r.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select sales_par2.* from sales_par2 where id in (select s.b-1 from s,r where s.a = r.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  id | year | month | day | region 
 ----+------+-------+-----+--------
 (0 rows)
 
 -- heap table
 select s.* from s, r,sales_par2 where s.a = r.b and s.b = sales_par2.id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b  
 ---+----
  3 |  9
@@ -1300,11 +1300,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (2 rows)
 
 delete from s using r,sales_par2 where s.a = r.b and s.b = sales_par2.id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select s.* from s, r,sales_par2 where s.a = r.b and s.b = sales_par2.id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b 
 ---+---
 (0 rows)
@@ -1323,8 +1323,8 @@ create table s_ao (a int, b int) with (appendonly = true) distributed by (a);
 insert into s_ao select generate_series(1, 100), generate_series(1, 100) * 3;
 -- heap table: delete --
 select * from r where b in (select month-1 from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b 
 ---+---
  3 | 9
@@ -1333,27 +1333,27 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (3 rows)
 
 delete from r where b in (select month-1 from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select * from r where b in (select month-1 from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b 
 ---+---
 (0 rows)
 
 -- hdeap table: update: duplicate distribution key -- 
 SELECT InsertManyIntoSales(20,'sales_par_CO');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
 (1 row)
 
 select * from r where a in (select sales_par_CO.id from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a  | b  
 ----+----
   6 | 18
@@ -1364,11 +1364,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (5 rows)
 
 update r set b = r.b + 1 where a in (select sales_par_CO.id from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select * from r where a in (select sales_par_CO.id from sales_par_CO, s_ao where sales_par_CO.id = s_ao.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a  | b  
 ----+----
  15 | 46
@@ -1380,8 +1380,8 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 
 -- heap table: delete:
 select * from r where a in (select month from sales_par_CO, s_ao, s where sales_par_CO.id = s_ao.b and s_ao.a = s.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a  | b  
 ----+----
   7 | 21
@@ -1389,11 +1389,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (2 rows)
 
 delete from r where a in (select month from sales_par_CO, s_ao, s where sales_par_CO.id = s_ao.b and s_ao.a = s.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select * from r where a in (select month from sales_par_CO, s_ao, s where sales_par_CO.id = s_ao.b and s_ao.a = s.b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b 
 ---+---
 (0 rows)
@@ -1409,8 +1409,8 @@ insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
 insert into s select generate_series(1, 10), generate_series(1, 10) * 4;
 insert into m select generate_series(1, 1000), generate_series(1, 1000) * 4;
 SELECT InsertManyIntoSales(20,'sales_par');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1507,8 +1507,8 @@ insert into s select generate_series(1, 100), generate_series(1, 100) * 3;
 insert into s select generate_series(1, 10), generate_series(1, 10) * 4;
 insert into m select generate_series(1, 1000), generate_series(1, 1000) * 4;
 SELECT InsertManyIntoSales(20,'sales_par');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  insertmanyintosales 
 ---------------------
  
@@ -1660,17 +1660,17 @@ analyze tab3;
 -- the `::regclass` way as it only matches the table in current search_path.
 set allow_system_table_mods=true;
 update pg_class set relpages = 10000 where oid='tab2'::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 update pg_class set reltuples = 100000000 where oid='tab2'::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 update pg_class set relpages = 100000000 where oid='tab3'::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 update pg_class set reltuples = 100000 where oid='tab3'::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 -- Planner: there is redistribute motion above tab1, however, we can also
 -- remove the explicit redistribute motion here because the final join
 -- co-locate with the result relation tab1.

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -27,8 +27,8 @@ SELECT avg(b)::numeric(10,3) AS avg_107_943 FROM aggtest;
 (1 row)
 
 SELECT avg(gpa) AS avg_3_4 FROM ONLY student;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  avg_3_4 
 ---------
      3.4
@@ -53,8 +53,8 @@ SELECT sum(b) AS avg_431_773 FROM aggtest;
 (1 row)
 
 SELECT sum(gpa) AS avg_6_8 FROM ONLY student;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  avg_6_8 
 ---------
      6.8
@@ -79,8 +79,8 @@ SELECT max(aggtest.b) AS max_324_78 FROM aggtest;
 (1 row)
 
 SELECT max(student.gpa) AS max_3_7 FROM student;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  max_3_7 
 ---------
      3.7
@@ -571,8 +571,8 @@ SELECT oldcnt(*) AS cnt_1000 FROM onek;
 (1 row)
 
 SELECT sum2(q1,q2) FROM int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
        sum2        
 -------------------
  18271560493827981
@@ -605,7 +605,7 @@ LINE 4:                where sum(distinct a.four + b.four) = b.four)...
 select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1)))
 from tenk1 o;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  max  
 ------
@@ -620,8 +620,8 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -648,8 +648,8 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  s1 | s2 | sm 
 ----+----+----
   1 |  1 |  2
@@ -667,8 +667,8 @@ explain (verbose, costs off)
 select array(select sum(x+y) s
             from generate_series(1,3) y group by y order by s)
   from generate_series(1,3) x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Function Scan on pg_catalog.generate_series x
@@ -690,8 +690,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 select array(select sum(x+y) s
             from generate_series(1,3) y group by y order by s)
   from generate_series(1,3) x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
   array  
 ---------
  {2,3,4}
@@ -1142,8 +1142,8 @@ create index minmaxtest1i on minmaxtest1(f1);
 create index minmaxtest2i on minmaxtest2(f1 desc);
 create index minmaxtest3i on minmaxtest3(f1) where f1 is not null;
 insert into minmaxtest values(11), (12);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 insert into minmaxtest1 values(13), (14);
 insert into minmaxtest2 values(15), (16);
 insert into minmaxtest3 values(17), (18);
@@ -1154,8 +1154,8 @@ analyze minmaxtest3;
 set enable_seqscan=off;
 explain (costs off)
   select min(f1), max(f1) from minmaxtest;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Result
@@ -1189,8 +1189,8 @@ DETAIL:  Feature not supported: Inherited tables
 (30 rows)
 
 select min(f1), max(f1) from minmaxtest;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  min | max 
 -----+-----
   11 |  18
@@ -1200,8 +1200,8 @@ reset enable_seqscan;
 -- DISTINCT doesn't do anything useful here, but it shouldn't fail
 explain (costs off)
   select distinct min(f1), max(f1) from minmaxtest;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                           QUERY PLAN                          
 --------------------------------------------------------------
  Unique
@@ -1220,8 +1220,8 @@ DETAIL:  Feature not supported: Inherited tables
 (13 rows)
 
 select distinct min(f1), max(f1) from minmaxtest;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  min | max 
 -----+-----
   11 |  18
@@ -1318,8 +1318,8 @@ create temp table t1c () inherits (t1);
 NOTICE:  table has parent, setting distribution columns to match parent table
 -- Ensure we don't remove any columns when t1 has a child table
 explain (costs off) select * from t1 group by a,b,c,d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                 QUERY PLAN                 
 -------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1333,8 +1333,8 @@ DETAIL:  Feature not supported: Inherited tables
 
 -- Okay to remove columns if we're only querying the parent.
 explain (costs off) select * from only t1 group by a,b,c,d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1432,8 +1432,8 @@ select array_agg(distinct a order by a desc nulls last)
 -- multi-arg aggs, strict/nonstrict, distinct/order by
 select aggfstr(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -1442,8 +1442,8 @@ CONTEXT:  SQL function "aggf_trans" during startup
 
 select aggfns(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1453,8 +1453,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -1464,8 +1464,8 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1475,8 +1475,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfstr(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
@@ -1486,8 +1486,8 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1498,8 +1498,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by c using ~<~,a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1509,8 +1509,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by c using ~<~)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1520,8 +1520,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
@@ -1531,8 +1531,8 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,b,c order by a,c using ~<~,b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
@@ -1728,8 +1728,8 @@ select string_agg(distinct f1::text, ',' order by f1::text) from varchar_tbl;  -
 
 -- FILTER tests
 select min(unique1) filter (where unique1 > 100) from tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  min 
 -----
  101
@@ -1737,8 +1737,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
 group by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -1756,8 +1756,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select ten, sum(distinct four) filter (where four > 10) from onek a
 group by ten
 having exists (select 1 from onek b where sum(distinct a.four) = b.four);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -1769,8 +1769,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
 from (values ('a', 'b')) AS v(foo,bar);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  max 
 -----
  a
@@ -1789,8 +1789,8 @@ from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
 select (select count(*) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      2
@@ -1799,8 +1799,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select (select count(inner_c) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      1
@@ -1811,8 +1811,8 @@ select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1))
      filter (where o.unique1 < 10))
 from tenk1 o;					-- outer query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  max  
 ------
  9998
@@ -1821,8 +1821,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- subquery in FILTER clause (PostgreSQL extension)
 select sum(unique1) FILTER (WHERE
   unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum  
 ------
  4950
@@ -1832,10 +1832,10 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
     generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
           aggfns           
 ---------------------------
@@ -1962,8 +1962,8 @@ from generate_series(1,6) x;
 (1 row)
 
 select ten, mode() within group (order by string4) from tenk1 group by ten order by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  ten |  mode  
 -----+--------
    0 | HHHHxx
@@ -1988,8 +1988,8 @@ from unnest('{fred,jim,fred,jack,jill,fred,jill,jim,jim,sheila,jim,sheila}'::tex
 -- check collation propagates up in suitable cases:
 select pg_collation_for(percentile_disc(1) within group (order by x collate "POSIX"))
   from (values ('fred'),('jim')) v(x);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  pg_collation_for 
 ------------------
  "POSIX"
@@ -2087,8 +2087,8 @@ select pg_get_viewdef('aggordview1');
 (1 row)
 
 select * from aggordview1 order by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | p50 | px  | rank 
 -----+-----+-----+------
    0 | 490 |     |  101
@@ -2106,8 +2106,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 drop view aggordview1;
 -- variadic aggregates
 select least_agg(q1,q2) from int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "least_accum" during startup
      least_agg     
 -------------------
@@ -2115,8 +2115,8 @@ CONTEXT:  SQL function "least_accum" during startup
 (1 row)
 
 select least_agg(variadic array[q1,q2]) from int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
      least_agg     
 -------------------
  -4567890123456789
@@ -2161,16 +2161,16 @@ select string_agg(v, decode('ee', 'hex')) from bytea_test_table;
 drop table bytea_test_table;
 -- FILTER tests
 select min(unique1) filter (where unique1 > 100) from tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  min 
 -----
  101
 (1 row)
 
 select sum(1/ten) filter (where ten > 0) from tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum  
 ------
  1000
@@ -2178,8 +2178,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
 group by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -2197,8 +2197,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select ten, sum(distinct four) filter (where four > 10) from onek a
 group by ten
 having exists (select 1 from onek b where sum(distinct a.four) = b.four);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -2210,8 +2210,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
 from (values ('a', 'b')) AS v(foo,bar);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  max 
 -----
  a
@@ -2230,8 +2230,8 @@ from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
 select (select count(*) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- outer query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      2
@@ -2240,8 +2240,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select (select count(inner_c) filter (where outer_c <> 0)
         from (values (1)) t0(inner_c))
 from (values (2),(3)) t1(outer_c); -- inner query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count 
 -------
      1
@@ -2252,8 +2252,8 @@ select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1))
      filter (where o.unique1 < 10))
 from tenk1 o;					-- outer query is aggregation query
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  max  
 ------
  9998
@@ -2262,8 +2262,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 -- subquery in FILTER clause (PostgreSQL extension)
 select sum(unique1) FILTER (WHERE
   unique1 IN (SELECT unique1 FROM onek where unique1 < 100)) FROM tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum  
 ------
  4950
@@ -2273,10 +2273,10 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
     from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
     generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup
           aggfns           
 ---------------------------
@@ -2285,16 +2285,16 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 
 -- check handling of bare boolean Var in FILTER
 select max(0) filter (where b1) from bool_test;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  max 
 -----
    0
 (1 row)
 
 select (select max(0) filter (where b1)) from bool_test;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  max 
 -----
    0
@@ -2437,8 +2437,8 @@ from generate_series(1,6) x;
 (1 row)
 
 select ten, mode() within group (order by string4) from tenk1 group by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  ten |  mode  
 -----+--------
    0 | HHHHxx
@@ -2463,8 +2463,8 @@ from unnest('{fred,jim,fred,jack,jill,fred,jill,jim,jim,sheila,jim,sheila}'::tex
 -- check collation propagates up in suitable cases:
 select pg_collation_for(percentile_disc(1) within group (order by x collate "POSIX"))
   from (values ('fred'),('jim')) v(x);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  pg_collation_for 
 ------------------
  "POSIX"
@@ -2562,8 +2562,8 @@ select pg_get_viewdef('aggordview1');
 (1 row)
 
 select * from aggordview1 order by ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | p50 | px  | rank 
 -----+-----+-----+------
    0 | 490 |     |  101
@@ -2581,8 +2581,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 drop view aggordview1;
 -- variadic aggregates
 select least_agg(q1,q2) from int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "least_accum" during startup
      least_agg     
 -------------------
@@ -2590,8 +2590,8 @@ CONTEXT:  SQL function "least_accum" during startup
 (1 row)
 
 select least_agg(variadic array[q1,q2]) from int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
      least_agg     
 -------------------
  -4567890123456789
@@ -2657,26 +2657,26 @@ create aggregate my_sum(int4)
 discard plans;
 -- aggregate state should be shared as aggs are the same.
 select my_avg(one),my_avg(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_avg 
 --------+--------
       2 |      2
@@ -2685,30 +2685,30 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- aggregate state should be shared as transfn is the same for both aggs.
 select my_avg(one),my_sum(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_sum 
 --------+--------
       2 |      4
@@ -2717,30 +2717,30 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- same as previous one, but with DISTINCT, which requires sorting the input.
 select my_avg(distinct one),my_sum(distinct one) from (values(1),(3),(1)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_sum 
 --------+--------
       2 |      4
@@ -2749,32 +2749,32 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- shouldn't share states due to the distinctness not matching.
 select my_avg(distinct one),my_sum(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_sum 
 --------+--------
       2 |      4
@@ -2783,33 +2783,33 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- shouldn't share states due to the filter clause not matching.
 select my_avg(one) filter (where one > 1),my_sum(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_sum 
 --------+--------
       3 |      4
@@ -2818,32 +2818,32 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- this should not share the state due to different input columns.
 select my_avg(one),my_sum(two) from (values(1,2),(3,4)) t(one,two);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
 NOTICE:  avg_transfn called with 4
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_avg | my_sum 
 --------+--------
       2 |      6
@@ -2904,26 +2904,26 @@ create aggregate my_avg_init2(int4)
 discard plans;
 -- state should be shared if INITCONDs are matching
 select my_sum_init(one),my_avg_init(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_sum_init | my_avg_init 
 -------------+-------------
           14 |           7
@@ -2933,28 +2933,28 @@ DETAIL:  Feature not supported: Query Parameter
 discard plans;
 -- Varying INITCONDs should cause the states not to be shared.
 select my_sum_init(one),my_avg_init2(one) from (values(1),(3)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  avg_transfn called with 1
 NOTICE:  avg_transfn called with 3
 NOTICE:  avg_transfn called with 3
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_sum_init | my_avg_init2 
 -------------+--------------
           14 |            4
@@ -3007,26 +3007,26 @@ create aggregate my_half_sum(int4)
 discard plans;
 -- Agg state should be shared even though my_sum has no finalfn
 select my_sum(one),my_half_sum(one) from (values(1),(2),(3),(4)) t(one);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  sum_transfn called with 1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  sum_transfn called with 2
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 NOTICE:  sum_transfn called with 3
 NOTICE:  sum_transfn called with 4
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  my_sum | my_half_sum 
 --------+-------------
      10 |           5
@@ -3055,8 +3055,8 @@ CREATE AGGREGATE balk(int4)
     INITCOND = '0'
 );
 SELECT balk(hundred) FROM tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  balk 
 ------
      
@@ -3101,8 +3101,8 @@ EXPLAIN (COSTS OFF) SELECT balk(hundred) FROM tenk1;
 (5 rows)
 
 SELECT balk(hundred) FROM tenk1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  balk 
 ------
      
@@ -3126,8 +3126,8 @@ FROM (SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1) u;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                                                                       QUERY PLAN                                                                                       
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -3154,8 +3154,8 @@ FROM (SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1) u;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
        variance       |    sum    | regr_count 
 ----------------------+-----------+------------
  8333541.588539713493 | 199980000 |      40000
@@ -3169,8 +3169,8 @@ FROM (SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1) u;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -3197,8 +3197,8 @@ FROM (SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1
       UNION ALL SELECT * FROM tenk1) u;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
        variance       |          avg          
 ----------------------+-----------------------
  8333541.588539713493 | 4999.5000000000000000
@@ -3254,8 +3254,8 @@ select v||'a', case when v||'a' = 'aa' then 1 else 0 end, count(*)
 explain (costs off)
   select 1 from tenk1
    where (hundred, thousand) in (select twothousand, twothousand from onek);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3475,8 +3475,8 @@ drop table agg_hash_4;
 -- This test can be nondeterministic depending on the number of entries in pg_class
 set enable_indexonlyscan=off;
 explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=10000000047.27..10000000047.28 rows=1 width=8) (actual time=0.435..0.437 rows=1 loops=1)

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -5,7 +5,7 @@
 -- s/tableoid \d+/tableoid XXXXX/
 -- end_matchsubs
 -- start_matchignore
--- m/^LOG: .*Feature not supported: Queries on coordinator-only tables./
+-- m/^LOG: .*Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables./
 -- m/^LOG:.*ERROR,"PG exception raised"/
 -- end_matchignore
 set gp_autostats_mode=on_change;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -274,7 +274,7 @@ select max(b) over (partition by a) from foo order by 1;
  ccc
 (3 rows)
 
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'GPORCA');
  count_operator 
 ----------------
               0

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -273,7 +273,7 @@ select max(b) over (partition by a) from foo order by 1;
  ccc
 (3 rows)
 
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'GPORCA');
  count_operator 
 ----------------
               1

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -231,7 +231,7 @@ set optimizer_trace_fallback = on;
 -- Subquery that returns a row rather than a single scalar isn't supported
 -- in ORCA currently, so we can use that to trigger fallback.
 update update_pk_test set a=1 where row(1,2) = (SELECT 1, 2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 select * from update_pk_test order by 1,2;
  a | b 
 ---+---

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -839,7 +839,7 @@ select (select rn from (select row_number() over () as rn, name
 ,sum(sum(a.salary)) over()
 from t2_github_issue_10143 a
 group by a.code;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  dongnm | sum  
 --------+------

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -87,8 +87,8 @@ distributed by (subscription_id, bill_stmt_id)
     
 -- TEST
 select count_operator('select cust_type, subscription_status,count(distinct subscription_id),sum(voice_call_min),sum(minute_per_call) from mpp7980 where month_id =E''2009-04-01'' group by rollup(1,2);','SIGSEGV');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               0
@@ -132,8 +132,8 @@ insert into mpp23195_t1 values (generate_series(1,19));
 insert into mpp23195_t2 values (1);
 -- TEST
 select find_operator('select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;', 'Dynamic Index Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['true']
@@ -146,8 +146,8 @@ select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;
 
 vacuum mpp23195_t1;
 select find_operator('select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;', 'Dynamic Index Only Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
 NOTICE:  One or more columns in the following table(s) do not have statistics: mpp23195_t1
 HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
  find_operator 
@@ -190,16 +190,16 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- TEST
 set optimizer_enable_hashjoin = off;
 select find_operator('analyze select * from mpp21834_t2,mpp21834_t1 where mpp21834_t2.i < mpp21834_t1.i;','Dynamic Index Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['false']
 (1 row)
 
 select find_operator('analyze select * from mpp21834_t2,mpp21834_t1 where mpp21834_t2.i < mpp21834_t1.i;','Nested Loop');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['true']
@@ -233,8 +233,8 @@ insert into mpp23288(a) select generate_series(1,20);
 analyze mpp23288;
 -- TEST
 select count_operator('select t2.a, t1.a from mpp23288 as t1 join mpp23288 as t2 on (t1.a < t2.a and t2.a =10) order by t2.a, t1.a;','Dynamic Seq Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -255,8 +255,8 @@ select t2.a, t1.a from mpp23288 as t1 join mpp23288 as t2 on (t1.a < t2.a and t2
 (9 rows)
 
 select count_operator('select t2.a, t1.a from mpp23288 as t1 join mpp23288 as t2 on (t1.a < t2.a and (t2.a = 10 or t2.a = 5 or t2.a = 12)) order by t2.a, t1.a;','Dynamic Seq Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -292,8 +292,8 @@ select t2.a, t1.a from mpp23288 as t1 join mpp23288 as t2 on (t1.a < t2.a and (t
 (24 rows)
 
 select count_operator('select t2.a, t1.a from mpp23288 as t1 join mpp23288 as t2 on t1.a < t2.a and t2.a = 1 or t2.a < 10 order by t2.a, t1.a;','Dynamic Seq Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -532,80 +532,80 @@ analyze p3;
 analyze p;
 -- TEST
 select count_operator('select * from (select * from p1 union all select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 except all select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               0
 (1 row)
 
 select count_operator('select * from (select * from p1 except select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 intersect all select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p2 union all select * from p3) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               3
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p2 union all select * from p) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p union all select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p2 intersect all select * from p3) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               3
 (1 row)
 
 select count_operator('select * from (select * from p1 union select * from p intersect all select * from p2) as p_all, t where p_all.b=t.b;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -644,8 +644,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create index dbs_index on dbs using bitmap(c3);
 -- TEST
 select find_operator('(select * from dts where c2 = 1) union (select * from dts where c2 = 2) union (select * from dts where c2 = 3) union (select * from dts where c2 = 4) union (select * from dts where c2 = 5) union (select * from dts where c2 = 6) union (select * from dts where c2 = 7) union (select * from dts where c2 = 8) union (select * from dts where c2 = 9) union (select * from dts where c2 = 10);', 'Dynamic Seq Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['true']
@@ -667,8 +667,8 @@ DETAIL:  Feature not supported: SIRV functions
 
 set optimizer_enable_dynamictablescan = off;
 select find_operator('(select * from dis where c3 = 1) union (select * from dis where c3 = 2) union (select * from dis where c3 = 3) union (select * from dis where c3 = 4) union (select * from dis where c3 = 5) union (select * from dis where c3 = 6) union (select * from dis where c3 = 7) union (select * from dis where c3 = 8) union (select * from dis where c3 = 9) union (select * from dis where c3 = 10);', 'Dynamic Index Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['true']
@@ -689,8 +689,8 @@ DETAIL:  Feature not supported: SIRV functions
 (0 rows)
 
 select find_operator('select * from dbs where c2= 15 and c3 = 5;', 'Bitmap Heap Scan');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  find_operator 
 ---------------
  ['false']
@@ -736,17 +736,17 @@ create index pp_rest_2_idx on pp_1_prt_3(c,a);
 -- TEST
 set optimizer_enable_dynamictablescan = off;
 select * from pp where b=2 and c=2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  a | b | c 
 ---+---+---
 (0 rows)
 
 select count_operator('select * from pp where b=2 and c=2;','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  count_operator 
 ----------------
               0
@@ -793,8 +793,8 @@ select * from ds_4 where month_id = '200800';
 (0 rows)
 
 select count_operator('select * from ds_4 where month_id = E''200800'';','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               0
@@ -806,8 +806,8 @@ select * from ds_4 where month_id > '200800';
 (0 rows)
 
 select count_operator('select * from ds_4 where month_id > E''200800'';','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               0
@@ -819,8 +819,8 @@ select * from ds_4 where month_id <= '200800';
 (0 rows)
 
 select count_operator('select * from ds_4 where month_id <= E''200800'';','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               0
@@ -832,8 +832,8 @@ select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > 
 (0 rows)
 
 select count_operator('select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > E''200800'';','Partition Selector');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
@@ -963,16 +963,16 @@ SUBPARTITION TEMPLATE
 END (2015111100::numeric) WITH (appendonly=false)
 );
 INSERT INTO part_tbl VALUES (2015111000, 479534741, 99999999);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 INSERT INTO part_tbl VALUES (2015111000, 479534742, 99999999);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 CREATE INDEX part_tbl_idx 
 ON part_tbl(profile_key);
 EXPLAIN SELECT * FROM part_tbl WHERE profile_key = 99999999;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.07 rows=2 width=25)
@@ -985,8 +985,8 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (7 rows)
 
 SELECT * FROM part_tbl WHERE profile_key = 99999999;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  time_client_key | ngin_service_key | profile_key 
 -----------------+------------------+-------------
       2015111000 |        479534742 |    99999999
@@ -1239,8 +1239,8 @@ create table mpp6247_bar (like mpp6247_foo);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- EXPECT: Single HJ after partition elimination instead of sequence of HJ under Append
 select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_foo.c1 = mpp6247_bar.c1 and mpp6247_foo.dt = ''2009-05-03''', 'Hash Join');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1

--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -330,7 +330,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/brin_ao.out
+++ b/src/test/regress/expected/brin_ao.out
@@ -332,7 +332,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_ao%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -332,7 +332,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_ao%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -332,7 +332,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_aocs%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -332,7 +332,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_aocs%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -330,7 +330,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -55,7 +55,7 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
                            ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
                ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36)
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (15 rows)
 
 -- explain_processing_on
@@ -80,7 +80,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
          ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
                Buckets: 131072  Batches: 1  Memory Usage: 1024kB
                ->  Seq Scan on box_locations  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Planning Time: 0.893 ms
    (slice0)    Executor memory: 64K bytes.
    (slice1)    Executor memory: 1051K bytes avg x 3 workers, 1051K bytes max (seg0).  Work_mem: 1024K bytes max.
@@ -261,7 +261,7 @@ QUERY PLAN
                 Total Cost: 596.00
                 Plan Rows: 49600
                 Plan Width: 36
-  Optimizer: "Postgres query optimizer"
+  Optimizer: "Postgres-based planner"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
@@ -301,7 +301,7 @@ QUERY PLAN
           - "id"
           - "apple_id"
           - "location_id"
-  Optimizer: "Postgres query optimizer"
+  Optimizer: "Postgres-based planner"
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
@@ -346,7 +346,7 @@ QUERY PLAN
           - "id"
           - "apple_id"
           - "location_id"
-  Optimizer: "Postgres query optimizer"
+  Optimizer: "Postgres-based planner"
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
@@ -532,7 +532,7 @@ QUERY PLAN
                 Actual Total Time: 0.000
                 Actual Rows: 0
                 Actual Loops: 0
-  Optimizer: "Postgres query optimizer"
+  Optimizer: "Postgres-based planner"
   Planning Time: 5.148
   Triggers: 
   Slice statistics: 
@@ -588,7 +588,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 widt
         work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
         ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.010 rows=0 loops=1)
               Output: id, apple_id, location_id
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
 Planning Time: 0.397 ms
   (slice0)    Executor memory: 40K bytes.
@@ -624,7 +624,7 @@ QUERY PLAN
       "Function Name": "generate_series",
       "Alias": "generate_series"
     },
-    "Optimizer": "Postgres query optimizer"
+    "Optimizer": "Postgres-based planner"
   }
 ]
 (1 row)
@@ -641,7 +641,7 @@ QUERY PLAN
       <Function-Name>generate_series</Function-Name>
       <Alias>generate_series</Alias>
     </Plan>
-    <Optimizer>Postgres query optimizer</Optimizer>
+    <Optimizer>Postgres-based planner</Optimizer>
   </Query>
 </explain>
 (1 row)
@@ -676,7 +676,7 @@ QUERY PLAN
         }
       ]
     },
-    "Optimizer": "Postgres query optimizer"
+    "Optimizer": "Postgres-based planner"
   }
 ]
 (1 row)
@@ -705,7 +705,7 @@ Limit  (cost=35.50..35.67 rows=10 width=4)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4)
         ->  Limit  (cost=35.50..35.61 rows=10 width=4)
               ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 JIT:
   Functions: 2
   Options: Inlining false, Optimization false, Expressions true, Deforming true
@@ -719,7 +719,7 @@ Limit  (cost=35.50..35.67 rows=10 width=4) (actual time=13.199..13.310 rows=10 l
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (actual time=11.848..11.890 rows=10 loops=1)
         ->  Limit  (cost=35.50..35.61 rows=10 width=4) (actual time=0.861..0.971 rows=10 loops=1)
               ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4) (actual time=0.029..0.070 rows=10 loops=1)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 Planning Time: 0.158 ms
   (slice0)    Executor memory: 37K bytes.
   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
@@ -842,7 +842,7 @@ QUERY PLAN
         }
       ]
     },
-    "Optimizer": "Postgres query optimizer",
+    "Optimizer": "Postgres-based planner",
     "Planning Time": 0.244,
     "Triggers": [
     ],

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -55,7 +55,7 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
                            Index Cond: (id = boxes.location_id)
          ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12)
                Index Cond: (id = boxes.apple_id)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (15 rows)
 
 -- explain_processing_on
@@ -78,7 +78,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                            Index Cond: (id = boxes.location_id)
          ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12) (never executed)
                Index Cond: (id = boxes.apple_id)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
  Planning Time: 40.380 ms
    (slice0)    Executor memory: 56K bytes.
    (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
@@ -243,7 +243,7 @@ QUERY PLAN
             Plan Rows: 1
             Plan Width: 12
             Index Cond: "(id = boxes.apple_id)"
-  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Optimizer: "GPORCA"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
@@ -283,7 +283,7 @@ QUERY PLAN
           - "id"
           - "apple_id"
           - "location_id"
-  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Optimizer: "GPORCA"
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
@@ -328,7 +328,7 @@ QUERY PLAN
           - "id"
           - "apple_id"
           - "location_id"
-  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Optimizer: "GPORCA"
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
@@ -484,7 +484,7 @@ QUERY PLAN
             Actual Loops: 0
             Index Cond: "(id = boxes.apple_id)"
             Rows Removed by Index Recheck: 0
-  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Optimizer: "GPORCA"
   Planning Time: 14.827
   Triggers: 
   Slice statistics: 
@@ -538,7 +538,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (a
         work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
         ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.014 rows=0 loops=1)
               Output: id, apple_id, location_id
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
 Planning Time: 4.622 ms
   (slice0)    Executor memory: 40K bytes.
@@ -574,7 +574,7 @@ QUERY PLAN
       "Function Name": "generate_series",
       "Alias": "generate_series"
     },
-    "Optimizer": "Pivotal Optimizer (GPORCA)"
+    "Optimizer": "GPORCA"
   }
 ]
 (1 row)
@@ -591,7 +591,7 @@ QUERY PLAN
       <Function-Name>generate_series</Function-Name>
       <Alias>generate_series</Alias>
     </Plan>
-    <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>
+    <Optimizer>GPORCA</Optimizer>
   </Query>
 </explain>
 (1 row)
@@ -627,7 +627,7 @@ QUERY PLAN
         }
       ]
     },
-    "Optimizer": "Pivotal Optimizer (GPORCA)"
+    "Optimizer": "GPORCA"
   }
 ]
 (1 row)
@@ -655,7 +655,7 @@ QUERY PLAN
 Limit  (cost=0.00..431.00 rows=1 width=4)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
         ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 JIT:
   Functions: 2
   Options: Inlining false, Optimization false, Expressions true, Deforming true
@@ -668,7 +668,7 @@ QUERY PLAN
 Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=1.103..1.107 rows=10 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.013..0.014 rows=10 loops=1)
         ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4) (actual time=0.025..0.030 rows=38 loops=1)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 Planning Time: 5.824 ms
   (slice0)    Executor memory: 37K bytes.
   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
@@ -772,7 +772,7 @@ QUERY PLAN
         }
       ]
     },
-    "Optimizer": "Pivotal Optimizer (GPORCA)",
+    "Optimizer": "GPORCA",
     "Planning Time": 5.884,
     "Triggers": [
     ],

--- a/src/test/regress/expected/generated_optimizer.out
+++ b/src/test/regress/expected/generated_optimizer.out
@@ -1,8 +1,8 @@
 set optimizer_trace_fallback=on;
 -- sanity check of system catalog
 SELECT attrelid, attname, attgenerated FROM pg_attribute WHERE attgenerated NOT IN ('', 's');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  attrelid | attname | attgenerated 
 ----------+---------+--------------
 (0 rows)
@@ -10,8 +10,8 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 CREATE TABLE gtest0 (a int PRIMARY KEY, b int GENERATED ALWAYS AS (55) STORED);
 CREATE TABLE gtest1 (a int PRIMARY KEY, b int GENERATED ALWAYS AS (a * 2) STORED);
 SELECT table_name, column_name, column_default, is_nullable, is_generated, generation_expression FROM information_schema.columns WHERE table_name LIKE 'gtest_' ORDER BY 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  table_name | column_name | column_default | is_nullable | is_generated | generation_expression 
 ------------+-------------+----------------+-------------+--------------+-----------------------
  gtest0     | a           |                | NO          | NEVER        | 
@@ -21,34 +21,34 @@ DETAIL:  Feature not supported: Non-default collation
 (4 rows)
 
 SELECT table_name, column_name, dependent_column FROM information_schema.column_column_usage ORDER BY 1, 2, 3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  table_name | column_name | dependent_column 
 ------------+-------------+------------------
  gtest1     | a           | b
 (1 row)
 
 \d gtest1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                             Table "public.gtest1"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -242,24 +242,24 @@ SELECT * FROM gtest1_1;
 (0 rows)
 
 \d gtest1_1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Table "public.gtest1_1"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -275,8 +275,8 @@ SELECT * FROM gtest1_1;
 (1 row)
 
 SELECT * FROM gtest1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  a | b 
 ---+---
  3 | 6
@@ -291,24 +291,24 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  merging column "a" with inherited definition
 NOTICE:  merging column "b" with inherited definition
 \d gtest_normal_child
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                       Table "public.gtest_normal_child"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -318,12 +318,12 @@ Inherits: gtest_normal
 Distributed by: (a)
 
 INSERT INTO gtest_normal (a) VALUES (1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 INSERT INTO gtest_normal_child (a) VALUES (2);
 SELECT * FROM gtest_normal;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  a | b 
 ---+---
  1 |  
@@ -336,8 +336,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 ALTER TABLE gtest_normal_child2 INHERIT gtest_normal;
 INSERT INTO gtest_normal_child2 (a) VALUES (3);
 SELECT * FROM gtest_normal;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  a | b 
 ---+---
  2 | 4
@@ -439,8 +439,8 @@ SELECT * FROM gtest3a ORDER BY a;
 -- COPY
 TRUNCATE gtest1;
 INSERT INTO gtest1 (a) VALUES (1), (2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
 COPY gtest1 TO stdout;
 1
 2
@@ -452,8 +452,8 @@ COPY gtest1 (a, b) FROM stdin;
 ERROR:  column "b" is a generated column
 DETAIL:  Generated columns cannot be used in COPY.
 SELECT * FROM gtest1 ORDER BY a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  a | b 
 ---+---
  1 | 2
@@ -541,26 +541,26 @@ SELECT * FROM gtest_tableoid;
 CREATE TABLE gtest10 (a int PRIMARY KEY, b int, c int GENERATED ALWAYS AS (b * 2) STORED);
 ALTER TABLE gtest10 DROP COLUMN b;
 \d gtest10
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
               Table "public.gtest10"
  Column |  Type   | Collation | Nullable | Default 
 --------+---------+-----------+----------+---------
@@ -653,26 +653,26 @@ CREATE INDEX gtest22c_b_idx ON gtest22c (b);
 CREATE INDEX gtest22c_expr_idx ON gtest22c ((b * 3));
 CREATE INDEX gtest22c_pred_idx ON gtest22c (a) WHERE b > 0;
 \d gtest22c
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Table "public.gtest22c"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -743,32 +743,32 @@ CREATE TABLE gtest23x (a int PRIMARY KEY, b int GENERATED ALWAYS AS (a * 2) STOR
 ERROR:  invalid ON DELETE action for foreign key constraint containing generated column
 CREATE TABLE gtest23b (a int PRIMARY KEY, b int GENERATED ALWAYS AS (a * 2) STORED REFERENCES gtest23a (x));
 \d gtest23b
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Table "public.gtest23b"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -865,26 +865,26 @@ SELECT * FROM gtest25 ORDER BY a;
 (2 rows)
 
 \d gtest25
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                          Table "public.gtest25"
  Column |       Type       | Collation | Nullable |                       Default                        
 --------+------------------+-----------+----------+------------------------------------------------------
@@ -911,24 +911,24 @@ ERROR:  cannot alter type of a column used by a generated column
 DETAIL:  Column "a" is used by generated column "x".
 ALTER TABLE gtest27 ALTER COLUMN x TYPE numeric;
 \d gtest27
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                 Table "public.gtest27"
  Column |  Type   | Collation | Nullable |                  Default                   
 --------+---------+-----------+----------+--------------------------------------------
@@ -955,24 +955,24 @@ ALTER TABLE gtest27
   ALTER COLUMN b TYPE bigint,
   ADD COLUMN x bigint GENERATED ALWAYS AS ((a + b) * 2) STORED;
 \d gtest27
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                               Table "public.gtest27"
  Column |  Type  | Collation | Nullable |                 Default                  
 --------+--------+-----------+----------+------------------------------------------
@@ -988,24 +988,24 @@ ALTER TABLE gtest27
 ERROR:  cannot alter type of a column used by a generated column
 DETAIL:  Column "a" is used by generated column "x".
 \d gtest27
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                               Table "public.gtest27"
  Column |  Type  | Collation | Nullable |                 Default                  
 --------+--------+-----------+----------+------------------------------------------
@@ -1106,8 +1106,8 @@ INFO:  gtest4: AFTER: new = (-2,-4,)  (seg0 127.0.1.1:7002 pid=179471)
 alter table gtest26 drop column distkey;
 NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
 UPDATE gtest26 SET a = a * -2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE on a table with UPDATE triggers
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE on a table with UPDATE triggers
 INFO:  gtest1: BEFORE: old = (-2,-4)  (seg0 127.0.1.1:7002 pid=179471)
 INFO:  gtest1: BEFORE: new = (4,)  (seg0 127.0.1.1:7002 pid=179471)
 INFO:  gtest3: AFTER: old = (-2,-4)  (seg0 127.0.1.1:7002 pid=179471)
@@ -1149,8 +1149,8 @@ CREATE TRIGGER gtest11 BEFORE UPDATE OF b ON gtest26
   FOR EACH ROW
   EXECUTE PROCEDURE gtest_trigger_func3();
 UPDATE gtest26 SET a = 1 WHERE a = 0;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE on a table with UPDATE triggers
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE on a table with UPDATE triggers
 NOTICE:  OK
 DROP TRIGGER gtest11 ON gtest26;
 TRUNCATE gtest26;
@@ -1176,8 +1176,8 @@ CREATE TRIGGER gtest12_03 BEFORE UPDATE ON gtest26
   EXECUTE PROCEDURE gtest_trigger_func();
 INSERT INTO gtest26 (a) VALUES (1);
 UPDATE gtest26 SET a = 11 WHERE a = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE on a table with UPDATE triggers
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE on a table with UPDATE triggers
 INFO:  gtest12_01: BEFORE: old = (1,2)
 INFO:  gtest12_01: BEFORE: new = (11,)
 INFO:  gtest12_03: BEFORE: old = (1,2)
@@ -1198,24 +1198,24 @@ CREATE TABLE gtest28a (
 ALTER TABLE gtest28a DROP COLUMN a;
 CREATE TABLE gtest28b (LIKE gtest28a INCLUDING GENERATED);
 \d gtest28*
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Table "public.gtest28a"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------
@@ -1224,22 +1224,22 @@ DETAIL:  Feature not supported: Non-default collation
  x      | integer |           |          | generated always as (b * 2) stored
 Distributed randomly
 
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                            Table "public.gtest28b"
  Column |  Type   | Collation | Nullable |              Default               
 --------+---------+-----------+----------+------------------------------------

--- a/src/test/regress/expected/gp_array_agg_optimizer.out
+++ b/src/test/regress/expected/gp_array_agg_optimizer.out
@@ -127,8 +127,8 @@ select a, b, array_dims(gp_array_agg(x)) from mergeappend_test r group by a, b
 union all
 select null, null, array_dims(gp_array_agg(x)) from mergeappend_test r, pg_sleep(0)
 order by 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  a | b | array_dims 
 ---+---+------------
  0 | 0 | [1:99]
@@ -214,8 +214,8 @@ from (
 group by y;
 -- ensure results are correct.
 select * from v_pagg_test order by y;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  y | tmin | tmax | tndistinct | amin | amax | andistinct 
 ---+------+------+------------+------+------+------------
  0 |   10 | 5000 |        500 |   10 | 5000 |        500
@@ -231,8 +231,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (10 rows)
 
 explain (costs off) select * from v_pagg_test order by y;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -360,8 +360,8 @@ from arrtest;
 $query$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE)
 :qry ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -376,8 +376,8 @@ DETAIL:  Feature not supported: Non-default collation
 (9 rows)
 
 :qry ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
      agg_a     |        dims_b        |   dims_c   |             agg_d             |   dims_e   |               agg_f               |           agg_g           
 ---------------+----------------------+------------+-------------------------------+------------+-----------------------------------+---------------------------
  {{1,2},{1,2}} | [1:2][1:2][1:2][1:2] | [1:2][1:1] | {{{elt1,elt2}},{{elt1,elt2}}} | [1:2][1:2] | {{"abc  ",abcde},{"abc  ",abcde}} | {{abc,abcde},{abc,abcde}}

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -113,16 +113,16 @@ explain (costs off) select count(distinct d), sum(distinct d) from dqa_t1 group 
 (11 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count 
 -------+-------
     23 |    34
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Finalize Aggregate
@@ -139,16 +139,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | count 
 -------+-------+-------
     23 |    10 |    34
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Finalize Aggregate
@@ -165,8 +165,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count 
 -------+-------
     10 |    10
@@ -182,8 +182,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (10 rows)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Finalize HashAggregate
@@ -205,8 +205,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct d), count(distinct dt) from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count 
 -------+-------
      1 |     5
@@ -235,8 +235,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (23 rows)
 
 explain (costs off) select count(distinct d), count(distinct dt) from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Finalize HashAggregate
@@ -498,16 +498,16 @@ explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group 
 (9 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count 
 -------+-------
     10 |    34
 (1 row)
 
 explain (costs off) select count(distinct c), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Finalize Aggregate
@@ -524,8 +524,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | i  
 -------+-------+----
      5 |     9 |  3
@@ -543,8 +543,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (12 rows)
 
 explain (costs off) select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Finalize HashAggregate
@@ -566,8 +566,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct i), count(distinct c), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | d  
 -------+-------+----
      5 |     5 |  3
@@ -596,8 +596,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (23 rows)
 
 explain (costs off) select count(distinct i), count(distinct c), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Finalize HashAggregate
@@ -729,8 +729,8 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
 
 -- multidqa with groupby and order by
 select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum | count | count | i  | c 
 -----+-------+-------+----+---
   14 |     1 |     1 |  0 | 0
@@ -796,8 +796,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (60 rows)
 
 explain (costs off) select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Sort
@@ -908,16 +908,16 @@ explain (costs off) select to_char(corr(distinct d, i), '9.99999999999999') from
 
 -- multi args multidqa
 select count(distinct c), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count |        corr        
 -------+--------------------
     10 | 0.0824013341460019
 (1 row)
 
 explain (costs off) select count(distinct c), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -934,16 +934,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct d), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count |        corr        
 -------+--------------------
     23 | 0.0824013341460019
 (1 row)
 
 explain (costs off) select count(distinct d), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -960,16 +960,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count |        corr        
 -------+-------+--------------------
     23 |    12 | 0.0824013341460019
 (1 row)
 
 explain (costs off) select count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -986,16 +986,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (11 rows)
 
 select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | count |        corr        
 -------+-------+-------+--------------------
     10 |    23 |    12 | 0.0824013341460019
 (1 row)
 
 explain (costs off) select count(distinct c), count(distinct d), count(distinct i), corr(distinct d, i) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -1013,8 +1013,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 
 -- multi args multidqa with group by
 select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | corr | d  
 -------+------+----
      5 |      |  0
@@ -1043,8 +1043,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (23 rows)
 
 explain (costs off) select count(distinct c), corr(distinct d, i), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1066,8 +1066,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | corr | d  | i  
 -------+------+----+----
      1 |      |  0 |  0
@@ -1173,8 +1173,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (100 rows)
 
 explain (costs off) select count(distinct c), corr(distinct d, i), d, i from dqa_t1 group by d,i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1196,8 +1196,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count |        corr        |     dt     
 -------+--------------------+------------
      3 |   0.59603956067927 | 06-25-2009
@@ -1237,8 +1237,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (34 rows)
 
 explain (costs off) select count(distinct c), corr(distinct d, i), dt from dqa_t1 group by dt;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1260,8 +1260,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | corr | i  
 -------+------+----
      9 |      |  0
@@ -1279,8 +1279,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (12 rows)
 
 explain (costs off) select count(distinct d), corr(distinct d, i), i from dqa_t1 group by i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1302,8 +1302,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | corr | d  
 -------+------+----
      1 |      |  0
@@ -1332,8 +1332,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (23 rows)
 
 explain (costs off) select count(distinct d), corr(distinct d, i), d from dqa_t1 group by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1355,8 +1355,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (16 rows)
 
 select count(distinct d),  to_char(corr(distinct d, i), '9.99999999999999'), c from dqa_t1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count |      to_char      | c 
 -------+-------------------+---
     10 |   .13670602618479 | 0
@@ -1372,8 +1372,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (10 rows)
 
 explain (costs off) select count(distinct d),  to_char(corr(distinct d, i), '9.99999999999999'), c from dqa_t1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -1431,8 +1431,8 @@ from
      fact_route_aggregation T218094
 where  ( T43883.device_id = T218094.device_id ) 
 group by T43883.platform;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 
 ----+----+----+----+----+----+----+----+----
 (0 rows)
@@ -1460,8 +1460,8 @@ insert into t2_mdqa select i % 10 , i % 5, i || 'value' from generate_series(1, 
 analyze t2_mdqa;
 -- simple mdqa
 select count(distinct t1.a), count(distinct t2.b), t1.c, t2.c from t1_mdqa t1, t2_mdqa t2 where t1.c = t2.c group by t1.c, t2.c order by t1.c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count |    c    |    c    
 -------+-------+---------+---------
      1 |     1 | 10value | 10value
@@ -1488,8 +1488,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 
 -- distinct on top of some mdqas
 select distinct sum(distinct t1.a), avg(t2.a), sum(distinct t2.b), t1.a, t2.b from t1_mdqa t1, t2_mdqa t2 where t1.a = t2.a group by t1.a, t2.b order by t1.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum |          avg           | sum | a | b 
 -----+------------------------+-----+---+---
    0 | 0.00000000000000000000 |   0 | 0 | 0
@@ -1500,8 +1500,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (5 rows)
 
 select distinct sum (distinct t1.a), avg(distinct t2.a), sum(distinct t2.b), t1.c from t1_mdqa t1, t2_mdqa t2 where t1.a = t2.a group by t1.c order by t1.c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum |          avg           | sum |    c    
 -----+------------------------+-----+---------
    0 | 0.00000000000000000000 |   0 | 10value
@@ -1528,8 +1528,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 
 -- distinct on group by fields
 select distinct t1.c , sum(distinct t1.a), count(t2.b), sum(distinct t2.b) from t1_mdqa t1, t2_mdqa t2 where t1.a = t2.a group by t1.c order by t1.c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
     c    | sum | count | sum 
 ---------+-----+-------+-----
  10value |   0 |     8 |   0
@@ -1556,8 +1556,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 
 -- distinct on normal aggregates
 select distinct sum(t1.a), avg(distinct t2.a), sum(distinct (t1.a + t2.a)), t1.a, t2.b from t1_mdqa t1, t2_mdqa t2 where t1.a = t2.a group by t1.a, t2.b order by t1.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum |          avg           | sum | a | b 
 -----+------------------------+-----+---+---
    0 | 0.00000000000000000000 |   0 | 0 | 0
@@ -1568,8 +1568,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (5 rows)
 
 select distinct avg(t1.a + t2.b), count(distinct t1.c), count(distinct char_length(t1.c)), t1.a, t2.b from t1_mdqa t1, t2_mdqa t2 where t1.a = t2.a group by t1.a, t2.b order by t1.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
           avg           | count | count | a | b 
 ------------------------+-------+-------+---+---
  0.00000000000000000000 |     4 |     2 | 0 | 0
@@ -1598,8 +1598,8 @@ insert into gp_dqa_s select i, i %15, i%10 from generate_series(1,30) i;
 analyze gp_dqa_r;
 analyze gp_dqa_s;
 select a, d, count(distinct b) as c1, count(distinct c) as c2 from gp_dqa_r, gp_dqa_s where ( e = a ) group by d, a order by a,d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  a  | d  | c1 | c2 
 ----+----+----+----
   1 |  1 |  1 |  1
@@ -1641,8 +1641,8 @@ d as c9
 from gp_dqa_r, gp_dqa_s
 where ( e = a ) 
 group by d order by c9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | c3 | c2 | c9 
 ----+----+----+----+----
   1 |  2 |  1 |  1 |  1
@@ -1682,8 +1682,8 @@ d as c9
 from gp_dqa_r, gp_dqa_s
 where ( e = a ) 
 group by d order by c9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | c9 
 ----+----+----
   1 |  1 |  1
@@ -1720,8 +1720,8 @@ select distinct count(distinct b) as c1, count(distinct c) as c2, d as c9
 from gp_dqa_r, gp_dqa_s
 where ( e = a ) 
 group by d order by c9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | c9 
 ----+----+----
   1 |  1 |  1
@@ -1755,8 +1755,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (28 rows)
 
 select distinct d, count(distinct b) as c1, count(distinct c) as c2, d as c9 from gp_dqa_r, gp_dqa_s group by d order by c9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  d  | c1 | c2 | c9 
 ----+----+----+----
   1 | 10 |  5 |  1
@@ -1792,8 +1792,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (30 rows)
 
 select distinct d, count(distinct b) as c1, count(distinct c) as c2, d as c9 from gp_dqa_r, gp_dqa_s group by d, a order by c9;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  d  | c1 | c2 | c9 
 ----+----+----+----
   1 |  1 |  1 |  1
@@ -1829,24 +1829,24 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (30 rows)
 
 select distinct count(distinct b) as c1, count(distinct c) as c2 from gp_dqa_r, gp_dqa_s;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 
 ----+----
  10 |  5
 (1 row)
 
 select distinct count(distinct b) as c1, count(distinct c) as c2 from gp_dqa_r;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 
 ----+----
  10 |  5
 (1 row)
 
 select distinct count(distinct b) as c1, count(distinct c) as c2, d, a from gp_dqa_r, gp_dqa_s where ( e = a)group by d, a order by a,d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | d  | a  
 ----+----+----+----
   1 |  1 |  1 |  1
@@ -1884,8 +1884,8 @@ ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
 LINE 1: ...as c2, d from gp_dqa_r, gp_dqa_s group by d, a order by d,a;
                                                                      ^
 select distinct count(distinct b) as c1, count(distinct c) as c2, d from gp_dqa_r, gp_dqa_s group by d, a order by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | d  
 ----+----+----
   1 |  1 |  1
@@ -1921,8 +1921,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (30 rows)
 
 select distinct count(distinct b) as c1, count(distinct c) as c2, d from gp_dqa_r, gp_dqa_s group by d order by d;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  c1 | c2 | d  
 ----+----+----
  10 |  5 |  1
@@ -1972,8 +1972,8 @@ insert into gp_dqa_t2 select i , i %4 from generate_series(1,10) i;
 analyze gp_dqa_t1;
 analyze gp_dqa_t2;
 select distinct A.a, sum(distinct A.b), count(distinct B.c) from gp_dqa_t1 A left join gp_dqa_t2 B on (A.a = B.a) group by A.a order by A.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  a  | sum | count 
 ----+-----+-------
   1 |   1 |     1
@@ -1989,8 +1989,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (10 rows)
 
 select distinct A.a, sum(distinct A.b), count(distinct B.c) from gp_dqa_t1 A right join gp_dqa_t2 B on (A.a = B.a) group by A.a order by A.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  a  | sum | count 
 ----+-----+-------
   1 |   1 |     1
@@ -2043,16 +2043,16 @@ explain (costs off) select count(distinct d) from dqa_t1 group by i;
 (11 rows)
 
 select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | count 
 -------+-------+-------
     23 |    10 |    34
 (1 row)
 
 select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | i  
 -------+-------+----
      5 |     9 |  3
@@ -2076,15 +2076,15 @@ create table foo_mdqa(x int, y int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT 1 AS z FROM generate_series(1,10)) C, foo_mdqa FS GROUP BY z;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  z | count | count 
 ---+-------+-------
 (0 rows)
 
 SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i AS z FROM generate_series(1,10) i) C, foo_mdqa FS GROUP BY z;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  z | count | count 
 ---+-------+-------
 (0 rows)
@@ -2103,10 +2103,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into nonullstab select 1, 1 from generate_series(1, 100);
 -- This returns wrong result. countall(distinct a) should return 1.
 select countall(distinct a), count(distinct b) from nonullstab;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  countall | count 
 ----------+-------
         1 |     1
@@ -2122,16 +2122,16 @@ insert into dqa_f2 select i % 13, i % 5 , i % 11 from generate_series(1,1000) i;
 analyze dqa_f1;
 analyze dqa_f2;
 select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum 
 -----+-----
  136 |  10
 (1 row)
 
 select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum 
 -----+-----
  136 |   0
@@ -2142,8 +2142,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (5 rows)
 
 select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum 
 -----+-----
  136 |  10
@@ -2152,16 +2152,16 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (3 rows)
 
 select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), sum(distinct b) filter (where a > 0) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum 
 -----+-----
   78 |  10
 (1 row)
 
 select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | sum 
 -----+-----
   78 |  10
@@ -2170,8 +2170,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (3 rows)
 
 select count(distinct a) filter (where a > 3),count( distinct b) filter (where a > 4), sum(distinct b) filter( where a > 4) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count | count | sum 
 -------+-------+-----
     13 |     5 |  10
@@ -2179,16 +2179,16 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 -- fix hang of multi-dqa with filter (https://github.com/greenplum-db/gpdb/issues/14728)
 select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count | count 
 -------+-------
     13 |     5
 (1 row)
 
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Finalize Aggregate  (cost=20.66..20.67 rows=1 width=16)
@@ -2205,8 +2205,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (11 rows)
 
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate  (cost=21.62..21.67 rows=5 width=20)
@@ -2228,8 +2228,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (16 rows)
 
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate  (cost=21.20..21.23 rows=3 width=20)
@@ -2251,8 +2251,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (16 rows)
 
 explain select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), sum(distinct b) filter (where a > 0) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate  (cost=96.41..96.42 rows=1 width=16)
@@ -2275,8 +2275,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (17 rows)
 
 explain select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                                                 QUERY PLAN                                                                
 ------------------------------------------------------------------------------------------------------------------------------------------
  Finalize HashAggregate  (cost=181.11..181.14 rows=3 width=20)
@@ -2304,8 +2304,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (22 rows)
 
 explain select count(distinct a) filter (where a > 3),count( distinct b) filter (where a > 4), sum(distinct b) filter( where a > 4) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Finalize Aggregate  (cost=20.67..20.68 rows=1 width=24)
@@ -2326,16 +2326,16 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 set enable_hashagg = off;
 set enable_groupagg = on;
 select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  count | count 
 -------+-------
     13 |     5
 (1 row)
 
 explain (verbose, costs off)select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
 QUERY PLAN
 ___________
  Aggregate
@@ -2371,7 +2371,7 @@ create table dqa_unique(a int, b int, c int, d int, primary key(a, b));
 insert into dqa_unique select i%3, i%5, i%7, i%9 from generate_series(1, 10) i;
 analyze dqa_unique;
 explain(verbose on, costs off) select count(distinct a), count(distinct d), c from dqa_unique group by a, b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
@@ -2403,7 +2403,7 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
 (25 rows)
 
 select count(distinct a), count(distinct d), c from dqa_unique group by a, b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  count | count | c 
 -------+-------+---
@@ -2435,16 +2435,16 @@ analyze dqa_f3;
 --           ->  Seq Scan on public.dqa_f3
 --                 Output: b, a, (b)::text
 select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  b | a 
 ---+---
  3 | 7
 (1 row)
 
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Aggregate
@@ -2459,16 +2459,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 
 -- Case 2: Same as the above one, but convert the type of column 'a' to 'varchar' via binary-compatible types.
 select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  b | a 
 ---+---
  3 | 7
 (1 row)
 
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Aggregate
@@ -2493,16 +2493,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 --           ->  Seq Scan on public.dqa_f3
 --                 Output: b, a, (b)::text, (a)::integer
 select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  b | a 
 ---+---
  3 | 7
 (1 row)
 
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate
@@ -2518,16 +2518,16 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 -- Case 4: When converting the type of column 'a' from 'varchar' to 'int' to 'varchar', TupleSplit should generate an additional
 -- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
 select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  b | a 
 ---+---
  3 | 7
 (1 row)
 
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Aggregate
@@ -3173,8 +3173,8 @@ select distinct sum(Distinct b), count(c), sum(a) from dqa_f3;
 (1 row)
 
 explain (verbose on, costs off) select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -3197,8 +3197,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (17 rows)
 
 select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  sum | count | sum  
 -----+-------+------
   10 |   333 | 7993
@@ -3214,8 +3214,8 @@ insert into dqa_f4 values(1, 1, 1);
 insert into dqa_f4 values(2, 2, 2);
 analyze dqa_f4;
 select count(distinct a), count(distinct b) from dqa_f4 group by c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count 
 -------+-------
      0 |     0

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -270,7 +270,7 @@ explain (format json, costs off) SELECT * FROM dummy_ext_tab;
          }                                  +
        ]                                    +
      },                                     +
-     "Optimizer": "Postgres query optimizer"+
+     "Optimizer": "Postgres-based planner"  +
    }                                        +
  ]
 (1 row)
@@ -280,26 +280,26 @@ CREATE TEMP TABLE dummy_aotab (x int4) WITH (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 explain (format yaml, costs off) SELECT * FROM dummy_aotab;
-                QUERY PLAN                 
------------------------------------------
- - Plan:                                +
-     Node Type: "Gather Motion"         +
-     Senders: 3                         +
-     Receivers: 1                       +
-     Slice: 1                           +
-     Segments: 3                        +
-     Gang Type: "primary reader"        +
-     Parallel Aware: false              +
-     Plans:                             +
-       - Node Type: "Seq Scan"          +
-         Parent Relationship: "Outer"   +
-         Slice: 1                       +
-         Segments: 3                    +
-         Gang Type: "primary reader"    +
-         Parallel Aware: false          +
-         Relation Name: "dummy_aotab"   +
-         Alias: "dummy_aotab"           +
-   Optimizer: "Postgres query optimizer"
+              QUERY PLAN               
+---------------------------------------
+ - Plan:                              +
+     Node Type: "Gather Motion"       +
+     Senders: 3                       +
+     Receivers: 1                     +
+     Slice: 1                         +
+     Segments: 3                      +
+     Gang Type: "primary reader"      +
+     Parallel Aware: false            +
+     Plans:                           +
+       - Node Type: "Seq Scan"        +
+         Parent Relationship: "Outer" +
+         Slice: 1                     +
+         Segments: 3                  +
+         Gang Type: "primary reader"  +
+         Parallel Aware: false        +
+         Relation Name: "dummy_aotab" +
+         Alias: "dummy_aotab"         +
+   Optimizer: "Postgres-based planner"
 (1 row)
 
 -- DML node (with ORCA)
@@ -328,7 +328,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
          </Plan>                                            +
        </Plans>                                             +
      </Plan>                                                +
-     <Optimizer>Postgres query optimizer</Optimizer>        +
+     <Optimizer>Postgres-based planner</Optimizer>          +
    </Query>                                                 +
  </explain>
 (1 row)
@@ -397,49 +397,49 @@ explain (slicetable, costs off) SELECT * FROM explaintest;
 
 -- same in JSON format
 explain (slicetable, costs off, format json) SELECT * FROM explaintest;
-                  QUERY PLAN                   
-----------------------------------------------
- [                                           +
-   {                                         +
-     "Plan": {                               +
-       "Node Type": "Gather Motion",         +
-       "Senders": 3,                         +
-       "Receivers": 1,                       +
-       "Slice": 1,                           +
-       "Segments": 3,                        +
-       "Gang Type": "primary reader",        +
-       "Parallel Aware": false,              +
-       "Plans": [                            +
-         {                                   +
-           "Node Type": "Seq Scan",          +
-           "Parent Relationship": "Outer",   +
-           "Slice": 1,                       +
-           "Segments": 3,                    +
-           "Gang Type": "primary reader",    +
-           "Parallel Aware": false,          +
-           "Relation Name": "explaintest",   +
-           "Alias": "explaintest"            +
-         }                                   +
-       ]                                     +
-     },                                      +
-     "Optimizer": "Postgres query optimizer",+
-     "Slice Table": [                        +
-       {                                     +
-         "Slice ID": 0,                      +
-         "Gang Type": "Dispatcher",          +
-         "Root": 0,                          +
-         "Parent": -1,                       +
-         "Gang Size": 0                      +
-       },                                    +
-       {                                     +
-         "Slice ID": 1,                      +
-         "Gang Type": "Reader",              +
-         "Root": 0,                          +
-         "Parent": 0,                        +
-         "Gang Size": 3                      +
-       }                                     +
-     ]                                       +
-   }                                         +
+                 QUERY PLAN                 
+--------------------------------------------
+ [                                         +
+   {                                       +
+     "Plan": {                             +
+       "Node Type": "Gather Motion",       +
+       "Senders": 3,                       +
+       "Receivers": 1,                     +
+       "Slice": 1,                         +
+       "Segments": 3,                      +
+       "Gang Type": "primary reader",      +
+       "Parallel Aware": false,            +
+       "Plans": [                          +
+         {                                 +
+           "Node Type": "Seq Scan",        +
+           "Parent Relationship": "Outer", +
+           "Slice": 1,                     +
+           "Segments": 3,                  +
+           "Gang Type": "primary reader",  +
+           "Parallel Aware": false,        +
+           "Relation Name": "explaintest", +
+           "Alias": "explaintest"          +
+         }                                 +
+       ]                                   +
+     },                                    +
+     "Optimizer": "Postgres-based planner",+
+     "Slice Table": [                      +
+       {                                   +
+         "Slice ID": 0,                    +
+         "Gang Type": "Dispatcher",        +
+         "Root": 0,                        +
+         "Parent": -1,                     +
+         "Gang Size": 0                    +
+       },                                  +
+       {                                   +
+         "Slice ID": 1,                    +
+         "Gang Type": "Reader",            +
+         "Root": 0,                        +
+         "Parent": 0,                      +
+         "Gang Size": 3                    +
+       }                                   +
+     ]                                     +
+   }                                       +
  ]
 (1 row)
 

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -245,34 +245,34 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
 CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text';
 -- External Table Scan
 explain (format json, costs off) SELECT * FROM dummy_ext_tab;
-                  QUERY PLAN                   
------------------------------------------------
- [                                            +
-   {                                          +
-     "Plan": {                                +
-       "Node Type": "Gather Motion",          +
-       "Senders": 3,                          +
-       "Receivers": 1,                        +
-       "Slice": 1,                            +
-       "Segments": 3,                         +
-       "Gang Type": "primary reader",         +
-       "Parallel Aware": false,               +
-       "Plans": [                             +
-         {                                    +
-           "Node Type": "Foreign Scan",       +
-           "Operation": "Select",             +
-           "Parent Relationship": "Outer",    +
-           "Slice": 1,                        +
-           "Segments": 3,                     +
-           "Gang Type": "primary reader",     +
-           "Parallel Aware": false,           +
-           "Relation Name": "dummy_ext_tab",  +
-           "Alias": "dummy_ext_tab"           +
-         }                                    +
-       ]                                      +
-     },                                       +
-     "Optimizer": "Pivotal Optimizer (GPORCA)"+
-   }                                          +
+                 QUERY PLAN                  
+---------------------------------------------
+ [                                          +
+   {                                        +
+     "Plan": {                              +
+       "Node Type": "Gather Motion",        +
+       "Senders": 3,                        +
+       "Receivers": 1,                      +
+       "Slice": 1,                          +
+       "Segments": 3,                       +
+       "Gang Type": "primary reader",       +
+       "Parallel Aware": false,             +
+       "Plans": [                           +
+         {                                  +
+           "Node Type": "Foreign Scan",     +
+           "Operation": "Select",           +
+           "Parent Relationship": "Outer",  +
+           "Slice": 1,                      +
+           "Segments": 3,                   +
+           "Gang Type": "primary reader",   +
+           "Parallel Aware": false,         +
+           "Relation Name": "dummy_ext_tab",+
+           "Alias": "dummy_ext_tab"         +
+         }                                  +
+       ]                                    +
+     },                                     +
+     "Optimizer": "GPORCA"                  +
+   }                                        +
  ]
 (1 row)
 
@@ -281,26 +281,26 @@ CREATE TEMP TABLE dummy_aotab (x int4) WITH (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 explain (format yaml, costs off) SELECT * FROM dummy_aotab;
-                QUERY PLAN                 
--------------------------------------------
- - Plan:                                  +
-     Node Type: "Gather Motion"           +
-     Senders: 3                           +
-     Receivers: 1                         +
-     Slice: 1                             +
-     Segments: 3                          +
-     Gang Type: "primary reader"          +
-     Parallel Aware: false                +
-     Plans:                               +
-       - Node Type: "Seq Scan"            +
-         Parent Relationship: "Outer"     +
-         Slice: 1                         +
-         Segments: 3                      +
-         Gang Type: "primary reader"      +
-         Parallel Aware: false            +
-         Relation Name: "dummy_aotab"     +
-         Alias: "dummy_aotab"             +
-   Optimizer: "Pivotal Optimizer (GPORCA)"
+              QUERY PLAN              
+--------------------------------------
+ - Plan:                             +
+     Node Type: "Gather Motion"      +
+     Senders: 3                      +
+     Receivers: 1                    +
+     Slice: 1                        +
+     Segments: 3                     +
+     Gang Type: "primary reader"     +
+     Parallel Aware: false           +
+     Plans:                          +
+       - Node Type: "Seq Scan"       +
+         Parent Relationship: "Outer"+
+         Slice: 1                    +
+         Segments: 3                 +
+         Gang Type: "primary reader" +
+         Parallel Aware: false       +
+         Relation Name: "dummy_aotab"+
+         Alias: "dummy_aotab"        +
+   Optimizer: "GPORCA"
 (1 row)
 
 -- DML node (with ORCA)
@@ -349,7 +349,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
          </Plan>                                                   +
        </Plans>                                                    +
      </Plan>                                                       +
-     <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>             +
+     <Optimizer>GPORCA</Optimizer>                                 +
    </Query>                                                        +
  </explain>
 (1 row)
@@ -417,49 +417,49 @@ explain (slicetable, costs off) SELECT * FROM explaintest;
 
 -- same in JSON format
 explain (slicetable, costs off, format json) SELECT * FROM explaintest;
-                   QUERY PLAN                   
-------------------------------------------------
- [                                             +
-   {                                           +
-     "Plan": {                                 +
-       "Node Type": "Gather Motion",           +
-       "Senders": 3,                           +
-       "Receivers": 1,                         +
-       "Slice": 1,                             +
-       "Segments": 3,                          +
-       "Gang Type": "primary reader",          +
-       "Parallel Aware": false,                +
-       "Plans": [                              +
-         {                                     +
-           "Node Type": "Seq Scan",            +
-           "Parent Relationship": "Outer",     +
-           "Slice": 1,                         +
-           "Segments": 3,                      +
-           "Gang Type": "primary reader",      +
-           "Parallel Aware": false,            +
-           "Relation Name": "explaintest",     +
-           "Alias": "explaintest"              +
-         }                                     +
-       ]                                       +
-     },                                        +
-     "Optimizer": "Pivotal Optimizer (GPORCA)",+
-     "Slice Table": [                          +
-       {                                       +
-         "Slice ID": 0,                        +
-         "Gang Type": "Dispatcher",            +
-         "Root": 0,                            +
-         "Parent": -1,                         +
-         "Gang Size": 0                        +
-       },                                      +
-       {                                       +
-         "Slice ID": 1,                        +
-         "Gang Type": "Reader",                +
-         "Root": 0,                            +
-         "Parent": 0,                          +
-         "Gang Size": 3                        +
-       }                                       +
-     ]                                         +
-   }                                           +
+                QUERY PLAN                 
+-------------------------------------------
+ [                                        +
+   {                                      +
+     "Plan": {                            +
+       "Node Type": "Gather Motion",      +
+       "Senders": 3,                      +
+       "Receivers": 1,                    +
+       "Slice": 1,                        +
+       "Segments": 3,                     +
+       "Gang Type": "primary reader",     +
+       "Parallel Aware": false,           +
+       "Plans": [                         +
+         {                                +
+           "Node Type": "Seq Scan",       +
+           "Parent Relationship": "Outer",+
+           "Slice": 1,                    +
+           "Segments": 3,                 +
+           "Gang Type": "primary reader", +
+           "Parallel Aware": false,       +
+           "Relation Name": "explaintest",+
+           "Alias": "explaintest"         +
+         }                                +
+       ]                                  +
+     },                                   +
+     "Optimizer": "GPORCA",               +
+     "Slice Table": [                     +
+       {                                  +
+         "Slice ID": 0,                   +
+         "Gang Type": "Dispatcher",       +
+         "Root": 0,                       +
+         "Parent": -1,                    +
+         "Gang Size": 0                   +
+       },                                 +
+       {                                  +
+         "Slice ID": 1,                   +
+         "Gang Type": "Reader",           +
+         "Root": 0,                       +
+         "Parent": 0,                     +
+         "Gang Size": 3                   +
+       }                                  +
+     ]                                    +
+   }                                      +
  ]
 (1 row)
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10,8 +10,8 @@ SELECT count(*) from gp_opt_version();
 
 -- Mask out Log & timestamp for orca message that has feature not supported.
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 -- fix the number of segments for Orca
 set optimizer_segments = 3;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10,8 +10,8 @@ SELECT count(*) from gp_opt_version();
 
 -- Mask out Log & timestamp for orca message that has feature not supported.
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 -- fix the number of segments for Orca
 set optimizer_segments = 3;
@@ -39,8 +39,8 @@ set optimizer_enable_indexjoin=on;
 set optimizer_trace_fallback = on;
 -- expected fall back to the planner
 select sum(distinct a), count(distinct b) from orca.r;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  sum | count 
 -----+-------
  210 |     7
@@ -6811,7 +6811,7 @@ select * from orca.r where a in (select count(*)+1 as v from orca.foo full join 
 (1 row)
 
 select * from orca.r where r.a in (select d+r.b+1 as v from orca.foo full join orca.bar on (foo.d = bar.a) group by d+r.b) order by r.a, r.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  a  | b 
 ----+---
@@ -8202,11 +8202,11 @@ partition bb start(100) end(200) every (50) );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into orca.multilevel_p values (1,1), (100,200);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 select * from orca.multilevel_p;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
   a  |  b  
 -----+-----
    1 |   1
@@ -8826,8 +8826,8 @@ select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte where ct
 
 -- ctes inside aggs
 select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte cte1, cte cte2 where cte1.h = foo.b)) as t FROM foo GROUP BY foo.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  ?column? | t 
 ----------+---
         3 | 1
@@ -9052,8 +9052,8 @@ CREATE FUNCTION sum_sfunc(anyelement,anyelement) returns anyelement AS 'select $
 CREATE FUNCTION sum_combinefunc(anyelement,anyelement) returns anyelement AS 'select $1+$2' LANGUAGE SQL STRICT;
 CREATE AGGREGATE myagg1(anyelement) (SFUNC = sum_sfunc, COMBINEFUNC = sum_combinefunc, STYPE = anyelement, INITCOND = '0');
 SELECT myagg1(i) FROM orca.tab1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "sum_sfunc" during startup
  myagg1 
 --------
@@ -9063,8 +9063,8 @@ CONTEXT:  SQL function "sum_sfunc" during startup
 CREATE FUNCTION sum_sfunc2(anyelement,anyelement,anyelement) returns anyelement AS 'select $1+$2+$3' LANGUAGE SQL STRICT;
 CREATE AGGREGATE myagg2(anyelement,anyelement) (SFUNC = sum_sfunc2, STYPE = anyelement, INITCOND = '0');
 SELECT myagg2(i,j) FROM orca.tab1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "sum_sfunc2" during startup
  myagg2 
 --------
@@ -9086,10 +9086,10 @@ INSERT INTO array_table values(6,array[222],'c');
 INSERT INTO array_table values(7,array[3],'a');
 INSERT INTO array_table values(8,array[3],'b');
 SELECT f3, myagg3(f1) from (select * from array_table order by f1 limit 10) as foo GROUP BY f3 ORDER BY f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  f3 | myagg3  
 ----+---------
  a  | {4,1,7}
@@ -9698,8 +9698,8 @@ create table orca.arrtest (
 insert into orca.arrtest (a[1:5], b[1:1][1:2][1:2], c, d)
 values ('{1,2,3,4,5}', '{{{0,0},{1,2}}}', '{}', '{}');
 select a[1:3], b[1][2][1], c[1], d[1][1] FROM orca.arrtest order by 1,2,3,4;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
     a    | b | c | d 
 ---------+---+---+---
  {1,2,3} | 1 |   | 
@@ -10014,8 +10014,8 @@ set optimizer_enable_bitmapscan=on;
 set optimizer_enable_dynamictablescan = off;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test_onepart where i=2 and t='2';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.85 rows=22 width=10)
@@ -10036,8 +10036,8 @@ DETAIL:  No plan has been computed for required properties
 (15 rows)
 
 select * from orca.bm_dyn_test_onepart where i=2 and t='2';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  i | j | t 
 ---+---+---
  2 | 2 | 2
@@ -10067,14 +10067,14 @@ distributed by (id) partition by range (year)
       default subpartition other_regions )
   ( start (2018) end (2020) every (1) );
 insert into orca.bm_dyn_test_multilvl_part select i, 2018 + (i%2), i%2 + 1, 'usa' from generate_series(1,100)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 create index bm_multi_test_idx_part on orca.bm_dyn_test_multilvl_part using bitmap(year);
 analyze orca.bm_dyn_test_multilvl_part;
 -- print name of parent index
 explain select * from orca.bm_dyn_test_multilvl_part where year = 2019;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..7.95 rows=53 width=18)
@@ -10091,8 +10091,8 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (11 rows)
 
 select count(*) from orca.bm_dyn_test_multilvl_part where year = 2019;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  count 
 -------
     50
@@ -10740,8 +10740,8 @@ CREATE TYPE rainbow AS ENUM('red','yellow','blue');
 CREATE FUNCTION func_enum_element(ANYENUM, ANYELEMENT) RETURNS TABLE(a ANYENUM, b ANYARRAY)
 AS $$ SELECT $1, ARRAY[$2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_enum_element('red'::rainbow, 'blue'::rainbow::anyelement);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_enum_element" during startup
   a  |   b    
 -----+--------
@@ -10753,8 +10753,8 @@ DROP FUNCTION IF EXISTS func_enum_element(ANYENUM, ANYELEMENT);
 CREATE FUNCTION func_element_array(ANYELEMENT, ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
 AS $$ SELECT $1, $2[1]$$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array('red'::rainbow, ARRAY['blue'::rainbow]);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_element_array" during startup
   a  |  b   
 -----+------
@@ -10766,8 +10766,8 @@ DROP FUNCTION IF EXISTS func_element_array(ANYELEMENT, ANYARRAY);
 CREATE FUNCTION func_element_array(ANYARRAY, ANYENUM) RETURNS TABLE(a ANYELEMENT, b ANYELEMENT)
 AS $$ SELECT $1[1], $2 $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array(ARRAY['blue'::rainbow], 'blue'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_element_array" during startup
   a   |  b   
 ------+------
@@ -10779,8 +10779,8 @@ DROP FUNCTION IF EXISTS func_element_array(ANYARRAY, ANYENUM);
 CREATE FUNCTION func_array(ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
 AS $$ SELECT $1[1], $1[2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array(ARRAY['blue'::rainbow, 'yellow'::rainbow]);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_array" during startup
   a   |   b    
 ------+--------
@@ -10792,8 +10792,8 @@ DROP FUNCTION IF EXISTS func_array(ANYARRAY);
 CREATE FUNCTION func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY) RETURNS TABLE(a ANYARRAY)
 AS $$ SELECT array_prepend($1, $2); $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_variadic(1.1, 1.1, 2.2, 3.3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_element_variadic" during startup
          a         
 -------------------
@@ -10805,8 +10805,8 @@ DROP FUNCTION IF EXISTS func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY);
 CREATE FUNCTION func_nonarray(ANYNONARRAY) RETURNS TABLE(a ANYNONARRAY)
 AS $$ SELECT $1; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray(5);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_nonarray" during startup
  a 
 ---
@@ -10818,8 +10818,8 @@ DROP FUNCTION IF EXISTS func_nonarray(ANYNONARRAY);
 CREATE FUNCTION func_nonarray_enum(ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYARRAY)
 AS $$ SELECT ARRAY[$1, $2]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray_enum('blue'::rainbow, 'red'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_nonarray_enum" during startup
      a      
 ------------
@@ -10831,8 +10831,8 @@ DROP FUNCTION IF EXISTS func_nonarray_enum(ANYNONARRAY, ANYENUM);
 CREATE FUNCTION func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYNONARRAY)
 AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "func_array_nonarray_enum" during startup
   a   
 ------
@@ -10844,8 +10844,8 @@ DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM)
 CREATE FUNCTION return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT) RETURNS TABLE (ae ANYENUM, aa ANYARRAY)
 AS $$ SELECT $1, array[$2, $3] $$ LANGUAGE SQL STABLE;
 SELECT * FROM return_enum_as_array('red'::rainbow, 'yellow'::rainbow, 'blue'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
 CONTEXT:  SQL function "return_enum_as_array" during startup
  ae  |      aa       
 -----+---------------
@@ -10877,9 +10877,9 @@ set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
 create table foo_ctas(a) as (select generate_series(1,10)) distributed by (a);
-LOG:  2017-05-31 14:43:22:338568 PDT,THD000,NOTICE,"Feature not supported: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA",
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA
+LOG:  2023-08-17 15:11:09:454388 PDT,THD000,NOTICE,"Falling back to Postgres-based planner because GPORCA does not support the following feature: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA",
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: CTAS. Set optimizer_enable_ctas to on to enable CTAS with GPORCA
 reset client_min_messages;
 reset log_min_duration_statement;
 reset log_statement;
@@ -11680,7 +11680,7 @@ update gp_distribution_policy set numsegments = numsegments-1 where localoid = '
 reset allow_system_table_mods;
 -- populate the tables on this smaller cluster
 explain insert into gpexp_hash select i, i from generate_series(1,50) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
@@ -11692,13 +11692,13 @@ DETAIL:  Unknown error: Partially Distributed Data
 (5 rows)
 
 insert into gpexp_hash select i, i from generate_series(1,50) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 insert into gpexp_rand select i, i from generate_series(1,50) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 insert into gpexp_repl select i, i from generate_series(1,50) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 analyze gpexp_hash;
 analyze gpexp_rand;
@@ -11706,7 +11706,7 @@ analyze gpexp_repl;
 -- the segment ids in the unmodified table should have one extra number
 select max(noexp_hash.gp_segment_id) - max(gpexp_hash.gp_segment_id) as expect_one
 from noexp_hash, gpexp_hash;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  expect_one 
 ------------
@@ -11715,7 +11715,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 
 -- join should have a redistribute motion for gpexp_hash
 explain select count(*) from noexp_hash n join gpexp_hash x on n.a=x.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -11733,7 +11733,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (11 rows)
 
 select count(*) from noexp_hash n join gpexp_hash x on n.a=x.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  count 
 -------
@@ -11741,10 +11741,10 @@ DETAIL:  Unknown error: Partially Distributed Data
 (1 row)
 
 delete from gpexp_hash where b between 21 and 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 select count(*) from gpexp_hash;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  count 
 -------
@@ -11752,10 +11752,10 @@ DETAIL:  Unknown error: Partially Distributed Data
 (1 row)
 
 update gpexp_hash set b=-1 where b between 11 and 100;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 select b, count(*) from gpexp_hash group by b order by b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  b  | count 
 ----+-------
@@ -11773,7 +11773,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (11 rows)
 
 explain update gpexp_rand set b=(select b from gpexp_hash where gpexp_rand.a = gpexp_hash.a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -11789,10 +11789,10 @@ DETAIL:  Unknown error: Partially Distributed Data
 (9 rows)
 
 update gpexp_rand set b=(select b from gpexp_hash where gpexp_rand.a = gpexp_hash.a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 select b, count(*) from gpexp_rand group by b order by b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  b  | count 
 ----+-------
@@ -11811,10 +11811,10 @@ DETAIL:  Unknown error: Partially Distributed Data
 (12 rows)
 
 delete from gpexp_repl where b >= 20;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 explain insert into gpexp_repl values (20, 20);
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                        QUERY PLAN                       
 --------------------------------------------------------
@@ -11824,10 +11824,10 @@ DETAIL:  Unknown error: Partially Distributed Data
 (3 rows)
 
 insert into gpexp_repl values (20, 20);
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 explain select count(*) from gpexp_hash h join gpexp_repl r on h.a=r.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -11843,7 +11843,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (9 rows)
 
 select count(*) as expect_20 from gpexp_hash h join gpexp_repl r on h.a=r.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  expect_20 
 -----------
@@ -11851,7 +11851,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (1 row)
 
 explain select count(*) as expect_20 from noexp_hash h join gpexp_repl r on h.a=r.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -11869,7 +11869,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (11 rows)
 
 select count(*) as expect_20 from noexp_hash h join gpexp_repl r on h.a=r.a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  expect_20 
 -----------
@@ -12568,8 +12568,8 @@ select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  a | b  
 ---+----
  1 | 99
@@ -12692,8 +12692,8 @@ select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  a | b  
 ---+----
  1 | 99
@@ -14449,8 +14449,8 @@ explain select c2 from quad_func_cast();
 (2 rows)
 
 explain select (c1).r from quad_func_cast();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=8)
@@ -14458,8 +14458,8 @@ DETAIL:  Feature not supported: FIELDSELECT
 (2 rows)
 
 explain select (c2).i from quad_func_cast();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=8)
@@ -14479,16 +14479,16 @@ select c2 from quad_func_cast();
 (1 row)
 
 select (c1).r from quad_func_cast();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
   r  
 -----
  1.1
 (1 row)
 
 select (c2).i from quad_func_cast();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
  i 
 ---
   
@@ -14548,8 +14548,8 @@ with cte as (
 select * 
 from empty_cte_tl_test
 where id in(select id from cte);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Empty target list
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Empty target list
  id 
 ----
 (0 rows)

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -114,8 +114,8 @@ set enable_hashagg = false;  -- test hashing explicitly later
 -- (and with ordering differing from grouping)
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by rollup (a,b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -134,8 +134,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by rollup (a,b) order by a,b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -154,8 +154,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by rollup (a,b) order by b desc, a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 |   |        1 |  60 |     5 |  14
@@ -174,8 +174,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
    |   |        3 | 145 |    10 |  19
@@ -199,8 +199,8 @@ select a, b, grouping(a,b),
        percentile_disc(0.5) within group (order by v),
        rank(1,2,12) within group (order by a,b,v)
   from gstest1 group by rollup (a,b) order by a,b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping |            array_agg            |          string_agg           | percentile_disc | rank 
 ---+---+----------+---------------------------------+-------------------------------+-----------------+------
  1 | 1 |        0 | {10,11}                         | 11:10                         |              10 |    3
@@ -269,8 +269,8 @@ select sum(c) from gstest2
 select sum(c) from gstest2
   group by grouping sets(grouping sets(rollup(c), grouping sets(cube(c))))
   order by 1 desc;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: nested grouping set
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  sum 
 -----
   12
@@ -284,8 +284,8 @@ DETAIL:  Feature not supported: nested grouping set
 select sum(c) from gstest2
   group by grouping sets(a, grouping sets(a, cube(b)))
   order by 1 desc;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: nested grouping set
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  sum 
 -----
   12
@@ -408,8 +408,8 @@ select t1.a, t2.b, sum(t1.v), count(*) from gstest_empty t1, gstest_empty t2
 select t1.a, t2.b, grouping(t1.a, t2.b), sum(t1.v), max(t2.a)
   from gstest1 t1, gstest2 t2
  group by grouping sets ((t1.a, t2.b), ());
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum  | max 
 ---+---+----------+------+-----
  1 | 1 |        0 |  420 |   1
@@ -426,8 +426,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 select t1.a, t2.b, grouping(t1.a, t2.b), sum(t1.v), max(t2.a)
   from gstest1 t1 join gstest2 t2 on (t1.a=t2.a)
  group by grouping sets ((t1.a, t2.b), ());
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | max 
 ---+---+----------+-----+-----
  1 | 1 |        0 | 420 |   1
@@ -439,8 +439,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 select a, b, grouping(a, b), sum(t1.v), max(t2.c)
   from gstest1 t1 join gstest2 t2 using (a,b)
  group by grouping sets ((a, b), ());
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | max 
 ---+---+----------+-----+-----
  1 | 1 |        0 | 147 |   2
@@ -452,7 +452,7 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 select a, d, grouping(a,b,c)
   from gstest3
  group by grouping sets ((a,b), (a,c));
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  a | d | grouping 
 ---+---+----------
@@ -468,8 +468,8 @@ explain (costs off)
 select g as alias1, g as alias2
   from generate_series(1,3) g
  group by alias1, rollup(alias2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple grouping sets specifications with duplicate aliased columns
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple grouping sets specifications with duplicate aliased columns
                    QUERY PLAN                   
 ------------------------------------------------
  GroupAggregate
@@ -484,8 +484,8 @@ DETAIL:  Feature not supported: Multiple grouping sets specifications with dupli
 select g as alias1, g as alias2
   from generate_series(1,3) g
  group by alias1, rollup(alias2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple grouping sets specifications with duplicate aliased columns
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple grouping sets specifications with duplicate aliased columns
  alias1 | alias2 
 --------+--------
       1 |      1
@@ -574,8 +574,8 @@ select grouping(ss.x)
 from int8_tbl i1
 cross join lateral (select (select i1.q1) as x) ss
 group by ss.x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -602,8 +602,8 @@ select grouping(ss.x)
 from int8_tbl i1
 cross join lateral (select (select i1.q1) as x) ss
 group by ss.x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  grouping 
 ----------
         0
@@ -615,8 +615,8 @@ select (select grouping(ss.x))
 from int8_tbl i1
 cross join lateral (select (select i1.q1) as x) ss
 group by ss.x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -646,8 +646,8 @@ select (select grouping(ss.x))
 from int8_tbl i1
 cross join lateral (select (select i1.q1) as x) ss
 group by ss.x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  grouping 
 ----------
         0
@@ -658,8 +658,8 @@ DETAIL:  Feature not supported: LATERAL
 select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by rollup (a,b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | b | sum 
 ---+---+-----
  1 | 1 |   1
@@ -696,8 +696,8 @@ CREATE VIEW gstest_view AS select a, b, grouping(a,b), sum(c), count(*), max(c)
   from gstest2 group by rollup ((a,b,c),(c,d));
 NOTICE:  view "gstest_view" will be a temporary view
 select pg_get_viewdef('gstest_view'::regclass, true);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                 pg_get_viewdef                                 
 -------------------------------------------------------------------------------
   SELECT gstest2.a,                                                           +
@@ -712,8 +712,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 -- Nested queries with 3 or more levels of nesting
 select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  grouping 
 ----------
         0
@@ -722,8 +722,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 (3 rows)
 
 select(select (select grouping(e,f) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  grouping 
 ----------
         0
@@ -773,8 +773,8 @@ select a, b from (values (1,2),(2,3)) v(a,b) group by a,b, grouping sets(a);
 -- Tests for chained aggregates
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -801,8 +801,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 (21 rows)
 
 select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP((e+1),(f+1));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  grouping 
 ----------
         0
@@ -811,8 +811,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 (3 rows)
 
 select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY CUBE((e+1),(f+1)) ORDER BY (e+1),(f+1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  grouping 
 ----------
         0
@@ -855,8 +855,8 @@ select a, b, sum(c) from (values (1,1,10),(1,1,11),(1,2,12),(1,2,13),(1,3,14),(2
 select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by cube (a,b) order by a,b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | b | sum 
 ---+---+-----
  1 | 1 |   1
@@ -904,8 +904,8 @@ LINE 1: select (select grouping(a,b) from gstest2) from gstest2 grou...
                                 ^
 --Nested queries
 select a, b, sum(c), count(*) from gstest2 group by grouping sets (rollup(a,b),a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: nested grouping set
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  a | b | sum | count 
 ---+---+-----+-------
  1 | 1 |   8 |     7
@@ -999,8 +999,8 @@ explain (costs off)
 
 select v.c, (select count(*) from gstest2 group by () having v.c)
   from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
  c | count 
 ---+-------
  f |      
@@ -1010,8 +1010,8 @@ DETAIL:  Feature not supported: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :va
 explain (costs off)
   select v.c, (select count(*) from gstest2 group by () having v.c)
     from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
  Sort
@@ -1094,8 +1094,8 @@ order by 2,1;
 -- FILTER queries
 select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
 group by rollup(ten);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
  ten | sum 
 -----+-----
    0 |    
@@ -1113,8 +1113,8 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 
 -- More rescan tests
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | a | four | ten | count 
 ---+---+------+-----+-------
  1 | 1 |    0 |   0 |    50
@@ -1190,8 +1190,8 @@ DETAIL:  Feature not supported: LATERAL
 (70 rows)
 
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
                                                                         array                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  {"(1,0,0,250)","(1,0,2,250)","(1,0,,500)","(1,1,1,250)","(1,1,3,250)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)","(1,,,1000)"}
@@ -1225,20 +1225,20 @@ select sum(ten) from onek group by rollup(four::text), two order by 1;
 set enable_hashagg = true;
 -- failure cases
 select count(*) from gstest4 group by rollup(unhashable_col,unsortable_col);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
 ERROR:  could not implement GROUP BY
 DETAIL:  Some of the datatypes only support hashing, while others only support sorting.
 select array_agg(v order by v) from gstest4 group by grouping sets ((id,unsortable_col),(id));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Hash aggregation with ORDER BY
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Hash aggregation with ORDER BY
 ERROR:  could not implement GROUP BY
 DETAIL:  Some of the datatypes only support hashing, while others only support sorting.
 -- simple cases
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by grouping sets ((a),(b)) order by 3,1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 |   |        1 |  60 |     5 |  14
@@ -1253,8 +1253,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 explain (costs off) select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by grouping sets ((a),(b)) order by 3,1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Sort
@@ -1268,8 +1268,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by cube(a,b) order by 3,1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -1292,8 +1292,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 explain (costs off) select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by cube(a,b) order by 3,1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Sort
@@ -1311,8 +1311,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 explain (costs off)
   select a, b, grouping(a,b), array_agg(v order by v)
     from gstest1 group by cube(a,b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                         QUERY PLAN                        
 ----------------------------------------------------------
  GroupAggregate
@@ -1345,8 +1345,8 @@ select unhashable_col, unsortable_col,
        count(*), sum(v)
   from gstest4 group by grouping sets ((unhashable_col),(unsortable_col))
  order by 3, 5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  unhashable_col | unsortable_col | grouping | count | sum 
 ----------------+----------------+----------+-------+-----
  0000           |                |        1 |     2 |  17
@@ -1363,8 +1363,8 @@ explain (costs off)
          count(*), sum(v)
     from gstest4 group by grouping sets ((unhashable_col),(unsortable_col))
    order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Sort
@@ -1385,8 +1385,8 @@ select unhashable_col, unsortable_col,
        count(*), sum(v)
   from gstest4 group by grouping sets ((v,unhashable_col),(v,unsortable_col))
  order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  unhashable_col | unsortable_col | grouping | count | sum 
 ----------------+----------------+----------+-------+-----
  0000           |                |        1 |     1 |   1
@@ -1413,8 +1413,8 @@ explain (costs off)
          count(*), sum(v)
     from gstest4 group by grouping sets ((v,unhashable_col),(v,unsortable_col))
    order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1437,8 +1437,8 @@ select unsortable_col1, unsortable_col2,
        count(*), sum(v)
   from gstest5 group by grouping sets ((unsortable_col1),(unsortable_col2))
  order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  unsortable_col1 | unsortable_col2 | grouping | count | sum 
 -----------------+-----------------+----------+-------+-----
                4 |                 |        1 |     4 |  60
@@ -1453,8 +1453,8 @@ explain (costs off)
        count(*), sum(v)
   from gstest5 group by grouping sets ((unsortable_col1),(unsortable_col2))
  order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1477,8 +1477,8 @@ select unsortable_col1, unsortable_col2,
        count(*), sum(v)
   from gstest5 group by grouping sets ((unsortable_col1),(unsortable_col2),())
  order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  unsortable_col1 | unsortable_col2 | grouping | count | sum 
 -----------------+-----------------+----------+-------+-----
                4 |                 |        1 |     4 |  60
@@ -1494,8 +1494,8 @@ explain (costs off)
        count(*), sum(v)
   from gstest5 group by grouping sets ((unsortable_col1),(unsortable_col2),())
  order by 3,5;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1609,7 +1609,7 @@ explain (costs off)
 select a, d, grouping(a,b,c)
   from gstest3
  group by grouping sets ((a,b), (a,c));
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  a | d | grouping 
 ---+---+----------
@@ -1623,7 +1623,7 @@ explain (costs off)
   select a, d, grouping(a,b,c)
     from gstest3
    group by grouping sets ((a,b), (a,c));
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
                 QUERY PLAN                
 ------------------------------------------
@@ -1640,8 +1640,8 @@ select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by grouping sets (a,b)
  order by 1, 2, 3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | b | sum 
 ---+---+-----
  1 |   |   3
@@ -1656,8 +1656,8 @@ explain (costs off)
     from (values (1),(2)) v(x), gstest_data(v.x)
    group by grouping sets (a,b)
    order by 3, 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                              QUERY PLAN                              
 ---------------------------------------------------------------------
  Sort
@@ -1687,8 +1687,8 @@ LINE 4:          lateral (select a, b, sum(v.x) from gstest_data(v.x...
 -- Tests for chained aggregates
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -1717,8 +1717,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 explain (costs off)
   select a, b, grouping(a,b), sum(v), count(*), max(v)
     from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Sort
@@ -1795,8 +1795,8 @@ explain (costs off)
 select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by cube (a,b) order by a,b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | b | sum 
 ---+---+-----
  1 | 1 |   1
@@ -1817,8 +1817,8 @@ explain (costs off)
   select a, b, sum(v.x)
     from (values (1),(2)) v(x), gstest_data(v.x)
    group by cube (a,b) order by a,b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                    QUERY PLAN                   
 ------------------------------------------------
  Sort
@@ -1913,8 +1913,8 @@ SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,(
 COMMIT;
 -- More rescan tests
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | a | four | ten | count 
 ---+---+------+-----+-------
  1 | 1 |    0 |   0 |    50
@@ -1990,8 +1990,8 @@ DETAIL:  Feature not supported: LATERAL
 (70 rows)
 
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
                                                                         array                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  {"(1,0,0,250)","(1,0,2,250)","(1,0,,500)","(1,1,1,250)","(1,1,3,250)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)","(1,,,1000)"}
@@ -2001,8 +2001,8 @@ DETAIL:  Feature not supported: ROW EXPRESSION
 -- Rescan logic changes when there are no empty grouping sets, so test
 -- that too:
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by grouping sets(four,ten)) s on true order by v.a,four,ten;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | a | four | ten | count 
 ---+---+------+-----+-------
  1 | 1 |    0 |     |   250
@@ -2036,8 +2036,8 @@ DETAIL:  Feature not supported: LATERAL
 (28 rows)
 
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by grouping sets(two,four) order by two,four) s1) from (values (1),(2)) v(a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ROW EXPRESSION
                                       array                                      
 ---------------------------------------------------------------------------------
  {"(1,0,,500)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)"}
@@ -2229,8 +2229,8 @@ explain (costs off)
 select v||'a', case grouping(v||'a') when 1 then 1 else 0 end, count(*)
   from unnest(array[1,1], array['a','b']) u(i,v)
  group by rollup(i, v||'a') order by 1,3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-argument UNNEST() or TABLE()
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-argument UNNEST() or TABLE()
  ?column? | case | count 
 ----------+------+-------
  aa       |    0 |     1
@@ -2242,8 +2242,8 @@ DETAIL:  Feature not supported: Multi-argument UNNEST() or TABLE()
 select v||'a', case when grouping(v||'a') = 1 then 1 else 0 end, count(*)
   from unnest(array[1,1], array['a','b']) u(i,v)
  group by rollup(i, v||'a') order by 1,3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-argument UNNEST() or TABLE()
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-argument UNNEST() or TABLE()
  ?column? | case | count 
 ----------+------+-------
  aa       |    0 |     1
@@ -2255,8 +2255,8 @@ DETAIL:  Feature not supported: Multi-argument UNNEST() or TABLE()
 -- test handling of outer GroupingFunc within subqueries
 explain (costs off)
 select (select grouping(v1)) from (values ((select 1))) v(v1) group by cube(v1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with outer references
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with outer references
              QUERY PLAN              
 -------------------------------------
  MixedAggregate
@@ -2271,8 +2271,8 @@ DETAIL:  Feature not supported: Grouping function with outer references
 (9 rows)
 
 select (select grouping(v1)) from (values ((select 1))) v(v1) group by cube(v1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with outer references
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with outer references
  grouping 
 ----------
         1
@@ -2281,8 +2281,8 @@ DETAIL:  Feature not supported: Grouping function with outer references
 
 explain (costs off)
 select (select grouping(v1)) from (values ((select 1))) v(v1) group by v1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with outer references
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with outer references
              QUERY PLAN              
 -------------------------------------
  GroupAggregate
@@ -2298,8 +2298,8 @@ DETAIL:  Feature not supported: Grouping function with outer references
 (10 rows)
 
 select (select grouping(v1)) from (values ((select 1))) v(v1) group by v1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with outer references
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with outer references
  grouping 
 ----------
         0
@@ -2314,8 +2314,8 @@ ALTER TABLE bug_16784 SET (autovacuum_enabled = 'false');
 WARNING:  autovacuum is not supported in Greenplum
 SET allow_system_table_mods=true;
 UPDATE pg_class SET reltuples = 10 WHERE relname='bug_16784';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 SET allow_system_table_mods=false;
 INSERT INTO bug_16784 SELECT g/10, g FROM generate_series(1,40) g;
 SET work_mem='64kB';
@@ -2325,8 +2325,8 @@ explain (costs off) select * from
   lateral (select v.a, i, j, count(*) from
              bug_16784 group by cube(i,j)) s
   order by v.a, i, j;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -2350,8 +2350,8 @@ select * from
   lateral (select a, i, j, count(*) from
              bug_16784 group by cube(i,j)) s
   order by v.a, i, j;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
  a | a | i | j  | count 
 ---+---+---+----+-------
  1 | 1 | 0 |  1 |     1

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -241,7 +241,7 @@ explain (costs off, format json) insert into insertconflicttest values (0, 'Bilb
          }                                                                 +
        ]                                                                   +
      },                                                                    +
-     "Optimizer": "Postgres query optimizer"                               +
+     "Optimizer": "Postgres-based planner"                                 +
    }                                                                       +
  ]
 (1 row)

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -19,8 +19,8 @@ insert into gstest1 values (2, 42, 40, 53, 400);
 -- [1] https://www.postgresql.org/message-id/flat/CAHnPFjSdFx_TtNpQturPMkRSJMYaD5rGP2=8iFH9V24-OjHGiQ@mail.gmail.com
 -- [2] https://www.postgresql.org/message-id/flat/830269.1656693747@sss.pgh.pa.us
 select a as alias1, a as alias2 from gstest1 group by alias1, rollup(alias2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple grouping sets specifications with duplicate aliased columns
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple grouping sets specifications with duplicate aliased columns
  alias1 | alias2 
 --------+--------
       1 |      1
@@ -30,8 +30,8 @@ DETAIL:  Feature not supported: Multiple grouping sets specifications with dupli
 (4 rows)
 
 select a as alias1, a as alias2 from gstest1 group by alias1, cube(alias2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple grouping sets specifications with duplicate aliased columns
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple grouping sets specifications with duplicate aliased columns
  alias1 | alias2 
 --------+--------
       2 |      2
@@ -51,8 +51,8 @@ select a as alias1, a as alias2 from gstest1 group by alias1, alias2;
 
 -- Orca falls back due to nested grouping sets
 select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b, rollup(c, d));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: nested grouping set
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  sum  | b  | a | c  | d  
 ------+----+---+----+----
  1000 |    |   |    |   
@@ -76,7 +76,7 @@ create temp table gstest2 (a int primary key, b int, c int, d int, v int);
 insert into gstest2 values (1, 1, 1, 1, 1);
 insert into gstest2 values (2, 2, 2, 2, 1);
 select d from gstest2 group by grouping sets ((a,b), (a));
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  d 
 ---
@@ -88,8 +88,8 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
 
 -- Orca falls back due to HAVING clause with outer references
 select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
  c | count 
 ---+-------
  f |      
@@ -98,8 +98,8 @@ DETAIL:  Feature not supported: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :va
 
 -- Orca falls back due to grouping function with multiple arguments
 select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with multiple arguments
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | b  | grouping | sum  | count | max 
 ---+----+----------+------+-------+-----
  1 |  5 |        0 |  100 |     1 | 100
@@ -113,8 +113,8 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 -- Orca falls back due to grouping function with outer references
 select (select grouping(a) from (values(1)) v2(c)) from (values(1, 2)) v1(a, b) group by (a, b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping function with outer references
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with outer references
  grouping 
 ----------
         0

--- a/src/test/regress/expected/orca_static_pruning_optimizer.out
+++ b/src/test/regress/expected/orca_static_pruning_optimizer.out
@@ -160,8 +160,8 @@ WHERE b = 42
 $query$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE)
 :qry ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: hash partitioning
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: hash partitioning
                 QUERY PLAN                 
 -------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -174,8 +174,8 @@ DETAIL:  Feature not supported: hash partitioning
 (7 rows)
 
 :qry ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: hash partitioning
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: hash partitioning
  a | b  
 ---+----
  0 | 42

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -21,8 +21,8 @@ DROP ROLE IF EXISTS regress_priv_user5;
 DROP ROLE IF EXISTS regress_priv_user6;
 -- start_ignore
 SELECT lo_unlink(oid) FROM pg_largeobject_metadata WHERE oid >= 1000 AND oid < 3000 ORDER BY oid;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  lo_unlink 
 -----------
 (0 rows)
@@ -47,8 +47,8 @@ GRANT regress_priv_group2 TO regress_priv_user4 WITH ADMIN OPTION;
 -- test owner privileges
 SET SESSION AUTHORIZATION regress_priv_user1;
 SELECT session_user, current_user;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
     session_user    |    current_user    
 --------------------+--------------------
  regress_priv_user1 | regress_priv_user1
@@ -88,8 +88,8 @@ GRANT INSERT ON atest2 TO regress_priv_user4;
 GRANT TRUNCATE ON atest2 TO regress_priv_user5;
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT session_user, current_user;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
     session_user    |    current_user    
 --------------------+--------------------
  regress_priv_user2 | regress_priv_user2
@@ -150,8 +150,8 @@ create table atest2_ctas_ok as select col1 from atest2
 where col1 in (select distinct b from atest1); -- ok 
 SET SESSION AUTHORIZATION regress_priv_user3;
 SELECT session_user, current_user;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {SQLVALUEFUNCTION :op 12 :type 19 :typmod -1 :location 7}
     session_user    |    current_user    
 --------------------+--------------------
  regress_priv_user3 | regress_priv_user3
@@ -594,7 +594,7 @@ ERROR:  permission denied for table atest5
 INSERT INTO atest5 VALUES (5,5,5); -- fail
 ERROR:  permission denied for table atest5
 UPDATE atest5 SET three = 10; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Operator Update on replicated tables not supported
 UPDATE atest5 SET one = 8; -- fail
 ERROR:  permission denied for table atest5
@@ -603,15 +603,15 @@ ERROR:  permission denied for table atest5
 -- Check that column level privs are enforced in RETURNING
 -- Ok.
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 -- Error. No SELECT on column three.
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10 RETURNING atest5.three;
 ERROR:  permission denied for table atest5
 -- Ok.  May SELECT on column "one":
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = 10 RETURNING atest5.one;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RETURNING clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
  one 
 -----
     
@@ -620,8 +620,8 @@ DETAIL:  Feature not supported: RETURNING clause
 -- Check that column level privileges are enforced for EXCLUDED
 -- Ok. we may select one
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = EXCLUDED.one;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 -- Error. No select rights on three
 INSERT INTO atest5(two) VALUES (6) ON CONFLICT (two) DO UPDATE set three = EXCLUDED.three;
 ERROR:  permission denied for table atest5
@@ -644,11 +644,11 @@ SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT (four) ON atest5 TO regress_priv_user4;
 SET SESSION AUTHORIZATION regress_priv_user4;
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT (four) DO UPDATE set three = 3; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 INSERT INTO atest5(four) VALUES (4) ON CONFLICT ON CONSTRAINT atest5_four_key DO UPDATE set three = 3; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ON CONFLICT clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ON CONFLICT clause
 SET SESSION AUTHORIZATION regress_priv_user1;
 REVOKE ALL (one) ON atest5 FROM regress_priv_user4;
 GRANT SELECT (one,two,blue) ON atest6 TO regress_priv_user4;
@@ -658,8 +658,8 @@ ERROR:  permission denied for table atest5
 UPDATE atest5 SET one = 1; -- fail
 ERROR:  permission denied for table atest5
 SELECT atest6 FROM atest6; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
  atest6 
 --------
 (0 rows)
@@ -751,8 +751,8 @@ SET SESSION AUTHORIZATION regress_priv_user1;
 ALTER TABLE atest6 DROP COLUMN three;
 SET SESSION AUTHORIZATION regress_priv_user4;
 SELECT atest6 FROM atest6; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
  atest6 
 --------
 (0 rows)
@@ -774,7 +774,7 @@ SET SESSION AUTHORIZATION regress_priv_user3;
 DELETE FROM atest5 WHERE one = 1; -- fail
 ERROR:  permission denied for table atest5
 DELETE FROM atest5 WHERE two = 2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Operator Delete on replicated tables not supported
 -- check inheritance cases
 SET SESSION AUTHORIZATION regress_priv_user1;
@@ -785,29 +785,29 @@ GRANT SELECT(fx,fy,tableoid) ON atestp2 TO regress_priv_user2;
 GRANT SELECT(fx) ON atestc TO regress_priv_user2;
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT fx FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  fx 
 ----
 (0 rows)
 
 SELECT fy FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  fy 
 ----
 (0 rows)
 
 SELECT atestp2 FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  atestp2 
 ---------
 (0 rows)
 
 SELECT tableoid FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid 
 ----------
 (0 rows)
@@ -818,29 +818,29 @@ SET SESSION AUTHORIZATION regress_priv_user1;
 GRANT SELECT(fy,tableoid) ON atestc TO regress_priv_user2;
 SET SESSION AUTHORIZATION regress_priv_user2;
 SELECT fx FROM atestp2; -- still ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  fx 
 ----
 (0 rows)
 
 SELECT fy FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  fy 
 ----
 (0 rows)
 
 SELECT atestp2 FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  atestp2 
 ---------
 (0 rows)
 
 SELECT tableoid FROM atestp2; -- ok
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  tableoid 
 ----------
 (0 rows)

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1830,20 +1830,20 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
 
 -- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------
 select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i | i  
 ---+----
  1 | -1
@@ -1861,8 +1861,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 (12 rows)
 
 select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i  | i  
 ----+----
  19 | -1
@@ -1909,8 +1909,8 @@ select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.
 (18 rows)
 
 select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i | i  
 ---+----
  1 | -1
@@ -1928,8 +1928,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 (12 rows)
 
 select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i | i | i 
 ---+---+---
  1 | 1 | 1
@@ -2184,8 +2184,8 @@ select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B wher
 (240 rows)
 
 select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i | i | i 
 ---+---+---
  1 | 1 | 1
@@ -2195,8 +2195,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 (4 rows)
 
 select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  i  | j | i  | j | i  | j  
 ----+---+----+---+----+----
   1 | 1 |  2 | 7 |  2 |  7
@@ -2210,8 +2210,8 @@ DETAIL:  Feature not supported: Non-Scalar Subquery
 (8 rows)
 
 select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select min(A.i), min(B.i) from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  a_i | b_i | c_i 
 -----+-----+-----
    1 |   1 |   1
@@ -2340,8 +2340,8 @@ SELECT id, first_name FROM employee WHERE id IN
 SELECT id, first_name, salary from employee
     where (id, salary) IN
         (SELECT id, MIN(salary) FROM employee GROUP BY id) order by id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  id | first_name | salary  
 ----+------------+---------
  01 | Jason      | 1234.56
@@ -4013,8 +4013,8 @@ WHERE EXISTS (
         FROM skip_correlated_t2
     )
 );
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
 ERROR:  correlated subquery with skip-level correlations is not supported
 EXPLAIN (COSTS OFF)
 SELECT *
@@ -4030,8 +4030,8 @@ WHERE EXISTS (
         )
         )
 );
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
 ERROR:  correlated subquery with skip-level correlations is not supported
 EXPLAIN (COSTS OFF)
 SELECT *
@@ -4047,8 +4047,8 @@ WHERE EXISTS (
         )
         )
 );
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
 ERROR:  correlated subquery with skip-level correlations is not supported
 --------------------------------------------------------------------------------
 -- Query should not cause segfault on ORCA. Will fallback to planner as no plan
@@ -4065,8 +4065,8 @@ WHERE EXISTS (
         FROM skip_correlated_t2
     )
 );
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -11867,8 +11867,8 @@ select tjoin1.c1,tjoin2.c2 from tjoin1 left outer join tjoin2 on tjoin1.c1=tjoin
 group by
 f1,f2
 ) Q ) P;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
           test_name_part           | pass_ind 
 -----------------------------------+----------
  JoinCoreOnConditionSetFunction_p1 |        1
@@ -12864,8 +12864,8 @@ select sum( distinct c1 ), count( distinct c2 ) from tset1
 group by
 f1,f2
 ) Q ) P;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
      test_name_part     | pass_ind 
 ------------------------+----------
  MultipleSumDistinct_p1 |        1
@@ -14796,8 +14796,8 @@ select rnum, c1, c2 from tjoin1 where (c1,'BB') in (select c1, c2 from tjoin2 wh
 group by
 f1,f2,f3
 ) Q ) P;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
  test_name_part | pass_ind 
 ----------------+----------
  RowSubquery_p1 |        1
@@ -14816,8 +14816,8 @@ select * from tset1 where (c1,c2) in (select c1,c2 from tset2)
 group by
 f1,f2,f3
 ) Q ) P;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-Scalar Subquery
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-Scalar Subquery
      test_name_part     | pass_ind 
 ------------------------+----------
  RowValueConstructor_p1 |        1

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -6,8 +6,8 @@ NOTICE:  table "constr_tab" does not exist, skipping
 CREATE TABLE constr_tab ( a int check (a>0) , b int, c int, d int, CHECK (a+b>5)) DISTRIBUTED BY (a);
 set optimizer_enable_dml_constraints = off;
 explain insert into constr_tab values (1,2,3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: INSERT with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: INSERT with constraints
                        QUERY PLAN                       
 --------------------------------------------------------
  Insert on constr_tab  (cost=0.00..0.01 rows=1 width=0)
@@ -30,8 +30,8 @@ explain insert into constr_tab values (1,2,3);
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE with constraints
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
@@ -42,8 +42,8 @@ DETAIL:  Feature not supported: UPDATE with constraints
 (5 rows)
 
 explain update constr_tab set b = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE with constraints
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.01 rows=1 width=22)
@@ -66,8 +66,8 @@ CREATE TABLE constr_tab ( a int NOT NULL, b int, c int, d int, CHECK (a+b>5)) DI
 INSERT INTO constr_tab VALUES(1,5,3,4);
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set a = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE with constraints
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
@@ -80,15 +80,15 @@ DETAIL:  Feature not supported: UPDATE with constraints
 DROP TABLE IF EXISTS constr_tab;
 CREATE TABLE constr_tab ( a int NOT NULL, b int NOT NULL, c int NOT NULL, d int NOT NULL) DISTRIBUTED BY (a,b);
 INSERT INTO constr_tab VALUES(1,5,3,4);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: INSERT with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: INSERT with constraints
 INSERT INTO constr_tab VALUES(1,5,3,4);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: INSERT with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: INSERT with constraints
 set optimizer_enable_dml_constraints=off;
 explain update constr_tab set b = 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE with constraints
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: UPDATE with constraints
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..1.03 rows=1 width=22)
@@ -125,28 +125,28 @@ PARTITION BY range(b)
         )
 (START(0) END(4) EVERY(2));
 INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
 SELECT * FROM ONLY homer;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  a | b | c 
 ---+---+---
 (0 rows)
 
 SELECT * FROM ONLY homer_1_prt_1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
  a | b | c 
 ---+---+---
 (0 rows)
 
 UPDATE ONLY homer SET c = c + 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
 SELECT * FROM homer;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b | c  
 ---+---+----
  1 | 0 | 40
@@ -156,11 +156,11 @@ DETAIL:  Feature not supported: Multi-level partitioned tables
 (4 rows)
 
 DELETE FROM ONLY homer WHERE a = 3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
 SELECT * FROM homer;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multi-level partitioned tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multi-level partitioned tables
  a | b | c  
 ---+---+----
  1 | 0 | 40
@@ -183,8 +183,8 @@ EXPLAIN SELECT * FROM ext_table_no_fallback;
 (3 rows)
 
 EXPLAIN SELECT * FROM ONLY ext_table_no_fallback;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..31000.00 rows=1000000 width=8)
@@ -193,8 +193,8 @@ DETAIL:  Feature not supported: ONLY in the FROM clause
 (3 rows)
 
 EXPLAIN INSERT INTO heap_t1 SELECT * FROM ONLY ext_table_no_fallback;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ONLY in the FROM clause
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: ONLY in the FROM clause
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Insert on heap_t1  (cost=0.00..31000.00 rows=333334 width=8)
@@ -206,8 +206,8 @@ DETAIL:  Feature not supported: ONLY in the FROM clause
 
 set optimizer_enable_dml=off;
 EXPLAIN INSERT INTO homer VALUES (1,0,40),(2,1,43),(3,2,41),(4,3,44);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: DML not enabled
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: DML not enabled
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Insert on homer  (cost=0.00..0.05 rows=2 width=12)
@@ -218,8 +218,8 @@ DETAIL:  Feature not supported: DML not enabled
 (5 rows)
 
 EXPLAIN UPDATE ONLY homer SET c = c + 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: DML not enabled
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: DML not enabled
                     QUERY PLAN                     
 ---------------------------------------------------
  Update on homer  (cost=0.00..0.00 rows=0 width=0)
@@ -229,8 +229,8 @@ DETAIL:  Feature not supported: DML not enabled
 (3 rows)
 
 EXPLAIN DELETE FROM ONLY homer WHERE a = 3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: DML not enabled
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: DML not enabled
                     QUERY PLAN                     
 ---------------------------------------------------
  Delete on homer  (cost=0.00..0.00 rows=0 width=0)
@@ -274,8 +274,8 @@ explain select count(*) from foo group by a;
 set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;
 explain select count(*) from foo group by a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=163.00..164.00 rows=100 width=12)
@@ -287,8 +287,8 @@ DETAIL:  No plan has been computed for required properties
 
 -- Orca should fallback for RTE_TABLEFUNC RTE type
 explain SELECT * FROM xmltable('/root' passing '' COLUMNS element text);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: RangeTableEntry of type Table Function
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RangeTableEntry of type Table Function
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Table Function Scan on "xmltable"  (cost=0.00..1.00 rows=100 width=32)
@@ -306,8 +306,8 @@ alter table ext_part attach partition p1 for values in (1);
 alter table ext_part attach partition p2_ext for values in (2);
 NOTICE:  partition constraints are not validated when attaching a readable external table
 explain insert into ext_part values (1);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
                       QUERY PLAN                      
 ------------------------------------------------------
  Insert on ext_part  (cost=0.00..0.03 rows=1 width=4)
@@ -316,8 +316,8 @@ DETAIL:  Feature not supported: Insert with External/foreign partition storage t
 (3 rows)
 
 explain delete from ext_part where a=1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Delete with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Delete with External/foreign partition storage types
                          QUERY PLAN                         
 ------------------------------------------------------------
  Delete on ext_part  (cost=0.00..435.25 rows=32 width=10)
@@ -328,6 +328,6 @@ DETAIL:  Feature not supported: Delete with External/foreign partition storage t
 (5 rows)
 
 explain update ext_part set a=1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Update with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Update with External/foreign partition storage types
 ERROR:  cannot update foreign table "p2_ext"

--- a/src/test/regress/expected/qp_query_execution.out
+++ b/src/test/regress/expected/qp_query_execution.out
@@ -9,7 +9,7 @@ create or replace function qx_count_operator(query text, planner_operator text, 
 $$
 rv = plpy.execute('EXPLAIN '+ query)
 plan = '\n'.join([row['QUERY PLAN'] for row in rv])
-optimizer = plan.find('Pivotal Optimizer (GPORCA)')
+optimizer = plan.find('GPORCA')
 
 if optimizer >= 0:
     return plan.count(optimizer_operator)

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -2030,8 +2030,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -2141,8 +2141,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -2873,8 +2873,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -2984,8 +2984,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -3279,8 +3279,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -4493,8 +4493,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -4608,8 +4608,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -5292,8 +5292,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -5407,8 +5407,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -6138,8 +6138,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -6249,8 +6249,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -7031,8 +7031,8 @@ and CITY_AO_CNT/LANG_CNT > (select  max(CITY_AO_CNT/LANG_CNT)  from allcountry_a
 WHERE allcountry_aostats.code = country_ao.code
 and FOO.region = country_ao.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_ao_cnt | region_lang_cnt |          region           
 --------------------+-----------------+---------------------------
                 840 |             192 | Caribbean
@@ -7146,8 +7146,8 @@ where longlivingregions.region = denseregions.region and allcountry_aostats.code
 and country_ao.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_ao_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 -------------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
            4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -7922,8 +7922,8 @@ and CITY_CO_CNT/LANG_CNT > (select  max(CITY_CO_CNT/LANG_CNT)  from allcountry_c
 WHERE allcountry_costats.code = country_co.code
 and FOO.region = country_co.region
 group by FOO.region order by FOO.region;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_co_cnt | region_lang_cnt |          region           
 --------------------+-----------------+---------------------------
                 840 |             192 | Caribbean
@@ -8037,8 +8037,8 @@ where longlivingregions.region = denseregions.region and allcountry_costats.code
 and country_co.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_co_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 -------------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
            4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -8276,8 +8276,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -9515,20 +9515,20 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 );
 \d+ view_with_shared_scans;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
                            View "qp_with_clause.view_with_shared_scans"
        Column        |       Type       | Collation | Nullable | Default | Storage  | Description 
 ---------------------+------------------+-----------+----------+---------+----------+-------------
@@ -9631,8 +9631,8 @@ UNION ALL
   WHERE longlivingregions.region = denseregions.region AND allcountrystats.code = country.code AND country.region = longlivingregions.region AND country.indepyear > 1900;
 
 select city_cnt,lang_cnt,name,region from view_with_shared_scans order by name LIMIT 50;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  |          region           
 ----------+----------+---------------------------------------+---------------------------
         4 |        5 | Afghanistan                           | Southern and Central Asia
@@ -9688,8 +9688,8 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
 (50 rows)
 
 select city_cnt,lang_cnt,name,"REGION_POP","REGION_GNP",region from view_with_shared_scans where region = 'Eastern Europe';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |        name        | REGION_POP | REGION_GNP |     region     
 ----------+----------+--------------------+------------+------------+----------------
       189 |       12 | Russian Federation |  307026000 |  659980.00 | Eastern Europe

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1290,8 +1290,8 @@ explain (costs off) select * from rep_tab;
 set optimizer_enable_replicated_table=off;
 set optimizer_trace_fallback=on;
 explain (costs off) select * from rep_tab;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_replicated_table to enable replicated tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Use optimizer_enable_replicated_table to enable replicated tables
                 QUERY PLAN
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)

--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -51,8 +51,8 @@ select 1 a, row_number() over (partition by 'a') union all (select 1 a , 2 b);
 -- This should preserve domain types
 select pg_typeof(a) from (select 'a'::information_schema.sql_identifier a union all
 select 'b'::information_schema.sql_identifier)a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
              pg_typeof             
 -----------------------------------
  information_schema.sql_identifier
@@ -78,8 +78,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 -- Yet, we keep behaviors on text-like columns
 select pg_typeof(a) from(select 'foo' a union select 'foo'::name)s;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  pg_typeof 
 -----------
  name
@@ -87,8 +87,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 select pg_typeof(a) from(select 1 x, 'foo' a union
     select 1, 'foo' union select 1, 'foo'::name)s;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  pg_typeof 
 -----------
  text
@@ -96,8 +96,8 @@ DETAIL:  Feature not supported: Non-default collation
 
 select pg_typeof(a) from(select 1 x, 'foo' a union
     (select 1, 'foo' union select 1, 'foo'::name))s;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  pg_typeof 
 -----------
  name
@@ -302,13 +302,13 @@ create table rep3(c1 int, c2 int) distributed replicated;
 set allow_system_table_mods = on;
 update gp_distribution_policy set numsegments = 2
   where localoid = 'rep2'::regclass;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 select localoid::regclass, policytype, numsegments
   from gp_distribution_policy
   where localoid::regclass in ('rep2', 'rep3');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  localoid | policytype | numsegments 
 ----------+------------+-------------
  rep3     | r          |           3
@@ -316,7 +316,7 @@ DETAIL:  Feature not supported: Queries on coordinator-only tables
 (2 rows)
 
 explain select * from rep2 union all select * from rep3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
@@ -328,7 +328,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 (5 rows)
 
 select * from rep2 union all select * from rep3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  c1 | c2 
 ----+----
@@ -707,8 +707,8 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -728,8 +728,8 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -749,8 +749,8 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -770,8 +770,8 @@ UNION ALL
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -993,8 +993,8 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1014,8 +1014,8 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1035,8 +1035,8 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1056,8 +1056,8 @@ UNION
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1493,56 +1493,56 @@ UNION ALL SELECT 300, 300)
 -- Binary UNION ALL explain
 --
 select count_operator('(select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select b1 from T_b2) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select a1 from T_a1) UNION ALL (select c1 from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select c1 from T_random) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_a1) UNION ALL (select * from T_b2) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_a1) UNION ALL (select * from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_b2) UNION ALL (select * from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
@@ -1554,8 +1554,8 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1567,8 +1567,8 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1580,8 +1580,8 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1592,8 +1592,8 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select c1 from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -1949,56 +1949,56 @@ UNION SELECT 300, 300)
 -- Binary UNION explain
 --
 select count_operator('(select a1 from T_a1) UNION (select b1 from T_b2) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select b1 from T_b2) UNION (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select a1 from T_a1) UNION (select c1 from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select c1 from T_random) UNION (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_a1) UNION (select * from T_b2) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_a1) UNION (select * from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('(select * from T_b2) UNION (select * from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               1
@@ -2010,8 +2010,8 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select a1 from T_a1) UNION (select d1 from T_constant) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -2023,8 +2023,8 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select a1 from T_a1) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -2036,8 +2036,8 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select c1 from T_random) UNION (select d1 from T_constant) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -2048,8 +2048,8 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;', 'APPEND');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  count_operator 
 ----------------
               2
@@ -2133,20 +2133,20 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 set allow_system_table_mods = on;
 update gp_distribution_policy set numsegments = 1
   where localoid = 'union_schema.t1'::regclass::oid;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 update gp_distribution_policy set numsegments = 2
   where localoid = 'union_schema.t2'::regclass::oid;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on coordinator-only tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
 select relname, policytype, numsegments, distkey
   from pg_class, gp_distribution_policy, pg_namespace ns
   where pg_class.oid = localoid and relnamespace = ns.oid
     and nspname = 'union_schema'
     and relname in ('t1', 't2', 't3')
   order by relname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  relname | policytype | numsegments | distkey 
 ---------+------------+-------------+---------
  t1      | p          |           1 | 1
@@ -2155,16 +2155,16 @@ DETAIL:  Feature not supported: Non-default collation
 (3 rows)
 
 insert into union_schema.t1 select i, i from generate_series(1,10)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 insert into union_schema.t2 select i, i from generate_series(1,20)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 analyze union_schema.t1;
 analyze union_schema.t2;
 explain select * from union_schema.t1 join union_schema.t2
     on union_schema.t1.a = union_schema.t2.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
@@ -2184,7 +2184,7 @@ explain select union_schema.t1.a, union_schema.t2.b
     on union_schema.t1.a = union_schema.t2.b
   union all
   select * from union_schema.t3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
@@ -2204,7 +2204,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 
 select * from union_schema.t1 join union_schema.t2
   on union_schema.t1.a = union_schema.t2.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  a  | b  | a  | b  
 ----+----+----+----
@@ -2225,7 +2225,7 @@ select union_schema.t1.a, union_schema.t2.b
     on union_schema.t1.a = union_schema.t2.b
 union all
 select * from union_schema.t3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  a  | b  
 ----+----
@@ -2243,16 +2243,16 @@ DETAIL:  Unknown error: Partially Distributed Data
 
 truncate union_schema.t1, union_schema.t2;
 insert into union_schema.t1 select i, i from generate_series(1,20)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 insert into union_schema.t2 select i, i from generate_series(1,10)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
 analyze union_schema.t1;
 analyze union_schema.t2;
 explain select * from union_schema.t1 join union_schema.t2
     on union_schema.t1.a = union_schema.t2.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
@@ -2272,7 +2272,7 @@ explain select union_schema.t1.a, union_schema.t2.b
 	  on union_schema.t1.a = union_schema.t2.b
   union all
   select * from union_schema.t3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -2292,7 +2292,7 @@ DETAIL:  Unknown error: Partially Distributed Data
 
 select * from union_schema.t1 join union_schema.t2
   on union_schema.t1.a = union_schema.t2.b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  a  | b  | a  | b  
 ----+----+----+----
@@ -2313,7 +2313,7 @@ select union_schema.t1.a, union_schema.t2.b
     on union_schema.t1.a = union_schema.t2.b
 union all
 select * from union_schema.t3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Unknown error: Partially Distributed Data
  a  | b  
 ----+----

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -794,8 +794,8 @@ explain (costs off)
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                          QUERY PLAN                         
 ------------------------------------------------------------
  Limit
@@ -816,8 +816,8 @@ DETAIL:  Feature not supported: Inherited tables
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
  ab 
 ----
  ab
@@ -846,8 +846,8 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Inherited tables
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Inherited tables
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -872,8 +872,8 @@ explain (costs off)
    UNION ALL
    SELECT 2 AS t, * FROM tenk1 b) c
  WHERE t = 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -958,8 +958,8 @@ SELECT * FROM
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3
 ORDER BY x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Sort
@@ -982,8 +982,8 @@ SELECT * FROM
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3
 ORDER BY x;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  t | x 
 ---+---
  2 | 4

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -1178,8 +1178,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                     pg_get_viewdef                                     
 ---------------------------------------------------------------------------------------
   SELECT i.i,                                                                         +
@@ -1207,8 +1207,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                               pg_get_viewdef                                               
 -----------------------------------------------------------------------------------------------------------
   SELECT i.i,                                                                                             +
@@ -1235,8 +1235,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                            pg_get_viewdef                                            
 -----------------------------------------------------------------------------------------------------
   SELECT i.i,                                                                                       +
@@ -1263,8 +1263,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                            pg_get_viewdef                                           
 ----------------------------------------------------------------------------------------------------
   SELECT i.i,                                                                                      +
@@ -1291,8 +1291,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                     pg_get_viewdef                                     
 ---------------------------------------------------------------------------------------
   SELECT i.i,                                                                         +
@@ -1318,8 +1318,8 @@ SELECT * FROM v_window;
 (10 rows)
 
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                      pg_get_viewdef                                      
 -----------------------------------------------------------------------------------------
   SELECT i.i,                                                                           +
@@ -1332,8 +1332,8 @@ CREATE TEMP VIEW v_window AS
 	SELECT i, min(i) over (order by i range between '1 day' preceding and '10 days' following) as min_i
   FROM generate_series(now(), now()+'100 days'::interval, '1 hour') i;
 SELECT pg_get_viewdef('v_window');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
                                                       pg_get_viewdef                                                       
 ---------------------------------------------------------------------------------------------------------------------------
   SELECT i.i,                                                                                                             +
@@ -2858,8 +2858,8 @@ WINDOW w AS (ORDER BY x groups between 1 preceding and 1 following);
 
 -- with UNION
 SELECT count(*) OVER (PARTITION BY four) FROM (SELECT * FROM tenk1 UNION ALL SELECT * FROM tenk2)s LIMIT 0;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Non-default collation
  count 
 -------
 (0 rows)
@@ -3038,8 +3038,8 @@ SELECT sum(salary), row_number() OVER (ORDER BY depname), sum(
 ) FILTER (WHERE depname <> 'sales') OVER (ORDER BY depname DESC) AS "filtered_sum",
     depname
 FROM empsalary GROUP BY depname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
   sum  | row_number | filtered_sum |  depname  
 -------+------------+--------------+-----------
  25100 |          1 |        22600 | develop
@@ -3294,22 +3294,22 @@ FROM (VALUES
 ) AS t(p, i, v)
 WINDOW wnd AS (PARTITION BY P ORDER BY i ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 ORDER BY p, i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
    row    |                    nstrict                    |                  nstrict_init                   |  strict   |  strict_init   
 ----------+-----------------------------------------------+-------------------------------------------------+-----------+----------------
  1,1:NULL | +NULL                                         | MI+NULL                                         |           | MI
@@ -3344,14 +3344,14 @@ FROM (VALUES
 ) AS t(p, i, f, v)
 WINDOW wnd AS (PARTITION BY p ORDER BY i ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 ORDER BY p, i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
    row    | nstrict_filt | nstrict_init_filt | strict_filt | strict_init_filt 
 ----------+--------------+-------------------+-------------+------------------
  1,1:NULL | +NULL        | MI+NULL           |             | MI
@@ -3379,12 +3379,12 @@ FROM (VALUES
 ) AS t(i, v)
 WINDOW wnd AS (ORDER BY i ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 ORDER BY i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  row |    inverse    | noinverse 
 -----+---------------+-----------
  1:a | a             | a
@@ -3405,14 +3405,14 @@ FROM (VALUES
 ) AS t(i, v)
 WINDOW wnd AS (ORDER BY i ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 ORDER BY i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Aggregate functions with FILTER
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
  row |    inverse    | noinverse 
 -----+---------------+-----------
  1:a | a             | a
@@ -3578,14 +3578,14 @@ JOIN sum_following ON sum_following.i = vs.i
 WINDOW fwd AS (
 	ORDER BY vs.i ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
 );
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  eq1 | eq2 | eq3 
 -----+-----+-----
  t   | t   | t
@@ -4108,8 +4108,8 @@ EXPLAIN (costs off) SELECT * FROM pg_temp.f(2);
 (2 rows)
 
 SELECT * FROM pg_temp.f(2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
     f    
 ---------
  {1,2,3}

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -19,6 +19,8 @@ m/NOTICE:  extension "postgres_fdw" already exists, skipping/
 m/^ Optimizer status:.*/
 m/^ Optimizer: Pivotal Optimizer \(GPORCA\).*/
 m/^ Optimizer: Postgres query optimizer/
+m/^ Optimizer: GPORCA/
+m/^ Optimizer: Postgres-based planner/
 m/^ Settings:.*/
 
 # There are a number of NOTICE and HINT messages around table distribution,

--- a/src/test/regress/output/external_table_persistent_error_log_optimizer.source
+++ b/src/test/regress/output/external_table_persistent_error_log_optimizer.source
@@ -39,8 +39,8 @@ NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related
 (2 rows)
 
 SELECT (gp_read_persistent_error_log('ext_error_persistent')).errmsg;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
                 errmsg                 
 ---------------------------------------
  extra data after last expected column
@@ -48,39 +48,39 @@ DETAIL:  Feature not supported: FIELDSELECT
 (2 rows)
 
 select errmsg from gp_read_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  errmsg 
 --------
 (0 rows)
 
 select * from gp_truncate_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_error_log 
 -----------------------
  t
 (1 row)
 
 select * from gp_truncate_error_log('*');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_error_log 
 -----------------------
  t
 (1 row)
 
 select * from gp_truncate_error_log('*.*');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_error_log 
 -----------------------
  t
 (1 row)
 
 SELECT (gp_read_persistent_error_log('ext_error_persistent')).errmsg;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: FIELDSELECT
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: FIELDSELECT
                 errmsg                 
 ---------------------------------------
  extra data after last expected column
@@ -88,16 +88,16 @@ DETAIL:  Feature not supported: FIELDSELECT
 (2 rows)
 
 SELECT gp_truncate_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_persistent_error_log 
 ----------------------------------
  t
 (1 row)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)
@@ -111,8 +111,8 @@ NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related
 (2 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -120,16 +120,16 @@ DETAIL:  Feature not supported: unsupported exec location
 (2 rows)
 
 SELECT gp_truncate_persistent_error_log('*');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_persistent_error_log 
 ----------------------------------
  t
 (1 row)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)
@@ -143,8 +143,8 @@ NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related
 (2 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -152,16 +152,16 @@ DETAIL:  Feature not supported: unsupported exec location
 (2 rows)
 
 SELECT gp_truncate_persistent_error_log('*.*');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_persistent_error_log 
 ----------------------------------
  t
 (1 row)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)
@@ -175,8 +175,8 @@ NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related
 (2 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -186,8 +186,8 @@ DETAIL:  Feature not supported: unsupported exec location
 DROP EXTERNAL TABLE ext_error_persistent;
 -- error log still exists
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -208,8 +208,8 @@ NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related
 (2 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -218,8 +218,8 @@ DETAIL:  Feature not supported: unsupported exec location
 
 -- persistent error log has no change
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -228,15 +228,15 @@ DETAIL:  Feature not supported: unsupported exec location
 
 DROP EXTERNAL TABLE ext_error_persistent;
 SELECT relname, linenum, errmsg FROM gp_read_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
        relname        | linenum |                errmsg                 
 ----------------------+---------+---------------------------------------
  ext_error_persistent |       2 | extra data after last expected column
@@ -244,16 +244,16 @@ DETAIL:  Feature not supported: unsupported exec location
 (2 rows)
 
 SELECT gp_truncate_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_persistent_error_log 
 ----------------------------------
  t
 (1 row)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_error_persistent');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)
@@ -274,24 +274,24 @@ NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related
 (3 rows)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_bytea');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
   relname  | linenum |                     errmsg                     
 -----------+---------+------------------------------------------------
  ext_bytea |       4 | invalid hexadecimal digit: "T", column content
 (1 row)
 
 SELECT gp_truncate_persistent_error_log('ext_bytea');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  gp_truncate_persistent_error_log 
 ----------------------------------
  t
 (1 row)
 
 SELECT relname, linenum, errmsg FROM gp_read_persistent_error_log('ext_bytea');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: unsupported exec location
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: unsupported exec location
  relname | linenum | errmsg 
 ---------+---------+--------
 (0 rows)

--- a/src/test/regress/output/part_external_table_optimizer.source
+++ b/src/test/regress/output/part_external_table_optimizer.source
@@ -152,8 +152,8 @@ create table p4 (a int, b int) distributed by (a);
 alter table part attach partition p3 for values from (20) to (30);
 alter table part attach partition p4 for values from (30) to (40);
 insert into part select i,i from generate_series(25,35)i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Insert with External/foreign partition storage types
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Insert with External/foreign partition storage types
 analyze part;
 WARNING:  skipping "p2_e" --- cannot analyze this foreign table
 WARNING:  skipping "p1_e" --- cannot analyze this foreign table

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -402,8 +402,8 @@ set optimizer_enable_tablescan = FALSE;
 set optimizer_trace_fallback = TRUE;
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
             owner            | property 
 -----------------------------+----------
  A. Gent                     | 
@@ -413,10 +413,10 @@ DETAIL:  No plan has been computed for required properties
 (4 rows)
 
 SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  count_index_scans 
 -------------------
                  1
@@ -428,7 +428,7 @@ SELECT owner, property FROM GistTable1
  WHERE property IS NULL
  ORDER BY id
  ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=51)
@@ -447,8 +447,8 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id
  ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  id | property 
 ----+----------
   8 | 
@@ -458,10 +458,10 @@ DETAIL:  No plan has been computed for required properties
 (4 rows)
 
 SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  No plan has been computed for required properties
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  count_index_scans 
 -------------------
                  1
@@ -473,7 +473,7 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id
  ;
-INFO:  GPORCA failed to produce a plan, falling back to planner
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=701.28..701.28 rows=2 width=36)

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -5,7 +5,7 @@
 -- s/tableoid \d+/tableoid XXXXX/
 -- end_matchsubs
 -- start_matchignore
--- m/^LOG: .*Feature not supported: Queries on coordinator-only tables./
+-- m/^LOG: .*Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables./
 -- m/^LOG:.*ERROR,"PG exception raised"/
 -- end_matchignore
 set gp_autostats_mode=on_change;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -180,7 +180,7 @@ select string_agg(b, '') over (partition by a) from foo order by 1;
 select string_agg(b, '') over (partition by a,b) from foo order by 1;
 -- should not fall back
 select max(b) over (partition by a) from foo order by 1;
-select count_operator('select max(b) over (partition by a) from foo order by 1;', 'Pivotal Optimizer (GPORCA)');
+select count_operator('select max(b) over (partition by a) from foo order by 1;', 'GPORCA');
 -- fall back
 select string_agg(b, '') over (partition by a+1) from foo order by 1;
 select string_agg(b || 'txt', '') over (partition by a) from foo order by 1;

--- a/src/test/regress/sql/brin.sql
+++ b/src/test/regress/sql/brin.sql
@@ -337,7 +337,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/sql/brin_ao.sql
+++ b/src/test/regress/sql/brin_ao.sql
@@ -340,7 +340,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_ao%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/sql/brin_aocs.sql
+++ b/src/test/regress/sql/brin_aocs.sql
@@ -340,7 +340,7 @@ BEGIN
 			IF plan_line LIKE '%Bitmap Heap Scan on brintest_aocs%' THEN
 				plan_ok := true;
 			END IF;
-			IF plan_line LIKE '%Postgres query optimizer%' THEN
+			IF plan_line LIKE '%Postgres-based planner%' THEN
 				is_planner_plan := true;
 			END IF;
 		END LOOP;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -7,8 +7,8 @@ SELECT count(*) from gp_opt_version();
 
 -- Mask out Log & timestamp for orca message that has feature not supported.
 -- start_matchsubs
--- m/^LOG.*\"Feature/
--- s/^LOG.*\"Feature/\"Feature/
+-- m/^LOG.*\"Falling/
+-- s/^LOG.*\"Falling/\"Falling/
 -- end_matchsubs
 
 -- fix the number of segments for Orca

--- a/src/test/regress/sql/qp_query_execution.sql
+++ b/src/test/regress/sql/qp_query_execution.sql
@@ -9,7 +9,7 @@ create or replace function qx_count_operator(query text, planner_operator text, 
 $$
 rv = plpy.execute('EXPLAIN '+ query)
 plan = '\n'.join([row['QUERY PLAN'] for row in rv])
-optimizer = plan.find('Pivotal Optimizer (GPORCA)')
+optimizer = plan.find('GPORCA')
 
 if optimizer >= 0:
     return plan.count(optimizer_operator)


### PR DESCRIPTION
This has a few commits that modify logging and explain messages. See individual commits for details. The main ones are

1) Rename Pivotal Optimizer to "GPORCA", and rename "Postgres query
optimizer" to "Postgres-based planner". This is most visible in EXPLAIN output.

2) Change fallback message from GPORCA to Postgres-based planner It will now be: "Falling back to Postgres-based planner because GPORCA does not support the following feature:<>" instead of: "Feature not supported:<>". Currently when looking through logs it's not obvious that it's an GPORCA fallback vs some other failure.

Both of these will result in quite a few ICW changes, so I'm looking for approvals/consensus before I mass change those files.

Note: This will not be backported to 6X