### PR TITLE
planner: Adjust index scan path by numsegments

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
@@ -8045,28 +8045,24 @@ explain (verbose, costs off)
                      ->  Merge Join
                            Output: foo.f1, loct1.f1, foo.f2
                            Merge Cond: (foo.f1 = loct1.f1)
-                           ->  Sort
+                           ->  Redistribute Motion 1:3  (slice2)
                                  Output: foo.f1, foo.f2
-                                 Sort Key: foo.f1
-                                 ->  Redistribute Motion 1:3  (slice2)
-                                       Output: foo.f1, foo.f2
-                                       Hash Key: foo.f1
-                                       ->  Append
-                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Hash Key: foo.f1
+                                 ->  Merge Append
+                                       Sort Key: foo.f1
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             Output: foo.f1, foo.f2
+                                             Merge Key: foo.f1
+                                             ->  Index Scan using i_foo_f1 on public.foo
                                                    Output: foo.f1, foo.f2
-                                                   ->  Seq Scan on public.foo
-                                                         Output: foo.f1, foo.f2
-                                             ->  Foreign Scan on public.foo2
-                                                   Output: foo2.f1, foo2.f2
-                                                   Remote SQL: SELECT f1, f2 FROM public.loct1
-                           ->  Sort
+                                       ->  Foreign Scan on public.foo2
+                                             Output: foo2.f1, foo2.f2
+                                             Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           ->  Index Only Scan using i_loct1_f1 on public.loct1
                                  Output: loct1.f1
-                                 Sort Key: loct1.f1
-                                 ->  Seq Scan on public.loct1
-                                       Output: loct1.f1
  Optimizer: Postgres query optimizer
  Settings: constraint_exclusion = 'off', enable_hashjoin = 'off', enable_mergejoin = 'on', optimizer = 'off'
-(34 rows)
+(30 rows)
 
 select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
  f1 | f1 
@@ -8087,8 +8083,8 @@ select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.
 -- list but no output change as compared to the previous query
 explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit
    Output: foo.f1, loct1.f1, foo.f2
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -8102,28 +8098,24 @@ explain (verbose, costs off)
                      ->  Merge Left Join
                            Output: foo.f1, loct1.f1, foo.f2
                            Merge Cond: (foo.f1 = loct1.f1)
-                           ->  Sort
+                           ->  Redistribute Motion 1:3  (slice2)
                                  Output: foo.f1, foo.f2
-                                 Sort Key: foo.f1
-                                 ->  Redistribute Motion 1:3  (slice2)
-                                       Output: foo.f1, foo.f2
-                                       Hash Key: foo.f1
-                                       ->  Append
-                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Hash Key: foo.f1
+                                 ->  Merge Append
+                                       Sort Key: foo.f1
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             Output: foo.f1, foo.f2
+                                             Merge Key: foo.f1
+                                             ->  Index Scan using i_foo_f1 on public.foo
                                                    Output: foo.f1, foo.f2
-                                                   ->  Seq Scan on public.foo
-                                                         Output: foo.f1, foo.f2
-                                             ->  Foreign Scan on public.foo2
-                                                   Output: foo2.f1, foo2.f2
-                                                   Remote SQL: SELECT f1, f2 FROM public.loct1
-                           ->  Sort
+                                       ->  Foreign Scan on public.foo2
+                                             Output: foo2.f1, foo2.f2
+                                             Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           ->  Index Only Scan using i_loct1_f1 on public.loct1
                                  Output: loct1.f1
-                                 Sort Key: loct1.f1
-                                 ->  Seq Scan on public.loct1
-                                       Output: loct1.f1
  Optimizer: Postgres query optimizer
  Settings: constraint_exclusion = 'off', enable_hashjoin = 'off', enable_mergejoin = 'on', optimizer = 'off'
