### PR TITLE
docs - start statistics docs reorg, add info about extended stats

### DIFF
--- a/gpdb-doc/markdown/admin_guide/intro/about_statistics.html.md
+++ b/gpdb-doc/markdown/admin_guide/intro/about_statistics.html.md
@@ -2,228 +2,39 @@
 title: About Database Statistics in Greenplum Database 
 ---
 
-An overview of statistics gathered by the ANALYZE command in Greenplum Database.
-
-Statistics are metadata that describe the data stored in the database. The query optimizer needs up-to-date statistics to choose the best execution plan for a query. For example, if a query joins two tables and one of them must be broadcast to all segments, the optimizer can choose the smaller of the two tables to minimize network traffic.
-
-The statistics used by the optimizer are calculated and saved in the system catalog by the `ANALYZE` command. There are three ways to initiate an analyze operation:
-
--   You can run the `ANALYZE` command directly.
--   You can run the `analyzedb` management utility outside of the database, at the command line.
--   An automatic analyze operation can be triggered when DML operations are performed on tables that have no statistics or when a DML operation modifies a number of rows greater than a specified threshold.
-
-These methods are described in the following sections. The `VACUUM ANALYZE` command is another way to initiate an analyze operation, but its use is discouraged because vacuum and analyze are different operations with different purposes.
+Statistics are metadata that describe the data stored in the database. The Postgres Planner and Greenplum Query Optimizer need up-to-date statistics to choose the best execution plan for a query. For example, if a query joins two tables and one of them must be broadcast to all segments, the planner or optimizer can choose the smaller of the two tables to minimize network traffic.
 
 Calculating statistics consumes time and resources, so Greenplum Database produces estimates by calculating statistics on samples of large tables. In most cases, the default settings provide the information needed to generate correct execution plans for queries. If the statistics produced are not producing optimal query execution plans, the administrator can tune configuration parameters to produce more accurate statistics by increasing the sample size or the granularity of statistics saved in the system catalog. Producing more accurate statistics has CPU and storage costs and may not produce better plans, so it is important to view explain plans and test query performance to ensure that the additional statistics-related costs result in better query performance.
 
+Statistics used by the planner and optimizer are calculated and saved in the system catalog by the `ANALYZE` command. You can initiate an analyze operation in one of three ways:
+
+-   Running the [ANALYZE](../../ref_guide/sql_commands/ANALYZE.html) command directly.
+-   Running the [analyzedb](../../utility_guide/ref/analyzedb.html) management utility outside of the database, at the system command line.
+-   Triggering an automatic analyze operation when DML operations are performed on tables that have no statistics or when a DML operation modifies a number of rows greater than a specified threshold.
+
+(The `VACUUM ANALYZE` command is another way to initiate an analyze operation, but its use is discouraged because vacuum and analyze are different operations with different purposes.)
+
+Refer to [About Single-Column and Extended Statistics](extended_statistics.html) for more information about the statistics collected by Greenplum Database.
+
 **Parent topic:** [Greenplum Database Concepts](../intro/partI.html)
 
-## <a id="topic_oq3_qxj_3s"></a>System Statistics 
+## <a id="topic_oq3_qxj_3s"></a>About System Statistics
 
-### <a id="tabsize"></a>Table Size 
+### <a id="tabsize"></a>Table Size
 
 The query planner seeks to minimize the disk I/O and network traffic required to run a query, using estimates of the number of rows that must be processed and the number of disk pages the query must access. The data from which these estimates are derived are the `pg_class` system table columns `reltuples` and `relpages`, which contain the number of rows and pages at the time a `VACUUM` or `ANALYZE` command was last run. As rows are added or deleted, the numbers become less accurate. However, an accurate count of disk pages is always available from the operating system, so as long as the ratio of `reltuples` to `relpages` does not change significantly, the optimizer can produce an estimate of the number of rows that is sufficiently accurate to choose the correct query execution plan.
 
 When the `reltuples` column differs significantly from the row count returned by `SELECT COUNT(*)`, an analyze should be performed to update the statistics.
 
-When a `REINDEX` command finishes recreating an index, the `relpages` and `reltuples` columns are set to zero. The `ANALYZE` command should be run on the base table to update these columns.
+Further details about Greenplum Database's use of statistics can be found in [How the Planner Uses Statistics](https://www.postgresql.org/docs/12/planner-stats-details.html) in the PostgreSQL documentation.
 
-### <a id="pgstattab"></a>The pg\_statistic System Table and pg\_stats View 
+### <a id="pgstattab"></a>Statistics-Related System Tables and Views
 
-The `pg_statistic` system table holds the results of the last `ANALYZE` operation on each database table. There is a row for each column of every table. It has the following columns:
+The [pg_statistic](../../ref_guide/system_catalogs/pg_statistic.html) system table holds the results of the last `ANALYZE` operation on each database table. The `pg_statistic` table has a row for each column of every table.
 
