### PR TITLE
[6X] fix placeholder var ERROR of HavingQual in planner

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -2706,14 +2706,12 @@ make_subplan_tlist(List *tlist, Node *havingQual,
 
 	Assert(dqa_args != NIL ? pnum_dqas != NULL && pcols_dqas != NULL : true);
 
-	/* GPDB_84_MERGE_FIXME: Should we pass includePlaceHolderVars as true */
-	/* in pull_var_clause ? */
 	sub_tlist = flatten_tlist(tlist,
 							  PVC_RECURSE_AGGREGATES,
 							  PVC_INCLUDE_PLACEHOLDERS);
 	extravars = pull_var_clause(havingQual,
 								PVC_RECURSE_AGGREGATES,
-								PVC_REJECT_PLACEHOLDERS);
+								PVC_INCLUDE_PLACEHOLDERS);
 	sub_tlist = add_to_flat_tlist(sub_tlist, extravars);
 	list_free(extravars);
 

--- a/src/test/regress/expected/select_having.out
+++ b/src/test/regress/expected/select_having.out
@@ -90,4 +90,21 @@ SELECT 1 AS one FROM test_having WHERE 1/a = 1 HAVING 1 < 2;
    1
 (1 row)
 
+-- placeholder var in haveingQual
+select
+  count(t2.b), count(t1c) t1c
+from
+  test_having t2
+  left join (
+    select
+      a, format('%s', c) t1c
+    from
+      test_having t1
+  ) tt on t2.a = tt.a
+having count(t1c) is not null;
+ count | t1c 
+-------+-----
+    10 |  10
+(1 row)
+
 DROP TABLE test_having;

--- a/src/test/regress/sql/select_having.sql
+++ b/src/test/regress/sql/select_having.sql
@@ -47,4 +47,17 @@ SELECT 1 AS one FROM test_having HAVING 1 < 2;
 -- and just to prove that we aren't scanning the table:
 SELECT 1 AS one FROM test_having WHERE 1/a = 1 HAVING 1 < 2;
 
+-- placeholder var in haveingQual
+select
+  count(t2.b), count(t1c) t1c
+from
+  test_having t2
+  left join (
+    select
+      a, format('%s', c) t1c
+    from
+      test_having t1
+  ) tt on t2.a = tt.a
+having count(t1c) is not null;
+
 DROP TABLE test_having;


### PR DESCRIPTION
Replace PVC_REJECT_PLACEHOLDERS with PVC_INCLUDE_PLACEHOLDERS so we could accept placeholders as targtelists of lower plan, that's the behavior we expected.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
