### PR TITLE
Update ORCA ans files for index costing change

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -9540,8 +9540,8 @@ explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Inherited tables
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit
    Output: foo.f1, loct1.f1, foo.f2
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -9555,28 +9555,24 @@ DETAIL:  Feature not supported: Inherited tables
                      ->  Merge Join
                            Output: foo.f1, loct1.f1, foo.f2
                            Merge Cond: (foo.f1 = loct1.f1)
-                           ->  Sort
+                           ->  Redistribute Motion 1:3  (slice2)
                                  Output: foo.f1, foo.f2
-                                 Sort Key: foo.f1
-                                 ->  Redistribute Motion 1:3  (slice2)
-                                       Output: foo.f1, foo.f2
-                                       Hash Key: foo.f1
-                                       ->  Append
-                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Hash Key: foo.f1
+                                 ->  Merge Append
+                                       Sort Key: foo.f1
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             Output: foo.f1, foo.f2
+                                             Merge Key: foo.f1
+                                             ->  Index Scan using i_foo_f1 on public.foo
                                                    Output: foo.f1, foo.f2
-                                                   ->  Seq Scan on public.foo
-                                                         Output: foo.f1, foo.f2
-                                             ->  Foreign Scan on public.foo2
-                                                   Output: foo2.f1, foo2.f2
-                                                   Remote SQL: SELECT f1, f2 FROM public.loct1
-                           ->  Sort
+                                       ->  Foreign Scan on public.foo2
+                                             Output: foo2.f1, foo2.f2
+                                             Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           ->  Index Only Scan using i_loct1_f1 on public.loct1
                                  Output: loct1.f1
-                                 Sort Key: loct1.f1
-                                 ->  Seq Scan on public.loct1
-                                       Output: loct1.f1
  Optimizer: Postgres query optimizer
  Settings: constraint_exclusion = 'off', enable_hashjoin = 'off', enable_mergejoin = 'on'
-(34 rows)
+(30 rows)
 
 select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -9601,8 +9597,8 @@ explain (verbose, costs off)
 	select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Inherited tables
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Limit
    Output: foo.f1, loct1.f1, foo.f2
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -9616,28 +9612,24 @@ DETAIL:  Feature not supported: Inherited tables
                      ->  Merge Left Join
                            Output: foo.f1, loct1.f1, foo.f2
                            Merge Cond: (foo.f1 = loct1.f1)
-                           ->  Sort
+                           ->  Redistribute Motion 1:3  (slice2)
                                  Output: foo.f1, foo.f2
-                                 Sort Key: foo.f1
-                                 ->  Redistribute Motion 1:3  (slice2)
-                                       Output: foo.f1, foo.f2
-                                       Hash Key: foo.f1
-                                       ->  Append
-                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Hash Key: foo.f1
+                                 ->  Merge Append
+                                       Sort Key: foo.f1
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             Output: foo.f1, foo.f2
+                                             Merge Key: foo.f1
+                                             ->  Index Scan using i_foo_f1 on public.foo
                                                    Output: foo.f1, foo.f2
-                                                   ->  Seq Scan on public.foo
-                                                         Output: foo.f1, foo.f2
-                                             ->  Foreign Scan on public.foo2
-                                                   Output: foo2.f1, foo2.f2
-                                                   Remote SQL: SELECT f1, f2 FROM public.loct1
-                           ->  Sort
+                                       ->  Foreign Scan on public.foo2
+                                             Output: foo2.f1, foo2.f2
+                                             Remote SQL: SELECT f1, f2 FROM public.loct1 ORDER BY f1 ASC NULLS LAST
+                           ->  Index Only Scan using i_loct1_f1 on public.loct1
                                  Output: loct1.f1
-                                 Sort Key: loct1.f1
-                                 ->  Seq Scan on public.loct1
-                                       Output: loct1.f1
  Optimizer: Postgres query optimizer
  Settings: constraint_exclusion = 'off', enable_hashjoin = 'off', enable_mergejoin = 'on'
-(34 rows)
+(30 rows)
 
 select foo.f1, loct1.f1 from foo left join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
 INFO:  GPORCA failed to produce a plan, falling back to planner

--- a/src/test/regress/expected/select_optimizer.out
+++ b/src/test/regress/expected/select_optimizer.out
@@ -888,19 +888,15 @@ RESET enable_indexscan;
 explain (costs off)
 select unique1, unique2 from onek2
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Heap Scan on onek2
-         Recheck Cond: (((unique2 = 11) AND (stringu1 < 'B'::name)) OR (unique1 = 0))
-         Filter: (stringu1 < 'B'::name)
-         ->  BitmapOr
-               ->  Bitmap Index Scan on onek2_u2_prtl
-                     Index Cond: (unique2 = 11)
-               ->  Bitmap Index Scan on onek2_u1_prtl
-                     Index Cond: (unique1 = 0)
+         Recheck Cond: (stringu1 < 'B'::name)
+         Filter: ((unique2 = 11) OR (unique1 = 0))
+         ->  Bitmap Index Scan on onek2_u2_prtl
  Optimizer: Postgres query optimizer
-(10 rows)
+(6 rows)
 
 select unique1, unique2 from onek2
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';


### PR DESCRIPTION
With the planner cost model changes introduced in 167a67f7f82, two ORCA
answer files were missed. ORCA falls back to planner in these files, and
a similar plan diff needs to be incorporated.