### PR TITLE
[6x Backport] Fix gprecoverseg with unreachable failed host

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -100,7 +100,7 @@ class GpRecoverSegmentProgram:
         if self.__options.rebalanceSegments:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
         else:
-            instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts)
+            instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
             segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
                     for t in instance.getTriplets()]
             return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -30,7 +30,7 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
         with tempfile.NamedTemporaryFile() as f:
             f.write(test["config"].encode("utf-8"))
             f.flush()
-            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, None,
+            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, test.get("unreachable_hosts"),
                                                      test.get("is_pgrewind_running", itertools.repeat(False)),
                                                      test.get("is_seg_in_backup_mode", itertools.repeat(False)),
                                                      test.get("segments_with_running_basebackup", set()),
@@ -290,6 +290,21 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3""",
                 "config": "sdw1|20000|/primary/gpseg0 sdw3|20000|/primary/gpseg5",
                 "expected": "For content 2, the dbid values are the same.  A segment may not be recovered from itself"
+            },
+            {
+                "name": "failover_unreachable",
+                "gparray": """1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                               2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0
+                               3|1|p|p|s|u|sdw1|sdw1|20001|/primary/gpseg1
+                               8|2|m|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                               9|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                               6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0
+                               7|1|m|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                               4|2|p|p|s|u|sdw2|sdw2|20000|/primary/gpseg2
+                               5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3""",
+                "config": "sdw1|20000|/primary/gpseg0 new_1|20000|/primary/gpseg0",
+                "unreachable_hosts": ['new_1'],
+                "expected": "The recovery target segment new_1 \(content 0\) is unreachable."
             },
             {
                 "name": "invalid_failed_hostname_with_4_parameter",
@@ -598,6 +613,21 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                        5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3""",
             "new_hosts": ['new_1'],
             "expected": "For content 2, the dbid values are the same.  A segment may not be recovered from itself"
+            },
+            {
+            "name": "failover_unreachable",
+            "gparray": """1|-1|p|p|n|u|mdw|mdw|5432|/master/gpseg-1
+                       2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0
+                       3|1|p|p|s|u|sdw1|sdw1|20001|/primary/gpseg1
+                       8|2|m|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2
+                       9|3|m|m|s|u|sdw3|sdw3|21001|/mirror/gpseg3
+                       6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0
+                       7|1|m|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1
+                       4|2|p|p|s|u|sdw2|sdw2|20000|/primary/gpseg2
+                       5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3""",
+            "new_hosts": ['new_1'],
+            "unreachable_hosts": ['new_1'],
+            "expected": "Cannot recover. The following recovery target hosts are unreachable: \['new_1'\]"
             }
         ]
         self.run_fail_tests(tests, self.run_single_GpArray_test)

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -103,6 +103,9 @@ def before_scenario(context, scenario):
     if 'gprecoverseg' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 
+    if 'gprecoverseg_newhost' in context.feature.tags:
+        context.mirror_context = MirrorMgmtContext()
+
     if 'gpconfig' in context.feature.tags:
         context.gpconfig_context = GpConfigContext()
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -99,3 +99,85 @@ Feature: gprecoverseg tests involving migrating to a new host
     And the original cluster state is recreated for "one_host_down"
     And the cluster configuration is saved for "after_recreation"
     And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+  @concourse_cluster
