### PR TITLE
Analyzing leaf partitions of multi-level partition table causes resampling of intermediate partition.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -699,7 +699,11 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		}
 	}
 
-	sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
+	if (onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && inh)
+		sample_needed = false;
+	else
+		sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
+
 	if (ctx || sample_needed)
 	{
 		if (ctx)

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -700,7 +700,6 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	}
 
 	sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
-
 	if (ctx || sample_needed)
 	{
 		if (ctx)

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -699,10 +699,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		}
 	}
 
-	if (onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && inh)
-		sample_needed = false;
-	else
-		sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
+	sample_needed = needs_sample(onerel, vacattrstats, attr_cnt);
 
 	if (ctx || sample_needed)
 	{

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1045,11 +1045,16 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 				if (!leaf_parts_analyzed(parent_relid, child_relid, vrel->va_cols, elevel))
 					break;
 
-				oldcontext = MemoryContextSwitchTo(vac_context);
-				vacrels = lappend(vacrels, makeVacuumRelation(vrel->relation,
-															  parent_relid,
-															  vrel->va_cols));
-				MemoryContextSwitchTo(oldcontext);
+				if(!(get_rel_relkind(parent_relid) == RELKIND_PARTITIONED_TABLE &&
+					get_rel_relispartition(parent_relid)) &&
+					optimizer_analyze_midlevel_partition)
+				{
+					oldcontext = MemoryContextSwitchTo(vac_context);
+					vacrels = lappend(vacrels, makeVacuumRelation(vrel->relation,
+											  parent_relid,
+											  vrel->va_cols));
+					MemoryContextSwitchTo(oldcontext);
+				}
 
 				/* If the parent is also a partition, update its parent too. */
 				ispartition = get_rel_relispartition(parent_relid);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1037,6 +1037,7 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 				int			elevel = ((options & VACOPT_VERBOSE) ? LOG : DEBUG2);
 
 				parent_relid = get_partition_parent(child_relid);
+				ispartition = get_rel_relispartition(parent_relid);
 
 				/*
 				 * Only ANALYZE the parent if the stats can be updated by merging
@@ -1045,9 +1046,11 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 				if (!leaf_parts_analyzed(parent_relid, child_relid, vrel->va_cols, elevel))
 					break;
 
-				if(!(get_rel_relkind(parent_relid) == RELKIND_PARTITIONED_TABLE &&
-					get_rel_relispartition(parent_relid)) &&
-					optimizer_analyze_midlevel_partition)
+				/*
+				 * Do not add midlevel partition unless optimizer_analyze_midlevel_partition
+				 * is enabled.
+				 */
+				if(!ispartition || optimizer_analyze_midlevel_partition)
 				{
 					oldcontext = MemoryContextSwitchTo(vac_context);
 					vacrels = lappend(vacrels, makeVacuumRelation(vrel->relation,
@@ -1056,8 +1059,6 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 					MemoryContextSwitchTo(oldcontext);
 				}
 
-				/* If the parent is also a partition, update its parent too. */
-				ispartition = get_rel_relispartition(parent_relid);
 				child_relid = parent_relid;
 			}
 		}

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1048,7 +1048,8 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 
 				/*
 				 * Do not add midlevel partition unless optimizer_analyze_midlevel_partition
-				 * is enabled.
+				 * is enabled. But always add root table.
+				 * ispartition is set with relispartition flag of the parent_relid.
 				 */
 				if(!ispartition || optimizer_analyze_midlevel_partition)
 				{

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -1,6 +1,8 @@
 -- start_matchsubs
 -- m/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'t\'\);/
 -- s/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'t\'\);/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(XXX, XXX, \'t\'\)/;
+-- m/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'f\'\);/
+-- s/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'f\'\);/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(XXX, XXX, \'f\'\)/;
 -- end_matchsubs
 DROP DATABASE IF EXISTS testanalyze;
 CREATE DATABASE testanalyze;
@@ -1293,3 +1295,47 @@ create table analyze_replicated(tc1 int,tc2 int) distributed replicated;
 insert into analyze_replicated select i, i from generate_series(1,1000) i;
 analyze analyze_replicated;
 drop table analyze_replicated;
+--
+-- Analyzing a leaf partition should not sample midlevel partition unless
+-- optimizer_analyze_midlevel_partition is set to On.
+--
+create table multipart(a int)  partition by range(a);
+create table part2(a int) partition by range(a);
+create table part3(a int) partition by range(a);
+create table p1(a int);
+create table p2(a int);
+create table p3(a int);
+create table p4(a int);
+alter table multipart attach partition part2 for values from (0) to (10);
+alter table multipart attach partition part3 for values from (10) to (20);
+alter table part2 attach partition p1 for values from (0) to (5);
+alter table part2 attach partition p2 for values from (5) to (10);
+alter table part3 attach partition p3 for values from (10) to (15);
+alter table part3 attach partition p4 for values from (15) to (20);
+insert into multipart select i%20 from generate_series(1,20)i;
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+analyze verbose p1;
+INFO:  analyzing "public.p1"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24981, 10000, 'f');
+analyze verbose p2;
+INFO:  analyzing "public.p2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24984, 10000, 'f');
+select * from pg_stats where tablename like 'part2';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
+(0 rows)
+
+set optimizer_analyze_midlevel_partition=on;
+analyze verbose p2;
+INFO:  analyzing "public.p2"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24984, 10000, 'f');
+INFO:  analyzing "public.part2" inheritance tree
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(24975, 10000, 't');
+select * from pg_stats where tablename like 'part2';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs |   histogram_bounds    | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+-----------------------+-------------+-------------------+------------------------+----------------------
+ public     | part2     | a       | t         |         0 |         4 |         -1 |                  |                   | {0,1,2,3,4,5,6,7,8,9} |  0.33333334 |                   |                        | 
+(1 row)
+
+drop table multipart cascade;

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -1,6 +1,8 @@
 -- start_matchsubs
 -- m/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'t\'\);/
 -- s/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'t\'\);/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(XXX, XXX, \'t\'\)/;
