### PR TITLE
Fix gpstop pipeline flakiness after #15727

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -167,14 +167,13 @@ Feature: gpstop behave tests
         Given the database is running
         And the user asynchronously runs "psql postgres" and the process is saved
         When the user runs gpstop -a, selects s and interrupt the process
-        And the user runs command "pkill postgres"
-        Then verify if the gpstop.lock directory is present in coordinator_data_directory
+        Then all postgres processes are killed on "current" hosts
+        And verify if the gpstop.lock directory is present in coordinator_data_directory
         And the user runs "gpstart -a"
         And gpstart -a should return a return code of 0
         # proceeding graceful shutdown of the database.
         And the user runs gpstop -a and selects f
         And gpstop should return a return code of 0
-
 
     @concourse_cluster
     @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
@@ -1,5 +1,6 @@
 import subprocess
 import tempfile
+import socket
 
 from behave import given, when, then
 
@@ -88,7 +89,10 @@ def _blackhole_route_helper(disconnect_host, hosts, disconnect=False):
         subprocess.check_output(["ssh", host, cmd])
 
 @given('all postgres processes are killed on "{disconnected}" hosts')
+@then('all postgres processes are killed on "{disconnected}" hosts')
 def impl(context, disconnected):
+    if disconnected == "current":
+        disconnected = socket.gethostname()
     disconnected_hosts = disconnected.split(',')
 
     # clean up disconnected


### PR DESCRIPTION
Following the merging of changes from pull request #15727, there was an intermittent test failure in gpstop. This situation occurred when testing how the gpstart process behaves in the presence of a lock directory created by a previous gpstop operation.

In this specific scenario, the expected behavior was that the lock directory from gpstop shouldn't disrupt the gpstart process. To examine this, a test was set up where a gpstop process was started and stopped before completion. This created a lock directory in COORDINATOR_DATA_DIRECTORY. Subsequently, an attempt was made to clean up any remaining parts of the postgres process on the coordinator using the `pkill postgres `command. This was essential to prevent issues where gpstart might fail with errors like ‘Greenplum instance already exists’. But sometimes, the remaining parts of the postgres process didn't get cleaned up properly, causing the test to fail intermittently with the error `gpstart error: Coordinator instance process running`

To fix this, added a step for cleaning all the postgres processes on the host by removing the lock file /tmp/.s.PGSQL.* along with `pkill -9 postgres` to make sure everything is cleaned up.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
