### PR TITLE
Enable index scan on AO tables for indexes that don’t have amgetbitmap

### DIFF
--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -804,7 +804,10 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 * the last decompressed block between fetch calls.
 		 * Index scan path on GPDB's bitmap index should works the same as bitmap paths.
 		 *
-		 * Enable index only scan on AO here, but the index scan is still disabled.
+		 * Enable index only scan on AO here, and other indexes which don't support
+		 * 'ambitmap' as well, such as ivfflat and hsnw indexes in pgvector, otherwise
+		 * they would not be used on AO tables, but they might improve the perfomance
+		 * in some situations.
 		 */
 		if (index->amhasgettuple &&
 				((!IsAccessMethodAO(rel->relam) ||

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -809,7 +809,8 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		if (index->amhasgettuple &&
 				((!IsAccessMethodAO(rel->relam) ||
 				 index->amcostestimate == bmcostestimate ||
-				 ipath->path.pathtype == T_IndexOnlyScan)))
+				 ipath->path.pathtype == T_IndexOnlyScan ||
+				 (!index->amhasgetbitmap))))
 			add_path(rel, (Path *) ipath);
 
 		if (index->amhasgetbitmap &&

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -798,16 +798,19 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 
 		/*
 		 * Random access to Append-Only is slow because AO doesn't use the buffer
-		 * pool and we want to avoid decompressing blocks multiple times.  So,
-		 * only consider bitmap paths because they are processed in TID order.
-		 * The appendonlyam.c module will optimize fetches in TID order by keeping
-		 * the last decompressed block between fetch calls.
-		 * Index scan path on GPDB's bitmap index should works the same as bitmap paths.
+		 * pool and we want to avoid decompressing blocks multiple times.
 		 *
-		 * Enable index only scan on AO here, and other indexes which don't support
-		 * 'ambitmap' as well, such as ivfflat and hsnw indexes in pgvector, otherwise
-		 * they would not be used on AO tables, but they might improve the perfomance
-		 * in some situations.
+		 * Bitmap scans on the other hand are processed in TID order and the
+		 * AO table AMs optimize fetches in TID order by keeping the last
+		 * decompressed block between fetch calls.
+		 *
+		 * Thus, we ban index scans on append-optimized tables, and generally
+		 * only pick bitmap index scans.
+		 *
+		 * Exceptions:
+		 * (1) Index-only scans as they don't need to access the base table.
+		 * (2) If the index AM does not support a bitmap index scan, like
+		 * pgvector's ivfflat or hsnw.
 		 */
 		if (index->amhasgettuple &&
 				((!IsAccessMethodAO(rel->relam) ||


### PR DESCRIPTION
Ivfflat and hsnw indexes both don't support 'amgetbitmap', after this pr they can be used on AO tables.

The main reason for us to enable those 2 indexes on AO tables is that they both only support `ORDER BY` queries and the typical query on embedding data is `ORDER BY embedding LIMIT `, as only limited rows fetched from the base tables, the cost on AO table random access won't be big.

The other reason is that the IVFFLAT index only fetches part of the index tuples when doing a query (the percent is probes/lists), so generally using the index can improve the performance.

No such indexes (amgetbitmap=NULL but amgettuple=non-NULL) exist in core or have ever been supported for GPDB customers, so no chance of regression with this change.

No test has been added to this pr because there isn't any index that satisfies the condition (amgetbitmap=NULL but amgettuple=non-NULL),  it can only be tested in other places. And the behaviors of the indexes that have existed in the core don't change, so no new test cases are needed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
