### PR TITLE
add distributed transaction information when dispatch set command

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -330,7 +330,6 @@ cdbdisp_makeDispatcherState(bool isExtendedQuery)
 	handle->dispatcherState->allocatedGangs = NIL;
 	handle->dispatcherState->largestGangSize = 0;
 	handle->dispatcherState->rootGangSize = 0;
-	handle->dispatcherState->destroyIdleReaderGang = false;
 
 	return handle->dispatcherState;
 }
@@ -406,12 +405,6 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 
 		RecycleGang(gp, ds->forceDestroyGang);
 	}
-
-	/*
-	 * Destroy all the idle reader gangs when flag destroyIdleReaderGang is true
-	 */
-	if (ds->destroyIdleReaderGang)
-		cdbcomponent_cleanupIdleQEs(false);
 
 	ds->allocatedGangs = NIL;
 	ds->dispatchParams = NULL;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -464,23 +464,6 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
 
-	/*
-	 * Reader gangs use local snapshot to access catalog, as a result, it will
-	 * not synchronize with the global snapshot from write gang which will lead
-	 * to inconsistent visibilty of catalog table. Considering the case:
-	 * 
-	 * select * from t, t t1; -- create a reader gang.
-	 * begin;
-	 * create role r1;
-	 * set role r1;  -- set command will also dispatched to idle reader gang
-	 *
-	 * When set role command dispatched to reader gang, reader gang cannot see
-	 * the new tuple t1 in catalog table pg_auth.
-	 * To fix this issue, we should drop the idle reader gangs after each
-	 * utility statement which may modify the catalog table.
-	 */
-	ds->destroyIdleReaderGang = true;
-
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
 
 	/*

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -50,7 +50,6 @@ typedef struct CdbDispatcherState
 #ifdef USE_ASSERT_CHECKING
 	bool isGangDestroying;
 #endif
-	bool destroyIdleReaderGang;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs


### PR DESCRIPTION
This PR is based on PR #10400, and trying to fix the same issue which has been
fixed by #10456 in a different way.

------

## Problems

```
postgres=# create table t(a int);
postgres=# create table s(a int);

postgres=# select * from t, s;          -- create reader gangs
 a | b | a | b 
---+---+---+---
(0 rows)

postgres=# begin;
postgres=# create role r1;                -- modify catalog 
CREATE ROLE
postgres=# set role r1;
ERROR:  role "r1" does not exist  (seg0 127.0.1.1:6002 pid=2227573)
```

here is the RCA, thanks @kainwen 's comments [RCA](https://github.com/greenplum-db/gpdb/issues/12916#issuecomment-1057949461):

1. Before the begin block, due to gang cache, there are several idle gangs on segments.
2. Then a create role statement comes to seg, and this will only dispatch to writer gang.
3. The reader gang is still idle.
4. The reader gang got the set role command, and finally it will scan the pg_authid catalog 
fetch the tuple, and use MVCC `HeapTupleSatisfiesMVCC` to test visibility.
6. Reader gang never generate transaction id, so `TransactionIdIsCurrentTransactionId`
returns false.
8. And comes to `TransactionIdIsInProgress` test, this hit, thus the tuple cannot be seen
lead to the bug in this issue.

## Resolution

My resolution is quite direct and simple, since the reader gang could not notice what writer
gang has changed, then let reader gang sync distributed snapshot from it when it executes
the SET command.

Generally speaking, we will not grab a snapshot when we execute SET command, as the
the function `PlannedStmtRequiresSnapshot()` did. But in Greenplum, the reader gang
needs to know what writer gang has done, so when the reader gang is executing the SET
command, it should retrieve `CatalogSnapshot` again, this is why this PR update `segmateSync`
in writer gang and invalid catalog snapshot in the reader gang. Only this way the reader
will invoke `readerFillLocalSnapshot()` to sync snapshot from the writer.


------
## Reference

- [Inconsistent visibilty between reader gang and writer gang for 6X ](https://github.com/greenplum-db/gpdb/issues/12916)
- [Idle reader gangs will be destroyed every time, when execute SELECT statement using extended query protocol.](https://github.com/greenplum-db/gpdb/issues/15413)

