### PR TITLE
[Backport] gpstop does not work if previous gpstop was interrupted.

### DIFF
--- a/concourse/scripts/test_upgrade.bash
+++ b/concourse/scripts/test_upgrade.bash
@@ -211,6 +211,7 @@ gpinitsystem_for_upgrade() {
     # Greenplum clusters should be upgraded when GUC settings' defaults change.
     ssh -ttn ${MASTER_HOST} '
         source '"${OLD_GPHOME}"'/greenplum_path.sh
+        export MASTER_DATA_DIRECTORY='${OLD_MASTER_DATA_DIRECTORY}'
         gpstop -a -d '"${OLD_MASTER_DATA_DIRECTORY}"'
 
         source '"${NEW_GPHOME}"'/greenplum_path.sh
@@ -224,6 +225,7 @@ gpinitsystem_for_upgrade() {
         # echo "standard_conforming_strings = off" >> upgrade_addopts
         # echo "escape_string_warning = off" >> upgrade_addopts
         gpinitsystem -a -c gpinitsystem_config_new -h '"${GPINITSYSTEM_HOSTFILE}"' # -p ~gpadmin/upgrade_addopts
+        export MASTER_DATA_DIRECTORY='${NEW_MASTER_DATA_DIRECTORY}'
         gpstop -a -d '"${NEW_MASTER_DATA_DIRECTORY}"'
     '
 }

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -170,6 +170,11 @@ class SimpleMainLock:
             if self.pidfilepid == self.parentpid:
                 return None
 
+            # Check if the process that holds the lock exists.
+            # If the process is already killed, remove the lock directory.
+            if not unix.check_pid(self.pidfilepid):
+                shutil.rmtree(self.ppath)
+
         # try and acquire the lock
         try:
             self.pidlockfile.acquire()
@@ -232,7 +237,7 @@ class ExceptionNoStackTraceNeeded(Exception):
 
 class UserAbortedException(Exception):
     """
-    UserAbortedException should be thrown when a user decides to stop the 
+    UserAbortedException should be thrown when a user decides to stop the
     program (at a y/n prompt, for example).
     """
     pass
@@ -463,4 +468,3 @@ def parseStatusLine(line, isStart = False, isStop = False):
     reasonArr = reasonArr[1:]
     reasonStr = ":".join(reasonArr)
     return reasonCode, reasonStr, started, dir
-

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -174,7 +174,7 @@ class SimpleMainLock:
             # If the process is already killed, remove the lock directory.
             if not unix.check_pid(self.pidfilepid):
                 shutil.rmtree(self.ppath)
-
+                
         # try and acquire the lock
         try:
             self.pidlockfile.acquire()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstop.py
@@ -11,7 +11,7 @@ from mock import Mock, call, patch
 from gppylib.gparray import Segment, GpArray, SegmentPair
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands import base
-from gppylib.commands.base import Command, WorkerPool
+from gppylib.commands.base import Command, WorkerPool, CommandResult
 from gppylib.commands.gp import GpSegStopCmd
 from gppylib.mainUtils import ProgramArgumentValidationException
 
@@ -56,6 +56,8 @@ class GpStop(GpTestCase):
             patch('gpstop.base.WorkerPool'),
             patch('gpstop.socket.gethostname'),
             patch('gpstop.print_progress'),
+            patch('gpstop.userinput', return_value=Mock(spec=['ask_string'])),
+            patch('gppylib.commands.base.Command')
         ])
 
         sys.argv = ["gpstop"]  # reset to relatively empty args list
@@ -66,6 +68,9 @@ class GpStop(GpTestCase):
         self.mock_gparray = self.get_mock_from_apply_patch('initFromCatalog')
         self.mock_gparray.return_value = self.gparray
         self.mock_socket = self.get_mock_from_apply_patch('gethostname')
+        self.mock_userinput = self.get_mock_from_apply_patch('userinput')
+        self.mock_cmd = self.get_mock_from_apply_patch('Command')
+        self.mock_conn = self.get_mock_from_apply_patch('connect')
 
     def tearDown(self):
         super(GpStop, self).tearDown()
@@ -98,7 +103,6 @@ class GpStop(GpTestCase):
 
     def get_error_messages(self):
         return [args[0][0] for args in self.subject.logger.error.call_args_list]
-
 
     @patch('gpstop.userinput', return_value=Mock(spec=['ask_yesno']))
     def test_option_master_success_without_auto_accept(self, mock_userinput):
