### PR TITLE
Fix compilation error

### DIFF
--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 
+#include "fmgr.h"
 #include "lib/stringinfo.h"
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
@@ -22,7 +23,7 @@ Datum
 LibraryVersion(void)
 {
 	elog(ERROR, "mock implementation of LibraryVersion called");
-	return NULL;
+	return (Datum) 0;
 }
 
 Datum


### PR DESCRIPTION
When running cmockery, I was hitting some compilation issues. This commit fixes those problems.

error: incompatible pointer to integer conversion returning 'void *'from
    a function with result type 'Datum' (aka 'unsigned long') [-Wint-conversion]
        return NULL;
error: parameter 'PG_FUNCTION_ARGS' was not declared, defaults to 'int';
    ISO C99 and later do not support implicit int [-Wimplicit-int]
EnableXform(PG_FUNCTION_ARGS)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
