### PR TITLE
[Draft] Add an extension for partition maintenance in GPDB7

### DIFF
--- a/gpcontrib/gp_partition_maint/.gitignore
+++ b/gpcontrib/gp_partition_maint/.gitignore
@@ -1,0 +1,1 @@
+gp_partition_maint.sql

--- a/gpcontrib/gp_partition_maint/Makefile
+++ b/gpcontrib/gp_partition_maint/Makefile
@@ -1,0 +1,19 @@
+MODULES = gp_partition_maint
+
+EXTENSION = gp_partition_maint
+DATA = gp_partition_maint--1.0.sql
+
+REGRESS = partition_maint_test
+
+PG_CPPFLAGS = -I$(libpq_srcdir)
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/gp_partition_maint
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_partition_maint/README
+++ b/gpcontrib/gp_partition_maint/README
@@ -1,0 +1,3 @@
+Partition Maintenance Tools
+=========================
+

--- a/gpcontrib/gp_partition_maint/expected/partition_maint_test.out
+++ b/gpcontrib/gp_partition_maint/expected/partition_maint_test.out
@@ -25,18 +25,18 @@ SUBPARTITION BY list(c)
 		DEFAULT SUBPARTITION others
 	)
 );
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
-            relid             | level | rank |         relpartbound         | range_from | range_to 
-------------------------------+-------+------+------------------------------+------------+----------
- partrl                       |     0 |      |                              |            | 
- partrl_1_prt_p1_1            |     1 |    2 | FOR VALUES FROM (10) TO (15) | 10         | 15
- partrl_1_prt_p1_2            |     1 |    3 | FOR VALUES FROM (15) TO (20) | 15         | 20
- partrl_1_prt_p2              |     1 |    1 | FOR VALUES FROM (0) TO (10)  | 0          | 10
- partrl_1_prt_p1_1_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            | 
- partrl_1_prt_p1_2_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            | 
- partrl_1_prt_p2_2_prt_others |     2 |      | DEFAULT                      |            | 
- partrl_1_prt_p2_2_prt_sp2    |     2 |      | FOR VALUES IN (3, 4)         |            | 
- partrl_1_prt_p2_2_prt_sp1    |     2 |      | FOR VALUES IN (1, 2)         |            | 
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+            relid             | level | rank |         relpartbound         | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+------------------------------+-------+------+------------------------------+------------+----------+---------------------------+----------------------------
+ partrl                       |     0 |      |                              |            |          | partrl_1_prt_p2           | partrl_1_prt_p1_2
+ partrl_1_prt_p1_1            |     1 |    2 | FOR VALUES FROM (10) TO (15) | 10         | 15       |                           | 
+ partrl_1_prt_p1_2            |     1 |    3 | FOR VALUES FROM (15) TO (20) | 15         | 20       |                           | 
+ partrl_1_prt_p2              |     1 |    1 | FOR VALUES FROM (0) TO (10)  | 0          | 10       |                           | 
+ partrl_1_prt_p1_1_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
+ partrl_1_prt_p1_2_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
+ partrl_1_prt_p2_2_prt_others |     2 |      | DEFAULT                      |            |          |                           | 
+ partrl_1_prt_p2_2_prt_sp2    |     2 |      | FOR VALUES IN (3, 4)         |            |          |                           | 
+ partrl_1_prt_p2_2_prt_sp1    |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
 (9 rows)
 
 -- Classic Syntax
@@ -57,16 +57,16 @@ SUBPARTITION BY range(c)
 		DEFAULT SUBPARTITION other_c
 	)
 );
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
-             relid             | level | rank |          relpartbound          | range_from | range_to 
--------------------------------+-------+------+--------------------------------+------------+----------
- partrr                        |     0 |      |                                |            | 
- partrr_1_prt_p1               |     1 |    1 | FOR VALUES FROM (0) TO (10)    | 0          | 10
- partrr_1_prt_p2               |     1 |    2 | FOR VALUES FROM (10) TO (20)   | 10         | 20
- partrr_1_prt_p1_2_prt_other_c |     2 |      | DEFAULT                        |            | 
- partrr_1_prt_p2_2_prt_other_c |     2 |      | DEFAULT                        |            | 
- partrr_1_prt_p2_2_prt_sp2     |     2 |    2 | FOR VALUES FROM (300) TO (600) | 300        | 600
- partrr_1_prt_p2_2_prt_sp1     |     2 |    1 | FOR VALUES FROM (100) TO (300) | 100        | 300
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid)  from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+             relid             | level | rank |          relpartbound          | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+-------------------------------+-------+------+--------------------------------+------------+----------+---------------------------+----------------------------
+ partrr                        |     0 |      |                                |            |          | partrr_1_prt_p1           | partrr_1_prt_p2
+ partrr_1_prt_p1               |     1 |    1 | FOR VALUES FROM (0) TO (10)    | 0          | 10       |                           | 
+ partrr_1_prt_p2               |     1 |    2 | FOR VALUES FROM (10) TO (20)   | 10         | 20       | partrr_1_prt_p2_2_prt_sp1 | partrr_1_prt_p2_2_prt_sp2
+ partrr_1_prt_p1_2_prt_other_c |     2 |      | DEFAULT                        |            |          |                           | 
+ partrr_1_prt_p2_2_prt_other_c |     2 |      | DEFAULT                        |            |          |                           | 
+ partrr_1_prt_p2_2_prt_sp2     |     2 |    2 | FOR VALUES FROM (300) TO (600) | 300        | 600      |                           | 
+ partrr_1_prt_p2_2_prt_sp1     |     2 |    1 | FOR VALUES FROM (100) TO (300) | 100        | 300      |                           | 
 (7 rows)
 
 -- w/ minvalue and maxvalue
