### PR TITLE
Allow more types of index scan on ao tables

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -6291,13 +6291,13 @@ compute_bitmap_pages(PlannerInfo *root, RelOptInfo *baserel_orig, Path *bitmapqu
 static double
 ao_random_page_cost(RangeTblEntry *rte)
 {
-	double random_page_cost = DEFAULT_AO_RAMDOM_PAGE_COST;
+	double random_page_cost = gp_appendonly_random_page_cost;
 	NameData        compresstype;
 	GetAppendOnlyEntryAttributes(rte->relid, NULL, NULL, NULL, &compresstype);
 	if (!(strcmp(NameStr(compresstype), "") == 0 ||
 				pg_strcasecmp(NameStr(compresstype), "none") == 0))
 	{
-		random_page_cost += DEFAULT_COMPRESS_PAGE_COST;
+		random_page_cost += gp_decompress_random_page_cost;
 	}
 	return random_page_cost;
 }

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -806,7 +806,11 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 *
 		 * Enable index only scan on AO here, but the index scan is still disabled.
 		 */
-		if (index->amhasgettuple)
+		if (index->amhasgettuple &&
+				((!IsAccessMethodAO(rel->relam) ||
+				  index->amcostestimate == bmcostestimate ||
+				  ipath->path.pathtype == T_IndexOnlyScan ||
+				  (!index->amhasgetbitmap))))
 			add_path(rel, (Path *) ipath);
 
 		if (index->amhasgetbitmap &&

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -806,10 +806,7 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 *
 		 * Enable index only scan on AO here, but the index scan is still disabled.
 		 */
-		if (index->amhasgettuple &&
-				((!IsAccessMethodAO(rel->relam) ||
-				 index->amcostestimate == bmcostestimate ||
-				 ipath->path.pathtype == T_IndexOnlyScan)))
+		if (index->amhasgettuple)
 			add_path(rel, (Path *) ipath);
 
 		if (index->amhasgetbitmap &&

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -262,6 +262,8 @@ bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
 bool		gp_eager_two_phase_agg = false;
 bool		gp_force_random_redistribution = false;
+double 		gp_appendonly_random_page_cost = DEFAULT_GP_APPENDONLY_RANDOM_PAGE_COST;
+double 		gp_decompress_random_page_cost = DEFAULT_GP_DECOMPRESS_RANDOM_PAGE_COST;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -4378,6 +4380,29 @@ struct config_real ConfigureNamesReal_gp[] =
 		37500, -1, DBL_MAX,
 		NULL, NULL, NULL
 	},
+
+	{
+		{"gp_appendonly_random_page_cost", PGC_USERSET, QUERY_TUNING_COST,
+			gettext_noop("Sets the planner's estimate of the cost of a "
+						 "nonsequentially fetched disk page from an append-only table."),
+			NULL
+		},
+		&gp_appendonly_random_page_cost,
+		DEFAULT_GP_APPENDONLY_RANDOM_PAGE_COST, 0, DBL_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_decompress_random_page_cost", PGC_USERSET, QUERY_TUNING_COST,
+			gettext_noop("Sets the planner's estimate of the cost of"
+						 "decompressing a page from a compressed append-only table."),
+			NULL
+		},
+		&gp_decompress_random_page_cost,
+		DEFAULT_GP_DECOMPRESS_RANDOM_PAGE_COST, 0, DBL_MAX,
+		NULL, NULL, NULL
+	},
+
 
 	/* End-of-list marker */
 	{

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -33,6 +33,10 @@
 
 #define DEFAULT_EFFECTIVE_CACHE_SIZE  524288	/* measured in pages */
 
+#define DEFAULT_AO_RAMDOM_PAGE_COST  4.0
+#define DEFAULT_COMPRESS_PAGE_COST  4.0
+
+
 typedef enum
 {
 	CONSTRAINT_EXCLUSION_OFF,	/* do not use c_e */

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -33,8 +33,8 @@
 
 #define DEFAULT_EFFECTIVE_CACHE_SIZE  524288	/* measured in pages */
 
-#define DEFAULT_AO_RAMDOM_PAGE_COST  4.0
-#define DEFAULT_COMPRESS_PAGE_COST  4.0
+#define DEFAULT_GP_APPENDONLY_RANDOM_PAGE_COST 4.0
+#define DEFAULT_GP_DECOMPRESS_RANDOM_PAGE_COST 4.0
 
 
 typedef enum
@@ -90,6 +90,8 @@ extern PGDLLIMPORT bool enable_parallel_append;
 extern PGDLLIMPORT bool enable_parallel_hash;
 extern PGDLLIMPORT bool enable_partition_pruning;
 extern PGDLLIMPORT int constraint_exclusion;
+extern PGDLLIMPORT double	gp_appendonly_random_page_cost;
+extern PGDLLIMPORT double	gp_decompress_random_page_cost;
 
 extern bool gp_enable_hashjoin_size_heuristic;          /*CDB*/
 extern bool gp_enable_predicate_propagation;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -171,3 +171,5 @@
 		"wal_sender_timeout",
 		"work_mem",
 		"zero_damaged_pages",
+		"gp_appendonly_random_page_cost",
+		"gp_decompress_random_page_cost",


### PR DESCRIPTION
Considering the cost of random page access on an ao table is high, an ao table supports only two types of index scan on it - index_only and bitmap  index.

That kind of makes sense，but restricts the planner from using index scan on ao tables to achieve better performance. For example, can not support using ivfflat index to do approximate nearest neighbor search on ao tables, which can have better performance than seq scan in some situations

Adding additional cost for ao tables' random page scan when calculating index path cost and removing the restriction of index type on ao tables to solve above issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