@@ -406,6 +410,105 @@ class GpStop(GpTestCase):
         self.assertTrue("Stopping master standby host smdw mode=fast" not in log_message)
         self.assertTrue("No standby master host configured" not in log_message)
 
+    @patch('gpstop.gp.GpStart')
+    def test_gpstop_fast_if_previous_gpstop_was_interrupted(self, mockGpStart):
+        sys.argv = ["gpstop", "-a"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('the database system is shutting down')
+        self.mock_userinput.ask_string.return_value = 'f'
+        self.mock_cmd.results = CommandResult(0, ''.encode(), ''.encode(), True, False)
+        self.mock_cmd.get_return_code.return_value = 0
+        mockGpStart.return_value = self.mock_cmd
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+
+        self.assertEqual(self.mock_userinput.ask_string.call_count, 1)
+        self.subject.logger.warning.assert_any_call("The database is currently in the process of shutting down.")
+        self.subject.logger.info.assert_any_call("Your choice was 'f'")
+        self.subject.logger.info.assert_any_call("Stopping the master to finish the database shutdown")
+        self.subject.logger.info.assert_any_call("Running gpstart in master_only mode.")
+        self.subject.logger.info.assert_any_call("Database successfully shutdown with no errors reported")
+
+    @patch('gpstop.gp.GpStart')
+    def test_gpstop_immediate_if_previous_gpstop_was_interrupted(self, mockGpStart):
+        sys.argv = ["gpstop", "--host", "sdw1"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('the database system is shutting down')
+        self.mock_userinput.ask_string.return_value = 'i'
+        self.mock_cmd.results = CommandResult(0, ''.encode(), ''.encode(), True, False)
+        self.mock_cmd.get_return_code.return_value = 0
+        mockGpStart.return_value = self.mock_cmd
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        gpstop.run()
+
+        self.assertEqual(self.mock_userinput.ask_string.call_count, 1)
+        self.subject.logger.warning.assert_any_call("The database is currently in the process of shutting down.")
+        self.subject.logger.info.assert_any_call("Your choice was 'i'")
+        self.subject.logger.info.assert_any_call("Stopping the master to finish the database shutdown")
+        self.subject.logger.info.assert_any_call("Running gpstart in master_only mode.")
+        self.subject.logger.info.assert_any_call("Database successfully shutdown with no errors reported")
+
+    @patch('gpstop.gp.GpStart')
+    def test_gpstop_fails_to_start_master_after_interrupt(self, mockGpstart):
+        sys.argv = ["gpstop", "-am"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('the database system is shutting down')
+        self.mock_userinput.ask_string.return_value = 'f'
+        self.mock_cmd.run.side_effect = Exception('error')
+        mockGpstart.return_value = self.mock_cmd
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        with self.assertRaisesRegexp(Exception, 'Unable to start the cluster in master_only mode: error'):
+            gpstop.run()
+
+    @patch('gpstop.gp.MasterStop')
+    def test_gpstop_fails_to_stop_master_processes_after_interrupt(self, mockMasterStop):
+        sys.argv = ["gpstop", "-am"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('the database system is shutting down')
+        self.mock_userinput.ask_string.return_value = 'f'
+        self.mock_cmd.run.side_effect = Exception('error')
+        mockMasterStop.return_value = self.mock_cmd
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        with self.assertRaisesRegexp(Exception, 'Unable to stop the master: error'):
+            gpstop.run()
+
+    def test_gpstop_sighup_option_after_interrupt(self):
+        sys.argv = ["gpstop", "-u"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('the database system is shutting down')
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        with self.assertRaises(SystemExit):
+            gpstop.run()
+
+        self.subject.logger.warning.assert_any_call("The database is currently in the process of shutting down.")
+        self.subject.logger.fatal.assert_any_call("Cannot send SIGHUP to postmaster as the database is shutting down. "
+                                                  "Please run 'gpstop' to complete the shutdown process.")
+
+    @patch('gpstop.GpArray.initFromCatalog')
+    def test_gpstop_raise_exception_other_than_database_system_shutting_down(self, mock_initFromCatalog):
+        sys.argv = ["gpstop", "-a"]
+        parser = self.subject.GpStop.createParser()
+        options, args = parser.parse_args()
+
+        self.mock_conn.side_effect = Exception('unexpected exception')
+        mock_initFromCatalog.side_effect = [Exception('unexpected exception')]
+
+        gpstop = self.subject.GpStop.createProgram(options, args)
+        with self.assertRaisesRegexp(Exception, 'unexpected exception'):
+            gpstop.run()
+
 
 # Perform an 'import gpstop', as above.
 _gpstop_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpstop")
@@ -562,3 +665,5 @@ class GpStopSmartModeTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     run_tests()
+
+

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -35,6 +35,7 @@ try:
     from gppylib.operations.utils import ParallelOperation, RemoteOperation
     from gppylib.operations.rebalanceSegments import ReconfigDetectionSQLQueryCommand
     from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
+    from contextlib import closing
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -367,6 +368,8 @@ class GpStop:
         gp.check_permissions(self.user)
         self._read_postgresqlconf()
         self._check_db_running()
+        if self._is_db_shutting_down():
+            self._handle_shutdown_state()
         self._build_gparray()
         if self.onlyThisHost:
             self._is_hostname_valid()
@@ -425,6 +428,60 @@ class GpStop:
         logger.info("Obtaining Segment details from master...")
         self.dburl = dbconn.DbURL(port=self.port, dbname='template1')
         self.gparray = GpArray.initFromCatalog(self.dburl, utility=True)
+
+    def _handle_shutdown_state(self):
+        """
+        Handle the scenario where the Greenplum database is in shutting down state.
+        """
+        # Check if gpstop is called with -u option
+        if self.sighup:
+            logger.fatal("Cannot send SIGHUP to postmaster as the database is shutting down. "
+                         "Please run 'gpstop' to complete the shutdown process.")
+            sys.exit(1)
+
+        # Prompt user for mode selection
+        mode_selection = userinput.ask_string("Please select fast or immediate mode to complete the shutdown:",
+                                              "['(f)ast_mode', '(i)mmediate_mode']", 'f',
+                                              ['f', 'i'])
+        logger.info("Your choice was '{0}'".format(mode_selection))
+        self.mode = 'fast' if mode_selection == 'f' else 'immediate'
+
+        # Stop the master processes stuck in shutting down state
+        logger.info("Stopping the master to finish the database shutdown")
+        try:
+            cmd = gp.MasterStop("stopping master", self.master_datadir, mode='immediate')
+            cmd.run(validateAfter=True)
+        except Exception as exc:
+            raise Exception("Unable to stop the master: {0}".format(exc))
+
+        # Starting the cluster in master_only mode. It is required to gather segment information
+        # in subsequent steps in order to continue the normal gpstop workflow.
+        self._start_db_masteronly()
+
+    def _is_db_shutting_down(self):
+        """
+        Check if the Greenplum database is in the process of shutting down.
+        Returns True if the database is shutting down.
+        """
+        try:
+            self.dburl = dbconn.DbURL(port=self.port, dbname='template1')
+            with closing(dbconn.connect(self.dburl)) as conn:
+                pass  # Nothing to do here, as we are only testing the database connection
+        except Exception as exc:
+            if "the database system is shutting down" in str(exc):
+                logger.warning("The database is currently in the process of shutting down.")
+                return True
+
+    def _start_db_masteronly(self):
+        """
+        Starting the cluster in master-only mode.
+        """
+        logger.info("Running gpstart in master_only mode.")
+        try:
+            cmd = gp.GpStart("running gpstart -am", masterOnly=True)
+            cmd.run(validateAfter=True)
+        except Exception as exc:
+            raise Exception("Unable to start the cluster in master_only mode: {0}".format(exc))
 
     class _SigIntHandler(object):
         def __init__(self):
@@ -1028,6 +1085,14 @@ class GpStop:
                       logfileDirectory=logfileDirectory,
                       onlyThisHost=options.only_this_host)
 
+    @staticmethod
+    def mainOptions():
+        """
+        This method returns a dictionary instructing simple_main to check for
+        a gpstop.lock file under MASTER_DATA_DIRECTORY in order to prevent
+        the customer from running multiple instances of gpstop.
+        """
+        return {'pidlockpath': 'gpstop.lock', 'parentpidvar': 'GPSTOPPID'}
 
 if __name__ == '__main__':
-    simple_main(GpStop.createParser, GpStop.createProgram)
+    simple_main(GpStop.createParser, GpStop.createProgram, GpStop.mainOptions())

--- a/gpMgmt/doc/gpstop_help
+++ b/gpMgmt/doc/gpstop_help
@@ -117,9 +117,13 @@ OPTIONS
 
 
 -M smart
- 
- Smart shut down. If there are active connections, this command 
- fails with a warning. This is the default shutdown mode.
+
+ Smart shut down. This is the default shutdown mode. gpstop waits for
+ active user connections to disconnect and then proceeds with the
+ shutdown. If any user connections remain open after the timeout period
+ (or if you interrupt by pressing CTRL-C) gpstop lists the open user
+ connections and prompts whether to continue waiting for connections to
+ finish, or to perform a fast or immediate shutdown.
 
 
 -q

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -66,3 +66,126 @@ Feature: gpstop behave tests
           And gpstop should print "Commencing Master instance shutdown with mode='immediate'" to stdout
          Then gpstop should return a return code of 0
           And verify no postgres process is running on all hosts
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario Outline: when the first gpstop interrupted and second gpstop handles the unfinished state with <scenario> mode
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        And running postgres processes are saved in context
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then verify if the gpstop.lock directory is present in master_data_directory
+        And the user runs gpstop -a and selects <option>
+        And gpstop should print "The database is currently in the process of shutting down." to stdout
+        And gpstop should print "Your choice was '<option>'" to stdout
+        And gpstop should print "Stopping the master to finish the database shutdown" to stdout
+        And gpstop should print "Running gpstart in master_only mode." to stdout
+        Then gpstop should return a return code of 0
+        And verify no postgres process is running on all hosts
+        Examples:
+        | scenario  | option  |
+        | immediate | i       |
+        | fast      | f       |
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: when the first gpstop interrupted and second gpstop handles the unfinished state with default mode
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        And running postgres processes are saved in context
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then the user runs gpstop -a and selects no mode but presses enter
+        And gpstop should print "The database is currently in the process of shutting down." to stdout
+        And gpstop should print "Your choice was 'f'" to stdout
+        And gpstop should print "Stopping the master to finish the database shutdown" to stdout
+        And gpstop should print "Running gpstart in master_only mode." to stdout
+        Then gpstop should return a return code of 0
+        And verify no postgres process is running on all hosts
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario Outline: when the first gpstop interrupted and second gpstop with <scenario> succeed
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then the user runs <command> and selects f
+        And gpstop should print "The database is currently in the process of shutting down." to stdout
+        And gpstop should print "Stopping the master to finish the database shutdown" to stdout
+        And gpstop should print "Running gpstart in master_only mode." to stdout
+        Then gpstop should return a return code of 0
+        Examples:
+        | scenario           | command            |
+        | timeout            | gpstop -a -t 130   |
+        | skip_standby       | gpstop -ay         |
+        | master_only        | gpstop -am         |
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: when the first gpstop interrupted and second gpstop with restart option succeed
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then the user runs gpstop -ar and selects f
+        And gpstop should print "The database is currently in the process of shutting down." to stdout
+        And gpstop should print "Stopping the master to finish the database shutdown" to stdout
+        And gpstop should print "Running gpstart in master_only mode." to stdout
+        Then gpstop should return a return code of 0
+        # proceeding graceful shutdown of the database.
+        And the user runs gpstop -a and selects f
+        And gpstop should return a return code of 0
+
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: when the first gpstop interrupted and second gpstop with sighup option fails
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then the user runs "gpstop -u"
+        And gpstop should print "The database is currently in the process of shutting down." to stdout
+        And gpstop should print "Cannot send SIGHUP to postmaster as the database is shutting down. Please run 'gpstop' to complete the shutdown process." to stdout
+        Then gpstop should return a return code of 1
+        # proceeding graceful shutdown of the database.
+        And the user runs gpstop -a and selects f
+        And gpstop should return a return code of 0
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpstop fails when the lock file is already held by another gpstop process
+        Given the database is running
+        And we run a sample background script to generate a pid on "master" segment
+        Then a sample gpstop.lock directory is created using the background pid in master_data_directory
+        And the user runs "gpstop -a"
+        And gpstop should print "gpstop.lock indicates that an instance of gpstop is already running" to stdout
+        # proceeding graceful shutdown of the database.
+        And the background pid is killed on "master" segment
+        And the user runs gpstop -a and selects f
+        And gpstop should return a return code of 0
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpstart succeed when the lock file is already held by a gpstop process
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then verify if the gpstop.lock directory is present in master_data_directory
+        And all postgres processes are killed on "current" hosts
+        And the user runs "gpstart -a"
+        And gpstart -a should return a return code of 0
+        # proceeding graceful shutdown of the database.
+        And the user runs gpstop -a and selects f
+        And gpstop should return a return code of 0
+
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: when the first gpstop is killed abruptly and the lock file is getting removed.
+        Given the database is running
+        And the user asynchronously runs "psql postgres" and the process is saved
+        When the user runs gpstop -a, selects s and interrupt the process
+        Then the user runs "gpstop -a"
+        And gpstop should not print "gpstop.lock indicates that an instance of gpstop is already running" to stdout
+        # proceeding graceful shutdown of the database.
+        And the user runs gpstop -a and selects f
+        And gpstop should return a return code of 0
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -19,18 +19,18 @@ def impl(context):
         fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
         fp.write("incremental:6: 1/1371875 kB (1%)")
 
-@then('a sample gprecoverseg.lock directory is created using the background pid in master_data_directory')
-@given('a sample gprecoverseg.lock directory is created using the background pid in master_data_directory')
-def impl(context):
+@then('a sample {lock_file} directory is created using the background pid in master_data_directory')
+@given('a sample {lock_file} directory is created using the background pid in master_data_directory')
+def impl(context, lock_file):
     bg_pid = context.bg_pid
     if not unix.check_pid(bg_pid):
         raise Exception("The background process with PID {} is not running.".format(bg_pid))
-    gprecoverseg_lock_dir = os.path.join(get_masterdatadir() + '/gprecoverseg.lock')
-    os.mkdir(gprecoverseg_lock_dir)
+    lock_dir = os.path.join(get_masterdatadir() + '/{0}'.format(lock_file))
+    os.mkdir(lock_dir)
 
-    gprecoverseg_pidfile = os.path.join(gprecoverseg_lock_dir, 'PID')
+    utility_pidfile = os.path.join(lock_dir, 'PID')
 
-    with open(gprecoverseg_pidfile, 'w') as f:
+    with open(utility_pidfile, 'w') as f:
         f.write(bg_pid)
 
 @given('a sample recovery_progress.file is created with completed recoveries in gpAdminLogs')
@@ -124,3 +124,4 @@ def check_stdout_msg_in_order(context, msg):
         raise Exception(err_str)
 
     context.stdout_position = match.end()
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
@@ -1,3 +1,4 @@
+import socket
 import subprocess
 import tempfile
 import platform
@@ -89,7 +90,10 @@ def _blackhole_route_helper(disconnect_host, hosts, disconnect=False):
         subprocess.check_output(["ssh", host, cmd])
 
 @given('all postgres processes are killed on "{disconnected}" hosts')
+@then('all postgres processes are killed on "{disconnected}" hosts')
 def impl(context, disconnected):
+    if disconnected == "current":
+        disconnected = socket.gethostname()
     disconnected_hosts = disconnected.split(',')
 
     # clean up disconnected


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/15727

Issue:
When a gpstop process with 'smart' option is interrupted, the subsequent gpstop command becomes stuck with an error message stating "the database system is shutting down". This error message also appears when attempting to connect to the database using psql and other utilities.
The problem is that the error message does not provide clear instructions on how to stop the database, leading to confusion and an inability to perform a graceful shutdown. Gpstop will not work at this point and the only way to stop the database is to manually kill the master processes.

RCA
The issue occurs due to the interruption of the gpstop process, which leaves the database system in an incomplete shutdown state with unfinished master processes. Also, this will not allow any further operations on the database until the shutdown is complete.

Solution:
This issue will be addressed by modifying the gpstop code to check if the database is shutting down. If yes, it will show a warning stating "The database is currently in the process of shutting down". After this warning, the code will prompt the user to choose between a "Fast" or "Immediate" shutdown option. Depending on the user's selection, the code will proceed as follows:

Terminate all master processes stuck in shutdown state from previously interrupted gpstop.
Start the cluster in master-only mode so that we can get the cluster information required in subsequent steps
Continue the normal gpstop workflow.
Other changes include

adding a 'pidlockpath' in mainOptions of gpstop. This creates a gpstop.lock file under MASTER_DATA_DIRECTORY to prevent the user from running multiple instances of gpstop.
Because of the above change there was one error in pg_upgrade step ("Environment Variable MASTER_DATA_DIRECTORY not set!"). Added fix for that as well.

Tests done:
Added new unit test cases and behave test cases for testing the scenario

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