-starelid
-:   The object ID of the table or index the column belongs to.
+The [pg_stats](../../ref_guide/system_catalogs/catalog_ref-views.html#pg_stats) system view presents the contents of `pg_statistic` in a friendlier format. `pg_stats` is readable by all, whereas `pg_statistic` is readable only by a superuser. This prevents unprivileged users from learning something about the contents of other users' tables from the statistics. Greenplum Database restricts the `pg_stats` view to show only rows about tables that the current user can read.
 
-staattnum
-:   The number of the described column, beginning with 1.
-
-stainherit
-:   If true, the statistics include inheritance child columns, not just the values in the specified relation.
-
-stanullfrac
-:   The fraction of the column's entries that are null.
-
-stawidth
-:   The average stored width, in bytes, of non-null entries.
-
-stadistinct
-:   A positive number is an estimate of the number of distinct values in the column; the number is not expected to vary with the number of rows. A negative value is the number of distinct values divided by the number of rows, that is, the ratio of rows with distinct values for the column, negated. This form is used when the number of distinct values increases with the number of rows. A unique column, for example, has an `n_distinct` value of -1.0. Columns with an average width greater than 1024 are considered unique.
-
-stakind<i>N</i>
-:   A code number indicating the kind of statistics stored in the <i>N</i>th slot of the `pg_statistic` row.
-
-staop<i>N</i>
-:   An operator used to derive the statistics stored in the <i>N</i>th slot. For example, a histogram slot would show the < operator that defines the sort order of the data.
-
-stanumbers<i>N</i>
-:   float4 array containing numerical statistics of the appropriate kind for the <i>N</i>th slot, or `NULL` if the slot kind does not involve numerical values.
-
-stavalues<i>N</i>
-:   Column data values of the appropriate kind for the <i>N</i>th slot, or `NULL` if the slot kind does not store any data values. Each array's element values are actually of the specific column's data type, so there is no way to define these columns' types more specifically than <i>anyarray</i>.
-
-The statistics collected for a column vary for different data types, so the `pg_statistic` table stores statistics that are appropriate for the data type in four <i>slots</i>, consisting of four columns per slot. For example, the first slot, which normally contains the most common values for a column, consists of the columns `stakind1`, `staop1`, `stanumbers1`, and `stavalues1`.
-
-The `stakindN` columns each contain a numeric code to describe the type of statistics stored in their slot. The `stakind` code numbers from 1 to 99 are reserved for core PostgreSQL data types. Greenplum Database uses code numbers 1, 2, 3, 4, 5, and 99. A value of 0 means the slot is unused. The following table describes the kinds of statistics stored for the three codes.
-
-<table class="table frame-all" id="topic_oq3_qxj_3s__table_upf_1yc_nt"><caption><span class="table--title-label">Table 1. </span><span class="title">Contents of pg_statistic "slots"</span></caption><colgroup><col style="width:14.285714285714285%"><col style="width:85.71428571428571%"></colgroup><thead class="thead">
-                <tr class="row">
-                  <th class="entry" id="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">stakind Code</th>
-                  <th class="entry" id="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2">Description</th>
-                </tr>
-              </thead><tbody class="tbody">
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">1</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Most CommonValues (MCV) Slot</em>
-                    <ul class="ul" id="topic_oq3_qxj_3s__ul_ipg_gyc_nt">
-                      <li class="li"><code class="ph codeph">staop</code> contains the object ID of the "=" operator, used to
-                        decide whether values are the same or not.</li>
-                      <li class="li"><code class="ph codeph">stavalues</code> contains an array of the <var class="keyword varname">K</var>
-                        most common non-null values appearing in the column.</li>
-                      <li class="li"><code class="ph codeph">stanumbers</code> contains the frequencies (fractions of total
-                        row count) of the values in the <code class="ph codeph">stavalues</code> array. </li>
-                    </ul>The values are ordered in decreasing frequency. Since the arrays are
-                    variable-size, <var class="keyword varname">K</var> can be chosen by the statistics collector.
-                    Values must occur more than once to be added to the <code class="ph codeph">stavalues</code>
-                    array; a unique column has no MCV slot.</td>
-                </tr>
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">2</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Histogram Slot</em> – describes the distribution of scalar data.<ul class="ul" id="topic_oq3_qxj_3s__ul_t2f_zyc_nt">
-                      <li class="li"><code class="ph codeph">staop</code> is the object ID of the "&lt;" operator, which
-                        describes the sort ordering. </li>
-                      <li class="li"><code class="ph codeph">stavalues</code> contains <var class="keyword varname">M</var> (where
-                            <code class="ph codeph"><var class="keyword varname">M</var>&gt;=2</code>) non-null values that divide
-                        the non-null column data values into <code class="ph codeph"><var class="keyword varname">M</var>-1</code>
-                        bins of approximately equal population. The first <code class="ph codeph">stavalues</code>
-                        item is the minimum value and the last is the maximum value. </li>
-                      <li class="li"><code class="ph codeph">stanumbers</code> is not used and should be
-                          <code class="ph codeph">NULL</code>. </li>
-                    </ul><p class="p">If a Most Common Values slot is also provided, then the histogram
-                      describes the data distribution after removing the values listed in the MCV
-                      array. (It is a <em class="ph i">compressed histogram</em> in the technical parlance). This
-                      allows a more accurate representation of the distribution of a column with
-                      some very common values. In a column with only a few distinct values, it is
-                      possible that the MCV list describes the entire data population; in this case
-                      the histogram reduces to empty and should be omitted.</p></td>
-                </tr>
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">3</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Correlation Slot</em> – describes the correlation between the physical
-                    order of table tuples and the ordering of data values of this column. <ul class="ul" id="topic_oq3_qxj_3s__ul_yvj_sfd_nt">
-                      <li class="li"><code class="ph codeph">staop</code> is the object ID of the "&lt;" operator. As with
-                        the histogram, more than one entry could theoretically appear.</li>
-                      <li class="li"><code class="ph codeph">stavalues</code> is not used and should be
-                        <code class="ph codeph">NULL</code>. </li>
-                      <li class="li"><code class="ph codeph">stanumbers</code> contains a single entry, the correlation
-                        coefficient between the sequence of data values and the sequence of their
-                        actual tuple positions. The coefficient ranges from +1 to -1.</li>
-                    </ul></td>
-                </tr>
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">4</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Most Common Elements Slot</em> - is similar to a Most Common Values (MCV)
-                    Slot, except that it stores the most common non-null <em class="ph i">elements</em> of the
-                    column values. This is useful when the column datatype is an array or some other
-                    type with identifiable elements (for instance, <code class="ph codeph">tsvector</code>). <ul class="ul" id="topic_oq3_qxj_3s__ul_kj4_wnm_y2b">
-                      <li class="li"><code class="ph codeph">staop</code> contains the equality operator appropriate to the
-                        element type. </li>
-                      <li class="li"><code class="ph codeph">stavalues</code> contains the most common element values.</li>
-                      <li class="li"><code class="ph codeph">stanumbers</code> contains common element frequencies. </li>
-                    </ul><p class="p">Frequencies are measured as the fraction of non-null rows the element
-                      value appears in, not the frequency of all rows. Also, the values are sorted
-                      into the element type's default order (to support binary search for a
-                      particular value). Since this puts the minimum and maximum frequencies at
-                      unpredictable spots in <code class="ph codeph">stanumbers</code>, there are two extra
-                      members of <code class="ph codeph">stanumbers</code> that hold copies of the minimum and
-                      maximum frequencies. Optionally, there can be a third extra member that holds
-                      the frequency of null elements (the frequency is expressed in the same terms:
-                      the fraction of non-null rows that contain at least one null element). If this
-                      member is omitted, the column is presumed to contain no <code class="ph codeph">NULL</code>
-                      elements. </p>
-                    <div class="note note note_note"><span class="note__title">Note:</span> For <code class="ph codeph">tsvector</code> columns, the <code class="ph codeph">stavalues</code>
-                      elements are of type <code class="ph codeph">text</code>, even though their representation
-                      within <code class="ph codeph">tsvector</code> is not exactly
-                    <code class="ph codeph">text</code>.</div></td>
-                </tr>
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">5</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Distinct Elements Count Histogram Slot</em> - describes the distribution
-                    of the number of distinct element values present in each row of an array-type
-                    column. Only non-null rows are considered, and only non-null elements.<ul class="ul" id="topic_oq3_qxj_3s__ul_gmr_jnm_y2b">
-                      <li class="li"><code class="ph codeph">staop</code> contains the equality operator appropriate to the
-                        element type. </li>
-                      <li class="li"><code class="ph codeph">stavalues</code> is not used and should be
-                        <code class="ph codeph">NULL</code>. </li>
-                      <li class="li"><code class="ph codeph">stanumbers</code> contains information about distinct elements.
-                        The last member of <code class="ph codeph">stanumbers</code> is the average count of
-                        distinct element values over all non-null rows. The preceding
-                          <var class="keyword varname">M</var> (where <code class="ph codeph"><var class="keyword varname">M</var> &gt;=2</code>)
-                        members form a histogram that divides the population of distinct-elements
-                        counts into <code class="ph codeph"><var class="keyword varname">M</var>-1</code> bins of approximately
-                        equal population. The first of these is the minimum observed count, and the
-                        last the maximum.</li>
-                    </ul></td>
-                </tr>
-                <tr class="row">
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">99</td>
-                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Hyperloglog Slot</em> - for child leaf partitions of a partitioned table,
-                    stores the <code class="ph codeph">hyperloglog_counter</code> created for the sampled data.
-                    The <code class="ph codeph">hyperloglog_counter</code> data structure is converted into a
-                      <code class="ph codeph">bytea</code> and stored in a <code class="ph codeph">stavalues5</code> slot of the
-                      <code class="ph codeph">pg_statistic</code> catalog table.</td>
-                </tr>
-              </tbody></table>
-
-The `pg_stats` view presents the contents of `pg_statistic` in a friendlier format. The `pg_stats` view has the following columns:
-
-schemaname
-:   The name of the schema containing the table.
-
-tablename
-:   The name of the table.
-
-attname
-:   The name of the column this row describes.
-
-inherited
-:   If true, the statistics include inheritance child columns.
-
-null\_frac
-:   The fraction of column entries that are null.
-
-avg\_width
-:   The average storage width in bytes of the column's entries, calculated as `avg(pg_column_size(column_name))`.
-
-n\_distinct
-:   A positive number is an estimate of the number of distinct values in the column; the number is not expected to vary with the number of rows. A negative value is the number of distinct values divided by the number of rows, that is, the ratio of rows with distinct values for the column, negated. This form is used when the number of distinct values increases with the number of rows. A unique column, for example, has an `n_distinct` value of -1.0. Columns with an average width greater than 1024 are considered unique.
-
-most\_common\_vals
-:   An array containing the most common values in the column, or null if no values seem to be more common. If the `n_distinct` column is -1, `most_common_vals` is null. The length of the array is the lesser of the number of actual distinct column values or the value of the `default_statistics_target` configuration parameter. The number of values can be overridden for a column using `ALTER TABLE table SET COLUMN column SET STATISTICS N`.
-
-most\_common\_freqs
-:   An array containing the frequencies of the values in the `most_common_vals` array. This is the number of occurrences of the value divided by the total number of rows. The array is the same length as the `most_common_vals` array. It is null if `most_common_vals` is null.
-
-histogram\_bounds
-:   An array of values that divide the column values into groups of approximately the same size. A histogram can be defined only if there is a `max()` aggregate function for the column. The number of groups in the histogram is the same as the `most_common_vals` array size.
-
-correlation
-:   Greenplum Database computes correlation statistics for both heap and AO/AOCO tables, but the Postgres Planner uses these statistics only for heap tables.
-
-most\_common\_elems
-:   An array that contains the most common element values.
-
-most\_common\_elem\_freqs
-:   An array that contains common element frequencies.
-
-elem\_count\_histogram
-:   An array that describes the distribution of the number of distinct element values present in each row of an array-type column.
-
-Newly created tables and indexes have no statistics. You can check for tables with missing statistics using the `gp_stats_missing` view, which is in the `gp_toolkit` schema:
-
-```
-SELECT * from gp_toolkit.gp_stats_missing;
-```
+Newly-created tables and indexes have no statistics. You can check for tables with missing statistics using the `gp_stats_missing` view, which is located in the `gp_toolkit` schema.
 
 ### <a id="section_wsy_1rv_mt"></a>Sampling 
 