@@ -89,17 +89,17 @@ CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue)
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
 NOTICE:  table has parent, setting distribution columns to match parent table
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
-     relid     | level | rank |            relpartbound            | range_from | range_to 
----------------+-------+------+------------------------------------+------------+----------
- range_parted2 |     0 |      |                                    |            | 
- part1         |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10
- part2         |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20
- part3         |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30
- part4         |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40
- part5         |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50
- part6         |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE
- part7         |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+     relid     | level | rank |            relpartbound            | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+---------------+-------+------+------------------------------------+------------+----------+---------------------------+----------------------------
+ range_parted2 |     0 |      |                                    |            |          | part7                     | part6
+ part1         |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10       |                           | 
+ part2         |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20       |                           | 
+ part3         |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30       |                           | 
+ part4         |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40       |                           | 
+ part5         |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50       |                           | 
+ part6         |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE |                           | 
+ part7         |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1        |                           | 
 (8 rows)
 
 -- w/ expressions
@@ -123,17 +123,17 @@ CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60)
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
 NOTICE:  table has parent, setting distribution columns to match parent table
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
-        relid        | level | rank |            relpartbound            | range_from | range_to 
----------------------+-------+------+------------------------------------+------------+----------
- range_parted3       |     0 |      |                                    |            | 
- range_parted3_part1 |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10
- range_parted3_part2 |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20
- range_parted3_part3 |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30
- range_parted3_part4 |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40
- range_parted3_part5 |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50
- range_parted3_part6 |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE
- range_parted3_part7 |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+        relid        | level | rank |            relpartbound            | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+---------------------+-------+------+------------------------------------+------------+----------+---------------------------+----------------------------
+ range_parted3       |     0 |      |                                    |            |          | range_parted3_part7       | range_parted3_part6
+ range_parted3_part1 |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10       |                           | 
+ range_parted3_part2 |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20       |                           | 
+ range_parted3_part3 |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30       |                           | 
+ range_parted3_part4 |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40       |                           | 
+ range_parted3_part5 |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50       |                           | 
+ range_parted3_part6 |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE |                           | 
+ range_parted3_part7 |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1        |                           | 
 (8 rows)
 
 -- date partitioned table
