### PR TITLE
[ORCA] Allow index only scan on more index types

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -35,6 +35,7 @@
 extern "C" {
 #include "access/amapi.h"
 #include "access/external.h"
+#include "access/genam.h"
 #include "catalog/pg_inherits.h"
 #include "foreign/fdwapi.h"
 #include "nodes/nodeFuncs.h"
@@ -2107,6 +2108,17 @@ gpdb::IndexOpProperties(Oid opno, Oid opfamily, StrategyNumber *strategynumber,
 					strategy <= std::numeric_limits<StrategyNumber>::max());
 		*strategynumber = static_cast<StrategyNumber>(strategy);
 		return;
+	}
+	GP_WRAP_END;
+}
+
+// check whether index column is returnable (for index-only scans)
+gpos::BOOL
+gpdb::IndexCanReturn(Relation index, int attno)
+{
+	GP_WRAP_START;
+	{
+		return index_can_return(index, attno);
 	}
 	GP_WRAP_END;
 }

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1043,7 +1043,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 		}
 
-		// check if index can return column or index-only scans
+		// check if index can return column for index-only scans
 		if (gpdb::IndexCanReturn(index_rel.get(), attno))
 		{
 			returnable_cols->Append(

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1023,6 +1023,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 	// extract the position of the key columns
 	index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
 	ULongPtrArray *included_cols = GPOS_NEW(mp) ULongPtrArray(mp);
+	ULongPtrArray *returnable_cols = GPOS_NEW(mp) ULongPtrArray(mp);
 
 	for (int i = 0; i < form_pg_index->indnatts; i++)
 	{
@@ -1039,6 +1040,13 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 		else
 		{
 			included_cols->Append(
+				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+		}
+
+		// check if index can return column or index-only scans
+		if (gpdb::IndexCanReturn(index_rel.get(), attno))
+		{
+			returnable_cols->Append(
 				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 		}
 	}
@@ -1099,11 +1107,11 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 		child_index_oids = GPOS_NEW(mp) IMdIdArray(mp);
 	}
 
-	CMDIndexGPDB *index = GPOS_NEW(mp)
-		CMDIndexGPDB(mp, mdid_index, mdname, index_clustered, index_partitioned,
-					 index_amcanorder, index_type, mdid_item_type,
-					 index_key_cols_array, included_cols, op_families_mdids,
-					 child_index_oids, sort_direction, nulls_direction);
+	CMDIndexGPDB *index = GPOS_NEW(mp) CMDIndexGPDB(
+		mp, mdid_index, mdname, index_clustered, index_partitioned,
+		index_amcanorder, index_type, mdid_item_type, index_key_cols_array,
+		included_cols, returnable_cols, op_families_mdids, child_index_oids,
+		sort_direction, nulls_direction);
 
 	GPOS_DELETE_ARRAY(attno_mapping);
 	return index;

--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
@@ -597,7 +597,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -665,7 +665,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
@@ -613,7 +613,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -671,7 +671,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
@@ -613,7 +613,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -659,7 +659,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
+++ b/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
@@ -3481,7 +3481,7 @@
           <dxl:Opfamily Mdid="0.3018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="">
+      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="" ReturnableColumns="2,9">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -8410,7 +8410,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="">
+      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="" ReturnableColumns="2,9">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -13164,7 +13164,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAABldv" LintValue="756671276"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/metadata/md.xml
+++ b/src/backend/gporca/data/dxl/metadata/md.xml
@@ -104,7 +104,7 @@
       </dxl:IndexInfoList>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" KeyColumns="1" IncludedColumns="">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.1978.1.0"/>
       </dxl:Opfamilies>
@@ -113,7 +113,7 @@
         <dxl:Partition Mdid="6.2351.2.1"/>
       </dxl:Partitions>
     </dxl:Index>
-    <dxl:Index Mdid="0.2347.1.1" Name="T_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
+    <dxl:Index Mdid="0.2347.1.1" Name="T_a" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -1176,7 +1176,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" IsClustered="false" KeyColumns="1" IncludedColumns="">
+    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -1185,7 +1185,7 @@
         <dxl:Partition Mdid="6.13144344.1.0"/>
       </dxl:Partitions>
     </dxl:Index>
-    <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" IsClustered="false" KeyColumns="0" IncludedColumns="">
+    <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -2688,13 +2688,13 @@
       <dxl:SumAgg Mdid="0.0.0.0"/>
       <dxl:CountAgg Mdid="0.2147.1.0"/>
     </dxl:Type>
-    <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
+    <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
     </dxl:Index>
-    <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
+    <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -3688,7 +3688,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.27324.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+    <dxl:Index Mdid="0.27324.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnAppendOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnAppendOnlyTable.mdp
@@ -596,7 +596,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.90477.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.90477.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnMixedAppendOnlyPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnMixedAppendOnlyPartitionedTable.mdp
@@ -198,7 +198,7 @@
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.172033.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="7.172052.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.172052.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnMixedPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnMixedPartitionedTable.mdp
@@ -152,7 +152,7 @@
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.172075.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.172075.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpInList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpInList.mdp
@@ -42,12 +42,12 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102074,102113,102120,102144,103001,103014,103015,103022,103027,103029,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.123270.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.123270.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.123266.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.123266.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
@@ -748,13 +748,13 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
           <dxl:Opfamily Mdid="0.3033.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="31" IncludedColumns="">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="31" IncludedColumns="" ReturnableColumns="31">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BRINScan-Or.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BRINScan-Or.mdp
@@ -101,7 +101,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.180254.1.0" Name="foo_brin" IsClustered="false" IndexType="Brin" IndexItemType="0.2283.1.0" KeyColumns="0,1,2,3,4,5" IncludedColumns="">
+      <dxl:Index Mdid="0.180254.1.0" Name="foo_brin" IsClustered="false" IndexType="Brin" IndexItemType="0.2283.1.0" KeyColumns="0,1,2,3,4,5" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4054.1.0"/>
           <dxl:Opfamily Mdid="0.4054.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -243,7 +243,7 @@ SELECT * FROM test WHERE a in (1, 47);
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.41692.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.41692.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
@@ -507,7 +507,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="998114"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.65597.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.65597.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -35,7 +35,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Backward-IndexOnlyScan-OrderBy-on-MultiCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Backward-IndexOnlyScan-OrderBy-on-MultiCol-Index.mdp
@@ -42,7 +42,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -50,7 +50,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Backward-IndexScan-OrderBy-on-MultiCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Backward-IndexScan-OrderBy-on-MultiCol-Index.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -48,7 +48,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Backward-IndexScan-OrderBy-on-SingleCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Backward-IndexScan-OrderBy-on-SingleCol-Index.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -48,7 +48,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
@@ -171,12 +171,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -184,14 +184,14 @@
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
@@ -171,22 +171,22 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
@@ -42,7 +42,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -263,7 +263,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
@@ -43,7 +43,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -264,7 +264,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
@@ -28,7 +28,7 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
       <dxl:TraceFlags Value="102001,102002,102003,102004,102005,102006,102007,102024,102025,102121,102144,103001,103016,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
@@ -248,12 +248,12 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
           <dxl:UpperBound Closed="true" TypeMdid="0.16.1.0" Value="true"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
@@ -190,12 +190,12 @@ explain select * from r where a = 1 or b = 2;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -203,14 +203,14 @@ explain select * from r where a = 1 or b = 2;
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
@@ -20,7 +20,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
       <dxl:TraceFlags Value="101013,102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
@@ -3378,7 +3378,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.677686.1.0" Name="bar_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.677686.1.0" Name="bar_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
@@ -258,7 +258,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.7" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
@@ -177,7 +177,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.3" Name="c4" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.2" Name="c3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
@@ -51,7 +51,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -146,7 +146,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
           <dxl:Opfamily Mdid="0.3022.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -232,7 +232,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -554,7 +554,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1103,7 +1103,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
@@ -1721,7 +1721,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33012.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
+      <dxl:Index Mdid="0.33012.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
@@ -198,7 +198,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.33184.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
+      <dxl:Index Mdid="0.33184.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -890,7 +890,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32957.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
+      <dxl:Index Mdid="0.32957.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
@@ -286,7 +286,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33108.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
+      <dxl:Index Mdid="0.33108.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -212,7 +212,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.44979.1.0" Name="idx_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.44979.1.0" Name="idx_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -684,7 +684,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10001"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.45040.1.0" Name="idx_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.45040.1.0" Name="idx_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
@@ -586,7 +586,7 @@ inferred from the second operator (c4 = 'f')
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -191,7 +191,7 @@ see sql/BitmapIndexScan.sql
       <dxl:ColumnStatistics Mdid="1.24702.1.1.12" Name="dataowner" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.5" Name="created_by" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.4" Name="creation_date" Width="4.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1988.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
@@ -149,7 +149,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.857985.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.857985.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -236,7 +236,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.16445.1.0" Name="ix_test_ix01" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16445.1.0" Name="ix_test_ix01" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -93,7 +93,7 @@ undefined for Bitmap Index Scan. ORCA should find a plan transforming
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32784.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.32784.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.10002.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
@@ -264,7 +264,7 @@ explain select * from t where b=3;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.181454.1.0" Name="idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.181454.1.0" Name="idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickIndexWithNoGap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickIndexWithNoGap.mdp
@@ -525,7 +525,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.55598.1.0" Name="idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.55598.1.0" Name="idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -552,13 +552,13 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.55603.1.0" Name="idx_ac" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
+      <dxl:Index Mdid="0.55603.1.0" Name="idx_ac" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="" ReturnableColumns="0,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.55602.1.0" Name="idx_abc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.55602.1.0" Name="idx_abc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
@@ -67,7 +67,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49558.1.0" Name="jazz_lo_btree" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.49558.1.0" Name="jazz_lo_btree" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -87,7 +87,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.49554.1.0" Name="jazz_hi" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.49554.1.0" Name="jazz_hi" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -231,7 +231,7 @@ explain select * from indexonao where a = 21;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99997"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
@@ -495,7 +495,7 @@ explain select * from t_ao where c2 = 'HEAP';
         <dxl:SumAgg Mdid="0.2111.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
@@ -195,7 +195,7 @@ explain select * from xfoo where j = 1 and k = 2;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
@@ -9,7 +9,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102144,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
@@ -234,7 +234,7 @@ SELECT * FROM my_tq_agg_small tq WHERE 110 >= tq.ets;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
@@ -80,7 +80,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55583.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.55583.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -175,7 +175,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55587.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.55587.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ConjDisjWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ConjDisjWithOuterRefs.mdp
@@ -142,7 +142,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55607.1.0" Name="xa" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.55607.1.0" Name="xa" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -208,7 +208,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.55604.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.55604.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.55611.1.0" Name="xb" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.55611.1.0" Name="xb" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLJWithProjectNoPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLJWithProjectNoPart.mdp
@@ -708,7 +708,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33097.1.0" Name="t1_idx_ac" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
+      <dxl:Index Mdid="0.33097.1.0" Name="t1_idx_ac" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="" ReturnableColumns="0,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -530,7 +530,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33144.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
+      <dxl:Index Mdid="0.33144.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="" ReturnableColumns="0,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -320,7 +320,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -330,7 +330,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
           <dxl:Partition Mdid="6.2435371003.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,0" IncludedColumns="">
+      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,0" IncludedColumns="" ReturnableColumns="2,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -5740,7 +5740,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
@@ -233,7 +233,7 @@
       <dxl:ColumnStatistics Mdid="1.49155.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.49155.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.49221.1.0" Name="pt_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.49221.1.0" Name="pt_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -243,7 +243,7 @@
           <dxl:Partition Mdid="6.49221002.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.49238.1.0" Name="pt_idx_1_prt_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.49238.1.0" Name="pt_idx_1_prt_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -165,12 +165,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" IsClustered="false" KeyColumns="12" IncludedColumns="">
+      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" IsClustered="false" KeyColumns="12" IncludedColumns="" ReturnableColumns="12">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -339,12 +339,12 @@
       <dxl:GPDBFunc Mdid="0.1597.1.0" Name="pg_encoding_to_char" ReturnsSet="false" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.19.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="">
+      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="" ReturnableColumns="8">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -914,12 +914,12 @@ SELECT * FROM information_schema.tables;
         <dxl:Commutator Mdid="0.607.1.0"/>
         <dxl:InverseOp Mdid="0.608.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="31" IncludedColumns="">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="31" IncludedColumns="" ReturnableColumns="31">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -1509,12 +1509,12 @@ SELECT * FROM information_schema.tables;
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="" ReturnableColumns="4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -51,12 +51,12 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
       <dxl:TraceFlags Value="103027,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -462,7 +462,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
@@ -182,7 +182,7 @@ create table customer
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16404.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16404.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -347,7 +347,7 @@ create table customer
       <dxl:ColumnStatistics Mdid="1.16406.1.0.0" Name="pn" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16427.1.0.7" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16427.1.0.6" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.16425.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16425.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -369,7 +369,7 @@ create table customer
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16441.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.16441.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -51,12 +51,12 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102115,102116,102120,102128,102144,103001,103014,103015,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -461,7 +461,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
@@ -75,7 +75,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.65569.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+      <dxl:Index Mdid="7.65569.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1" ReturnableColumns="0,1,3,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
@@ -177,7 +177,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.65575.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+      <dxl:Index Mdid="7.65575.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1" ReturnableColumns="0,1,3,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
@@ -185,6 +185,19 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.65577.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:RelationExtendedStatistics Mdid="10.65577.1.0" Name="t"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
@@ -58,7 +58,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.65580.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+      <dxl:Index Mdid="7.65580.1.0" Name="t_d_e_a_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1" ReturnableColumns="0,1,3,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-Cost-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-Cost-1.mdp
@@ -37,52 +37,52 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.41017.1.0" Name="idx_2_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2">
+      <dxl:Index Mdid="7.41017.1.0" Name="idx_2_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41016.1.0" Name="idx_3_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3">
+      <dxl:Index Mdid="7.41016.1.0" Name="idx_3_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41018.1.0" Name="idx_1_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.41018.1.0" Name="idx_1_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41013.1.0" Name="idx_5_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5">
+      <dxl:Index Mdid="7.41013.1.0" Name="idx_5_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41012.1.0" Name="idx_6_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6">
+      <dxl:Index Mdid="7.41012.1.0" Name="idx_6_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41015.1.0" Name="idx_4_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4">
+      <dxl:Index Mdid="7.41015.1.0" Name="idx_4_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41014.1.0" Name="idx_0_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.41014.1.0" Name="idx_0_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41009.1.0" Name="idx_9_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.41009.1.0" Name="idx_9_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8,9" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41011.1.0" Name="idx_7_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7">
+      <dxl:Index Mdid="7.41011.1.0" Name="idx_7_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41010.1.0" Name="idx_8_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="7.41010.1.0" Name="idx_8_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-Cost-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-Cost-2.mdp
@@ -182,52 +182,52 @@
           <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="7.41049.1.0" Name="idx_1_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.41049.1.0" Name="idx_1_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41048.1.0" Name="idx_2_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2">
+      <dxl:Index Mdid="7.41048.1.0" Name="idx_2_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41045.1.0" Name="idx_0_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.41045.1.0" Name="idx_0_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41044.1.0" Name="idx_5_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5">
+      <dxl:Index Mdid="7.41044.1.0" Name="idx_5_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41047.1.0" Name="idx_3_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3">
+      <dxl:Index Mdid="7.41047.1.0" Name="idx_3_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41046.1.0" Name="idx_4_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4">
+      <dxl:Index Mdid="7.41046.1.0" Name="idx_4_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41041.1.0" Name="idx_8_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="7.41041.1.0" Name="idx_8_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41040.1.0" Name="idx_9_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.41040.1.0" Name="idx_9_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7,8,9" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41043.1.0" Name="idx_6_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6">
+      <dxl:Index Mdid="7.41043.1.0" Name="idx_6_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.41042.1.0" Name="idx_7_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7">
+      <dxl:Index Mdid="7.41042.1.0" Name="idx_7_include_cols" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1,2,3,4,5,6,7" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesNotSupport-Gin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesNotSupport-Gin.mdp
@@ -191,28 +191,20 @@
       <dxl:Relation Mdid="6.76127.1.0" Name="test" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
         <dxl:Columns>
           <dxl:Column Name="data" Attno="1" Mdid="0.3802.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesNotSupport-Gin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesNotSupport-Gin.mdp
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Test that Gin is not allowed to choose Index-Only Scan even when
+    the index covers the project and filter columns.
+
+      CREATE TABLE test (
+        data jsonb
+      );
+      INSERT INTO test(data) VALUES ('{"field": "value1"}');
+      INSERT INTO test(data) VALUES ('{"field": "value2"}');
+      INSERT INTO test(data) VALUES ('{"other_field": "value42"}');
+      CREATE INDEX ON test USING gin(data);
+
+      SET optimizer_enable_bitmapscan=off;
+
+      EXPLAIN SELECT data FROM test WHERE data ? 'field';
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102115,102116,102120,102144,102153,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationExtendedStatistics Mdid="10.76127.1.0" Name="test"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.3247.1.0" Name="?" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.3802.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.4047.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.4036.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.3802.1.0" Name="jsonb" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.4034.1.0"/>
+        <dxl:PartOpfamily Mdid="0.4033.1.0"/>
+        <dxl:EqualityOp Mdid="0.3240.1.0"/>
+        <dxl:InequalityOp Mdid="0.3241.1.0"/>
+        <dxl:LessThanOp Mdid="0.3242.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.3244.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.3243.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.3245.1.0"/>
+        <dxl:ComparisonOp Mdid="0.4044.1.0"/>
+        <dxl:ArrayType Mdid="0.3807.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.76127.1.0.0" Name="data" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Index Mdid="7.76132.1.0" Name="test_data_idx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.4036.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.76127.1.0" Name="test" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.76127.1.0" Name="test" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="data" Attno="1" Mdid="0.3802.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.76132.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.4034.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="data" TypeMdid="0.3802.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="?" OperatorMdid="0.3247.1.0">
+          <dxl:Ident ColId="1" ColName="data" TypeMdid="0.3802.1.0"/>
+          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACWZpZWxk" LintValue="2153822734"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.76127.1.0" TableName="test" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="data" TypeMdid="0.3802.1.0" ColWidth="8"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="data">
+            <dxl:Ident ColId="0" ColName="data" TypeMdid="0.3802.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="data">
+              <dxl:Ident ColId="0" ColName="data" TypeMdid="0.3802.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="?" OperatorMdid="0.3247.1.0">
+              <dxl:Ident ColId="0" ColName="data" TypeMdid="0.3802.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACWZpZWxk" LintValue="2153822734"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.76127.1.0" TableName="test" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="data" TypeMdid="0.3802.1.0" ColWidth="8"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesSupport-Gist.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesSupport-Gist.mdp
@@ -41,28 +41,20 @@
       <dxl:Relation Mdid="6.76091.1.0" Name="points" IsTemporary="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
         <dxl:Columns>
           <dxl:Column Name="p" Attno="1" Mdid="0.600.1.0" Nullable="true" ColWidth="16">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesSupport-Gist.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-DoesSupport-Gist.mdp
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Test that Gist allows Index-Only Scan when the index covers the
+    project and filter columns.
+
+      CREATE TABLE points(p point);
+      INSERT INTO points(p) VALUES
+        (point '(1,1)'), (point '(3,2)'), (point '(6,3)'),
+        (point '(5,5)'), (point '(7,8)'), (point '(8,6)');
+      CREATE INDEX ON points USING gist(p);
+      VACUUM ANALYZE points;
+
+      SET optimizer_enable_indexscan = off;
+      SET optimizer_enable_bitmapscan = off;
+
+      EXPLAIN(COSTS OFF) SELECT * FROM points WHERE p <@ box '(2,1),(7,4)';
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102004,102005,102043,102074,102115,102116,102120,102144,102153,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Index Mdid="7.76094.1.0" Name="points_p_idx" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1029.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.76091.1.0" Name="points" Rows="6.000000" RelPages="3" RelAllVisible="3" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.76091.1.0" Name="points" IsTemporary="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="p" Attno="1" Mdid="0.600.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.76094.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.600.1.0" Name="point" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1017.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.603.1.0" Name="box" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="32" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1020.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.76091.1.0" Name="points"/>
+      <dxl:ColumnStatistics Mdid="1.76091.1.0.0" Name="p" Width="16.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBScalarOp Mdid="0.511.1.0" Name="&lt;@" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.600.1.0"/>
+        <dxl:RightType Mdid="0.603.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.136.1.0"/>
+        <dxl:Commutator Mdid="0.433.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1029.1.0"/>
+          <dxl:Opfamily Mdid="0.4015.1.0"/>
+          <dxl:Opfamily Mdid="0.4016.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="p" TypeMdid="0.600.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="&lt;@" OperatorMdid="0.511.1.0">
+          <dxl:Ident ColId="1" ColName="p" TypeMdid="0.600.1.0"/>
+          <dxl:ConstValue TypeMdid="0.603.1.0" Value="AAAAAAAAHEAAAAAAAAAQQAAAAAAAAABAAAAAAAAA8D8="/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.76091.1.0" TableName="points" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="p" TypeMdid="0.600.1.0" ColWidth="16"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000325" Rows="2.400000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="p">
+            <dxl:Ident ColId="0" ColName="p" TypeMdid="0.600.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexOnlyScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000132" Rows="2.400000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="p">
+              <dxl:Ident ColId="0" ColName="p" TypeMdid="0.600.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="&lt;@" OperatorMdid="0.511.1.0">
+              <dxl:Ident ColId="0" ColName="p" TypeMdid="0.600.1.0"/>
+              <dxl:ConstValue TypeMdid="0.603.1.0" Value="AAAAAAAAHEAAAAAAAAAQQAAAAAAAAABAAAAAAAAA8D8="/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.76094.1.0" IndexName="points_p_idx"/>
+          <dxl:TableDescriptor Mdid="6.76091.1.0" TableName="points" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="p" TypeMdid="0.600.1.0" ColWidth="16"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexOnlyScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-CoordinatorOnlyTable-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-CoordinatorOnlyTable-1.mdp
@@ -58,13 +58,13 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="7.7139.1.0" Name="gp_segment_config_content_preferred_role_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3" IncludedColumns="">
+      <dxl:Index Mdid="7.7139.1.0" Name="gp_segment_config_content_preferred_role_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3" IncludedColumns="" ReturnableColumns="1,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.429.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.7140.1.0" Name="gp_segment_config_dbid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.7140.1.0" Name="gp_segment_config_dbid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -858,7 +858,7 @@ where a=1 and b>0;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.21553.1.1.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.21553.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
@@ -349,12 +349,12 @@ where a=1 and b=0;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
@@ -135,7 +135,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" Value="5200000000000097561"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.213016.1.0" Name="idx_mytable_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.213016.1.0" Name="idx_mytable_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
@@ -19,7 +19,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102006,102024,102025,102144,103001,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -139,7 +139,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -760,7 +760,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -555,7 +555,7 @@ see sql/DynamicBitmapIndexScan.sql
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.1" Name="flex_value_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.0" Name="flex_value_set_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -604,7 +604,7 @@
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.3723795.1.0" Name="x2_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.3723795.1.0" Name="x2_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
@@ -116,7 +116,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.3" Name="t" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.2" Name="j" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
@@ -333,7 +333,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.2950.1.0" IsNull="false" Value="An6J9DnRTROsv3WhVjnmNQ==" LintValue="4123921962"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.20403.1.0" Name="i_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.20403.1.0" Name="i_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2968.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -5848,7 +5848,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33441.1.0" Name="web_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,17,0" IncludedColumns="">
+      <dxl:Index Mdid="0.33441.1.0" Name="web_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,17,0" IncludedColumns="" ReturnableColumns="3,17,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -9653,7 +9653,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33851.1.0" Name="date_dim_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,6" IncludedColumns="">
+      <dxl:Index Mdid="0.33851.1.0" Name="date_dim_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,6" IncludedColumns="" ReturnableColumns="0,6">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -1050,7 +1050,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
           <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" Value="12"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.29404.1.0" Name="solo_idx_1_prt_y2016_2_prt_jan" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="">
+      <dxl:Index Mdid="0.29404.1.0" Name="solo_idx_1_prt_y2016_2_prt_jan" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="" ReturnableColumns="1,2,7,17,22,29">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-Homogenous.mdp
@@ -303,7 +303,7 @@
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
       <dxl:RelationExtendedStatistics Mdid="10.91323.1.0" Name="part_table"/>
-      <dxl:Index Mdid="7.91351.1.0" Name="rp_i1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.91351.1.0" Name="rp_i1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
@@ -155,7 +155,7 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:RelationExtendedStatistics Mdid="10.114813.1.0" Name="test_basic_cover_index"/>
-      <dxl:Index Mdid="7.114832.1.0" Name="i_test_cover_index_scan_on_partition_table" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.114832.1.0" Name="i_test_cover_index_scan_on_partition_table" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -432,7 +432,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="7.114816.1.0" Name="i_test_basic_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.114816.1.0" Name="i_test_basic_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
@@ -155,7 +155,7 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:RelationExtendedStatistics Mdid="10.114813.1.0" Name="test_basic_cover_index"/>
-      <dxl:Index Mdid="7.114832.1.0" Name="i_test_cover_index_scan_on_partition_table" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.114832.1.0" Name="i_test_cover_index_scan_on_partition_table" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -432,7 +432,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="7.114816.1.0" Name="i_test_basic_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1">
+      <dxl:Index Mdid="7.114816.1.0" Name="i_test_basic_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="1" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
@@ -390,7 +390,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
@@ -390,7 +390,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -288,7 +288,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" IsClustered="false" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -487,7 +487,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -168,7 +168,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.3" Name="ctid" Width="6.000000"/>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.2" Name="c" Width="8.000000"/>
-      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
@@ -299,7 +299,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32962.1.0" Name="idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.32962.1.0" Name="idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -497,7 +497,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" IsClustered="false" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" IsClustered="false" KeyColumns="3" IncludedColumns="" ReturnableColumns="3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -187,7 +187,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -87,7 +87,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.3" Name="1.27119.15.1.3" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.2" Name="1.27119.15.1.2" Width="8.000000"/>
-      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -182,7 +182,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.15.1.8" Name="1.27119.15.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.0" Name="1.27119.15.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.1" Name="1.27119.15.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -85,7 +85,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -100,7 +100,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.25.1.8" Name="1.27119.25.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.0" Name="1.27119.25.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.1" Name="1.27119.25.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -87,7 +87,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -87,7 +87,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
@@ -537,7 +537,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.3723124.1.0.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723124.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.3723283.1.0" Name="p_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.3723283.1.0" Name="p_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -163,7 +163,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -36,7 +36,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.7" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -170,7 +170,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -87,7 +87,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.5" Name="xmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.4" Name="cmin" Width="4.000000"/>
-      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -99,7 +99,7 @@
           <dxl:Partition Mdid="6.27323005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -137,7 +137,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="4.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>
@@ -196,7 +196,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -100,7 +100,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="4.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>
@@ -180,7 +180,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -127,7 +127,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.3722984.1.0" Name="p_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.3722984.1.0" Name="p_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -333,7 +333,7 @@
         <dxl:Commutator Mdid="0.521.1.0"/>
         <dxl:InverseOp Mdid="0.525.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
@@ -1038,7 +1038,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAABzk3Mw==" LintValue="921330540"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2003.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
@@ -105,7 +105,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32783.1.0" Name="t3idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32783.1.0" Name="t3idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Forward-IndexOnlyScan-OrderBy-on-MultiCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Forward-IndexOnlyScan-OrderBy-on-MultiCol-Index.mdp
@@ -42,7 +42,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -63,7 +63,7 @@
           <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Forward-IndexScan-OrderBy-on-MultiCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Forward-IndexScan-OrderBy-on-MultiCol-Index.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -48,7 +48,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Forward-IndexScan-OrderBy-on-SingleCol-Index.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Forward-IndexScan-OrderBy-on-SingleCol-Index.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -48,7 +48,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -54,7 +54,7 @@
       <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103015,103022,103027,103029,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.32772.1.0" Name="t2_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32772.1.0" Name="t2_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -136,7 +136,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
@@ -56,7 +56,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.5" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.4" Name="xmin" Width="4.000000"/>
-      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" IsClustered="false" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -163,7 +163,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20130.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.20130.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4036.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
@@ -163,7 +163,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4037.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
@@ -163,7 +163,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4037.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
@@ -160,7 +160,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.566300.1.0" Name="boxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.566300.1.0" Name="boxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Lossy-IndexPlan.mdp
@@ -85,7 +85,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16406.1.0" Name="poly_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16406.1.0" Name="poly_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
@@ -159,7 +159,7 @@ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..433.00 rows=1 width=24)
       <dxl:GPDBFunc Mdid="0.566917.1.0" Name="_st_contains" ReturnsSet="false" Stability="Immutable" IsStrict="true">
         <dxl:ResultType Mdid="0.16.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.581647.1.0" Name="multi" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.581647.1.0" Name="multi" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.566580.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-BitmapIndexPlan.mdp
@@ -156,7 +156,7 @@ Optimizer status: PQO version 2.65.1
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.566276.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.566276.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-IndexPlan.mdp
@@ -156,7 +156,7 @@ Optimizer status: PQO version 2.65.1
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.573703.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.573703.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
@@ -241,7 +241,7 @@ Result  (cost=0.00..0.00 rows=1 width=36)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
@@ -279,7 +279,7 @@ Result  (cost=0.00..8.00 rows=2 width=36)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
@@ -86,7 +86,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.574046.1.0" Name="partpolyindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.574046.1.0" Name="partpolyindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
@@ -53,7 +53,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.566356.1.0" Name="partboxindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.566356.1.0" Name="partboxindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
@@ -302,7 +302,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=44)
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.573531.1.0.1" Name="b" Width="32.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.573531.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.573613.1.0" Name="partialboxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.573613.1.0" Name="partialboxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -3303,7 +3303,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -7801,7 +7801,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="">
+      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="" ReturnableColumns="2,9">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -1274,7 +1274,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Hash-BitmapScan-InArray.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hash-BitmapScan-InArray.mdp
@@ -858,7 +858,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="7.16950.1.0" Name="hash_idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="7.16950.1.0" Name="hash_idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Hash-BitmapScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hash-BitmapScan.mdp
@@ -184,7 +184,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Hash-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hash-IndexScan.mdp
@@ -181,7 +181,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Hash-TableScan-AllArray.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hash-TableScan-AllArray.mdp
@@ -857,7 +857,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="7.16950.1.0" Name="hash_idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="7.16950.1.0" Name="hash_idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
@@ -2354,7 +2354,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="">
+      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="" ReturnableColumns="3,17">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -232,7 +232,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.6639069.1.0" Name="myidx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.6639069.1.0" Name="myidx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
@@ -173,7 +173,7 @@ select * from x, y where (x.i > y.j);
       <dxl:ColumnStatistics Mdid="1.54648535.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -441,7 +441,7 @@ select * from x, y where (x.i > y.j);
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
@@ -611,7 +611,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
+      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="" ReturnableColumns="0,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -637,7 +637,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -259,7 +259,7 @@ ORDER BY 1 asc ;
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
+      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="" ReturnableColumns="0,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -543,7 +543,7 @@ ORDER BY 1 asc ;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
@@ -230,7 +230,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -238,7 +238,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnCoordinatorOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnCoordinatorOnlyTable.mdp
@@ -482,7 +482,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="" ReturnableColumns="31">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -928,7 +928,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1086.1.0"/>
           <dxl:Opfamily Mdid="0.1089.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
@@ -322,7 +322,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
           <dxl:Opfamily Mdid="0.3040.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
@@ -593,7 +593,7 @@ WHERE tt.event_ts >= tq.ets AND
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
+      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="" ReturnableColumns="0,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -613,7 +613,7 @@ WHERE tt.event_ts >= tq.ets AND
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.10" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.3" Name="ask_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.2" Name="bid_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -568,7 +568,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -315,7 +315,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.57376.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.57376.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.57404.1.0" Name="idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.57404.1.0" Name="idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -68,7 +68,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
       <dxl:TraceFlags Value="101013,102001,102002,102003,103045,102046,102048,102053,102054,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.195590.1.0" Name="t1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.195590.1.0" Name="t1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -113,7 +113,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.195606.1.0" Name="t2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.195606.1.0" Name="t2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -227,7 +227,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.195652.1.0" Name="idx_t4_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.195652.1.0" Name="idx_t4_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -304,7 +304,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.195690.1.0" Name="idx_t3_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.195690.1.0" Name="idx_t3_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
@@ -59,7 +59,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -53,7 +53,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -52,7 +52,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
@@ -226,7 +226,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.409651.1.0" Name="bar_ixb" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.409651.1.0" Name="bar_ixb" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -291,7 +291,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -323,7 +323,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -61,7 +61,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -168,7 +168,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -410,7 +410,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
@@ -451,7 +451,7 @@ select count(*) from x10, y10 where (x10.i > y10.j AND x10.j <= y10.i);
           <dxl:UpperBound Closed="true" TypeMdid="0.25.1.0" Value="AAAAJGVjY2JjODdlNGI1Y2UyZmUyODMwOGZkOWYyYTdiYWYz" LintValue="162161524"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1104,7 +1104,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="" ReturnableColumns="0,4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -291,7 +291,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -312,7 +312,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
@@ -267,7 +267,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
@@ -262,7 +262,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
@@ -255,7 +255,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
@@ -262,7 +262,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
@@ -262,7 +262,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
@@ -107,7 +107,7 @@
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.16402.1.0" Name="id1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16402.1.0" Name="id1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -204,7 +204,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16416.1.0" Name="id2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16416.1.0" Name="id2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexConstraintsMDidCache.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexConstraintsMDidCache.mdp
@@ -305,7 +305,7 @@
           <dxl:Opfamily Mdid="0.10003.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="7.16406.1.0" Name="test_mdid_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16406.1.0" Name="test_mdid_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -120,7 +120,7 @@
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.8" Name="gp_segment_id" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.1" Name="b" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.0" Name="a" Width="8.000000"/>
-      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -55,7 +55,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.98319.1.0" Name="bar" Rows="100.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.98318.1.0" Name="foo_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.98318.1.0" Name="foo_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -45,7 +45,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
       <dxl:TraceFlags Value="101013,102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.130052.1.0" Name="r1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.130052.1.0" Name="r1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -65,7 +65,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.130069.1.0" Name="s1_b_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.130069.1.0" Name="s1_b_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -225,7 +225,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.130092.1.0" Name="r2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.130092.1.0" Name="r2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -233,7 +233,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
       <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:ColumnStatistics Mdid="1.122064.1.0.0" Name="a" Width="2.000000" NullFreq="0.000000" NdvRemain="11.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.130113.1.0" Name="s2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.130113.1.0" Name="s2_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddNewPartitionToRootTableContainingHeterogenousIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddNewPartitionToRootTableContainingHeterogenousIndex.mdp
@@ -204,7 +204,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p3 WHERE c > 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.829540.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.829540.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
@@ -54,7 +54,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p3 WHERE c > 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.829384.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.829384.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
@@ -268,7 +268,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827950.1.0" Name="complete_idx_c_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.827950.1.0" Name="complete_idx_c_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-AO.mdp
@@ -124,13 +124,13 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 15;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.25116.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.25116.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.25133.1.0" Name="idx_p2_fe" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="">
+      <dxl:Index Mdid="0.25133.1.0" Name="idx_p2_fe" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -157,13 +157,13 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 12;
       <dxl:ColumnStatistics Mdid="1.828078.1.0.12" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.828078.1.0.4" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.828078.1.0.5" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828133.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.828133.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.828147.1.0" Name="idx_p2_cd" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="">
+      <dxl:Index Mdid="0.828147.1.0" Name="idx_p2_cd" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="" ReturnableColumns="4,5">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 14;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31024.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.31024.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -142,7 +142,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 14;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31069.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="">
+      <dxl:Index Mdid="0.31069.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
@@ -79,7 +79,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.24976.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="">
+      <dxl:Index Mdid="0.24976.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -173,7 +173,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
           <dxl:CheckConstraint Mdid="0.24866.1.0"/>
         </dxl:CheckConstraints>
       </dxl:Relation>
-      <dxl:Index Mdid="0.25018.1.0" Name="complete_idx_f_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5" IncludedColumns="">
+      <dxl:Index Mdid="0.25018.1.0" Name="complete_idx_f_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -188,7 +188,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.24931.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.24931.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-AO.mdp
@@ -79,7 +79,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.30100.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.30100.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -255,7 +255,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.30066.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.30066.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -330,7 +330,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
       <dxl:ColumnStatistics Mdid="1.827971.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828029.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.828029.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -344,7 +344,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
       <dxl:ColumnStatistics Mdid="1.827971.1.0.8" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828057.1.0" Name="idx_p1_cd" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.828057.1.0" Name="idx_p1_cd" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c > 11 OR d > 20;
       <dxl:TraceFlags Value="102001,102002,102003,102074,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.24833.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.24833.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -317,7 +317,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c > 11 OR d > 20;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.24799.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
+      <dxl:Index Mdid="0.24799.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 13;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31282.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.31282.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -139,7 +139,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 13;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31327.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.31327.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
@@ -52,7 +52,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.24718.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
+      <dxl:Index Mdid="0.24718.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -169,7 +169,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
         </dxl:And>
       </dxl:CheckConstraint>
       <dxl:ColumnStatistics Mdid="1.24606.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.24673.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.24673.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
@@ -192,7 +192,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 12 OR d > 13;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16790.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
+      <dxl:Index Mdid="0.16790.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -293,7 +293,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 12 OR d > 13;
           </dxl:Comparison>
         </dxl:And>
       </dxl:CheckConstraint>
-      <dxl:Index Mdid="0.16745.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.16745.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
@@ -112,7 +112,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -279,7 +279,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -155,7 +155,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="" ReturnableColumns="3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
@@ -112,7 +112,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -172,7 +172,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -155,7 +155,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="" ReturnableColumns="3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-CTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-CTE.mdp
@@ -144,7 +144,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.32781.1.0" Name="i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.32781.1.0" Name="i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
@@ -176,7 +176,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.73764.1.0" Name="table_with_index_not_covering_distribution_column_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.73764.1.0" Name="table_with_index_not_covering_distribution_column_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-OrderBy-on-MultiCol-NonIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-OrderBy-on-MultiCol-NonIndex.mdp
@@ -45,7 +45,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.21298.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" SortDirection="ASC,DESC,ASC,DESC" NullsDirection="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -53,7 +53,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST">
+      <dxl:Index Mdid="7.21297.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" SortDirection="DESC" NullsDirection="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
@@ -47,7 +47,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
@@ -2209,7 +2209,7 @@
           <dxl:Opfamily Mdid="0.12732.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.106220.1.0" Name="tenk1_thous_tenthous" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.106220.1.0" Name="tenk1_thous_tenthous" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
@@ -67,7 +67,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567205.1.0" Name="r_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.567205.1.0" Name="r_c" IsClustered="false" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
@@ -373,7 +373,7 @@
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.372761.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.372827.1.0" Name="foo_ab_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.372827.1.0" Name="foo_ab_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
@@ -161,7 +161,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.372760.1.0" Name="foo_ab_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.372760.1.0" Name="foo_ab_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-MultiCol-NonIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-MultiCol-NonIndex.mdp
@@ -42,7 +42,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" KeyColumnsSortOrder="ASC,DESC,ASC,DESC" KeyColumnsNullsOrder="LAST,FIRST,FIRST,FIRST">
+      <dxl:Index Mdid="7.37053.1.0" Name="index_dbea" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,1,4,0" IncludedColumns="" KeyColumnsSortOrder="ASC,DESC,ASC,DESC" KeyColumnsNullsOrder="LAST,FIRST,FIRST,FIRST" ReturnableColumns="3,1,4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1970.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -50,7 +50,7 @@
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" KeyColumnsSortOrder="DESC" KeyColumnsNullsOrder="LAST">
+      <dxl:Index Mdid="7.37052.1.0" Name="index_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" KeyColumnsSortOrder="DESC" KeyColumnsNullsOrder="LAST" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-Multiple-IndexCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-Multiple-IndexCols.mdp
@@ -45,20 +45,20 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="">
+      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="" ReturnableColumns="1,3,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-NonIndexCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-NonIndexCol.mdp
@@ -46,20 +46,20 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="">
+      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="" ReturnableColumns="1,3,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-Single-IndexCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-OrderBy-on-Single-IndexCol.mdp
@@ -44,20 +44,20 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="">
+      <dxl:Index Mdid="7.16947.1.0" Name="index_bda" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,3,0" IncludedColumns="" ReturnableColumns="1,3,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16946.1.0" Name="index_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16945.1.0" Name="index_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
@@ -594,7 +594,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2003.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -102,7 +102,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.53653.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.53653.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -266,7 +266,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32178.1.0" Name="bar_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32178.1.0" Name="bar_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -388,7 +388,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32202.1.0" Name="foo_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32202.1.0" Name="foo_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -125,7 +125,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.57364.1.0" Name="country_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.57364.1.0" Name="country_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
@@ -296,7 +296,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.57385.1.0" Name="countrylanguage_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.57385.1.0" Name="countrylanguage_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -62,7 +62,7 @@ OR
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="" ReturnableColumns="11">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -658,12 +658,12 @@ OR
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="18" IncludedColumns="">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="18" IncludedColumns="" ReturnableColumns="18">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/JoinBelowUnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinBelowUnionAll.mdp
@@ -1129,7 +1129,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="7.18525.1.0" Name="dist_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="7.18525.1.0" Name="dist_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -130,7 +130,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="">
+      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="" ReturnableColumns="3,17">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -2919,7 +2919,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
@@ -890,7 +890,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -1680,7 +1680,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" Value="AAAADjk5OSAgICAgICA=" LintValue="825230246"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -354,7 +354,7 @@
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.417828.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.417854.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.417854.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -353,7 +353,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.417881.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.417881.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -215,7 +215,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.27540.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.27540.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -293,7 +293,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.27684.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.27684.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
@@ -61,7 +61,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
@@ -210,7 +210,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
       </dxl:Relation>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:RelationStatistics Mdid="2.65603.1.0" Name="zoo" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Index Mdid="0.65602.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.65602.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="1,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -238,7 +238,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.65577.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.65577.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.65626.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.65626.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
@@ -279,14 +279,14 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49205.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.49205.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="1,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.49209.1.0" Name="zoo_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.49209.1.0" Name="zoo_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="1,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CoordinatorOnly-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CoordinatorOnly-Table.mdp
@@ -63,12 +63,12 @@ union all
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2703.1.0" Name="pg_type_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="29" IncludedColumns="">
+      <dxl:Index Mdid="0.2703.1.0" Name="pg_type_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="29" IncludedColumns="" ReturnableColumns="29">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2704.1.0" Name="pg_type_typname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2704.1.0" Name="pg_type_typname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
@@ -409,13 +409,13 @@ union all
           <dxl:Opfamily Mdid="0.7033.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="27" IncludedColumns="">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="27" IncludedColumns="" ReturnableColumns="27">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
@@ -138,7 +138,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
           <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49175.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.49175.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -225,12 +225,12 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
           <dxl:Opfamily Mdid="0.10018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.49181.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.49181.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49180.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.49180.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -315,7 +315,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.49176.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.49176.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
@@ -97,7 +97,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -98,7 +98,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
@@ -52,7 +52,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
@@ -311,43 +311,43 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
         </dxl:DistrOpfamilies>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.49211.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.49236.1.0" Name="bar_idx_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.49236.1.0" Name="bar_idx_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49235.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.49235.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49234.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.49234.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49233.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.49233.1.0" Name="bar_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="1,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49243.1.0" Name="zoo_idx_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.49243.1.0" Name="zoo_idx_c" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49242.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.49242.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49241.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.49241.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49240.1.0" Name="zoo_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
+      <dxl:Index Mdid="0.49240.1.0" Name="zoo_idx_ab" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="" ReturnableColumns="1,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
@@ -60,7 +60,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -93,7 +93,7 @@ set optimizer_enable_hashjoin = off;
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:RelationStatistics Mdid="2.32791.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Index Mdid="0.32790.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32790.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -137,17 +137,17 @@ set optimizer_enable_hashjoin = off;
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32785.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32785.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.32784.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32784.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.32786.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32786.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-Negative-NonEqual-Predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-Negative-NonEqual-Predicate.mdp
@@ -210,7 +210,7 @@
           <dxl:Opfamily Mdid="0.12866.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.40990.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.40990.1.0" Name="zoo_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -263,12 +263,12 @@
           <dxl:Opfamily Mdid="0.12866.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.40985.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.40985.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.40984.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.40984.1.0" Name="bar_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -305,7 +305,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.40986.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.40986.1.0" Name="zoo_idx_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
@@ -178,7 +178,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.65570.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.65570.1.0" Name="bar_idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
@@ -51,7 +51,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32790.1.0" Name="idx_bar_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.32790.1.0" Name="idx_bar_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -259,7 +259,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -261,7 +261,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -981,17 +981,17 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" Value="1664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="18" IncludedColumns="">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="18" IncludedColumns="" ReturnableColumns="18">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="" ReturnableColumns="11">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruning.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruning.mdp
@@ -241,14 +241,14 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16390.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="">
+      <dxl:Index Mdid="7.16390.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="" ReturnableColumns="0,2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16388.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16388.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInOuterInnerQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInOuterInnerQuery.mdp
@@ -191,7 +191,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.16412.1.0" Name="idx3" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16412.1.0" Name="idx3" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -229,7 +229,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16402.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16402.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInnerQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInnerQuery.mdp
@@ -79,7 +79,7 @@
         </dxl:DistrOpfamilies>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.16419.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="7.16436.1.0" Name="t1joinpruning_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16436.1.0" Name="t1joinpruning_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -142,7 +142,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16424.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="">
+      <dxl:Index Mdid="7.16424.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="" ReturnableColumns="0,2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -275,7 +275,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.16422.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="7.16422.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningOuterQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningOuterQuery.mdp
@@ -42,7 +42,7 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.16446.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16446.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -317,7 +317,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16451.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.16451.1.0" Name="idx2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
@@ -1145,7 +1145,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.30058.1.0" Name="solo_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="">
+      <dxl:Index Mdid="0.30058.1.0" Name="solo_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="" ReturnableColumns="1,2,7,17,22,29">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
@@ -79,7 +79,7 @@
       <dxl:TraceFlags Value="103027,102074,102146,102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.74761.1.0" Name="idx_foo_new_fn" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.74761.1.0" Name="idx_foo_new_fn" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -193,7 +193,7 @@
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.74775.1.0" Name="idx_foo_new_pcd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0,2" IncludedColumns="">
+      <dxl:Index Mdid="0.74775.1.0" Name="idx_foo_new_pcd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0,2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -261,7 +261,7 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.74486.1.0.19" Name="bs" Width="3.000000" NullFreq="0.000000" NdvRemain="18.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.74789.1.0" Name="idx_foo_new_pl" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.74789.1.0" Name="idx_foo_new_pl" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -911,7 +911,7 @@
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.74730.1.0" Name="idx_foo_dd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="">
+      <dxl:Index Mdid="0.74730.1.0" Name="idx_foo_dd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -1055,7 +1055,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.74747.1.0" Name="idx_foo_ad" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="9,4" IncludedColumns="">
+      <dxl:Index Mdid="0.74747.1.0" Name="idx_foo_ad" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="9,4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply1.mdp
@@ -24,7 +24,7 @@ select * from z,tt where tt.i=5 and z.i=6 ;
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16387.1.0" Name="idx_tt_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16387.1.0" Name="idx_tt_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -59,7 +59,7 @@ select * from z,tt where tt.i=5 and z.i=6 ;
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="idx_z_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16391.1.0" Name="idx_z_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
@@ -187,7 +187,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16401.1.0" Name="idx_tt_p_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16401.1.0" Name="idx_tt_p_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -407,7 +407,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16413.1.0" Name="idx_z_p_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.16413.1.0" Name="idx_z_p_i" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -193,7 +193,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
@@ -97,7 +97,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.98421.1.0.1" Name="l_partkey" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.98421.1.0.0" Name="l_orderkey" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.98440.1.0" Name="lineitem_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,3" IncludedColumns="">
+      <dxl:Index Mdid="0.98440.1.0" Name="lineitem_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,3" IncludedColumns="" ReturnableColumns="0,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -131,7 +131,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.98326.1.0" Name="part_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.98326.1.0" Name="part_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -1863,7 +1863,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.48922.1.0" Name="ssm_oip_cidr" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.48922.1.0" Name="ssm_oip_cidr" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1974.1.0"/>
         </dxl:Opfamilies>
@@ -1894,7 +1894,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
           <dxl:Opfamily Mdid="0.3025.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.48950.1.0" Name="ssm_ria_ip_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.48950.1.0" Name="ssm_ria_ip_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1974.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NoSortPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoSortPlan.mdp
@@ -138,7 +138,7 @@
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -162,7 +162,7 @@
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.8" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237673.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.1237673.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -170,7 +170,7 @@
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.7" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.6" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237715.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="">
+      <dxl:Index Mdid="0.1237715.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="" ReturnableColumns="4,5">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -156,7 +156,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -166,7 +166,7 @@
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
@@ -156,7 +156,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -166,7 +166,7 @@
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="" ReturnableColumns="2,3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
@@ -1709,7 +1709,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3650"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.3749921.1.0" Name="date_parts_ind_1_prt_outlying_years_2_prt_q1_3_prt_other_days" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.3749921.1.0" Name="date_parts_ind_1_prt_outlying_years_2_prt_q1_3_prt_other_days" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
@@ -1138,7 +1138,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.3748065.1.0" Name="date_parts_ind_1_prt_1_2_prt_q1_3_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.3748065.1.0" Name="date_parts_ind_1_prt_1_2_prt_q1_3_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -74,7 +74,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -84,7 +84,7 @@
           <dxl:Partition Mdid="6.310609003.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-DynamicIndexOnlyScan-Range.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-DynamicIndexOnlyScan-Range.mdp
@@ -721,7 +721,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="7.17227.1.0" Name="ptid_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,1" IncludedColumns="">
+      <dxl:Index Mdid="7.17227.1.0" Name="ptid_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,1" IncludedColumns="" ReturnableColumns="2,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -975,7 +975,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1988.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -941,7 +941,7 @@
       <dxl:ColumnStatistics Mdid="1.810130.1.1.4" Name="hd_vehicle_count" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.5" Name="xmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.4" Name="ctid" Width="6.000000"/>
-      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="">
+      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="" ReturnableColumns="0,6">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -1273,7 +1273,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -212,7 +212,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -225,7 +225,7 @@
           <dxl:Partition Mdid="6.310609002.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsAndDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsAndDisjuncts.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102074,102119,102120,102128,102131,102132,102133,102134,102135,102136,102140,102141,102142,102143,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16523.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
+      <dxl:Index Mdid="0.16523.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -940,7 +940,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16540.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.16540.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -2207,7 +2207,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16506.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16506.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
@@ -91,7 +91,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16662.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16662.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
@@ -573,7 +573,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16679.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.16679.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -982,7 +982,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.16696.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
+      <dxl:Index Mdid="0.16696.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithLongConjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithLongConjunction.mdp
@@ -35,7 +35,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102074,102119,102120,102128,102131,102132,102133,102134,102135,102136,102140,102141,102142,102143,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16783.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
+      <dxl:Index Mdid="0.16783.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -936,7 +936,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16800.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
+      <dxl:Index Mdid="0.16800.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -3006,7 +3006,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.16766.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.16766.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnAppendOnlyVersion6UpgradedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnAppendOnlyVersion6UpgradedTable.mdp
@@ -574,7 +574,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" Value="1000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="7.90468.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.90468.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnMixedAppendOnlyPartitionedTableContainingAppendOnlyVersion6Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnMixedAppendOnlyPartitionedTableContainingAppendOnlyVersion6Child.mdp
@@ -765,7 +765,7 @@
       </dxl:ColumnStatistics>
       <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.416.1.0"/>
       <dxl:RelationExtendedStatistics Mdid="10.172082.1.0" Name="mypt"/>
-      <dxl:Index Mdid="7.172097.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.172097.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnMixedPartitionedTableContainingAppendOnlyVersion6Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PreventIndexOnlyScanOnMixedPartitionedTableContainingAppendOnlyVersion6Child.mdp
@@ -204,7 +204,7 @@
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
       <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.416.1.0"/>
-      <dxl:Index Mdid="7.172120.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="7.172120.1.0" Name="idx_mypt_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -651,7 +651,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
       <dxl:GPDBFunc Mdid="0.6084.1.0" Name="gp_partition_selection" ReturnsSet="false" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.26.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -329,12 +329,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" IsClustered="false" KeyColumns="24" IncludedColumns="">
+      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" IsClustered="false" KeyColumns="24" IncludedColumns="" ReturnableColumns="24">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
@@ -507,14 +507,14 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="" ReturnableColumns="0,12,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1991.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" KeyColumns="4" IncludedColumns="" ReturnableColumns="4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1089.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
@@ -947,7 +947,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
@@ -258,7 +258,7 @@
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.5" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.4" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237476.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.1237476.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-HEAP.mdp
@@ -27,7 +27,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.1237378.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.1237378.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -95,7 +95,7 @@ AND
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="11" IncludedColumns="">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="11" IncludedColumns="" ReturnableColumns="11">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -400,12 +400,12 @@ AND
           <dxl:Opfamily Mdid="0.3028.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="6" IncludedColumns="">
+      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="6" IncludedColumns="" ReturnableColumns="6">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -545,12 +545,12 @@ AND
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="18" IncludedColumns="">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="18" IncludedColumns="" ReturnableColumns="18">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -117,7 +117,7 @@ ON a = c
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.305420.1.0" Name="idx_abuela_aaa" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.305420.1.0" Name="idx_abuela_aaa" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -9,7 +9,7 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -67,7 +67,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -28,7 +28,7 @@ select  i_item_id
       <dxl:TraceFlags Value="103027,101013,102120,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
+      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="" ReturnableColumns="11">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -3973,7 +3973,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -4019,7 +4019,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
+      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="3" IncludedColumns="" ReturnableColumns="3">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -4068,12 +4068,12 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="9" IncludedColumns="">
+      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="9" IncludedColumns="" ReturnableColumns="9">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="" ReturnableColumns="4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5551,7 +5551,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgBjAKwm" DoubleValue="99.990000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="">
+      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="" ReturnableColumns="0,6">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -5601,7 +5601,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="4" IncludedColumns="" ReturnableColumns="4">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5650,7 +5650,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="5" IncludedColumns="">
+      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="5" IncludedColumns="" ReturnableColumns="5">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5669,7 +5669,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42120731005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5688,7 +5688,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42129433005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="15" IncludedColumns="">
+      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="15" IncludedColumns="" ReturnableColumns="15">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5719,7 +5719,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
+      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="11" IncludedColumns="" ReturnableColumns="11">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -7745,7 +7745,7 @@ select  i_item_id
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="13" IncludedColumns="">
+      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="13" IncludedColumns="" ReturnableColumns="13">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -7765,7 +7765,7 @@ select  i_item_id
         </dxl:Partitions>
       </dxl:Index>
       <dxl:RelationStatistics Mdid="2.42110250.1.1" Name="item" Rows="18000.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="17" IncludedColumns="">
+      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="17" IncludedColumns="" ReturnableColumns="17">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
         </dxl:Opfamilies>
@@ -7784,7 +7784,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42121130005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -7934,7 +7934,7 @@ select  i_item_id
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.42101810.1.1" Name="catalog_sales" Rows="14745100288.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -8629,7 +8629,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -9326,7 +9326,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -11235,7 +11235,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="14" IncludedColumns="">
+      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="14" IncludedColumns="" ReturnableColumns="14">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -11254,7 +11254,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42121529005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="14" IncludedColumns="">
+      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="14" IncludedColumns="" ReturnableColumns="14">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
@@ -14649,7 +14649,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -17736,7 +17736,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="7" IncludedColumns="">
+      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="7" IncludedColumns="" ReturnableColumns="7">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -20237,12 +20237,12 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="12" IncludedColumns="">
+      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="12" IncludedColumns="" ReturnableColumns="12">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="">
+      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="" ReturnableColumns="15,17,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -21619,7 +21619,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
+      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="2" IncludedColumns="" ReturnableColumns="2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -56,12 +56,12 @@ with results as
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6318,7 +6318,7 @@ with results as
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="">
+      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="" ReturnableColumns="2,9">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
@@ -92,7 +92,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" IsClustered="false" KeyColumns="1" IncludedColumns="">
+      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" IsClustered="false" KeyColumns="1" IncludedColumns="" ReturnableColumns="1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -150,7 +150,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -131,13 +131,13 @@ WHERE
         <dxl:Commutator Mdid="0.410.1.0"/>
         <dxl:InverseOp Mdid="0.411.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" IsClustered="false" KeyColumns="4,0" IncludedColumns="">
+      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" IsClustered="false" KeyColumns="4,0" IncludedColumns="" ReturnableColumns="4,0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" IsClustered="false" KeyColumns="26" IncludedColumns="">
+      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" IsClustered="false" KeyColumns="26" IncludedColumns="" ReturnableColumns="26">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -501,26 +501,26 @@ WHERE
         <dxl:Commutator Mdid="0.1869.1.0"/>
         <dxl:InverseOp Mdid="0.1862.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
+      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="" ReturnableColumns="0,1,2">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="">
+      <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="" ReturnableColumns="8">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -278,7 +278,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="" ReturnableColumns="31">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -535,7 +535,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="" ReturnableColumns="0,1">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -99,7 +99,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
+      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="" ReturnableColumns="0">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -2139,7 +2139,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAADTU4OTk1NTc3Mg==" LintValue="759579644"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
+      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="" ReturnableColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -33,7 +33,7 @@
       </dxl:IndexInfoList>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" SortDirection="ASC" NullsDirection="LAST" ReturnableColumns="1">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" ReturnableColumns="1" SortDirection="ASC" NullsDirection="LAST">
       <dxl:Opfamilies/>
     </dxl:Index>
     <dxl:Relation Mdid="6.1258.5.1" Name="S" IsTemporary="true" StorageType="AppendOnly, Column-oriented" AppendOnlyVersion="2" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="0;0,1" PartitionColumns="1">
@@ -100,7 +100,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="" SortDirection="ASC,ASC" NullsDirection="LAST,LAST" ReturnableColumns="0,6">
+    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="" ReturnableColumns="0,6" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.3027.1.0"/>
         <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -33,7 +33,7 @@
       </dxl:IndexInfoList>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" SortDirection="ASC" NullsDirection="LAST">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="1" IncludedColumns="" SortDirection="ASC" NullsDirection="LAST" ReturnableColumns="1">
       <dxl:Opfamilies/>
     </dxl:Index>
     <dxl:Relation Mdid="6.1258.5.1" Name="S" IsTemporary="true" StorageType="AppendOnly, Column-oriented" AppendOnlyVersion="2" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="0;0,1" PartitionColumns="1">
@@ -100,7 +100,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
+    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" AmCanOrder="true" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="" SortDirection="ASC,ASC" NullsDirection="LAST,LAST" ReturnableColumns="0,6">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.3027.1.0"/>
         <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -211,7 +211,7 @@
         <dxl:Ident ColId="2" ColName="B" TypeMdid="0.23.1.0"/>
       </dxl:Comparison>
     </dxl:CheckConstraint>
-    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
       <dxl:Opfamilies/>
     </dxl:Index>
     <dxl:Relation Mdid="6.378383.1.0" Name="ext_1" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Random" Keys="10,4" ForeignServer="0.91908.1.0">

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -66,13 +66,6 @@ using CExpressionArrays = CDynamicPtrArray<CExpressionArray, CleanupRelease>;
 class CXformUtils
 {
 private:
-	// enum marking the index column types
-	enum EIndexCols
-	{
-		EicKey,
-		EicKeyAndIncluded
-	};
-
 	// create a logical assert for the not nullable columns of the given table
 	// on top of the given child expression
 	static CExpression *PexprAssertNotNull(CMemoryPool *mp,
@@ -95,8 +88,7 @@ private:
 	static CColRefSet *PcrsIndexColumns(CMemoryPool *mp,
 										CColRefArray *colref_array,
 										const IMDIndex *pmdindex,
-										const IMDRelation *pmdrel,
-										EIndexCols eic);
+										const IMDRelation *pmdrel);
 
 	// return the set of columns from the given array of columns which are
 	// returnable through the index (to determine index-only scan capable)
@@ -110,8 +102,7 @@ private:
 	static CColRefArray *PdrgpcrIndexColumns(CMemoryPool *mp,
 											 CColRefArray *colref_array,
 											 const IMDIndex *pmdindex,
-											 const IMDRelation *pmdrel,
-											 EIndexCols eic);
+											 const IMDRelation *pmdrel);
 
 	// lookup join keys in scalar child group
 	static void LookupJoinKeys(CMemoryPool *mp, CExpression *pexpr,
@@ -389,13 +380,6 @@ public:
 										  CColRefArray *colref_array,
 										  const IMDIndex *pmdindex,
 										  const IMDRelation *pmdrel);
-
-	// return the set of key columns from the given array of columns which appear
-	// in the index key and included columns
-	static CColRefSet *PcrsIndexKeysAndIncludes(CMemoryPool *mp,
-												CColRefArray *colref_array,
-												const IMDIndex *pmdindex,
-												const IMDRelation *pmdrel);
 
 	// return the set of key columns from the given array of columns which appear
 	// in the index key columns

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -98,6 +98,13 @@ private:
 										const IMDRelation *pmdrel,
 										EIndexCols eic);
 
