### PR TITLE
Fix the wrong permissions warning on the pgpass file

### DIFF
--- a/gpMgmt/bin/gppylib/db/dbconn.py
+++ b/gpMgmt/bin/gppylib/db/dbconn.py
@@ -37,9 +37,9 @@ class Pgpass():
             return
 
         st_info = os.stat(PGPASSFILE)
-        mode = str(oct(st_info[stat.ST_MODE] & 0o777))
+        mode = st_info[stat.ST_MODE] & 0o777
 
-        if mode != "0600":
+        if mode != 0o600:
             print('WARNING: password file "%s" has group or world access; permissions should be u=rw (0600) or less' % PGPASSFILE)
             self.valid_pgpass = False
             return

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -14,7 +14,7 @@ Feature: gpstart behave tests
           And gpstart should print "Skipped segment starts \(segments are marked down in configuration\) += 1" to stdout
           And gpstart should print "Successfully started [0-9]+ of [0-9]+ segment instances, skipped 1 other segments" to stdout
           And gpstart should print "Number of segments not attempted to start: 1" to stdout
-	  And gpstart should print not "permissions should be" to stdout
+	  And gpstart should not print "permissions should be" to stdout
 
     Scenario: gpstart starts even if the standby host is unreachable
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -8,11 +8,13 @@ Feature: gpstart behave tests
           And a mirror has crashed
           And the database is not running
          When the user runs "gpstart -a"
+	  And pgpassfile is exists
          Then gpstart should return a return code of 0
           And gpstart should print "Skipping startup of segment marked down in configuration" to stdout
           And gpstart should print "Skipped segment starts \(segments are marked down in configuration\) += 1" to stdout
           And gpstart should print "Successfully started [0-9]+ of [0-9]+ segment instances, skipped 1 other segments" to stdout
           And gpstart should print "Number of segments not attempted to start: 1" to stdout
+	  And gpstart should print "permissions should be" to stdout
 
     Scenario: gpstart starts even if the standby host is unreachable
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -14,7 +14,7 @@ Feature: gpstart behave tests
           And gpstart should print "Skipped segment starts \(segments are marked down in configuration\) += 1" to stdout
           And gpstart should print "Successfully started [0-9]+ of [0-9]+ segment instances, skipped 1 other segments" to stdout
           And gpstart should print "Number of segments not attempted to start: 1" to stdout
-	  And gpstart should print "permissions should be" to stdout
+	  And gpstart should print not "permissions should be" to stdout
 
     Scenario: gpstart starts even if the standby host is unreachable
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -91,6 +91,24 @@ def impl(context, cmd):
     context.stdout_message, context.stderr_message = p.communicate()
     context.ret_code = p.returncode
 
+@when('pgpassfile is exists')
+def impl(context)
+    """
+    Create a pgpassfile
+    """
+    user_dir = os.path.expanduser("~")
+    file_name = '.pgpass'
+    file_path = os.path.join(user_dir, file_name)
+    if not os.path.exists(file_path):
+        try:
+            with open(file_path, "w") as file:
+                os.chmod(file_path, 0o600)
+        except Exception as e:
+            print("create pgpass file error")
+
+
+
+
 @given('the host for the {seg_type} on content {content} is made unreachable')
 def impl(context, seg_type, content):
     if seg_type == "primary":

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -106,9 +106,6 @@ def impl(context)
         except Exception as e:
             print("create pgpass file error")
 
-
-
-
 @given('the host for the {seg_type} on content {content} is made unreachable')
 def impl(context, seg_type, content):
     if seg_type == "primary":

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -92,7 +92,7 @@ def impl(context, cmd):
     context.ret_code = p.returncode
 
 @when('pgpassfile is exists')
-def impl(context)
+def impl(context):
     """
     Create a pgpassfile
     """


### PR DESCRIPTION
The current logic uses string comparison to check the file mode, which results in a false warning on Python 3 due to the mode format difference ("0600" vs. "0o600"). We will get mode "0o600" on Python3, which will mismatch with "0600" and make a false warning.

https://github.com/greenplum-db/gpdb/blob/14fe09cb97419fc0f1e832c6baf764bf30ba2713/gpMgmt/bin/gppylib/db/dbconn.py#L39-L45

 ```
[gpadmin@gpcc-main gpcc_src]$ gpstop -air
20230906:07:01:00:742207 gpstop:gpcc-main:gpadmin-[INFO]:-Starting gpstop with args: -air
...
...
WARNING: password file "/home/gpadmin/.pgpass" has group or world access; permissions should be u=rw (0600) or less
...
...
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-----------------------------------------------------
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-   Segments stopped successfully      = 16
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-   Segments with errors during stop   = 0
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-----------------------------------------------------
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-Successfully shutdown 16 of 16 segment instances
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
20230906:07:01:09:742207 gpstop:gpcc-main:gpadmin-[INFO]:-Restarting System...
[gpadmin@gpcc-main gpcc_src]$ ls -al /home/gpadmin/.pgpass
-rw------- 1 gpadmin gpadmin 32 Aug 31 08:13 /home/gpadmin/.pgpass
```

To resolve this issue and improve code efficiency, I propose changing the comparison to an octal integer comparison. This not only eliminates the false warning but also ensures a more strict and faster comparison method that is compatible with tools like "2to3".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