@@ -231,85 +42,21 @@ When calculating statistics for large tables, Greenplum Database creates a small
 
 ### <a id="section_u5p_brv_mt"></a>Updating Statistics 
 
-Running `ANALYZE` with no arguments updates statistics for all tables in the database. This could take a very long time, so it is better to analyze tables selectively after data has changed. You can also analyze a subset of the columns in a table, for example columns used in joins, `WHERE` clauses, `SORT` clauses, `GROUP BY` clauses, or `HAVING` clauses.
+Running [ANALYZE](../../ref_guide/sql_commands/ANALYZE.html) with no arguments updates statistics for all tables in the database. This could take a very long time, so it is better to analyze tables selectively after data has changed. You can also analyze a subset of the columns in a table, for example columns used in `JOIN`s, `WHERE` clauses, `SORT` clauses, `GROUP BY` clauses, or `HAVING` clauses.
 
-Analyzing a severely bloated table can generate poor statistics if the sample contains empty pages, so it is good practice to vacuum a bloated table before analyzing it.
+Refer to [Updating Statistics with ANALYZE](../../best_practices/analyze.html) for more information about selective analyzing and configuring statistics.
 
-See the *SQL Command Reference* in the *Greenplum Database Reference Guide* for details of running the `ANALYZE` command.
-
-Refer to the *Greenplum Database Management Utility Reference* for details of running the `analyzedb` command.
-
-### <a id="section_cv2_crv_mt"></a>Analyzing Partitioned Tables 
+## <a id="section_cv2_crv_mt"></a>Analyzing Partitioned Tables 
 
 When the `ANALYZE` command is run on a partitioned table, it analyzes each child leaf partition table, one at a time. You can run `ANALYZE` on just new or changed partition tables to avoid analyzing partitions that have not changed.
 
-The `analyzedb` command-line utility skips unchanged partitions automatically. It also runs concurrent sessions so it can analyze several partitions concurrently. It runs five sessions by default, but the number of sessions can be set from 1 to 10 with the `-p` command-line option. Each time `analyzedb` runs, it saves state information for append-optimized tables and partitions in the `db_analyze` directory in the coordinator data directory. The next time it runs, `analyzedb` compares the current state of each table with the saved state and skips analyzing a table or partition if it is unchanged. Heap tables are always analyzed.
+The `analyzedb` command-line utility skips unchanged partitions automatically. It also runs concurrent sessions so it can analyze several partitions at the same time. It runs five sessions by default, but the number of sessions can be set from 1 to 10 with the `-p` command-line option. Each time `analyzedb` runs, it saves state information for append-optimized tables and partitions in the `db_analyze` directory in the coordinator data directory. The next time it runs, `analyzedb` compares the current state of each table with the saved state and skips analyzing a table or partition if it is unchanged. Heap tables are always analyzed.
 
-If GPORCA is enabled \(the default\), you also need to run `ANALYZE` or `ANALYZE ROOTPARTITION` on the root partition of a partitioned table \(not a leaf partition\) to refresh the root partition statistics. GPORCA requires statistics at the root level for partitioned tables. The Postgres Planner does not use these statistics.
+When the Greenplum Query Optimizer (GPORCA) is enabled \(the default\), you also need to run `ANALYZE` or `ANALYZE ROOTPARTITION` on the root partition of a partitioned table \(not a leaf partition\) to refresh the root partition statistics. GPORCA requires statistics at the root level for partitioned tables. The Postgres Planner does not use these statistics.
 
 The time to analyze a partitioned table is similar to the time to analyze a non-partitioned table with the same data. When all the leaf partitions have statistics, performing `ANALYZE ROOTPARTITION` to generate root partition statistics should be quick \(a few seconds depending on the number of partitions and table columns\). If some of the leaf partitions do not have statistics, then all the table data is sampled to generate root partition statistics. Sampling table data takes longer and results in lower quality root partition statistics.
 
