### PR TITLE
[Releng][6X] Unvendor libzstd for gpdb6 on rocky9/oel9/rhel9

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -96,7 +96,12 @@ function include_dependencies() {
 	header_search_path=( /usr/local/include/ /usr/include/ )
 	vendored_headers=(zstd*.h uv.h uv )
 	pkgconfigs=(libzstd.pc libuv.pc quicklz.pc)
+	# rocky9/oel9/rhel9 won't vendor zstd because of rsync on these platofrm does not work libzstd 1.3.7
+	if [[ ${BLD_ARCH} == "rhel9"* ]]; then
+	  vendored_libs=(libquicklz.so{,.1,.1.5.0} libuv.so{,.1,.1.0.0} libxerces-c{,-3.1}.so)
+	else
 	vendored_libs=(libquicklz.so{,.1,.1.5.0} libzstd.so{,.1,.1.3.7} libuv.so{,.1,.1.0.0} libxerces-c{,-3.1}.so)
+	fi
 
 	if [[ -d /opt/gcc-6.4.0 ]]; then
 		vendored_libs+=(libstdc++.so.6{,.0.22})


### PR DESCRIPTION
rsync is required dependency for gpdb6 server, also rsync used in multiple
gpManagement tools like gpcheckperf, rsync on rocky9/oel9/rhel9 happens 
to not work with our built zstd 1.3.7, error message:
/bin/rsync: undefined symbol: ZSTD_compressStream2
    
So we decided not to vendor our built zstd 1.3.7, but use system provided
zstd on  rocky9/oel9/rhel9 platform.


[GPR-1485]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