-(34 rows)
+(30 rows)
 
 select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
  f1 | f1 

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -464,12 +464,12 @@ explain (costs off) select cn, vn, pn, sum(qty*prc) from sale group by rollup(cn
          Group Key: cn, vn, pn, (GROUPINGSET_ID())
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: cn, vn, pn, (GROUPINGSET_ID())
-               ->  Partial MixedAggregate
-                     Hash Key: cn, vn, pn
-                     Hash Key: cn, vn
-                     Hash Key: cn
+               ->  Partial GroupAggregate
+                     Group Key: cn, vn, pn
+                     Group Key: cn, vn
+                     Group Key: cn
                      Group Key: ()
-                     ->  Seq Scan on sale
+                     ->  Index Scan using sale_pkey on sale
  Optimizer: Postgres query optimizer
 (12 rows)
 

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -361,15 +361,14 @@ SELECT b FROM test_select_best_cover WHERE b>42;
 -- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Index Only Scan using i_test_select_best_cover_a_b on test_select_best_cover (actual rows=25 loops=1)
-         Index Cond: (a > 42)
-         Filter: (b > 42)
+   ->  Index Only Scan using i_test_select_best_cover_ab on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: ((a > 42) AND (b > 42))
          Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 -- KEYS: [a]    INCLUDED: []
 -- KEYS: [a]    INCLUDED: [b]
@@ -504,16 +503,16 @@ SELECT pt.a, pt.b FROM test_cover_index_on_pt AS pt JOIN test_basic_cover_index 
 ---------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
-         Hash Cond: (pt.a = t.a)
-         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 524288 buckets.
-         ->  Index Only Scan using test_cover_index_on_pt_1_prt_3_a_b_idx on test_cover_index_on_pt_1_prt_3 pt (actual rows=1 loops=1)
+         Hash Cond: (t.a = pt.a)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+         ->  Index Only Scan using i_test_basic_index on test_basic_cover_index t (actual rows=5 loops=1)
                Index Cond: (a < 10)
-               Filter: (b = 2)
                Heap Fetches: 0
-         ->  Hash (actual rows=5 loops=1)
+         ->  Hash (actual rows=1 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
-               ->  Index Only Scan using i_test_basic_index on test_basic_cover_index t (actual rows=5 loops=1)
+               ->  Index Only Scan using test_cover_index_on_pt_1_prt_3_a_b_idx on test_cover_index_on_pt_1_prt_3 pt (actual rows=1 loops=1)
                      Index Cond: (a < 10)
+                     Filter: (b = 2)
                      Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (14 rows)

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6663,16 +6663,17 @@ analyze j1; -- GPDB also needs this to get the same plan as in upstream
 explain (costs off) select * from j1
 inner join j2 on j1.id1 = j2.id1 and j1.id2 = j2.id2
 where j1.id1 % 1000 = 1 and j2.id1 % 1000 = 1;
-                  QUERY PLAN                   
------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
-         Merge Cond: (j1.id1 = j2.id1)
-         Join Filter: (j1.id2 = j2.id2)
-         ->  Index Scan using j1_id1_idx on j1
-         ->  Index Scan using j2_id1_idx on j2
+         Merge Cond: ((j1.id1 = j2.id1) AND (j1.id2 = j2.id2))
+         ->  Index Only Scan using j1_pkey on j1
+               Filter: ((id1 % 1000) = 1)
+         ->  Index Only Scan using j2_pkey on j2
+               Filter: ((id1 % 1000) = 1)
  Optimizer: Postgres query optimizer
-(7 rows)
+(8 rows)
 
 select * from j1
 inner join j2 on j1.id1 = j2.id1 and j1.id2 = j2.id2

--- a/src/test/regress/expected/partition_join.out
+++ b/src/test/regress/expected/partition_join.out
@@ -642,49 +642,49 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_e t1, prt2_e t2 WHERE (t1.a + t1.b)/2 = 
 --
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM prt1 t1, prt2 t2, prt1_e t3 WHERE t1.a = t2.b AND t1.a = (t3.a + t3.b)/2 AND t1.b = 0 ORDER BY t1.a, t2.b;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: t1.a
    ->  Sort
          Sort Key: t1.a
          ->  Append
-               ->  Hash Join
-                     Hash Cond: (((t3.a + t3.b) / 2) = t1.a)
-                     ->  Seq Scan on prt1_e_p1 t3
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Hash Join
-                                       Hash Cond: (t2.b = t1.a)
-                                       ->  Seq Scan on prt2_p1 t2
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Seq Scan on prt1_p1 t1
-                                                         Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (((t3_1.a + t3_1.b) / 2) = t1_1.a)
-                     ->  Seq Scan on prt1_e_p2 t3_1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Hash Join
-                                       Hash Cond: (t2_1.b = t1_1.a)
-                                       ->  Seq Scan on prt2_p2 t2_1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                   ->  Seq Scan on prt1_p2 t1_1
-                                                         Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (((t3_2.a + t3_2.b) / 2) = t1_2.a)
-                     ->  Seq Scan on prt1_e_p3 t3_2
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                 ->  Hash Join
-                                       Hash Cond: (t2_2.b = t1_2.a)
-                                       ->  Seq Scan on prt2_p3 t2_2
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice7; segments: 3)
-                                                   ->  Seq Scan on prt1_p3 t1_2
-                                                         Filter: (b = 0)
+               ->  Nested Loop
+                     Join Filter: (t1.a = ((t3.a + t3.b) / 2))
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (t2.b = t1.a)
+                                 ->  Seq Scan on prt2_p1 t2
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Seq Scan on prt1_p1 t1
+                                                   Filter: (b = 0)
+                     ->  Index Scan using iprt1_e_p1_ab2 on prt1_e_p1 t3
+                           Index Cond: (((a + b) / 2) = t2.b)
+               ->  Nested Loop
+                     Join Filter: (t1_1.a = ((t3_1.a + t3_1.b) / 2))
+                     ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (t2_1.b = t1_1.a)
+                                 ->  Seq Scan on prt2_p2 t2_1
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                             ->  Seq Scan on prt1_p2 t1_1
+                                                   Filter: (b = 0)
+                     ->  Index Scan using iprt1_e_p2_ab2 on prt1_e_p2 t3_1
+                           Index Cond: (((a + b) / 2) = t2_1.b)
+               ->  Nested Loop
+                     Join Filter: (t1_2.a = ((t3_2.a + t3_2.b) / 2))
+                     ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (t2_2.b = t1_2.a)
+                                 ->  Seq Scan on prt2_p3 t2_2
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                             ->  Seq Scan on prt1_p3 t1_2
+                                                   Filter: (b = 0)
+                     ->  Index Scan using iprt1_e_p3_ab2 on prt1_e_p3 t3_2
+                           Index Cond: (((a + b) / 2) = t2_2.b)
  Optimizer: Postgres query optimizer
 (42 rows)
 
@@ -817,16 +817,15 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice9; segments: 3)
                                  Hash Key: t1_2.a