-The Greenplum Database server configuration parameter [optimizer\_analyze\_root\_partition](../../ref_guide/config_params/guc-list.html) affects when statistics are collected on the root partition of a partitioned table. If the parameter is `on` \(the default\), the `ROOTPARTITION` keyword is not required to collect statistics on the root partition when you run `ANALYZE`. Root partition statistics are collected when you run `ANALYZE` on the root partition, or when you run `ANALYZE` on a child leaf partition of the partitioned table and the other child leaf partitions have statistics. If the parameter is `off`, you must run `ANALYZE ROOTPARTITION` to collect root partition statistics.
+The Greenplum Database server configuration parameter [optimizer\_analyze\_root\_partition](../../ref_guide/config_params/guc-list.html#optimizer_analyze_root_partition) affects when statistics are collected on the root partition of a partitioned table. If the parameter is `on` \(the default\), the `ROOTPARTITION` keyword is not required to collect statistics on the root partition when you run `ANALYZE`. Root partition statistics are collected when you run `ANALYZE` on the root partition, or when you run `ANALYZE` on a child leaf partition of the partitioned table and the other child leaf partitions have statistics. If the parameter is `off`, you must run `ANALYZE ROOTPARTITION` to collect root partition statistics.
 
-If you do not intend to run queries on partitioned tables with GPORCA \(setting the server configuration parameter [optimizer](../../ref_guide/config_params/guc-list.html) to `off`\), you can also set the server configuration parameter `optimizer_analyze_root_partition` to `off` to limit when `ANALYZE` updates the root partition statistics.
-
-## <a id="topic_gyb_qrd_2t"></a>Configuring Statistics 
-
-There are several options for configuring Greenplum Database statistics collection.
-
-### <a id="stattarg"></a>Statistics Target 
-
-The statistics target is the size of the `most_common_vals`, `most_common_freqs`, and `histogram_bounds` arrays for an individual column. By default, the target is 25. The default target can be changed by setting a server configuration parameter and the target can be set for any column using the `ALTER TABLE` command. Larger values increase the time needed to do `ANALYZE`, but may improve the quality of the Postgres Planner estimates.
-
-Set the system default statistics target to a different value by setting the `default_statistics_target` server configuration parameter. The default value is usually sufficient, and you should only raise or lower it if your tests demonstrate that query plans improve with the new target. For example, to raise the default statistics target from 100 to 150 you can use the `gpconfig` utility:
-
-```
-gpconfig -c default_statistics_target -v 150
-```
-
-The statistics target for individual columns can be set with the `ALTER TABLE` command. For example, some queries can be improved by increasing the target for certain columns, especially columns that have irregular distributions. You can set the target to zero for columns that never contribute to query optimization. When the target is 0, `ANALYZE` ignores the column. For example, the following `ALTER TABLE` command sets the statistics target for the `notes` column in the `emp` table to zero:
-
-```
-ALTER TABLE emp ALTER COLUMN notes SET STATISTICS 0;
-```
-
-The statistics target can be set in the range 0 to 1000, or set it to -1 to revert to using the system default statistics target.
-
-Setting the statistics target on a parent partition table affects the child partitions. If you set statistics to 0 on some columns on the parent table, the statistics for the same columns are set to 0 for all children partitions. However, if you later add or exchange another child partition, the new child partition will use either the default statistics target or, in the case of an exchange, the previous statistics target. Therefore, if you add or exchange child partitions, you should set the statistics targets on the new child table.
-
-### <a id="section_j3p_drv_mt"></a>Automatic Statistics Collection 
-
-Greenplum Database can be set to automatically run `ANALYZE` on a table that either has no statistics or has changed significantly when certain operations are performed on the table. For partitioned tables, automatic statistics collection is only triggered when the operation is run directly on a leaf table, and then only the leaf table is analyzed.
-
-Automatic statistics collection is governed by a server configuration parameter, and has three modes:
-
--   `none` deactivates automatic statistics collection.
--   `on_no_stats` triggers an analyze operation for a table with no existing statistics when any of the commands `CREATE TABLE AS SELECT`, `INSERT`, or `COPY` are run on the table by the table owner.
--   `on_change` triggers an analyze operation when any of the commands `CREATE TABLE AS SELECT`, `UPDATE`, `DELETE`, `INSERT`, or `COPY` are run on the table by the table owner, and the number of rows affected exceeds the threshold defined by the `gp_autostats_on_change_threshold` configuration parameter.
-
-The automatic statistics collection mode is set separately for commands that occur within a procedural language function and commands that run outside of a function:
-
--   The `gp_autostats_mode` configuration parameter controls automatic statistics collection behavior outside of functions and is set to `on_no_stats` by default.
--   The `gp_autostats_mode_in_functions` parameter controls the behavior when table operations are performed within a procedural language function and is set to `none` by default.
-
-With the `on_change` mode, `ANALYZE` is triggered only if the number of rows affected exceeds the threshold defined by the `gp_autostats_on_change_threshold` configuration parameter. The default value for this parameter is a very high value, 2147483647, which effectively deactivates automatic statistics collection; you must set the threshold to a lower number to enable it. The `on_change` mode could trigger large, unexpected analyze operations that could disrupt the system, so it is not recommended to set it globally. It could be useful in a session, for example to automatically analyze a table following a load.
-
-Setting the `gp_autostats_allow_nonowner` server configuration parameter to `true` also instructs Greenplum Database to trigger automatic statistics collection on a table when:
-
--   `gp_autostats_mode=on_change` and the table is modified by a non-owner.
--   `gp_autostats_mode=on_no_stats` and the first user to `INSERT` or `COPY` into the table is a non-owner.
-
-To deactivate automatic statistics collection outside of functions, set the `gp_autostats_mode` parameter to `none`:
-
-```
-gpconfigure -c gp_autostats_mode -v none
-```
-
-To enable automatic statistics collection in functions for tables that have no statistics, change `gp_autostats_mode_in_functions` to `on_no_stats`:
-
-```
-gpconfigure -c gp_autostats_mode_in_functions -v on_no_stats
-```
-
-Set the `log_autostats` system configuration parameter to on if you want to log automatic statistics collection operations.
+If you do not intend to run queries on partitioned tables with GPORCA \(setting the server configuration parameter [optimizer](../../ref_guide/config_params/guc-list.html#optimizer) to `off`\), you can also set the server configuration parameter `optimizer_analyze_root_partition` to `off` to limit when `ANALYZE` updates the root partition statistics.
 

--- a/gpdb-doc/markdown/admin_guide/intro/extended_statistics.html.md
+++ b/gpdb-doc/markdown/admin_guide/intro/extended_statistics.html.md
@@ -1,0 +1,436 @@
+---
+title: About Single-Column and Extended Statistics
+---
+
+The query planner estimates the number of rows retrieved by a query in order to make good choices of query plans. Most queries retrieve only a fraction of the rows in a table, due to `WHERE` clauses that restrict the rows to be examined. The planner thus needs to make an estimate of the selectivity of `WHERE` clauses, that is, the fraction of rows that match each condition in the `WHERE` clause. The information used for this task is stored in the [pg_statistic](../../ref_guide/system_catalogs/pg_statistic.html) system catalog. Entries in `pg_statistic` are updated by the `ANALYZE` and `VACUUM ANALYZE` commands, and are always approximate even when freshly updated.
+
+The amount of information stored in `pg_statistic` by `ANALYZE`, in particular the maximum number of entries in the `most_common_vals` and `histogram_bounds` arrays for each column, can be set on a column-by-column basis using the `ALTER TABLE SET STATISTICS` command, or globally by setting the [default_statistics_target](../../ref_guide/config_params/guc-list.html#default_statistics_target) configuration variable. The default limit is presently 100 entries. Raising the limit might allow more accurate planner estimates to be made, particularly for columns with irregular data distributions, at the price of consuming more space in `pg_statistic` and slightly more time to compute the estimates. Conversely, a lower limit might be sufficient for columns with simple data distributions.
+
+## <a id="about_stats_collected"></a>About the Column Statistics Collected
+
+The statistics collected for a column vary for different data types, so the `pg_statistic` table stores statistics that are appropriate for the data type in four <i>slots</i>, consisting of four columns per slot. For example, the first slot, which normally contains the most common values for a column, consists of the columns `stakind1`, `staop1`, `stanumbers1`, and `stavalues1`.
+
+The `stakindN` columns each contain a numeric code to describe the type of statistics stored in their slot. The `stakind` code numbers from 1 to 99 are reserved for core PostgreSQL data types. Greenplum Database uses code numbers 1, 2, 3, 4, 5, and 99. A value of 0 means the slot is unused. The following table describes the kinds of statistics stored for the three codes.
+
+<table class="table frame-all" id="topic_oq3_qxj_3s__table_upf_1yc_nt"><caption><span class="table--title-label">Table 1. </span><span class="title">Contents of pg_statistic "slots"</span></caption><colgroup><col style="width:14.285714285714285%"><col style="width:85.71428571428571%"></colgroup><thead class="thead">
+                <tr class="row">
+                  <th class="entry" id="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">stakind Code</th>
+                  <th class="entry" id="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2">Description</th>
+                </tr>
+              </thead><tbody class="tbody">
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">1</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Most CommonValues (MCV) Slot</em>
+                    <ul class="ul" id="topic_oq3_qxj_3s__ul_ipg_gyc_nt">
+                      <li class="li"><code class="ph codeph">staop</code> contains the object ID of the "=" operator, used to
+                        decide whether values are the same or not.</li>
+                      <li class="li"><code class="ph codeph">stavalues</code> contains an array of the <var class="keyword varname">K</var>
+                        most common non-null values appearing in the column.</li>
+                      <li class="li"><code class="ph codeph">stanumbers</code> contains the frequencies (fractions of total
+                        row count) of the values in the <code class="ph codeph">stavalues</code> array. </li>
+                    </ul>The values are ordered in decreasing frequency. Since the arrays are
+                    variable-size, <var class="keyword varname">K</var> can be chosen by the statistics collector.
+                    Values must occur more than once to be added to the <code class="ph codeph">stavalues</code>
+                    array; a unique column has no MCV slot.</td>
+                </tr>
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">2</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Histogram Slot</em> – describes the distribution of scalar data.<ul class="ul" id="topic_oq3_qxj_3s__ul_t2f_zyc_nt">
+                      <li class="li"><code class="ph codeph">staop</code> is the object ID of the "&lt;" operator, which
+                        describes the sort ordering. </li>
+                      <li class="li"><code class="ph codeph">stavalues</code> contains <var class="keyword varname">M</var> (where
+                            <code class="ph codeph"><var class="keyword varname">M</var>&gt;=2</code>) non-null values that divide
+                        the non-null column data values into <code class="ph codeph"><var class="keyword varname">M</var>-1</code>
+                        bins of approximately equal population. The first <code class="ph codeph">stavalues</code>
+                        item is the minimum value and the last is the maximum value. </li>
+                      <li class="li"><code class="ph codeph">stanumbers</code> is not used and should be
+                          <code class="ph codeph">NULL</code>. </li>
+                    </ul><p class="p">If a Most Common Values slot is also provided, then the histogram
+                      describes the data distribution after removing the values listed in the MCV
+                      array. (It is a <em class="ph i">compressed histogram</em> in the technical parlance). This
+                      allows a more accurate representation of the distribution of a column with
+                      some very common values. In a column with only a few distinct values, it is
+                      possible that the MCV list describes the entire data population; in this case
+                      the histogram reduces to empty and should be omitted.</p></td>
+                </tr>
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">3</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Correlation Slot</em> – describes the correlation between the physical
+                    order of table tuples and the ordering of data values of this column. <ul class="ul" id="topic_oq3_qxj_3s__ul_yvj_sfd_nt">
+                      <li class="li"><code class="ph codeph">staop</code> is the object ID of the "&lt;" operator. As with
+                        the histogram, more than one entry could theoretically appear.</li>
+                      <li class="li"><code class="ph codeph">stavalues</code> is not used and should be
+                        <code class="ph codeph">NULL</code>. </li>
+                      <li class="li"><code class="ph codeph">stanumbers</code> contains a single entry, the correlation
+                        coefficient between the sequence of data values and the sequence of their
+                        actual tuple positions. The coefficient ranges from +1 to -1.</li>
+                    </ul></td>
+                </tr>
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">4</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Most Common Elements Slot</em> - is similar to a Most Common Values (MCV)
+                    Slot, except that it stores the most common non-null <em class="ph i">elements</em> of the
+                    column values. This is useful when the column datatype is an array or some other
+                    type with identifiable elements (for instance, <code class="ph codeph">tsvector</code>). <ul class="ul" id="topic_oq3_qxj_3s__ul_kj4_wnm_y2b">
+                      <li class="li"><code class="ph codeph">staop</code> contains the equality operator appropriate to the
+                        element type. </li>
+                      <li class="li"><code class="ph codeph">stavalues</code> contains the most common element values.</li>
+                      <li class="li"><code class="ph codeph">stanumbers</code> contains common element frequencies. </li>
+                    </ul><p class="p">Frequencies are measured as the fraction of non-null rows the element
+                      value appears in, not the frequency of all rows. Also, the values are sorted
+                      into the element type's default order (to support binary search for a
+                      particular value). Since this puts the minimum and maximum frequencies at
+                      unpredictable spots in <code class="ph codeph">stanumbers</code>, there are two extra
+                      members of <code class="ph codeph">stanumbers</code> that hold copies of the minimum and
+                      maximum frequencies. Optionally, there can be a third extra member that holds
+                      the frequency of null elements (the frequency is expressed in the same terms:
+                      the fraction of non-null rows that contain at least one null element). If this
+                      member is omitted, the column is presumed to contain no <code class="ph codeph">NULL</code>
+                      elements. </p>
+                    <div class="note note note_note"><span class="note__title">Note:</span> For <code class="ph codeph">tsvector</code> columns, the <code class="ph codeph">stavalues</code>
+                      elements are of type <code class="ph codeph">text</code>, even though their representation
+                      within <code class="ph codeph">tsvector</code> is not exactly
+                    <code class="ph codeph">text</code>.</div></td>
+                </tr>
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">5</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Distinct Elements Count Histogram Slot</em> - describes the distribution
+                    of the number of distinct element values present in each row of an array-type
+                    column. Only non-null rows are considered, and only non-null elements.<ul class="ul" id="topic_oq3_qxj_3s__ul_gmr_jnm_y2b">
+                      <li class="li"><code class="ph codeph">staop</code> contains the equality operator appropriate to the
+                        element type. </li>
+                      <li class="li"><code class="ph codeph">stavalues</code> is not used and should be
+                        <code class="ph codeph">NULL</code>. </li>
+                      <li class="li"><code class="ph codeph">stanumbers</code> contains information about distinct elements.
+                        The last member of <code class="ph codeph">stanumbers</code> is the average count of
+                        distinct element values over all non-null rows. The preceding
+                          <var class="keyword varname">M</var> (where <code class="ph codeph"><var class="keyword varname">M</var> &gt;=2</code>)
+                        members form a histogram that divides the population of distinct-elements
+                        counts into <code class="ph codeph"><var class="keyword varname">M</var>-1</code> bins of approximately
+                        equal population. The first of these is the minimum observed count, and the
+                        last the maximum.</li>
+                    </ul></td>
+                </tr>
+                <tr class="row">
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__1">99</td>
+                  <td class="entry" headers="topic_oq3_qxj_3s__table_upf_1yc_nt__entry__2"><em class="ph i">Hyperloglog Slot</em> - for child leaf partitions of a partitioned table,
+                    stores the <code class="ph codeph">hyperloglog_counter</code> created for the sampled data.
+                    The <code class="ph codeph">hyperloglog_counter</code> data structure is converted into a
+                      <code class="ph codeph">bytea</code> and stored in a <code class="ph codeph">stavalues5</code> slot of the
+                      <code class="ph codeph">pg_statistic</code> catalog table.</td>
+                </tr>
+              </tbody></table>
+
+
+## <a id="extended_stats"></a>Extended Statistics
+
+It is common to see slow queries running bad execution plans because multiple columns used in the query clauses are correlated. The planner normally assumes that multiple conditions are independent of each other, an assumption that does not hold when column values are correlated. Regular statistics, because of their per-individual-column nature, cannot capture any knowledge about cross-column correlation. However, Greenplum Database has the ability to compute multivariate statistics, which can capture such information.
+
+Because the number of possible column combinations is very large, it's impractical to compute multivariate statistics automatically. Instead, you can create extended statistics objects, more often called just statistics objects, to instruct the server to obtain statistics across interesting sets of columns.
+
+You create statistics objects using the [CREATE STATISTICS](../../ref_guide/sql_commands/CREATE_STATISTICS.html) command. Creation of such an object merely creates a catalog entry expressing interest in the statistics. Actual data collection is performed by [ANALYZE](../../ref_guide/sql_commands/ANALYZE.html) \(either a manual command, or background auto-analyze\). The collected values can be examined in the [pg_statistic_ext_data](../../ref_guide/system_catalogs/pg_statistic_ext_data.html) catalog.
+
+`ANALYZE` computes extended statistics based on the same sample of table rows that it takes for computing regular single-column statistics. Since the sample size is increased by increasing the statistics target for the table or any of its columns, a larger statistics target will normally result in more accurate extended statistics, as well as more time spent calculating them.
+
+The following subsections describe the kinds of extended statistics that are currently supported.
+
+### <a id="exstats_fd"></a>Functional Dependencies
+
+The simplest kind of extended statistics tracks *functional dependencies*, a concept used in definitions of database normal forms. We say that column `b` is functionally dependent on column `a` if knowledge of the value of `a` is sufficient to determine the value of `b`, that is there are no two rows having the same value of `a` but different values of `b`. In a fully normalized database, functional dependencies should exist only on primary keys and superkeys. However, in practice many data sets are not fully normalized for various reasons; intentional denormalization for performance reasons is a common example. Even in a fully normalized database, there may be partial correlation between some columns, which can be expressed as partial functional dependency.
+
+The existence of functional dependencies directly affects the accuracy of estimates in certain queries. If a query contains conditions on both the independent and the dependent column\(s\), the conditions on the dependent columns do not further reduce the result size; but without knowledge of the functional dependency, the query planner will assume that the conditions are independent, resulting in underestimating the result size.
+
+To inform the planner about functional dependencies, `ANALYZE` can collect measurements of cross-column dependency. Assessing the degree of dependency between all sets of columns would be prohibitively expensive, so data collection is limited to those groups of columns appearing together in a statistics object defined with the dependencies option. It is advisable to create dependencies statistics only for column groups that are strongly correlated, to avoid unnecessary overhead in both `ANALYZE` and later query planning.
+
+Here is an example of collecting functional-dependency statistics:
+
+``` sql
+CREATE STATISTICS stts (dependencies) ON city, zip FROM zipcodes;
+
+ANALYZE zipcodes;
+
+SELECT stxname, stxkeys, stxddependencies
+  FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid)
+  WHERE stxname = 'stts';
+ stxname | stxkeys |             stxddependencies             
+---------+---------+------------------------------------------
+ stts    | 1 5     | {"1 => 5": 1.000000, "5 => 1": 0.423130}
+(1 row)
+```
+
+Here it can be seen that column 1 \(zip code\) fully determines column 5 \(city\) so the coefficient is 1.0, while city only determines zip code about 42% of the time, meaning that there are many cities \(58%\) that are represented by more than a single ZIP code.
+
+When computing the selectivity for a query involving functionally dependent columns, the planner adjusts the per-condition selectivity estimates using the dependency coefficients so as not to produce an underestimate.
+
+#### <a id="exstats_fd_limit"></a>Limitations of Functional Dependencies
+
+Functional dependencies are currently only applied when considering simple equality conditions that compare columns to constant values. They are not used to improve estimates for equality conditions comparing two columns or comparing a column to an expression, nor for range clauses, `LIKE` or any other type of condition.
+
+When estimating with functional dependencies, the planner assumes that conditions on the involved columns are compatible and hence redundant. If they are incompatible, the correct estimate would be zero rows, but that possibility is not considered. For example, given a query like:
+
+``` sql
+SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '94105';
+```
+
+the planner will disregard the `city` clause as not changing the selectivity, which is correct. However, it will make the same assumption about:
+
+``` sql
+SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '90210';
+```
+
+even though there will really be zero rows satisfying this query. Functional dependency statistics do not provide enough information to conclude that, however.
+
+In many practical situations, this assumption is usually satisfied; for example, there might be a GUI in the application that only allows selecting compatible city and ZIP code values to use in a query. But if that's not the case, functional dependencies may not be a viable option.
+
+### <a id="exstats_nvndist"></a>Multivariate N-Distinct Counts
+
+Single-column statistics store the number of distinct values in each column. Estimates of the number of distinct values when combining more than one column \(for example, for `GROUP BY a, b`\) are frequently wrong when the planner only has single-column statistical data, causing it to select bad plans.
+
+To improve such estimates, `ANALYZE` can collect n-distinct statistics for groups of columns. As before, it's impractical to do this for every possible column grouping, so data is collected only for those groups of columns appearing together in a statistics object defined with the ndistinct option. Data will be collected for each possible combination of two or more columns from the set of listed columns.
+
+Continuing the previous example, the n-distinct counts in a table of ZIP codes might look like the following:
+
+``` sql
+CREATE STATISTICS stts2 (ndistinct) ON city, state, zip FROM zipcodes;
+
+ANALYZE zipcodes;
+
+SELECT stxkeys AS k, stxdndistinct AS nd
+  FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid)
+  WHERE stxname = 'stts2';
+-[ RECORD 1 ]--------------------------------------------------------
+k  | 1 2 5
+nd | {"1, 2": 33178, "1, 5": 33178, "2, 5": 27435, "1, 2, 5": 33178}
+(1 row)
+```
+
+This indicates that there are three combinations of columns that have 33178 distinct values: ZIP code and state; ZIP code and city; and ZIP code, city and state \(the fact that they are all equal is expected given that ZIP code alone is unique in this table\). On the other hand, the combination of city and state has only 27435 distinct values.
+
+It's advisable to create `ndistinct` statistics objects only on combinations of columns that are actually used for grouping, and for which misestimation of the number of groups is resulting in bad plans. Otherwise, the `ANALYZE` cycles are just wasted.
+
+### <a id="exstats_mvmcv"></a>Multivariate Most-Common Value Lists
+
+Another type of statistic stored for each column are most-common value (MCV) lists. This allows very accurate estimates for individual columns, but may result in significant misestimates for queries with conditions on multiple columns.
+
+To improve such estimates, `ANALYZE` can collect MCV lists on combinations of columns. Similarly to functional dependencies and n-distinct coefficients, it's impractical to do this for every possible column grouping. Even more so in this case, as the MCV list \(unlike functional dependencies and n-distinct coefficients\) does store the common column values. So data is collected only for those groups of columns appearing together in a statistics object defined with the `mcv` option.
+
+> **Note** The Greenplum Query Optimizer (GPORCA) does not support MCV list statistics.
+
+Continuing the previous example, the MCV list for a table of ZIP codes might look like the following \(unlike for simpler types of statistics, a function is required for inspection of MCV contents\):
+
+``` sql
+CREATE STATISTICS stts3 (mcv) ON city, state FROM zipcodes;
+
+ANALYZE zipcodes;
+
+SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
+                pg_mcv_list_items(stxdmcv) m WHERE stxname = 'stts3';
+
+ index |         values         | nulls | frequency | base_frequency 
+-------+------------------------+-------+-----------+----------------
+     0 | {Washington, DC}       | {f,f} |  0.003467 |        2.7e-05
+     1 | {Apo, AE}              | {f,f} |  0.003067 |        1.9e-05
+     2 | {Houston, TX}          | {f,f} |  0.002167 |       0.000133
+     3 | {El Paso, TX}          | {f,f} |     0.002 |       0.000113
+     4 | {New York, NY}         | {f,f} |  0.001967 |       0.000114
+     5 | {Atlanta, GA}          | {f,f} |  0.001633 |        3.3e-05
+     6 | {Sacramento, CA}       | {f,f} |  0.001433 |        7.8e-05
+     7 | {Miami, FL}            | {f,f} |    0.0014 |          6e-05
+     8 | {Dallas, TX}           | {f,f} |  0.001367 |        8.8e-05
+     9 | {Chicago, IL}          | {f,f} |  0.001333 |        5.1e-05
+   ...
+(99 rows)
+```
+
+This indicates that the most common combination of city and state is Washington in DC, with actual frequency \(in the sample\) about 0.35%. The base frequency of the combination \(as computed from the simple per-column frequencies\) is only 0.0027%, resulting in two orders of magnitude under-estimates.
+
+It's advisable to create MCV statistics objects only on combinations of columns that are actually used in conditions together, and for which misestimation of the number of groups is resulting in bad plans. Otherwise, the `ANALYZE` and planning cycles are just wasted.
+
+#### <a id="es_mcv_func"></a>About Inspecting MCV Lists
+
+Greenplum Database provides a function to inspect complex statistics defined using the [CREATE STATISTICS](../../ref_guide/sql_commands/CREATE_STATISTICS.html) command.
+
+The `pg_mcv_list_items()` function returns a list of all items stored in a multi-column MCV list, and returns the following columns:
+
+|Name|Type|Description|
+|----|----|-----------|
+| index | int | The index of the item in the MCV list. |
+| values | text[] | The values stored in the MCV item. |
+| nulls | boolean[] | Flags identifying NULL values. |
+| frequency | double precision | The frequency of this MCV item. |
+| base_frequency | double precision | The base frequency of this MCV item. |
+
+You can use the `pg_mcv_list_items()` function as follows:
+
+``` sql
+SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
+    pg_mcv_list_items(stxdmcv) m WHERE stxname = 'stts';
+```
+
+Values of the `pg_mcv_list` can be obtained only from the [pg_statistic_ext_data](../../ref_guide/system_catalogs/pg_statistic_ext_data.html).`stxdmcv` column.
+
+## <a id="multiex"></a>Multivariate Statistics Examples
+
+### <a id="func_depend"></a>Functional Dependencies
+
+Multivariate correlation can be demonstrated with a very simple data set — a table with two columns, both containing the same values:
+
+``` sql
+CREATE TABLE t (a INT, b INT);
+INSERT INTO t SELECT i % 100, i % 100 FROM generate_series(1, 10000) s(i);
+ANALYZE t;
+```
+
+As explained in Section 14.2, the Postgres Planner can determine cardinality of `t` using the number of pages and rows obtained from `pg_class`:
+
+``` sql
+SELECT relpages, reltuples FROM pg_class WHERE relname = 't';
+
+ relpages | reltuples
+----------+-----------
+       45 |     10000
+```
+
+The data distribution is very simple; there are only 100 distinct values in each column, uniformly distributed.
+
+The following example shows the result of estimating a `WHERE` condition on the a column:
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1;
+                                 QUERY PLAN                                  
+-------------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..170.00 rows=100 width=8) (actual rows=100 loops=1)
+   Filter: (a = 1)
+   Rows Removed by Filter: 9900
+```
+
+The Postgres Planner examines the condition and determines the selectivity of this clause to be 1%. By comparing this estimate and the actual number of rows, we see that the estimate is very accurate \(in fact exact, as the table is very small\). Changing the `WHERE` condition to use the `b` column, an identical plan is generated. But observe what happens if we apply the same condition on both columns, combining them with `AND`:
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..195.00 rows=1 width=8) (actual rows=100 loops=1)
+   Filter: ((a = 1) AND (b = 1))
+   Rows Removed by Filter: 9900
+```
+
+The Postgres Planner estimates the selectivity for each condition individually, arriving at the same 1% estimates as above. Then it assumes that the conditions are independent, and so it multiplies their selectivities, producing a final selectivity estimate of just 0.01%. This is a significant underestimate, as the actual number of rows matching the conditions \(100\) is two orders of magnitude higher.
+
+This problem can be fixed by creating a statistics object that directs `ANALYZE` to calculate functional-dependency multivariate statistics on the two columns:
+
+``` sql
+CREATE STATISTICS stts (dependencies) ON a, b FROM t;
+ANALYZE t;
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..195.00 rows=100 width=8) (actual rows=100 loops=1)
+   Filter: ((a = 1) AND (b = 1))
+   Rows Removed by Filter: 9900
+```
+
+### <a id="mvnd_counts"></a>Multivariate N-Distinct Counts
+
+A similar problem occurs with estimation of the cardinality of sets of multiple columns, such as the number of groups that would be generated by a `GROUP BY` clause. When `GROUP BY `lists a single column, the n-distinct estimate \(which is visible as the estimated number of rows returned by the HashAggregate node\) is very accurate:
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ HashAggregate  (cost=195.00..196.00 rows=100 width=12) (actual rows=100 loops=1)
+   Group Key: a
+   ->  Seq Scan on t  (cost=0.00..145.00 rows=10000 width=4) (actual rows=10000 loops=1)
+```
+
+But without multivariate statistics, the estimate for the number of groups in a query with two columns in `GROUP BY`, as in the following example, is off by an order of magnitude:
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
+                                       QUERY PLAN                                        
+--------------------------------------------------------------------------------------------
+ HashAggregate  (cost=220.00..230.00 rows=1000 width=16) (actual rows=100 loops=1)
+   Group Key: a, b
+   ->  Seq Scan on t  (cost=0.00..145.00 rows=10000 width=8) (actual rows=10000 loops=1)
+```
+
+By redefining the statistics object to include n-distinct counts for the two columns, the estimate is much improved:
+
+``` sql
+DROP STATISTICS stts;
+CREATE STATISTICS stts (dependencies, ndistinct) ON a, b FROM t;
+ANALYZE t;
+EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
+                                       QUERY PLAN                                        
+--------------------------------------------------------------------------------------------
+ HashAggregate  (cost=220.00..221.00 rows=100 width=16) (actual rows=100 loops=1)
+   Group Key: a, b
+   ->  Seq Scan on t  (cost=0.00..145.00 rows=10000 width=8) (actual rows=10000 loops=1)
+```
+
+### <a id="mcv_lists"></a>MCV Lists
+
+As explained in [Functional Dependencies](#func_depend) above, functional dependencies are very cheap and efficient type of statistics, but their main limitation is their global nature \(only tracking dependencies at the column level, not between individual column values\).
+
+This section introduces multivariate variant of MCV \(most-common values\) lists, a straightforward extension of the per-column statistics described in Section 71.1. These statistics address the limitation by storing individual values, but it is naturally more expensive, both in terms of building the statistics in `ANALYZE`, storage and planning time.
+
+Let's look at the query from the *Functional Dependencies* section again, but this time with a MCV list created on the same set of columns \(be sure to drop the functional dependencies, to make sure the Postgres Planner uses the newly created statistics\).
+
+``` sql
+DROP STATISTICS stts;
+CREATE STATISTICS stts2 (mcv) ON a, b FROM t;
+ANALYZE t;
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
+                                   QUERY PLAN
+-------------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..195.00 rows=100 width=8) (actual rows=100 loops=1)
+   Filter: ((a = 1) AND (b = 1))
+   Rows Removed by Filter: 9900
+```
+
+The estimate is as accurate as with the functional dependencies, mostly thanks to the table being fairly small and having a simple distribution with a low number of distinct values. Before looking at the second query, which was not handled by functional dependencies particularly well, let's inspect the MCV list a bit.
+
+Inspecting the MCV list is possible using the `pg_mcv_list_items()` set-returning function:
+
+``` sql
+SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
+                pg_mcv_list_items(stxdmcv) m WHERE stxname = 'stts2';
+ index |  values  | nulls | frequency | base_frequency 
+-------+----------+-------+-----------+----------------
+     0 | {0, 0}   | {f,f} |      0.01 |         0.0001
+     1 | {1, 1}   | {f,f} |      0.01 |         0.0001
+   ...
+    49 | {49, 49} | {f,f} |      0.01 |         0.0001
+    50 | {50, 50} | {f,f} |      0.01 |         0.0001
+   ...
+    97 | {97, 97} | {f,f} |      0.01 |         0.0001
+    98 | {98, 98} | {f,f} |      0.01 |         0.0001
+    99 | {99, 99} | {f,f} |      0.01 |         0.0001
+(100 rows)
+```
+
+This confirms that there are 100 distinct combinations in the two columns, and all of them are about equally likely \(1% frequency for each one\). The base frequency is the frequency computed from per-column statistics, as if there were no multi-column statistics. Had there been any null values in either of the columns, this would be identified in the nulls column.
+
+When estimating the selectivity, the Postgres Planner applies all the conditions on items in the MCV list, and then sums the frequencies of the matching ones.
+
+Compared to functional dependencies, MCV lists have two major advantages. Firstly, the list stores actual values, making it possible to decide which combinations are compatible.
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 10;
+                                 QUERY PLAN
+---------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..195.00 rows=1 width=8) (actual rows=0 loops=1)
+   Filter: ((a = 1) AND (b = 10))
+   Rows Removed by Filter: 10000
+```
+
+Secondly, MCV lists handle a wider range of clause types, not just equality clauses like functional dependencies. For example, consider the following range query for the same table:
+
+``` sql
+EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a <= 49 AND b > 49;
+                                QUERY PLAN
+---------------------------------------------------------------------------
+ Seq Scan on t  (cost=0.00..195.00 rows=1 width=8) (actual rows=0 loops=1)
+   Filter: ((a <= 49) AND (b > 49))
+   Rows Removed by Filter: 10000
+```

--- a/gpdb-doc/markdown/admin_guide/perf_issues.html.md
+++ b/gpdb-doc/markdown/admin_guide/perf_issues.html.md
@@ -48,11 +48,9 @@ See [Query Profiling](query/topics/query-profiling.html) for more information ab
 
 ### <a id="topic7"></a>Tuning Statistics Collection 
 
-The following configuration parameters control the amount of data sampled for statistics collection:
+The [default_statistics_target](../ref_guide/config_params/guc-list.html#default_statistics_target) server configuration parameter controls the amount of data sampled for statistics collection.
 
--   `default_statistics_target`
-
-These parameters control statistics sampling at the system level. It is better to sample only increased statistics for columns used most frequently in query predicates. You can adjust statistics for a particular column using the command:
+This parameter controls statistics sampling at the system level. It is better to sample only increased statistics for columns used most frequently in query predicates. You can adjust statistics for a particular column using the command:
 
 `ALTER TABLE...SET STATISTICS`
 
@@ -60,10 +58,11 @@ For example:
 
 ```
 ALTER TABLE sales ALTER COLUMN region SET STATISTICS 50;
-
 ```
 
 This is equivalent to changing `default_statistics_target` for a particular column. Subsequent `ANALYZE` operations will then gather more statistics data for that column and produce better query plans as a result.
+
+Refer to [Configuring the Statistics Target](../best_practices/analyze.html) for more information on configuring the statistics target.
 
 ## <a id="topic8"></a>Optimizing Data Distribution 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_STATISTICS.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_STATISTICS.html.md
@@ -20,7 +20,6 @@ If a schema name is given \(for example, `CREATE STATISTICS myschema.mystat ...`
 ## <a id="section4"></a>Parameters 
 
 IF NOT EXISTS
-
 :   Do not throw an error if a statistics object with the same name already exists. Greenplum Database issues a notice in this case. Note that only the name of the statistics object is considered here, not the details of its definition.
 
 statistics\_name

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_STATISTICS.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_STATISTICS.html.md
@@ -14,7 +14,7 @@ DROP STATISTICS [ IF EXISTS ] <name> [, ...] [ CASCADE | RESTRICT ]
 
 ## <a id="section4"></a>Parameters 
 
-`IF EXISTS`
+IF EXISTS
 :   Do not throw an error if the statistics object does not exist. Greenplum Database issues a notice in this case.
 
 name

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_statistic.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_statistic.html.md
@@ -10,7 +10,6 @@ Since different kinds of statistics may be appropriate for different kinds of da
 
 `pg_statistic` should not be readable by the public, since even statistical information about a table's contents should be considered sensitive. \(Example: minimum and maximum values of a salary column\). [pg\_stats](catalog_ref-views.html#pg_stats) is a publicly readable view on `pg_statistic` that only exposes information about those tables that are readable by the current user.
 
-XXX
 > **Caution** Diagnostic tools such as `gpsd` and `minirepro` collect sensitive information from `pg_statistic`, such as histogram boundaries, in a clear, readable form. Always review the output files of these utilities to ensure that the contents are acceptable for transport outside of the database in your organization.
 
 |column|type|references|description|

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_statistic_ext.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_statistic_ext.html.md
@@ -4,12 +4,12 @@ The `pg_statistic_ext` system catalog table holds definitions of extended planne
 
 |column|type|references|description|
 |------|----|----------|-----------|
-|`stxrelid`|oid|[pg\_class](pg_class.html).oid | The table containing the columns described by this object |
-|`stxname`|name| | The name of the statistics object |
-|`stxnamespace`|[pg\_namespace](pg_namespace.html).oid| | The object identifier of the namespace that contains this statistics object |
-|`stxowner`|oid|[pg\_authid](pg_authid.html).oid | The owner of the statistics object |
-|`stxkeys`|int2vector|[pg\_attribute](pg_attribute.html).oid | An array of attribute numbers, indicating which table columns are covered by this statistics object; for example, a value of `1 3` would mean that the first and the third table columns are covered |
-|`stxkind`|char[]| | An array containing codes for the enabled statistics kinds; valid values are: `d` for n-distinct statistics, `f` for functional dependency statistics, and `m` for most common values \(MCV\) list statistics |
+|`stxrelid`|oid|[pg\_class](pg_class.html).oid | The table containing the columns described by this object. |
+|`stxname`|name| | The name of the statistics object. |
+|`stxnamespace`|[pg\_namespace](pg_namespace.html).oid| | The object identifier of the namespace that contains this statistics object. |
+|`stxowner`|oid|[pg\_authid](pg_authid.html).oid | The owner of the statistics object. |
+|`stxkeys`|int2vector|[pg\_attribute](pg_attribute.html).oid | An array of attribute numbers, indicating which table columns are covered by this statistics object; for example, a value of `1 3` would mean that the first and the third table columns are covered. |
+|`stxkind`|char[]| | An array containing codes for the enabled statistics kinds; valid values are: `d` for n-distinct statistics, `f` for functional dependency statistics, and `m` for most common values \(MCV\) list statistics. |
 
 The `pg_statistic_ext` entry is filled in completely during `CREATE STATISTICS`, but the actual statistical values are not computed then. Subsequent `ANALYZE` commands compute the desired values and populate an entry in the [pg\_statistic\_ext\_data](pg_statistic_ext_data.html) catalog.
 


### PR DESCRIPTION
add info about extended statistics.  start reorg'ing some of the statistics content.

in this PR:
- updates to "About Database Statistics in Greenplum Database"
    - some rewording and reorg to include postgres info
    - this is in the concepts section, i think the focus of this topic should be general info.  moved per-column info to new page "About Single-Column and Extended Statistics".
    - removed pg_statistics and pg_stats column info from this topic, xref to the system catalog ref pages instead
    - moved slot info to section "about the column statistics collected" on the new percol/extended stats page
    - moved configuring statistics info and automatic stats collection info to the best practices page - didn't seem appropriate for an intro/concepts topic, and that page already had some of this info.
- new page "About Single Column and Extended Statistics"
    - add content from https://www.postgresql.org/docs/12/planner-stats.html to this page
    - noted that gporca does not support mcv list statistics
    - is there a better location for this topic?
- misc edits to related sql and catalog ref pages

NOTE:  if the changes to the intro topic are too extensive, i can pare this down to just the new extended stats topic and ref guide edits.

NOT IN THIS PR: the docs still need to be reviewed/updated for greenplum 7 analyze and autostats behavior, i did not address those changes in this PR.

doc review site links (behind vpn):
- "about statistics" concept topic:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/stats-using/greenplum-database/GUID-admin_guide-intro-about_statistics.html
   CURRENT DOCS FOR THIS TOPIC (for comparison):  https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/admin_guide-intro-about_statistics.html
- new "about single-column and extended statistics" topics:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/stats-using/greenplum-database/GUID-admin_guide-intro-extended_statistics.html
- analyze best practices:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/stats-using/greenplum-database/GUID-best_practices-analyze.html