+	// return the set of columns from the given array of columns which are
+	// returnable through the index (to determine index-only scan capable)
+	static CColRefSet *PcrsIndexReturnableColumns(CMemoryPool *mp,
+												  CColRefArray *colref_array,
+												  const IMDIndex *pmdindex,
+												  const IMDRelation *pmdrel);
+
 	// return the ordered array of columns from the given array of columns which appear
 	// in the index included / key columns
 	static CColRefArray *PdrgpcrIndexColumns(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -146,8 +146,7 @@ BOOL
 CIndexDescriptor::SupportsIndexOnlyScan(CTableDescriptor *ptabdesc) const
 {
 	// index only scan is not supported on GPDB 6 append-only tables.
-	return m_index_type == IMDIndex::EmdindBtree &&
-		   !((ptabdesc->IsAORowOrColTable() ||
+	return !((ptabdesc->IsAORowOrColTable() ||
 			  IMDRelation::ErelstorageMixedPartitioned ==
 				  ptabdesc->RetrieveRelStorageType()) &&
 			 ptabdesc->GetRelAOVersion() < IMDRelation::AORelationVersion_GP7);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -55,7 +55,6 @@ CXformIndexGet2IndexOnlyScan::Exfp(CExpressionHandle &exprhdl) const
 
 	if (!pindexdesc->SupportsIndexOnlyScan(ptabdesc))
 	{
-		// FIXME: relax btree requirement. GiST and SP-GiST indexes can support some operator classes, but Gin cannot
 		return CXform::ExfpNone;
 	}
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1857,6 +1857,38 @@ CXformUtils::PcrsIndexColumns(CMemoryPool *mp, CColRefArray *colref_array,
 //		appear in the index columns of the specified type (included / key)
 //
 //---------------------------------------------------------------------------
+CColRefSet *
+CXformUtils::PcrsIndexReturnableColumns(CMemoryPool *mp,
+										CColRefArray *colref_array,
+										const IMDIndex *pmdindex,
+										const IMDRelation *pmdrel)
+{
+	CColRefSet *pcrsCols = GPOS_NEW(mp) CColRefSet(mp);
+
+	// returnable columns
+	for (ULONG ul = 0; ul < pmdindex->ReturnableCols(); ul++)
+	{
+		ULONG ulPos = pmdindex->ReturnableColAt(ul);
+
+		ULONG ulPosNonDropped = pmdrel->NonDroppedColAt(ulPos);
+		GPOS_ASSERT(gpos::ulong_max != ulPosNonDropped);
+		GPOS_ASSERT(ulPosNonDropped < colref_array->Size());
+		CColRef *colref = (*colref_array)[ulPosNonDropped];
+		pcrsCols->Include(colref);
+	}
+
+	return pcrsCols;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformUtils::PdrgpcrIndexColumns
+//
+//	@doc:
+//		Return the ordered list of columns from the given array of columns which
+//		appear in the index columns of the specified type (included / key)
+//
+//---------------------------------------------------------------------------
 CColRefArray *
 CXformUtils::PdrgpcrIndexColumns(CMemoryPool *mp, CColRefArray *colref_array,
 								 const IMDIndex *pmdindex,
@@ -4098,7 +4130,7 @@ CXformUtils::FCoverIndex(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
 	GPOS_ASSERT(nullptr != pdrgpcrOutput);
 	pdrgpcrOutput->AddRef();
 
-	CColRefSet *matched_cols = CXformUtils::PcrsIndexKeysAndIncludes(
+	CColRefSet *matched_cols = CXformUtils::PcrsIndexReturnableColumns(
 		mp, pdrgpcrOutput, pmdindex, pmdrel);
 	CColRefSet *output_cols = GPOS_NEW(mp) CColRefSet(mp);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDIndex.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDIndex.h
@@ -61,6 +61,9 @@ private:
 	// included columns
 	ULongPtrArray *m_included_cols_array;
 
+	// returnable columns
+	ULongPtrArray *m_returnable_cols_array;
+
 	// index key's sort direction
 	ULongPtrArray *m_sort_direction;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -511,6 +511,7 @@ enum Edxltoken
 
 	EdxltokenIndexKeyCols,
 	EdxltokenIndexIncludedCols,
+	EdxltokenIndexReturnableCols,
 	EdxltokenIndexClustered,
 	EdxltokenIndexAmCanOrder,
 	EdxltokenIndexPartial,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
@@ -67,6 +67,9 @@ private:
 	// included columns
 	ULongPtrArray *m_included_cols_array;
 
+	// returnable columns
+	ULongPtrArray *m_returnable_cols_array;
+
 	// operator families for each index key
 	IMdIdArray *m_mdid_opfamilies_array;
 
@@ -91,6 +94,7 @@ public:
 				 EmdindexType index_type, IMDId *mdid_item_type,
 				 ULongPtrArray *index_key_cols_array,
 				 ULongPtrArray *included_cols_array,
+				 ULongPtrArray *returnable_cols_array,
 				 IMdIdArray *mdid_opfamilies_array,
 				 IMdIdArray *child_index_oids, ULongPtrArray *sort_direction,
 				 ULongPtrArray *nulls_direction);
@@ -130,6 +134,12 @@ public:
 
 	// return the n-th included column
 	ULONG IncludedColAt(ULONG pos) const override;
+
+	// number of returnable columns
+	ULONG ReturnableCols() const override;
+
+	// return the n-th returnable column
+	ULONG ReturnableColAt(ULONG pos) const override;
 
 	// return the n-th column sort direction
 	ULONG KeySortDirectionAt(ULONG pos) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDIndex.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDIndex.h
@@ -83,6 +83,12 @@ public:
 	// return the n-th included column
 	virtual ULONG IncludedColAt(ULONG pos) const = 0;
 
+	// number of returnable columns
+	virtual ULONG ReturnableCols() const = 0;
+
+	// return the n-th returnable column
+	virtual ULONG ReturnableColAt(ULONG pos) const = 0;
+
 	// return the n-th column sort direction
 	virtual ULONG KeySortDirectionAt(ULONG pos) const = 0;
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDIndex.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDIndex.cpp
@@ -43,6 +43,7 @@ CParseHandlerMDIndex::CParseHandlerMDIndex(
 	  m_mdid_item_type(nullptr),
 	  m_index_key_cols_array(nullptr),
 	  m_included_cols_array(nullptr),
+	  m_returnable_cols_array(nullptr),
 	  m_sort_direction(nullptr),
 	  m_nulls_direction(nullptr),
 	  m_child_indexes_parse_handler(nullptr)
@@ -139,6 +140,14 @@ CParseHandlerMDIndex::StartElement(const XMLCh *const element_uri,
 		m_parse_handler_mgr->GetDXLMemoryManager(), xmlszIndexIncludedCols,
 		EdxltokenIndexIncludedCols, EdxltokenIndex);
 
+	// parse index returnable column information
+	const XMLCh *xmlszIndexReturnableCols =
+		CDXLOperatorFactory::ExtractAttrValue(
+			attrs, EdxltokenIndexReturnableCols, EdxltokenIndex);
+	m_returnable_cols_array = CDXLOperatorFactory::ExtractIntsToUlongArray(
+		m_parse_handler_mgr->GetDXLMemoryManager(), xmlszIndexReturnableCols,
+		EdxltokenIndexReturnableCols, EdxltokenIndex);
+
 	// extract index keys sort directions
 	const XMLCh *xmlszIndexKeysSortDirections =
 		CDXLOperatorFactory::ExtractAttrValue(
@@ -215,8 +224,8 @@ CParseHandlerMDIndex::EndElement(const XMLCh *const,  // element_uri,
 	m_imd_obj = GPOS_NEW(m_mp) CMDIndexGPDB(
 		m_mp, m_mdid, m_mdname, m_clustered, is_partitioned, m_amcanorder,
 		m_index_type, m_mdid_item_type, m_index_key_cols_array,
-		m_included_cols_array, mdid_opfamilies_array, child_indexes,
-		m_sort_direction, m_nulls_direction);
+		m_included_cols_array, m_returnable_cols_array, mdid_opfamilies_array,
+		child_indexes, m_sort_direction, m_nulls_direction);
 
 	// deactivate handler
 	m_parse_handler_mgr->DeactivateHandler();

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -578,6 +578,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 
 		{EdxltokenIndexKeyCols, GPOS_WSZ_LIT("KeyColumns")},
 		{EdxltokenIndexIncludedCols, GPOS_WSZ_LIT("IncludedColumns")},
+		{EdxltokenIndexReturnableCols, GPOS_WSZ_LIT("ReturnableColumns")},
 		{EdxltokenIndexClustered, GPOS_WSZ_LIT("IsClustered")},
 		{EdxltokenIndexAmCanOrder, GPOS_WSZ_LIT("AmCanOrder")},
 		{EdxltokenIndexPartial, GPOS_WSZ_LIT("IsPartial")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -404,8 +404,9 @@ OrderedAggUsingGroupColumnInDirectArg OrderedAgg_multiple_samecol OrderedAgg_wit
 OrderedAgg_array_fraction OrderedAgg_multiple_samecol_difforderespec OrderedAgg_with_nonconst_fraction
 OrderedAgg_skewed_data;
 
-CoverintIndexTest:
-CoveringIndex-1 CoveringIndex-2 CoveringIndex-3 CoveringIndex-Cost-1 CoveringIndex-Cost-2;
+CoveringIndexTest:
+CoveringIndex-1 CoveringIndex-2 CoveringIndex-3 CoveringIndex-Cost-1 CoveringIndex-Cost-2
+CoveringIndex-DoesSupport-Gist CoveringIndex-DoesNotSupport-Gin;
 
 CForeignPartTest:
 ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE ForeignScanExecLocAnySimpleScan ForeignScanExecLocAnyJoin ForeignPartOneTimeFilterDPE

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -575,6 +575,9 @@ bool HasUpdateTriggers(Oid relid);
 void IndexOpProperties(Oid opno, Oid opfamily, StrategyNumber *strategynumber,
 					   Oid *righttype);
 
+// check whether index column is returnable (for index-only scans)
+gpos::BOOL IndexCanReturn(Relation index, int attno);
+
 // get oids of families this operator belongs to
 List *GetOpFamiliesForScOp(Oid opno);
 

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -694,7 +694,7 @@ INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
 CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types;
 -- KEYS: [a]    INCLUDED: [b]
--- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
+-- Check support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
                                          QUERY PLAN                                         
@@ -706,27 +706,35 @@ SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- ORCA_FEATURE_NOT_SUPPORTED: support dynamic-index-only-scan on GIST indexes
-ALTER TABLE test_cover_index_on_pt ADD COLUMN a_box box;
-CREATE INDEX i_pt_a_box ON test_cover_index_on_pt USING GIST (a_box);
-VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
+-- Check support dynamic-index-only-scan on GIST indexes
+CREATE TABLE test_partition_table_with_gist_index(a int, b_box box)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (a)
+(
+    START (0) END (4) EVERY (1)
+);
+CREATE INDEX gist_index_on_column_a_box ON test_partition_table_with_gist_index USING GIST (b_box) INCLUDE (a);
+INSERT INTO test_partition_table_with_gist_index VALUES (2, '(2.0,2.0,0.0,0.0)');
+INSERT INTO test_partition_table_with_gist_index VALUES (3, '(1.0,1.0,3.0,3.0)');
+VACUUM ANALYZE test_partition_table_with_gist_index;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
-SELECT a_box FROM test_cover_index_on_pt WHERE a_box<@ box '(0,0,3,3)';
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (actual rows=0 loops=1)
-         ->  Index Only Scan using test_cover_index_on_pt_1_prt_1_a_box_idx on test_cover_index_on_pt_1_prt_1 (actual rows=0 loops=1)
-               Index Cond: (a_box <@ '(3,3),(0,0)'::box)
+SELECT a, b_box FROM test_partition_table_with_gist_index WHERE b_box<@ box '(0,0,3,3)';
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   ->  Append (actual rows=2 loops=1)
+         ->  Index Only Scan using test_partition_table_with_gist_index_1_prt_1_b_box_a_idx on test_partition_table_with_gist_index_1_prt_1 (actual rows=0 loops=1)
+               Index Cond: (b_box <@ '(3,3),(0,0)'::box)
                Heap Fetches: 0
-         ->  Index Only Scan using test_cover_index_on_pt_1_prt_2_a_box_idx on test_cover_index_on_pt_1_prt_2 (actual rows=0 loops=1)
-               Index Cond: (a_box <@ '(3,3),(0,0)'::box)
+         ->  Index Only Scan using test_partition_table_with_gist_index_1_prt_2_b_box_a_idx on test_partition_table_with_gist_index_1_prt_2 (actual rows=0 loops=1)
+               Index Cond: (b_box <@ '(3,3),(0,0)'::box)
                Heap Fetches: 0
-         ->  Index Only Scan using test_cover_index_on_pt_1_prt_3_a_box_idx on test_cover_index_on_pt_1_prt_3 (actual rows=0 loops=1)
-               Index Cond: (a_box <@ '(3,3),(0,0)'::box)
+         ->  Index Only Scan using test_partition_table_with_gist_index_1_prt_3_b_box_a_idx on test_partition_table_with_gist_index_1_prt_3 (actual rows=1 loops=1)
+               Index Cond: (b_box <@ '(3,3),(0,0)'::box)
                Heap Fetches: 0
-         ->  Index Only Scan using test_cover_index_on_pt_1_prt_4_a_box_idx on test_cover_index_on_pt_1_prt_4 (actual rows=0 loops=1)
-               Index Cond: (a_box <@ '(3,3),(0,0)'::box)
+         ->  Index Only Scan using test_partition_table_with_gist_index_1_prt_4_b_box_a_idx on test_partition_table_with_gist_index_1_prt_4 (actual rows=1 loops=1)
+               Index Cond: (b_box <@ '(3,3),(0,0)'::box)
                Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (15 rows)

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -668,34 +668,43 @@ INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
 CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types;
 -- KEYS: [a]    INCLUDED: [b]
--- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
+-- Check support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-   ->  Index Scan using i_test_index_types on test_index_types (actual rows=2 loops=1)
+   ->  Index Only Scan using i_test_index_types on test_index_types (actual rows=2 loops=1)
          Index Cond: (a <@ '(3,3),(0,0)'::box)
-         Filter: (a <@ '(3,3),(0,0)'::box)
+         Heap Fetches: 0
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- ORCA_FEATURE_NOT_SUPPORTED: support dynamic-index-only-scan on GIST indexes
-ALTER TABLE test_cover_index_on_pt ADD COLUMN a_box box;
-CREATE INDEX i_pt_a_box ON test_cover_index_on_pt USING GIST (a_box);
-VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
+-- Check support dynamic-index-only-scan on GIST indexes
+CREATE TABLE test_partition_table_with_gist_index(a int, b_box box)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (a)
+(
+    START (0) END (4) EVERY (1)
+);
+CREATE INDEX gist_index_on_column_a_box ON test_partition_table_with_gist_index USING GIST (b_box) INCLUDE (a);
+INSERT INTO test_partition_table_with_gist_index VALUES (2, '(2.0,2.0,0.0,0.0)');
+INSERT INTO test_partition_table_with_gist_index VALUES (3, '(1.0,1.0,3.0,3.0)');
+VACUUM ANALYZE test_partition_table_with_gist_index;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
-SELECT a_box FROM test_cover_index_on_pt WHERE a_box<@ box '(0,0,3,3)';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Index Scan on i_pt_a_box on test_cover_index_on_pt (actual rows=0 loops=1)
-         Index Cond: (a_box <@ '(3,3),(0,0)'::box)
-         Filter: (a_box <@ '(3,3),(0,0)'::box)
+SELECT a, b_box FROM test_partition_table_with_gist_index WHERE b_box<@ box '(0,0,3,3)';
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   ->  Dynamic Index Only Scan on gist_index_on_column_a_box on test_partition_table_with_gist_index (actual rows=2 loops=1)
+         Index Cond: (b_box <@ '(3,3),(0,0)'::box)
+         Filter: (b_box <@ '(3,3),(0,0)'::box)
+         Heap Fetches: 0
          Number of partitions to scan: 4 (out of 4)
          Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(8 rows)
 
 -- 8) Test partial indexes
 --


### PR DESCRIPTION
In commit https://github.com/greenplum-db/gpdb/commit/3b72df1810411f4716137446f00b550378084835, ORCA introduced support for index-only scan on
only b-tree indexes. That restriction was intended to reduce the scope
of the commit. This commit expands the index types that ORCA allows for
index-only scan by checking the index's access method for returnable
columns.

Example Setup:
```sql
CREATE TABLE t(a box, b int, c int) DISTRIBUTED BY (b);
INSERT INTO t VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
CREATE INDEX i ON t USING GIST (a) INCLUDE (b);
VACUUM ANALYZE t;

EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
SELECT a, b FROM t WHERE a<@ box '(0,0,3,3)';

                            QUERY PLAN                            
------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
   ->  Index Only Scan using i on t (actual rows=1 loops=1)
         Index Cond: (a <@ '(3,3),(0,0)'::box)
         Heap Fetches: 0
 Optimizer: Pivotal Optimizer (GPORCA)
(5 rows)
```

Note: Many MDPs required update. Commit 7a72cd4 has the sed scripts I ran that
covered 98% of the updates. Commit ff7b27d contains the handful of ones that
required manual update due to IncludeColumn usage.