### PR TITLE
Fix flaky plan diffs for select.sql

### DIFF
--- a/src/test/regress/expected/select.out
+++ b/src/test/regress/expected/select.out
@@ -883,26 +883,41 @@ select unique2 from onek2 where unique2 = 11 and stringu1 < 'B';
 
 RESET enable_indexscan;
 -- check multi-index cases too
+-- GPDB: Use onek2_3x for 3x the data, in order for us to get the upstream plan
+-- utilizing both indexes.
+create table onek2_3x (like onek2 including all) distributed by (unique1);
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+analyze onek2_3x;
 explain (costs off)
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on onek2
-         Recheck Cond: (stringu1 < 'B'::name)
-         Filter: ((unique2 = 11) OR (unique1 = 0))
-         ->  Bitmap Index Scan on onek2_u2_prtl
+   ->  Bitmap Heap Scan on onek2_3x
+         Recheck Cond: (((unique2 = 11) AND (stringu1 < 'B'::name)) OR (unique1 = 0))
+         Filter: (stringu1 < 'B'::name)
+         ->  BitmapOr
+               ->  Bitmap Index Scan on onek2_3x_unique2_idx
+                     Index Cond: (unique2 = 11)
+               ->  Bitmap Index Scan on onek2_3x_unique1_idx
+                     Index Cond: (unique1 = 0)
  Optimizer: Postgres query optimizer
-(6 rows)
+(10 rows)
 
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
  unique1 | unique2 
 ---------+---------
      494 |      11
+     494 |      11
+     494 |      11
        0 |     998
-(2 rows)
+       0 |     998
+       0 |     998
+(6 rows)
 
 explain (costs off)
 select unique1, unique2 from onek2

--- a/src/test/regress/expected/select_optimizer.out
+++ b/src/test/regress/expected/select_optimizer.out
@@ -885,26 +885,41 @@ select unique2 from onek2 where unique2 = 11 and stringu1 < 'B';
 
 RESET enable_indexscan;
 -- check multi-index cases too
+-- GPDB: Use onek2_3x for 3x the data, in order for us to get the upstream plan
+-- utilizing both indexes.
+create table onek2_3x (like onek2 including all) distributed by (unique1);
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+analyze onek2_3x;
 explain (costs off)
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on onek2
-         Recheck Cond: (stringu1 < 'B'::name)
-         Filter: ((unique2 = 11) OR (unique1 = 0))
-         ->  Bitmap Index Scan on onek2_u2_prtl
+   ->  Bitmap Heap Scan on onek2_3x
+         Recheck Cond: (((unique2 = 11) AND (stringu1 < 'B'::name)) OR (unique1 = 0))
+         Filter: (stringu1 < 'B'::name)
+         ->  BitmapOr
+               ->  Bitmap Index Scan on onek2_3x_unique2_idx
+                     Index Cond: (unique2 = 11)
+               ->  Bitmap Index Scan on onek2_3x_unique1_idx
+                     Index Cond: (unique1 = 0)
  Optimizer: Postgres query optimizer
-(6 rows)
+(10 rows)
 
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
  unique1 | unique2 
 ---------+---------
      494 |      11
+     494 |      11
+     494 |      11
        0 |     998
-(2 rows)
+       0 |     998
+       0 |     998
+(6 rows)
 
 explain (costs off)
 select unique1, unique2 from onek2

--- a/src/test/regress/sql/select.sql
+++ b/src/test/regress/sql/select.sql
@@ -230,11 +230,19 @@ select unique2 from onek2 where unique2 = 11 and stringu1 < 'B';
 select unique2 from onek2 where unique2 = 11 and stringu1 < 'B';
 RESET enable_indexscan;
 -- check multi-index cases too
+-- GPDB: Use onek2_3x for 3x the data, in order for us to get the upstream plan
+-- utilizing both indexes.
+create table onek2_3x (like onek2 including all) distributed by (unique1);
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+insert into onek2_3x select * from onek2;
+analyze onek2_3x;
 explain (costs off)
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
-select unique1, unique2 from onek2
+select unique1, unique2 from onek2_3x
   where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';
+
 explain (costs off)
 select unique1, unique2 from onek2
   where (unique2 = 11 and stringu1 < 'B') or unique1 = 0;


### PR DESCRIPTION
Since 167a67f and b43316b, the following query has been flaking in CI,
alternating between the following plans (showed w/ costs on):
```
explain
select unique1, unique2 from onek2
  where (unique2 = 11 or unique1 = 0) and stringu1 < 'B';

                                       QUERY PLAN
----------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=8.29..12.32 rows=1 width=8)
   ->  Bitmap Heap Scan on onek2  (cost=8.29..12.30 rows=1 width=8)
         Recheck Cond: (((unique2 = 11) AND (stringu1 < 'B'::name)) OR (unique1 = 0))
         Filter: (stringu1 < 'B'::name)
         ->  BitmapOr  (cost=8.29..8.29 rows=1 width=0)
               ->  Bitmap Index Scan on onek2_u2_prtl  (cost=0.00..4.14 rows=1 width=0)
                     Index Cond: (unique2 = 11)
               ->  Bitmap Index Scan on onek2_u1_prtl  (cost=0.00..4.14 rows=1 width=0)
                     Index Cond: (unique1 = 0)
 Optimizer: Postgres query optimizer
(10 rows)
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=8.20..12.42 rows=1 width=8)
   ->  Bitmap Heap Scan on onek2  (cost=8.20..12.40 rows=1 width=8)
         Recheck Cond: (stringu1 < 'B'::name)
         Filter: ((unique2 = 11) OR (unique1 = 0))
         ->  Bitmap Index Scan on onek2_u2_prtl  (cost=0.00..8.20 rows=12 width=0)
 Optimizer: Postgres query optimizer
(6 rows)
```
The cost diff between choosing the BitmapOr vs not choosing it is
miniscule and is subject to differences in sampling of onek2.

We remedy the problem by creating a table with 3x the data. onek2 is
distributed across the 3 segments in the demo cluster as opposed to
upstream, so we compensate accordingly. This creates a large enough cost
diff so that the original multi-index plan is chosen, which is the
intent here.

Co-authored-by: Chris Hajas <chajas@vmware.com>
Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/select_diff