+-- m/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'f\'\);/
+-- s/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(\d+, \d+, \'f\'\);/Executing SQL: select pg_catalog.gp_acquire_sample_rows\(XXX, XXX, \'f\'\)/;
 -- end_matchsubs
 DROP DATABASE IF EXISTS testanalyze;
 CREATE DATABASE testanalyze;
@@ -657,3 +659,33 @@ create table analyze_replicated(tc1 int,tc2 int) distributed replicated;
 insert into analyze_replicated select i, i from generate_series(1,1000) i;
 analyze analyze_replicated;
 drop table analyze_replicated;
+
+--
+-- Analyzing a leaf partition should not sample midlevel partition unless
+-- optimizer_analyze_midlevel_partition is set to On.
+--
+create table multipart(a int)  partition by range(a);
+create table part2(a int) partition by range(a);
+create table part3(a int) partition by range(a);
+create table p1(a int);
+create table p2(a int);
+create table p3(a int);
+create table p4(a int);
+alter table multipart attach partition part2 for values from (0) to (10);
+alter table multipart attach partition part3 for values from (10) to (20);
+alter table part2 attach partition p1 for values from (0) to (5);
+alter table part2 attach partition p2 for values from (5) to (10);
+alter table part3 attach partition p3 for values from (10) to (15);
+alter table part3 attach partition p4 for values from (15) to (20);
+insert into multipart select i%20 from generate_series(1,20)i;
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+analyze verbose p1;
+analyze verbose p2;
+select * from pg_stats where tablename like 'part2';
+
+set optimizer_analyze_midlevel_partition=on;
+analyze verbose p2;
+select * from pg_stats where tablename like 'part2';
+
+drop table multipart cascade;


### PR DESCRIPTION
Problem: Analyzing leaf partitions of multi-level partition table causes
resampling of intermediate partition.

Solution: Remove the intermediate partition from the list of table to be analyzed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