-                                 ->  Hash Right Join
-                                       Hash Cond: (t1_2.a = ((t3_2.a + t3_2.b) / 2))
-                                       ->  Seq Scan on prt1_p3 t1_2
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice10; segments: 3)
-                                                   Hash Key: ((t3_2.a + t3_2.b) / 2)
-                                                   ->  Seq Scan on prt1_e_p3 t3_2
-                                                         Filter: (c = 0)
+                                 ->  Nested Loop Left Join
+                                       ->  Redistribute Motion 3:3  (slice10; segments: 3)
+                                             Hash Key: ((t3_2.a + t3_2.b) / 2)
+                                             ->  Seq Scan on prt1_e_p3 t3_2
+                                                   Filter: (c = 0)
+                                       ->  Index Scan using iprt1_p3_a on prt1_p3 t1_2
+                                             Index Cond: (a = ((t3_2.a + t3_2.b) / 2))
  Optimizer: Postgres query optimizer
-(54 rows)
+(53 rows)
 
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) RIGHT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t3.c = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
   a  |  c   |  b  |  c   | ?column? | c 

--- a/src/test/regress/expected/qp_join_union_all.out
+++ b/src/test/regress/expected/qp_join_union_all.out
@@ -755,13 +755,15 @@ explain analyze select c1 from dist_view_large join
                                        ->  Seq Scan on inner_2  (cost=0.00..1.03 rows=3 width=4) (never executed)
                                        ->  Hash  (cost=1.03..1.03 rows=1 width=4) (actual time=0.000..0.054 rows=0 loops=1)
                                              Buckets: 262144  Batches: 1  Memory Usage: 2048kB
-                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (actual time=0.000..0.048 rows=0 loops=1)
-                                                   ->  Seq Scan on inner_1  (cost=0.00..1.01 rows=1 width=4) (actual time=0.000..2.255 rows=0 loops=1)
-         ->  Append  (cost=0.00..1018.44 rows=22222 width=4) (never executed)
-               ->  Seq Scan on dist_large_1  (cost=0.00..453.67 rows=11111 width=4) (never executed)
-                     Filter: (c1 < inner_2.cc)
-               ->  Seq Scan on dist_large_2  (cost=0.00..453.67 rows=11111 width=4) (never executed)
-                     Filter: (c1 < inner_2.cc)
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (actual time=0.000..0.165 rows=0 loops=1)
+                                                   ->  Seq Scan on inner_1  (cost=0.00..1.01 rows=1 width=4) (actual time=0.000..0.006 rows=0 loops=1)
+         ->  Append  (cost=0.17..961.73 rows=22222 width=4) (never executed)
+               ->  Index Only Scan using dist_large_1_index on dist_large_1  (cost=0.17..425.31 rows=11111 width=4) (never executed)
+                     Index Cond: (c1 < inner_2.cc)
+                     Heap Fetches: 0
+               ->  Index Only Scan using dist_large_2_index on dist_large_2  (cost=0.17..425.31 rows=11111 width=4) (never executed)
+                     Index Cond: (c1 < inner_2.cc)
+                     Heap Fetches: 0
  Optimizer: Postgres query optimizer
  Planning Time: 1.368 ms
    (slice0)    Executor memory: 64K bytes.

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1091,17 +1091,16 @@ set optimizer_enable_hashjoin=off;
 set enable_hashjoin=off;
 set enable_nestloop=on;
 explain select b from dist_tab where b in (select distinct c from rep_tab);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000021.44 rows=4 width=4)
