### PR TITLE
Fix gpload unit test fail

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -70,13 +70,13 @@ class GpLoadTestCase(unittest.TestCase):
 
     def test_case_insert_transaction(self):
         self.help_test_with_config(['-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],
-                              False,
-                              False)
+                              True,
+                              True)
 
     def test_case_insert_transaction_t(self):
         self.help_test_with_config(['-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],
-                              False,
-                              False)
+                              True,
+                              True)
 
     def test_case_insert_without_transaction(self):
         self.help_test_with_config(['--no_auto_trans', '-f', os.path.join(os.path.dirname(__file__), 'gpload_insert.yml')],


### PR DESCRIPTION
Gpload insert mode was included in one transaction in this [pr](https://github.com/greenplum-db/gpdb/pull/16146).
So in the unit test, insert mode will expect a begin and commit. 

Gpload unit test has passed in my local environment.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