@@ -144,29 +144,29 @@ CREATE TABLE sales (trans_id int, date date, amount
         (START (date '2023-01-01')
         END (date '2023-05-01') EVERY (INTERVAL '7 day'),
         DEFAULT PARTITION other_date);
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
-         relid          | level | rank |                   relpartbound                   |  range_from  |   range_to   
-------------------------+-------+------+--------------------------------------------------+--------------+--------------
- sales_1_prt_2          |     1 |    1 | FOR VALUES FROM ('01-01-2023') TO ('01-08-2023') | '01-01-2023' | '01-08-2023'
- sales_1_prt_3          |     1 |    2 | FOR VALUES FROM ('01-08-2023') TO ('01-15-2023') | '01-08-2023' | '01-15-2023'
- sales_1_prt_4          |     1 |    3 | FOR VALUES FROM ('01-15-2023') TO ('01-22-2023') | '01-15-2023' | '01-22-2023'
- sales_1_prt_5          |     1 |    4 | FOR VALUES FROM ('01-22-2023') TO ('01-29-2023') | '01-22-2023' | '01-29-2023'
- sales_1_prt_6          |     1 |    5 | FOR VALUES FROM ('01-29-2023') TO ('02-05-2023') | '01-29-2023' | '02-05-2023'
- sales_1_prt_7          |     1 |    6 | FOR VALUES FROM ('02-05-2023') TO ('02-12-2023') | '02-05-2023' | '02-12-2023'
- sales_1_prt_8          |     1 |    7 | FOR VALUES FROM ('02-12-2023') TO ('02-19-2023') | '02-12-2023' | '02-19-2023'
- sales_1_prt_9          |     1 |    8 | FOR VALUES FROM ('02-19-2023') TO ('02-26-2023') | '02-19-2023' | '02-26-2023'
- sales_1_prt_10         |     1 |    9 | FOR VALUES FROM ('02-26-2023') TO ('03-05-2023') | '02-26-2023' | '03-05-2023'
- sales_1_prt_11         |     1 |   10 | FOR VALUES FROM ('03-05-2023') TO ('03-12-2023') | '03-05-2023' | '03-12-2023'
- sales_1_prt_12         |     1 |   11 | FOR VALUES FROM ('03-12-2023') TO ('03-19-2023') | '03-12-2023' | '03-19-2023'
- sales_1_prt_13         |     1 |   12 | FOR VALUES FROM ('03-19-2023') TO ('03-26-2023') | '03-19-2023' | '03-26-2023'
- sales_1_prt_14         |     1 |   13 | FOR VALUES FROM ('03-26-2023') TO ('04-02-2023') | '03-26-2023' | '04-02-2023'
- sales_1_prt_15         |     1 |   14 | FOR VALUES FROM ('04-02-2023') TO ('04-09-2023') | '04-02-2023' | '04-09-2023'
- sales_1_prt_16         |     1 |   15 | FOR VALUES FROM ('04-09-2023') TO ('04-16-2023') | '04-09-2023' | '04-16-2023'
- sales_1_prt_17         |     1 |   16 | FOR VALUES FROM ('04-16-2023') TO ('04-23-2023') | '04-16-2023' | '04-23-2023'
- sales_1_prt_18         |     1 |   17 | FOR VALUES FROM ('04-23-2023') TO ('04-30-2023') | '04-23-2023' | '04-30-2023'
- sales_1_prt_19         |     1 |   18 | FOR VALUES FROM ('04-30-2023') TO ('05-01-2023') | '04-30-2023' | '05-01-2023'
- sales_1_prt_other_date |     1 |      | DEFAULT                                          |              | 
- sales                  |     0 |      |                                                  |              | 
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
+         relid          | level | rank |                   relpartbound                   |  range_from  |   range_to   | pg_partition_lowest_child | pg_partition_highest_child 
+------------------------+-------+------+--------------------------------------------------+--------------+--------------+---------------------------+----------------------------
+ sales_1_prt_2          |     1 |    1 | FOR VALUES FROM ('01-01-2023') TO ('01-08-2023') | '01-01-2023' | '01-08-2023' |                           | 
+ sales_1_prt_3          |     1 |    2 | FOR VALUES FROM ('01-08-2023') TO ('01-15-2023') | '01-08-2023' | '01-15-2023' |                           | 
+ sales_1_prt_4          |     1 |    3 | FOR VALUES FROM ('01-15-2023') TO ('01-22-2023') | '01-15-2023' | '01-22-2023' |                           | 
+ sales_1_prt_5          |     1 |    4 | FOR VALUES FROM ('01-22-2023') TO ('01-29-2023') | '01-22-2023' | '01-29-2023' |                           | 
+ sales_1_prt_6          |     1 |    5 | FOR VALUES FROM ('01-29-2023') TO ('02-05-2023') | '01-29-2023' | '02-05-2023' |                           | 
+ sales_1_prt_7          |     1 |    6 | FOR VALUES FROM ('02-05-2023') TO ('02-12-2023') | '02-05-2023' | '02-12-2023' |                           | 
+ sales_1_prt_8          |     1 |    7 | FOR VALUES FROM ('02-12-2023') TO ('02-19-2023') | '02-12-2023' | '02-19-2023' |                           | 
+ sales_1_prt_9          |     1 |    8 | FOR VALUES FROM ('02-19-2023') TO ('02-26-2023') | '02-19-2023' | '02-26-2023' |                           | 
+ sales_1_prt_10         |     1 |    9 | FOR VALUES FROM ('02-26-2023') TO ('03-05-2023') | '02-26-2023' | '03-05-2023' |                           | 
+ sales_1_prt_11         |     1 |   10 | FOR VALUES FROM ('03-05-2023') TO ('03-12-2023') | '03-05-2023' | '03-12-2023' |                           | 
+ sales_1_prt_12         |     1 |   11 | FOR VALUES FROM ('03-12-2023') TO ('03-19-2023') | '03-12-2023' | '03-19-2023' |                           | 
+ sales_1_prt_13         |     1 |   12 | FOR VALUES FROM ('03-19-2023') TO ('03-26-2023') | '03-19-2023' | '03-26-2023' |                           | 
+ sales_1_prt_14         |     1 |   13 | FOR VALUES FROM ('03-26-2023') TO ('04-02-2023') | '03-26-2023' | '04-02-2023' |                           | 
+ sales_1_prt_15         |     1 |   14 | FOR VALUES FROM ('04-02-2023') TO ('04-09-2023') | '04-02-2023' | '04-09-2023' |                           | 
+ sales_1_prt_16         |     1 |   15 | FOR VALUES FROM ('04-09-2023') TO ('04-16-2023') | '04-09-2023' | '04-16-2023' |                           | 
+ sales_1_prt_17         |     1 |   16 | FOR VALUES FROM ('04-16-2023') TO ('04-23-2023') | '04-16-2023' | '04-23-2023' |                           | 
+ sales_1_prt_18         |     1 |   17 | FOR VALUES FROM ('04-23-2023') TO ('04-30-2023') | '04-23-2023' | '04-30-2023' |                           | 
+ sales_1_prt_19         |     1 |   18 | FOR VALUES FROM ('04-30-2023') TO ('05-01-2023') | '04-30-2023' | '05-01-2023' |                           | 
+ sales_1_prt_other_date |     1 |      | DEFAULT                                          |              |              |                           | 
+ sales                  |     0 |      |                                                  |              |              | sales_1_prt_2             | sales_1_prt_19
 (20 rows)
 
 -- Multi-column range partitioned table
@@ -192,18 +192,18 @@ create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20
 NOTICE:  table has parent, setting distribution columns to match parent table
 create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
 NOTICE:  table has parent, setting distribution columns to match parent table
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
-    relid     | level | rank |                          relpartbound                          | range_to 
---------------+-------+------+----------------------------------------------------------------+----------
- mc3p         |     0 |      |                                                                | 
- mc3p_default |     1 |      | DEFAULT                                                        | 
- mc3p0        |     1 |    1 | FOR VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (1, 1, 1)    | 
- mc3p1        |     1 |    2 | FOR VALUES FROM (1, 1, 1) TO (10, 5, 10)                       | 
- mc3p2        |     1 |    3 | FOR VALUES FROM (10, 5, 10) TO (10, 10, 10)                    | 
- mc3p3        |     1 |    4 | FOR VALUES FROM (10, 10, 10) TO (10, 10, 20)                   | 
- mc3p4        |     1 |    5 | FOR VALUES FROM (10, 10, 20) TO (10, MAXVALUE, MAXVALUE)       | 
- mc3p5        |     1 |    6 | FOR VALUES FROM (11, 1, 1) TO (20, 10, 10)                     | 
- mc3p6        |     1 |    7 | FOR VALUES FROM (20, 10, 10) TO (20, 20, 20)                   | 
- mc3p7        |     1 |    8 | FOR VALUES FROM (20, 20, 20) TO (MAXVALUE, MAXVALUE, MAXVALUE) | 
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
+    relid     | level | rank |                          relpartbound                          | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+--------------+-------+------+----------------------------------------------------------------+----------+---------------------------+----------------------------
+ mc3p         |     0 |      |                                                                |          | mc3p0                     | mc3p7
+ mc3p_default |     1 |      | DEFAULT                                                        |          |                           | 
+ mc3p0        |     1 |    1 | FOR VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (1, 1, 1)    |          |                           | 
+ mc3p1        |     1 |    2 | FOR VALUES FROM (1, 1, 1) TO (10, 5, 10)                       |          |                           | 
+ mc3p2        |     1 |    3 | FOR VALUES FROM (10, 5, 10) TO (10, 10, 10)                    |          |                           | 
+ mc3p3        |     1 |    4 | FOR VALUES FROM (10, 10, 10) TO (10, 10, 20)                   |          |                           | 
+ mc3p4        |     1 |    5 | FOR VALUES FROM (10, 10, 20) TO (10, MAXVALUE, MAXVALUE)       |          |                           | 
+ mc3p5        |     1 |    6 | FOR VALUES FROM (11, 1, 1) TO (20, 10, 10)                     |          |                           | 
+ mc3p6        |     1 |    7 | FOR VALUES FROM (20, 10, 10) TO (20, 20, 20)                   |          |                           | 
+ mc3p7        |     1 |    8 | FOR VALUES FROM (20, 20, 20) TO (MAXVALUE, MAXVALUE, MAXVALUE) |          |                           | 
 (10 rows)
 

--- a/gpcontrib/gp_partition_maint/expected/partition_maint_test.out
+++ b/gpcontrib/gp_partition_maint/expected/partition_maint_test.out
@@ -1,0 +1,209 @@
+DROP DATABASE IF EXISTS gp_partition_maint_test;
+CREATE DATABASE gp_partition_maint_test;
+\c gp_partition_maint_test
+DROP EXTENSION IF EXISTS gp_partition_maint;
+NOTICE:  extension "gp_partition_maint" does not exist, skipping
+CREATE EXTENSION gp_partition_maint;
+-- TODO: use modern syntax
+-- Classic Syntax
+-- Multi-level range-list partitioned table
+DROP TABLE IF EXISTS partrl;
+NOTICE:  table "partrl" does not exist, skipping
+CREATE TABLE partrl (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY list(c)
+(
+	PARTITION p1 START (10) END (20) EVERY (5)
+	(
+		SUBPARTITION sp1 VALUES (1, 2)
+	),
+	PARTITION p2 START (0) END (10)
+	(
+		SUBPARTITION sp2 VALUES (3, 4),
+		SUBPARTITION sp1 VALUES (1, 2),
+		DEFAULT SUBPARTITION others
+	)
+);
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+            relid             | level | rank |         relpartbound         | range_from | range_to 
+------------------------------+-------+------+------------------------------+------------+----------
+ partrl                       |     0 |      |                              |            | 
+ partrl_1_prt_p1_1            |     1 |    2 | FOR VALUES FROM (10) TO (15) | 10         | 15
+ partrl_1_prt_p1_2            |     1 |    3 | FOR VALUES FROM (15) TO (20) | 15         | 20
+ partrl_1_prt_p2              |     1 |    1 | FOR VALUES FROM (0) TO (10)  | 0          | 10
+ partrl_1_prt_p1_1_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            | 
+ partrl_1_prt_p1_2_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            | 
+ partrl_1_prt_p2_2_prt_others |     2 |      | DEFAULT                      |            | 
+ partrl_1_prt_p2_2_prt_sp2    |     2 |      | FOR VALUES IN (3, 4)         |            | 
+ partrl_1_prt_p2_2_prt_sp1    |     2 |      | FOR VALUES IN (1, 2)         |            | 
+(9 rows)
+
+-- Classic Syntax
+-- Multi-level range-range partitioned table
+CREATE TABLE partrr (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY range(c)
+(
+	PARTITION p1 START (0) END (10)
+	(
+		DEFAULT SUBPARTITION other_c
+	),
+	PARTITION p2 START (10) END (20)
+	(
+		SUBPARTITION sp2 START (300) END (600),
+		SUBPARTITION sp1 START (100) END (300),
+		DEFAULT SUBPARTITION other_c
+	)
+);
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+             relid             | level | rank |          relpartbound          | range_from | range_to 
+-------------------------------+-------+------+--------------------------------+------------+----------
+ partrr                        |     0 |      |                                |            | 
+ partrr_1_prt_p1               |     1 |    1 | FOR VALUES FROM (0) TO (10)    | 0          | 10
+ partrr_1_prt_p2               |     1 |    2 | FOR VALUES FROM (10) TO (20)   | 10         | 20
+ partrr_1_prt_p1_2_prt_other_c |     2 |      | DEFAULT                        |            | 
+ partrr_1_prt_p2_2_prt_other_c |     2 |      | DEFAULT                        |            | 
+ partrr_1_prt_p2_2_prt_sp2     |     2 |    2 | FOR VALUES FROM (300) TO (600) | 300        | 600
+ partrr_1_prt_p2_2_prt_sp1     |     2 |    1 | FOR VALUES FROM (100) TO (300) | 100        | 300
+(7 rows)
+
+-- w/ minvalue and maxvalue
+CREATE TABLE range_parted2 (
+    a int
+) PARTITION BY RANGE (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE part1 PARTITION OF range_parted2 FOR VALUES FROM (1) TO (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part2 PARTITION OF range_parted2 FOR VALUES FROM (10) TO (20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part3 PARTITION OF range_parted2 FOR VALUES FROM (20) TO (30);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part4 PARTITION OF range_parted2 FOR VALUES FROM (30) TO (40);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part5 PARTITION OF range_parted2 FOR VALUES FROM (40) TO (50);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+     relid     | level | rank |            relpartbound            | range_from | range_to 
+---------------+-------+------+------------------------------------+------------+----------
+ range_parted2 |     0 |      |                                    |            | 
+ part1         |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10
+ part2         |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20
+ part3         |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30
+ part4         |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40
+ part5         |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50
+ part6         |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE
+ part7         |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1
+(8 rows)
+
+-- w/ expressions
+CREATE TABLE range_parted3 (
+    a int,
+    b int
+) PARTITION BY RANGE (abs(a - b));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE range_parted3_part1 PARTITION OF range_parted3 FOR VALUES FROM (1) TO (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part2 PARTITION OF range_parted3 FOR VALUES FROM (10) TO (20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part3 PARTITION OF range_parted3 FOR VALUES FROM (20) TO (30);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part4 PARTITION OF range_parted3 FOR VALUES FROM (30) TO (40);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part5 PARTITION OF range_parted3 FOR VALUES FROM (40) TO (50);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60) TO (maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+        relid        | level | rank |            relpartbound            | range_from | range_to 
+---------------------+-------+------+------------------------------------+------------+----------
+ range_parted3       |     0 |      |                                    |            | 
+ range_parted3_part1 |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10
+ range_parted3_part2 |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20
+ range_parted3_part3 |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30
+ range_parted3_part4 |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40
+ range_parted3_part5 |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50
+ range_parted3_part6 |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE
+ range_parted3_part7 |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1
+(8 rows)
+
+-- date partitioned table
+CREATE TABLE sales (trans_id int, date date, amount
+                             decimal(9,2), region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (date)
+        (START (date '2023-01-01')
+        END (date '2023-05-01') EVERY (INTERVAL '7 day'),
+        DEFAULT PARTITION other_date);
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
+         relid          | level | rank |                   relpartbound                   |  range_from  |   range_to   
+------------------------+-------+------+--------------------------------------------------+--------------+--------------
+ sales_1_prt_2          |     1 |    1 | FOR VALUES FROM ('01-01-2023') TO ('01-08-2023') | '01-01-2023' | '01-08-2023'
+ sales_1_prt_3          |     1 |    2 | FOR VALUES FROM ('01-08-2023') TO ('01-15-2023') | '01-08-2023' | '01-15-2023'
+ sales_1_prt_4          |     1 |    3 | FOR VALUES FROM ('01-15-2023') TO ('01-22-2023') | '01-15-2023' | '01-22-2023'
+ sales_1_prt_5          |     1 |    4 | FOR VALUES FROM ('01-22-2023') TO ('01-29-2023') | '01-22-2023' | '01-29-2023'
+ sales_1_prt_6          |     1 |    5 | FOR VALUES FROM ('01-29-2023') TO ('02-05-2023') | '01-29-2023' | '02-05-2023'
+ sales_1_prt_7          |     1 |    6 | FOR VALUES FROM ('02-05-2023') TO ('02-12-2023') | '02-05-2023' | '02-12-2023'
+ sales_1_prt_8          |     1 |    7 | FOR VALUES FROM ('02-12-2023') TO ('02-19-2023') | '02-12-2023' | '02-19-2023'
+ sales_1_prt_9          |     1 |    8 | FOR VALUES FROM ('02-19-2023') TO ('02-26-2023') | '02-19-2023' | '02-26-2023'
+ sales_1_prt_10         |     1 |    9 | FOR VALUES FROM ('02-26-2023') TO ('03-05-2023') | '02-26-2023' | '03-05-2023'
+ sales_1_prt_11         |     1 |   10 | FOR VALUES FROM ('03-05-2023') TO ('03-12-2023') | '03-05-2023' | '03-12-2023'
+ sales_1_prt_12         |     1 |   11 | FOR VALUES FROM ('03-12-2023') TO ('03-19-2023') | '03-12-2023' | '03-19-2023'
+ sales_1_prt_13         |     1 |   12 | FOR VALUES FROM ('03-19-2023') TO ('03-26-2023') | '03-19-2023' | '03-26-2023'
+ sales_1_prt_14         |     1 |   13 | FOR VALUES FROM ('03-26-2023') TO ('04-02-2023') | '03-26-2023' | '04-02-2023'
+ sales_1_prt_15         |     1 |   14 | FOR VALUES FROM ('04-02-2023') TO ('04-09-2023') | '04-02-2023' | '04-09-2023'
+ sales_1_prt_16         |     1 |   15 | FOR VALUES FROM ('04-09-2023') TO ('04-16-2023') | '04-09-2023' | '04-16-2023'
+ sales_1_prt_17         |     1 |   16 | FOR VALUES FROM ('04-16-2023') TO ('04-23-2023') | '04-16-2023' | '04-23-2023'
+ sales_1_prt_18         |     1 |   17 | FOR VALUES FROM ('04-23-2023') TO ('04-30-2023') | '04-23-2023' | '04-30-2023'
+ sales_1_prt_19         |     1 |   18 | FOR VALUES FROM ('04-30-2023') TO ('05-01-2023') | '04-30-2023' | '05-01-2023'
+ sales_1_prt_other_date |     1 |      | DEFAULT                                          |              | 
+ sales                  |     0 |      |                                                  |              | 
+(20 rows)
+
+-- Multi-column range partitioned table
+-- multi-column keys
+create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table mc3p_default partition of mc3p default;
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p0 partition of mc3p for values from (minvalue, minvalue, minvalue) to (1, 1, 1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p1 partition of mc3p for values from (1, 1, 1) to (10, 5, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p2 partition of mc3p for values from (10, 5, 10) to (10, 10, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p3 partition of mc3p for values from (10, 10, 10) to (10, 10, 20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p4 partition of mc3p for values from (10, 10, 20) to (10, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
+    relid     | level | rank |                          relpartbound                          | range_to 
+--------------+-------+------+----------------------------------------------------------------+----------
+ mc3p         |     0 |      |                                                                | 
+ mc3p_default |     1 |      | DEFAULT                                                        | 
+ mc3p0        |     1 |    1 | FOR VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (1, 1, 1)    | 
+ mc3p1        |     1 |    2 | FOR VALUES FROM (1, 1, 1) TO (10, 5, 10)                       | 
+ mc3p2        |     1 |    3 | FOR VALUES FROM (10, 5, 10) TO (10, 10, 10)                    | 
+ mc3p3        |     1 |    4 | FOR VALUES FROM (10, 10, 10) TO (10, 10, 20)                   | 
+ mc3p4        |     1 |    5 | FOR VALUES FROM (10, 10, 20) TO (10, MAXVALUE, MAXVALUE)       | 
+ mc3p5        |     1 |    6 | FOR VALUES FROM (11, 1, 1) TO (20, 10, 10)                     | 
+ mc3p6        |     1 |    7 | FOR VALUES FROM (20, 10, 10) TO (20, 20, 20)                   | 
+ mc3p7        |     1 |    8 | FOR VALUES FROM (20, 20, 20) TO (MAXVALUE, MAXVALUE, MAXVALUE) | 
+(10 rows)
+

--- a/gpcontrib/gp_partition_maint/gp_partition_maint--1.0.sql
+++ b/gpcontrib/gp_partition_maint/gp_partition_maint--1.0.sql
@@ -1,0 +1,93 @@
+/* contrib/gp_partition_maint/gp_partition_maint--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_partition_maint" to load this file. \quit
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_rank(rp regclass)
+RETURNS int
+AS 'MODULE_PATHNAME'
+LANGUAGE C VOLATILE STRICT NO SQL;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_bound_value(rp regclass, bound_type text)
+RETURNS text AS $$
+DECLARE
+	v_relpartbound text;
+	v_bound_value text;
+	v_parent_table regclass;
+	v_nkeys int;
+BEGIN
+-- Check if the given table is a non-default child range partition
+SELECT inhparent INTO v_parent_table
+FROM pg_inherits
+WHERE inhrelid = rp;
+
+IF v_parent_table IS NULL THEN
+	RETURN NULL;
+END IF;
+
+-- Check if the parent table is partitioned by a single key
+SELECT partnatts INTO v_nkeys
+FROM pg_partitioned_table
+WHERE partrelid = v_parent_table;
+
+IF v_nkeys IS NOT NULL AND v_nkeys != 1 THEN
+	RETURN NULL;
+END IF;
+
+-- Get the partition bounds
+SELECT pg_get_expr(relpartbound, oid) INTO v_relpartbound
+FROM pg_class
+WHERE oid = rp;
+
+-- Parse the bound value from relpartbound
+IF lower(bound_type) = 'from' THEN
+	SELECT (regexp_matches(v_relpartbound, 'FOR VALUES FROM \((.+)\) TO \((.+)\)'))[1] INTO v_bound_value;
+ELSIF lower(bound_type) = 'to' THEN
+	SELECT (regexp_matches(v_relpartbound, 'FOR VALUES FROM \((.+)\) TO \((.+)\)'))[2] INTO v_bound_value;
+ELSE
+	RAISE EXCEPTION 'Invalid bound type: %', bound_type;
+END IF;
+
+RETURN v_bound_value;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_range_from(rp regclass)
+RETURNS text AS $$
+SELECT pg_partition_bound_value(rp, 'from');
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_range_to(rp regclass)
+RETURNS text AS $$
+SELECT pg_partition_bound_value(rp, 'to');
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_isdefault(relid regclass)
+RETURNS BOOLEAN AS $$
+DECLARE
+boundspec TEXT;
+BEGIN
+-- Get the partition bound definition for the relation
+SELECT pg_get_expr(relpartbound, oid) INTO boundspec
+FROM pg_catalog.pg_class
+WHERE oid = relid;
+
+-- If partition_def is null, the relation is not a partition at all
+IF boundspec IS NULL THEN
+RETURN FALSE;
+END IF;
+
+-- Check if the partition bound spec exactly matches 'DEFAULT'
+RETURN boundspec = 'DEFAULT';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_parent_partstrat(childrelname text)
+RETURNS "char" AS $$
+SELECT part.partstrat
+FROM pg_catalog.pg_inherits i
+JOIN pg_catalog.pg_class c ON i.inhrelid = c.oid
+JOIN pg_catalog.pg_partitioned_table part ON part.partrelid = i.inhparent
+WHERE c.relname = childrelname;
+$$
+LANGUAGE SQL;

--- a/gpcontrib/gp_partition_maint/gp_partition_maint--1.0.sql
+++ b/gpcontrib/gp_partition_maint/gp_partition_maint--1.0.sql
@@ -91,3 +91,13 @@ JOIN pg_catalog.pg_partitioned_table part ON part.partrelid = i.inhparent
 WHERE c.relname = childrelname;
 $$
 LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_lowest_child(rp regclass)
+RETURNS regclass
+AS 'MODULE_PATHNAME'
+LANGUAGE C VOLATILE STRICT NO SQL;
+
+CREATE OR REPLACE FUNCTION @extschema@.pg_partition_highest_child(rp regclass)
+RETURNS regclass
+AS 'MODULE_PATHNAME'
+LANGUAGE C VOLATILE STRICT NO SQL;

--- a/gpcontrib/gp_partition_maint/gp_partition_maint.c
+++ b/gpcontrib/gp_partition_maint/gp_partition_maint.c
@@ -1,0 +1,93 @@
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/relation.h"
+#include "catalog/pg_inherits.h"
+#include "catalog/pg_type.h"
+#include "catalog/partition.h"
+#include "fmgr.h"
+#include "nodes/parsenodes.h"
+#include "partitioning/partbounds.h"
+#include "partitioning/partdesc.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/partcache.h"
+#include "utils/rel.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+
+static bool
+rel_is_range_part_nondefault(Oid relid)
+{
+	HeapTuple			tuple;
+	Form_pg_class		classForm;
+	Datum				datum;
+	bool				isnull;
+	PartitionBoundSpec *boundspec = NULL;
+	bool				retval = false;
+
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for relation %u", relid);
+
+	/* check if the relation is a partition */
+	classForm = (Form_pg_class) GETSTRUCT(tuple);
+	if ((classForm->relkind == RELKIND_RELATION ||
+		classForm->relkind == RELKIND_PARTITIONED_TABLE) &&
+		classForm->relispartition)
+	{
+		datum = SysCacheGetAttr(RELOID, tuple, Anum_pg_class_relpartbound, &isnull);
+		if (!isnull)
+		{
+			boundspec = stringToNode(TextDatumGetCString(datum));
+			/* check if the partition is a non-default range partition */
+			if (boundspec->strategy == PARTITION_STRATEGY_RANGE &&
+				!boundspec->is_default)
+				retval = true;
+		}
+	}
+
+	ReleaseSysCache(tuple);
+	return retval;
+}
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+extern Datum pg_partition_rank(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(pg_partition_rank);
+
+Datum
+pg_partition_rank(PG_FUNCTION_ARGS)
+{
+	Oid					relid = PG_GETARG_OID(0);
+	Oid					parentrelid = InvalidOid;
+	Relation			parentrel = NULL;
+	PartitionDesc		parentpartdesc = NULL;
+	PartitionKey		parentpartkey = NULL;
+
+	if (!rel_is_range_part_nondefault(relid))
+		PG_RETURN_NULL();
+
+	parentrelid = get_partition_parent(relid);
+	parentrel = relation_open(parentrelid, AccessShareLock);
+	parentpartkey = RelationGetPartitionKey(parentrel);
+	parentpartdesc = RelationGetPartitionDesc(parentrel);
+
+	/*
+	 * Child oids are already sorted by range bounds in ascending order.
+	 * If default partition exists, it is the last partition.
+	 */
+	Assert(parentpartkey->strategy == PARTITION_STRATEGY_RANGE);
+	for (int i = 0; i < parentpartdesc->nparts; i++)
+	{
+		if (relid == parentpartdesc->oids[i])
+		{
+			relation_close(parentrel, AccessShareLock);
+			PG_RETURN_INT32(i + 1);
+		}
+	}
+	elog(ERROR, "partition not found in parent");
+}

--- a/gpcontrib/gp_partition_maint/gp_partition_maint.control
+++ b/gpcontrib/gp_partition_maint/gp_partition_maint.control
@@ -1,0 +1,5 @@
+# gp_fault_inject extension
+comment = 'simulate various faults for testing purposes'
+default_version = '1.0'
+module_pathname = '$libdir/gp_partition_maint'
+relocatable = false

--- a/gpcontrib/gp_partition_maint/sql/partition_maint_test.sql
+++ b/gpcontrib/gp_partition_maint/sql/partition_maint_test.sql
@@ -1,0 +1,103 @@
+DROP DATABASE IF EXISTS gp_partition_maint_test;
+CREATE DATABASE gp_partition_maint_test;
+\c gp_partition_maint_test
+DROP EXTENSION IF EXISTS gp_partition_maint;
+CREATE EXTENSION gp_partition_maint;
+
+-- TODO: use modern syntax
+-- Classic Syntax
+-- Multi-level range-list partitioned table
+DROP TABLE IF EXISTS partrl;
+CREATE TABLE partrl (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY list(c)
+(
+	PARTITION p1 START (10) END (20) EVERY (5)
+	(
+		SUBPARTITION sp1 VALUES (1, 2)
+	),
+	PARTITION p2 START (0) END (10)
+	(
+		SUBPARTITION sp2 VALUES (3, 4),
+		SUBPARTITION sp1 VALUES (1, 2),
+		DEFAULT SUBPARTITION others
+	)
+);
+
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+
+-- Classic Syntax
+-- Multi-level range-range partitioned table
+CREATE TABLE partrr (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY range(c)
+(
+	PARTITION p1 START (0) END (10)
+	(
+		DEFAULT SUBPARTITION other_c
+	),
+	PARTITION p2 START (10) END (20)
+	(
+		SUBPARTITION sp2 START (300) END (600),
+		SUBPARTITION sp1 START (100) END (300),
+		DEFAULT SUBPARTITION other_c
+	)
+);
+
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+
+-- w/ minvalue and maxvalue
+CREATE TABLE range_parted2 (
+    a int
+) PARTITION BY RANGE (a);
+CREATE TABLE part1 PARTITION OF range_parted2 FOR VALUES FROM (1) TO (10);
+CREATE TABLE part2 PARTITION OF range_parted2 FOR VALUES FROM (10) TO (20);
+CREATE TABLE part3 PARTITION OF range_parted2 FOR VALUES FROM (20) TO (30);
+CREATE TABLE part4 PARTITION OF range_parted2 FOR VALUES FROM (30) TO (40);
+CREATE TABLE part5 PARTITION OF range_parted2 FOR VALUES FROM (40) TO (50);
+CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue);
+CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
+
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+
+-- w/ expressions
+CREATE TABLE range_parted3 (
+    a int,
+    b int
+) PARTITION BY RANGE (abs(a - b));
+CREATE TABLE range_parted3_part1 PARTITION OF range_parted3 FOR VALUES FROM (1) TO (10);
+CREATE TABLE range_parted3_part2 PARTITION OF range_parted3 FOR VALUES FROM (10) TO (20);
+CREATE TABLE range_parted3_part3 PARTITION OF range_parted3 FOR VALUES FROM (20) TO (30);
+CREATE TABLE range_parted3_part4 PARTITION OF range_parted3 FOR VALUES FROM (30) TO (40);
+CREATE TABLE range_parted3_part5 PARTITION OF range_parted3 FOR VALUES FROM (40) TO (50);
+CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60) TO (maxvalue);
+CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
+
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+
+-- date partitioned table
+CREATE TABLE sales (trans_id int, date date, amount
+                             decimal(9,2), region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (date)
+        (START (date '2023-01-01')
+        END (date '2023-05-01') EVERY (INTERVAL '7 day'),
+        DEFAULT PARTITION other_date);
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
+
+-- Multi-column range partitioned table
+-- multi-column keys
+create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
+create table mc3p_default partition of mc3p default;
+create table mc3p0 partition of mc3p for values from (minvalue, minvalue, minvalue) to (1, 1, 1);
+create table mc3p1 partition of mc3p for values from (1, 1, 1) to (10, 5, 10);
+create table mc3p2 partition of mc3p for values from (10, 5, 10) to (10, 10, 10);
+create table mc3p3 partition of mc3p for values from (10, 10, 10) to (10, 10, 20);
+create table mc3p4 partition of mc3p for values from (10, 10, 20) to (10, maxvalue, maxvalue);
+create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
+create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
+create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
+
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;

--- a/gpcontrib/gp_partition_maint/sql/partition_maint_test.sql
+++ b/gpcontrib/gp_partition_maint/sql/partition_maint_test.sql
@@ -25,7 +25,7 @@ SUBPARTITION BY list(c)
 	)
 );
 
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
 
 -- Classic Syntax
 -- Multi-level range-range partitioned table
@@ -46,7 +46,7 @@ SUBPARTITION BY range(c)
 	)
 );
 
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid)  from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
 
 -- w/ minvalue and maxvalue
 CREATE TABLE range_parted2 (
@@ -60,7 +60,7 @@ CREATE TABLE part5 PARTITION OF range_parted2 FOR VALUES FROM (40) TO (50);
 CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue);
 CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
 
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
 
 -- w/ expressions
 CREATE TABLE range_parted3 (
@@ -75,7 +75,7 @@ CREATE TABLE range_parted3_part5 PARTITION OF range_parted3 FOR VALUES FROM (40)
 CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60) TO (maxvalue);
 CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
 
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
 
 -- date partitioned table
 CREATE TABLE sales (trans_id int, date date, amount
@@ -85,7 +85,7 @@ CREATE TABLE sales (trans_id int, date date, amount
         (START (date '2023-01-01')
         END (date '2023-05-01') EVERY (INTERVAL '7 day'),
         DEFAULT PARTITION other_date);
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_range_from(c.oid) as range_from, pg_partition_range_to(c.oid) as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid order by rank;
 
 -- Multi-column range partitioned table
 -- multi-column keys
@@ -100,4 +100,4 @@ create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
 create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
 create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
 
-SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
+SELECT relid, level, pg_partition_rank(relid) as rank, pg_get_expr(relpartbound, c.oid) as relpartbound, pg_partition_bound_value(c.oid, 'tto') as range_to, pg_partition_lowest_child(c.oid),pg_partition_highest_child(c.oid) from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;


### PR DESCRIPTION
Added the following UDFs:
- `pg_partition_rank()` : returns range partition rank. Start from 1, lower range has smaller rank. Default partition's rank is NULL.
- `pg_partition_range_from()`: returns text of FROM value parsed from relpartbound
- `pg_partition_range_to()`: returns text of TO value parsed from relpartbound
- `pg_partition_bound_value()`: internally called by pg_partition_range_from() and pg_partition_range_to(). Can be used by `pg_partition_list_values()` when we start implement support for list partitions.
- `pg_partition_isdefault()`: returns bool. True is input relation is a default partition.
- `pg_partition_lowest_child()`: takes a regclass and returns oid of its child partition who has the lowest rank. NULL if N/A.
- `pg_partition_highest_child()`: takes a regclass and returns oid of its child partition who has the lowest rank. NULL if N/A.

TODO:
- `pg_partition_get_hightest_range_end()`
- `pg_partition_get_oldest_range_start()`
- `pg_partition_get_range_gap()`
- `pg_partition_add_high_part(oid, part_num, interval, chk_part_num)`
- `pg_partition_remove_old_part(oid, part_num, chk_part_num)`
- `pg_partition_report_ranges()`

More TODOs:
- Design a new view that serves similar purposes as pg_partitions view in 6X?
- Make more similar to pg_partman so that retention policies are easier to manage?

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