-   ->  Nested Loop  (cost=10000000001.16..10000000021.39 rows=1 width=4)
-         ->  HashAggregate  (cost=10000000001.02..10000000001.03 rows=2 width=4)
-               Group Key: rep_tab.c
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.13..10000000009.27 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=10000000000.13..10000000009.21 rows=1 width=4)
+         Join Filter: (dist_tab.b = rep_tab.c)
+         ->  Index Only Scan using idx on dist_tab  (cost=0.13..8.15 rows=1 width=4)
+         ->  Materialize  (cost=10000000000.00..10000000001.03 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-         ->  Index Only Scan using idx on dist_tab  (cost=0.13..10.16 rows=1 width=4)
-               Index Cond: (b = rep_tab.c)
  Optimizer: Postgres query optimizer
-(8 rows)
+(7 rows)
 
 select b from dist_tab where b in (select distinct c from rep_tab);
  b 

--- a/src/test/regress/expected/select.out
+++ b/src/test/regress/expected/select.out
@@ -886,19 +886,15 @@ RESET enable_indexscan;
 explain (costs off)
 select unique1, unique2 from onek2
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Heap Scan on onek2
-         Recheck Cond: (((unique2 = 11) AND (stringu1 < 'B'::name)) OR (unique1 = 0))
-         Filter: (stringu1 < 'B'::name)
-         ->  BitmapOr
-               ->  Bitmap Index Scan on onek2_u2_prtl
-                     Index Cond: (unique2 = 11)
-               ->  Bitmap Index Scan on onek2_u1_prtl
-                     Index Cond: (unique1 = 0)
+         Recheck Cond: (stringu1 < 'B'::name)
+         Filter: ((unique2 = 11) OR (unique1 = 0))
+         ->  Bitmap Index Scan on onek2_u2_prtl
  Optimizer: Postgres query optimizer
-(10 rows)
+(6 rows)
 
 select unique1, unique2 from onek2
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';

--- a/src/test/regress/expected/subselect_gp_indexes.out
+++ b/src/test/regress/expected/subselect_gp_indexes.out
@@ -151,7 +151,7 @@ explain select t1.id1, (select count(*) from generate_series(1,5) g, choose_seqs
                              Filter: (t1.id1 = t2.id1)
                              ->  Materialize  (cost=0.00..4.75 rows=17 width=8)
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..4.50 rows=17 width=8)
-                                         ->  Seq Scan on choose_seqscan_t2 t2  (cost=0.00..3.50 rows=17 width=8)
+                                         ->  Index Scan using bidx2 on choose_seqscan_t2 t2 (cost=0.00..3.50 rows=17 width=8)
                        ->  Hash  (cost=0.05..0.05 rows=2 width=4)
                              ->  Function Scan on generate_series g  (cost=0.00..0.05 rows=2 width=4)
  Optimizer: Postgres query optimizer
@@ -192,7 +192,7 @@ explain select t1.id1, (select count(*) from choose_seqscan_t3 t3, choose_seqsca
                              Filter: (t3.id1 = t1.id1)
                              ->  Materialize  (cost=0.00..4.75 rows=50 width=4)
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..4.50 rows=17 width=4)
-                                         ->  Seq Scan on choose_seqscan_t3 t3  (cost=0.00..3.50 rows=17 width=4)
+                                         ->  Index Only Scan using bidx3 on choose_seqscan_t3 t3  (cost=0.00..3.50 rows=17 width=4)
                        ->  Materialize  (cost=0.00..5.00 rows=50 width=4)
                              ->  Result  (cost=0.00..4.75 rows=50 width=4)
                                    Filter: (t2.id1 = t1.id1)

--- a/src/test/regress/output/uao_dml/ao_covering_index.source
+++ b/src/test/regress/output/uao_dml/ao_covering_index.source
@@ -311,15 +311,14 @@ SELECT b FROM test_select_best_cover_@amname@ WHERE b>42;
 -- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab_@amname@
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover_@amname@ WHERE a>42 AND b>42;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Index Only Scan using i_test_select_best_cover_a_bc_@amname@ on test_select_best_cover_@amname@ (actual rows=25 loops=1)
-         Index Cond: (a > 42)
-         Filter: (b > 42)
+   ->  Index Only Scan using i_test_select_best_cover_ab_@amname@ on test_select_best_cover_@amname@ (actual rows=25 loops=1)
+         Index Cond: ((a > 42) AND (b > 42))
          Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(6 rows)
+(5 rows)
 
 -- KEYS: [a]    INCLUDED: []
 -- KEYS: [a]    INCLUDED: [b]


### PR DESCRIPTION
Since c5f6dbbe84c, we have changed planner's cost model to operate on
rows/tuples/pages scaled down by the number of segments, when
considering base tables.

However, we didn't do the same thing for the index's tuples/pages during
index costing, which we should. That way, we won't overcharge for index
access.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/cost_index