### PR TITLE
Fix Orca crash due to improper colref mapping with CTEs

### DIFF
--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -42,6 +42,10 @@ using UlongToIntMap =
 	CHashMap<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 			 CleanupDelete<ULONG>, CleanupDelete<INT>>;
 
+// iterator
+using UlongToIntMapIter =
+	CHashMapIter<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<INT>>;
 // hash maps ULONG -> array of ULONGs
 using UlongToUlongPtrArrayMap =
 	CHashMap<ULONG, ULongPtrArray, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
@@ -139,6 +143,13 @@ private:
 	static void AddWidthInfoWithRemap(CMemoryPool *mp,
 									  UlongToDoubleMap *src_width,
 									  UlongToDoubleMap *dest_width,
+									  UlongToColRefMap *colref_mapping,
+									  BOOL must_exist);
+
+	// helper method to add attno information where the column ids have been
+	// remapped
+	static void AddAttnoInfoWithRemap(CMemoryPool *mp, UlongToIntMap *src_attno,
+									  UlongToIntMap *dest_attno,
 									  UlongToColRefMap *colref_mapping,
 									  BOOL must_exist);
 

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -607,19 +607,20 @@ CStatistics::CopyStatsWithRemap(CMemoryPool *mp,
 	GPOS_ASSERT(nullptr != colref_mapping);
 	UlongToHistogramMap *histograms_new = GPOS_NEW(mp) UlongToHistogramMap(mp);
 	UlongToDoubleMap *widths_new = GPOS_NEW(mp) UlongToDoubleMap(mp);
+	UlongToIntMap *attnos_new = GPOS_NEW(mp) UlongToIntMap(mp);
 
 	AddHistogramsWithRemap(mp, m_colid_histogram_mapping, histograms_new,
 						   colref_mapping, must_exist);
 	AddWidthInfoWithRemap(mp, m_colid_width_mapping, widths_new, colref_mapping,
 						  must_exist);
-
-	m_colid_to_attno_mapping->AddRef();
+	AddAttnoInfoWithRemap(mp, m_colid_to_attno_mapping, attnos_new,
+						  colref_mapping, must_exist);
 
 	// create a copy of the stats object
 	CStatistics *stats_copy = GPOS_NEW(mp)
 		CStatistics(mp, histograms_new, widths_new, m_rows, IsEmpty(),
 					RelPages(), RelAllVisible(), NumRebinds(), m_num_predicates,
-					m_ext_stats, m_colid_to_attno_mapping);
+					m_ext_stats, attnos_new);
 
 	// In the output statistics object, the upper bound source cardinality of the join column
 	// cannot be greater than the the upper bound source cardinality information maintained in the input
@@ -737,6 +738,39 @@ CStatistics::AddWidthInfoWithRemap(CMemoryPool *mp, UlongToDoubleMap *src_width,
 			CDouble *width_copy = GPOS_NEW(mp) CDouble(*width);
 			BOOL result GPOS_ASSERTS_ONLY =
 				dest_width->Insert(GPOS_NEW(mp) ULONG(colid), width_copy);
+			GPOS_ASSERT(result);
+		}
+	}
+}
+
+// add attno information where the column ids have been re-mapped
+void
+CStatistics::AddAttnoInfoWithRemap(CMemoryPool *mp, UlongToIntMap *src_attno,
+								   UlongToIntMap *dest_attno,
+								   UlongToColRefMap *colref_mapping,
+								   BOOL must_exist)
+{
+	UlongToIntMapIter col_attno_map_iterator(src_attno);
+	while (col_attno_map_iterator.Advance())
+	{
+		ULONG colid = *(col_attno_map_iterator.Key());
+		CColRef *new_colref = colref_mapping->Find(&colid);
+		if (must_exist && nullptr == new_colref)
+		{
+			continue;
+		}
+
+		if (nullptr != new_colref)
+		{
+			colid = new_colref->Id();
+		}
+
+		if (nullptr == dest_attno->Find(&colid))
+		{
+			const INT *attno = col_attno_map_iterator.Value();
+			INT *attno_copy = GPOS_NEW(mp) INT(*attno);
+			BOOL result GPOS_ASSERTS_ONLY =
+				dest_attno->Insert(GPOS_NEW(mp) ULONG(colid), attno_copy);
 			GPOS_ASSERT(result);
 		}
 	}

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3983,6 +3983,16 @@ reset enable_bitmapscan;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;
+-- Should throw an error during planning: FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+-- Falls back on GPORCA, but shouldn't cause GPORCA to crash
+CREATE TABLE ext_stats_tbl(c0 name, c2 boolean);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON c2, c0 FROM ext_stats_tbl;
+INSERT INTO ext_stats_tbl VALUES('tC', true);
+ANALYZE ext_stats_tbl;
+explain SELECT 1 FROM ext_stats_tbl t11 FULL JOIN ext_stats_tbl t12 ON t12.c2;
+ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3996,6 +3996,16 @@ reset enable_bitmapscan;
 drop table l_table;
 drop table r_table1;
 drop table r_table2;
+-- Should throw an error during planning: FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+-- Falls back on GPORCA, but shouldn't cause GPORCA to crash
+CREATE TABLE ext_stats_tbl(c0 name, c2 boolean);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON c2, c0 FROM ext_stats_tbl;
+INSERT INTO ext_stats_tbl VALUES('tC', true);
+ANALYZE ext_stats_tbl;
+explain SELECT 1 FROM ext_stats_tbl t11 FULL JOIN ext_stats_tbl t12 ON t12.c2;
+ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -534,6 +534,16 @@ drop table l_table;
 drop table r_table1;
 drop table r_table2;
 
+-- Should throw an error during planning: FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+-- Falls back on GPORCA, but shouldn't cause GPORCA to crash
+CREATE TABLE ext_stats_tbl(c0 name, c2 boolean);
+CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON c2, c0 FROM ext_stats_tbl;
+
+INSERT INTO ext_stats_tbl VALUES('tC', true);
+ANALYZE ext_stats_tbl;
+
+explain SELECT 1 FROM ext_stats_tbl t11 FULL JOIN ext_stats_tbl t12 ON t12.c2;
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
When deriving stats in Orca for CTEs, we need to remap the statistics so that the CTE consumer uses the statistics of the CTE producer. This involves remapping the colrefs of associated statistics objects. While we did this for histograms and widths, we didn't do this for attnos, which then caused a crash in `ApplyCorrelatedStatsToScaleFactorFilterCalculation()` as it wasn't able to find the correct colref in the map.

Note that in the test case the error is expected (and Orca actually falls back), but it shouldn't cause a crash. The behavior should be the same both with and without extended statistics.

Fixes #15462