+  Scenario: failed host is not in reach gprecoverseg recovery works well with all instances recovered
+    Given  the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the cluster configuration is saved for "before"
+    And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+    And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover with content id 0 to host sdw5
+    And edit the input file to recover with content id 1 to host sdw5
+    And edit the input file to recover with content id 6 to host sdw5
+    And edit the input file to recover with content id 7 to host sdw5
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should return a return code of 0
+    Then the original cluster state is recreated for "one_host_down-1"
+    And the cluster configuration is saved for "after_recreation"
+    And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+  @concourse_cluster
+  Scenario: failed host is not in reach gprecoverseg recovery works well with partial recovery
+    Given  the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the cluster configuration is saved for "before"
+    And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+    And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover with content id 0 to host sdw5
+    And edit the input file to recover with content id 6 to host sdw5
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should return a return code of 0
+    Then the original cluster state is recreated for "one_host_down-2"
+    And the cluster configuration is saved for "after_recreation"
+    And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+  @concourse_cluster
+  Scenario: failed host is not in reach gprecoverseg recovery works well only primaries are recovered
+    Given  the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the cluster configuration is saved for "before"
+    And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+    And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover with content id 0 to host sdw5
+    And edit the input file to recover with content id 1 to host sdw5
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should return a return code of 0
+    Then the original cluster state is recreated for "one_host_down-3"
+    And the cluster configuration is saved for "after_recreation"
+    And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+  @concourse_cluster
+  Scenario: failover host is not in reach gprecoverseg recovery to new host skips
+    Given  the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the cluster configuration is saved for "before"
+    And the primary on content 0 is stopped with the immediate flag
+    And user can start transactions
+    And segment hosts "sdw1,sdw5" are disconnected from the cluster and from the spare segment hosts "sdw6"
+    And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover with content id 0 to host sdw5
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should return a return code of 2
+    And gprecoverseg  should print "The recovery target segment sdw5 (content 0) is unreachable" escaped to stdout
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -572,6 +572,22 @@ def impl(context, content):
                 fd.write('{}\n'.format(valid_config))
             break
 
+@given("edit the input file to recover with content id {content_id} to host {recovery_host}")
+def impl(context, content_id, recovery_host):
+    content_id = int(content_id)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    for seg in segments:
+        if seg.mirrorDB.getSegmentContentId() == content_id:
+            mirror = seg.mirrorDB
+            valid_config = '{}|{}|{} {}|{}|{}'.format(mirror.getSegmentHostName(),
+                                                      mirror.getSegmentPort(),
+                                                      mirror.getSegmentDataDirectory(),
+                                                      recovery_host,
+                                                      mirror.getSegmentPort(),
+                                                      mirror.getSegmentDataDirectory())
+            with open(context.mirror_context.input_file_path(), 'a') as fd:
+                fd.write('{}\n'.format(valid_config))
+            break
 
 @given("a temporary directory with mode '{mode}' is created under data_dir of primary with content {content}")
 @when("a temporary directory with mode '{mode}' is created under data_dir of primary with content {content}")

--- a/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
@@ -143,6 +143,30 @@ def impl(context, test_case):
 sdw5|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
 sdw5|20002|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6
 sdw5|20003|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7'''
+    elif test_case == "one_host_down-1":
+        down = 'sdw1'
+        spare = 'sdw5'
+        hostname_filter = "hostname in ('sdw5')"
+        expected_config = '''sdw5|20000|/data/gpdata/primary/gpseg0 sdw1|20000|/data/gpdata/primary/gpseg0
+sdw5|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
+sdw5|21000|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6
+sdw5|21001|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7'''
+    elif test_case == "one_host_down-2":
+        down = 'sdw1'
+        spare = 'sdw5'
+        hostname_filter = "hostname in ('sdw5')"
+        expected_config = '''sdw5|20000|/data/gpdata/primary/gpseg0 sdw1|20000|/data/gpdata/primary/gpseg0
+sdw1|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
+sdw1|21001|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7
+sdw5|21000|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6'''
+    elif test_case == "one_host_down-3":
+        down = 'sdw1'
+        spare = 'sdw5'
+        hostname_filter = "hostname in ('sdw5')"
+        expected_config = '''sdw5|20000|/data/gpdata/primary/gpseg0 sdw1|20000|/data/gpdata/primary/gpseg0
+sdw5|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
+sdw1|21001|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7
+sdw1|21000|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6'''
     elif test_case == "two_hosts_down":
         down = 'sdw1,sdw3'
         spare = 'sdw5,sdw6'


### PR DESCRIPTION
 This is a backport of [#13323](https://github.com/greenplum-db/gpdb/pull/13323)

 **Issue:**
 gprecoverseg -i fails to recover any segment if the failed host is unreachable.
 This is irrespective of full/incremental recovery, if the failed host is down then none of the down segments are recovered.
 Ideally the recovery should depend on the failover host status.

 **RCA:**
 Currently while recovering the segments with input configuration file, we check the status of failed host for both the below scenarios,
 1. when failed and failover host are same (in-place recovery)
 2. When failed and failover host are different
If the failed host is unreachable, recovery fails.

**Fix:**
Checking the status of failed host is done only in case of in-place recovery, specifically, when the failover information is not provided in the recover_config_file



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
