### PR TITLE
Modify UDF busy in resgroup_cpu_max_percent.sql to fix resource group flaky case

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpu_rate_limit.source
@@ -4,6 +4,8 @@ DROP ROLE IF EXISTS role1_cpu_test;
 DROP ROLE IF EXISTS role2_cpu_test;
 DROP RESOURCE GROUP rg1_cpu_test;
 DROP RESOURCE GROUP rg2_cpu_test;
+DROP VIEW IF EXISTS busy;
+DROP TABLE IF EXISTS bigtable;
 
 CREATE LANGUAGE plpythonu;
 -- end_ignore
@@ -59,29 +61,32 @@ RETURNS BOOL AS $$
     return verify_cpu_usage()
 $$ LANGUAGE plpythonu;
 
-CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$
-    import os
-    import signal
+CREATE TABLE bigtable AS
+    SELECT i AS c1, 'abc' AS c2
+    FROM generate_series(1,50000) i distributed randomly;
 
-    n = 15
-    for i in xrange(n):
-        if os.fork() == 0:
-			# children must quit without invoking the atexit hooks
-            signal.signal(signal.SIGINT,  lambda a, b: os._exit(0))
-            signal.signal(signal.SIGQUIT, lambda a, b: os._exit(0))
-            signal.signal(signal.SIGTERM, lambda a, b: os._exit(0))
-
-            # generate pure cpu load
-            while True:
-                pass
-
-    os.wait()
+CREATE OR REPLACE FUNCTION complex_compute(i int)
+RETURNS int AS $$
+    results = 1
+    for j in range(1, 10000 + i):
+        results = (results * j) % 35969
+    return results
 $$ LANGUAGE plpythonu;
+
+CREATE VIEW busy AS
+    WITH t1 as (select random(), complex_compute(c1) from bigtable),
+    t2 as (select random(), complex_compute(c1) from bigtable),
+    t3 as (select random(), complex_compute(c1) from bigtable),
+    t4 as (select random(), complex_compute(c1) from bigtable),
+    t5 as (select random(), complex_compute(c1) from bigtable)
+    SELECT count(*)
+    FROM
+    t1, t2, t3, t4, t5;
 
 CREATE VIEW cancel_all AS
     SELECT pg_cancel_backend(pid)
     FROM pg_stat_activity
-    WHERE query LIKE 'SELECT * FROM % WHERE busy%';
+    WHERE query LIKE 'SELECT * FROM busy%';
 
 -- create two resource groups
 CREATE RESOURCE GROUP rg1_cpu_test WITH (concurrency=5, cpu_rate_limit=10, memory_limit=20);
@@ -157,8 +162,10 @@ ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 1;
 -- create two roles and assign them to above groups
 CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;
 CREATE ROLE role2_cpu_test RESOURCE GROUP rg2_cpu_test;
-GRANT ALL ON FUNCTION busy() TO role1_cpu_test;
-GRANT ALL ON FUNCTION busy() TO role2_cpu_test;
+GRANT ALL ON FUNCTION complex_compute(int) TO role1_cpu_test;
+GRANT ALL ON FUNCTION complex_compute(int) TO role2_cpu_test;
+GRANT ALL ON busy TO role1_cpu_test;
+GRANT ALL ON busy TO role2_cpu_test;
 
 -- prepare parallel queries in the two groups
 10: SET ROLE TO role1_cpu_test;
@@ -189,11 +196,11 @@ GRANT ALL ON FUNCTION busy() TO role2_cpu_test;
 -- so the cpu usage shall be 90%
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+10&: SELECT * FROM busy;
+11&: SELECT * FROM busy;
+12&: SELECT * FROM busy;
+13&: SELECT * FROM busy;
+14&: SELECT * FROM busy;
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -254,17 +261,17 @@ SELECT * FROM cancel_all;
 -- - rg2_cpu_test gets 90% * 2/3 => 60%;
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+10&: SELECT * FROM busy;
+11&: SELECT * FROM busy;
+12&: SELECT * FROM busy;
+13&: SELECT * FROM busy;
+14&: SELECT * FROM busy;
 
-20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+20&: SELECT * FROM busy;
+21&: SELECT * FROM busy;
+22&: SELECT * FROM busy;
+23&: SELECT * FROM busy;
+24&: SELECT * FROM busy;
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -353,11 +360,11 @@ SELECT * FROM cancel_all;
 -- so the cpu usage shall be 10%
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+10&: SELECT * FROM busy;
+11&: SELECT * FROM busy;
+12&: SELECT * FROM busy;
+13&: SELECT * FROM busy;
+14&: SELECT * FROM busy;
 
 -- start_ignore
 1:TRUNCATE TABLE cpu_usage_samples;
@@ -418,17 +425,17 @@ SELECT * FROM cancel_all;
 -- - rg2_cpu_test gets 20%;
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+10&: SELECT * FROM busy;
+11&: SELECT * FROM busy;
+12&: SELECT * FROM busy;
+13&: SELECT * FROM busy;
+14&: SELECT * FROM busy;
 
-20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
-24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
+20&: SELECT * FROM busy;
+21&: SELECT * FROM busy;
+22&: SELECT * FROM busy;
+23&: SELECT * FROM busy;
+24&: SELECT * FROM busy;
 
 -- start_ignore
 1:TRUNCATE TABLE cpu_usage_samples;
@@ -497,8 +504,10 @@ SELECT * FROM cancel_all;
 2:ALTER RESOURCE GROUP admin_group SET cpu_rate_limit 10;
 
 -- cleanup
-2:REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
-2:REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
+2:REVOKE ALL ON FUNCTION complex_compute(int) FROM role1_cpu_test;
+2:REVOKE ALL ON FUNCTION complex_compute(int) FROM role2_cpu_test;
+2:REVOKE ALL ON busy FROM role1_cpu_test;
+2:REVOKE ALL ON busy FROM role2_cpu_test;
 2:DROP ROLE role1_cpu_test;
 2:DROP ROLE role2_cpu_test;
 2:DROP RESOURCE GROUP rg1_cpu_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpu_rate_limit.source
@@ -9,6 +9,10 @@ DROP RESOURCE GROUP rg1_cpu_test;
 ERROR:  resource group "rg1_cpu_test" does not exist
 DROP RESOURCE GROUP rg2_cpu_test;
 ERROR:  resource group "rg2_cpu_test" does not exist
+DROP VIEW IF EXISTS busy;
+DROP VIEW
+DROP TABLE IF EXISTS bigtable;
+DROP TABLE
 
 CREATE LANGUAGE plpythonu;
 CREATE
@@ -39,13 +43,16 @@ def verify_cpu_usage(): all_info = plpy.execute(''' SELECT sample::json->'{name}
 return verify_cpu_usage() $$ LANGUAGE plpythonu;
 CREATE
 
-CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$ import os import signal 
-n = 15 for i in xrange(n): if os.fork() == 0: # children must quit without invoking the atexit hooks signal.signal(signal.SIGINT,  lambda a, b: os._exit(0)) signal.signal(signal.SIGQUIT, lambda a, b: os._exit(0)) signal.signal(signal.SIGTERM, lambda a, b: os._exit(0)) 
-# generate pure cpu load while True: pass 
-os.wait() $$ LANGUAGE plpythonu;
+CREATE TABLE bigtable AS SELECT i AS c1, 'abc' AS c2 FROM generate_series(1,50000) i distributed randomly;
+CREATE 50000
+
+CREATE OR REPLACE FUNCTION complex_compute(i int) RETURNS int AS $$ results = 1 for j in range(1, 10000 + i): results = (results * j) % 35969 return results $$ LANGUAGE plpythonu;
 CREATE
 
-CREATE VIEW cancel_all AS SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM % WHERE busy%';
+CREATE VIEW busy AS WITH t1 as (select random(), complex_compute(c1) from bigtable), t2 as (select random(), complex_compute(c1) from bigtable), t3 as (select random(), complex_compute(c1) from bigtable), t4 as (select random(), complex_compute(c1) from bigtable), t5 as (select random(), complex_compute(c1) from bigtable) SELECT count(*) FROM t1, t2, t3, t4, t5;
+CREATE
+
+CREATE VIEW cancel_all AS SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM busy%';
 CREATE
 
 -- create two resource groups
@@ -82,9 +89,13 @@ CREATE ROLE role1_cpu_test RESOURCE GROUP rg1_cpu_test;
 CREATE
 CREATE ROLE role2_cpu_test RESOURCE GROUP rg2_cpu_test;
 CREATE
-GRANT ALL ON FUNCTION busy() TO role1_cpu_test;
+GRANT ALL ON FUNCTION complex_compute(int) TO role1_cpu_test;
 GRANT
-GRANT ALL ON FUNCTION busy() TO role2_cpu_test;
+GRANT ALL ON FUNCTION complex_compute(int) TO role2_cpu_test;
+GRANT
+GRANT ALL ON busy TO role1_cpu_test;
+GRANT
+GRANT ALL ON busy TO role2_cpu_test;
 GRANT
 
 -- prepare parallel queries in the two groups
@@ -126,11 +137,11 @@ SET
 -- so the cpu usage shall be 90%
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+10&: SELECT * FROM busy;  <waiting ...>
+11&: SELECT * FROM busy;  <waiting ...>
+12&: SELECT * FROM busy;  <waiting ...>
+13&: SELECT * FROM busy;  <waiting ...>
+14&: SELECT * FROM busy;  <waiting ...>
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -295,17 +306,17 @@ SET
 -- - rg2_cpu_test gets 90% * 2/3 => 60%;
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+10&: SELECT * FROM busy;  <waiting ...>
+11&: SELECT * FROM busy;  <waiting ...>
+12&: SELECT * FROM busy;  <waiting ...>
+13&: SELECT * FROM busy;  <waiting ...>
+14&: SELECT * FROM busy;  <waiting ...>
 
-20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+20&: SELECT * FROM busy;  <waiting ...>
+21&: SELECT * FROM busy;  <waiting ...>
+22&: SELECT * FROM busy;  <waiting ...>
+23&: SELECT * FROM busy;  <waiting ...>
+24&: SELECT * FROM busy;  <waiting ...>
 
 -- start_ignore
 TRUNCATE TABLE cpu_usage_samples;
@@ -550,11 +561,11 @@ SET
 -- so the cpu usage shall be 10%
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+10&: SELECT * FROM busy;  <waiting ...>
+11&: SELECT * FROM busy;  <waiting ...>
+12&: SELECT * FROM busy;  <waiting ...>
+13&: SELECT * FROM busy;  <waiting ...>
+14&: SELECT * FROM busy;  <waiting ...>
 
 -- start_ignore
 1:TRUNCATE TABLE cpu_usage_samples;
@@ -719,17 +730,17 @@ SET
 -- - rg2_cpu_test gets 20%;
 --
 
-10&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-11&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-12&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-13&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-14&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+10&: SELECT * FROM busy;  <waiting ...>
+11&: SELECT * FROM busy;  <waiting ...>
+12&: SELECT * FROM busy;  <waiting ...>
+13&: SELECT * FROM busy;  <waiting ...>
+14&: SELECT * FROM busy;  <waiting ...>
 
-20&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-21&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-22&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-23&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
-24&: SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;  <waiting ...>
+20&: SELECT * FROM busy;  <waiting ...>
+21&: SELECT * FROM busy;  <waiting ...>
+22&: SELECT * FROM busy;  <waiting ...>
+23&: SELECT * FROM busy;  <waiting ...>
+24&: SELECT * FROM busy;  <waiting ...>
 
 -- start_ignore
 1:TRUNCATE TABLE cpu_usage_samples;
@@ -945,9 +956,13 @@ ERROR:  canceling statement due to user request
 ALTER
 
 -- cleanup
-2:REVOKE ALL ON FUNCTION busy() FROM role1_cpu_test;
+2:REVOKE ALL ON FUNCTION complex_compute(int) FROM role1_cpu_test;
 REVOKE
-2:REVOKE ALL ON FUNCTION busy() FROM role2_cpu_test;
+2:REVOKE ALL ON FUNCTION complex_compute(int) FROM role2_cpu_test;
+REVOKE
+2:REVOKE ALL ON busy FROM role1_cpu_test;
+REVOKE
+2:REVOKE ALL ON busy FROM role2_cpu_test;
 REVOKE
 2:DROP ROLE role1_cpu_test;
 DROP


### PR DESCRIPTION
UDF busy in resgroup_cup_max_percent.sql is as follows:
```
CREATE OR REPLACE FUNCTION busy() RETURNS void AS $$
    import os
    import signal
    n = 15
    for i in range(n):
        if os.fork() == 0:
            # children must quit without invoking the atexit hooks
            signal.signal(signal.SIGINT,  lambda a, b: os._exit(0))
            signal.signal(signal.SIGQUIT, lambda a, b: os._exit(0))       
            signal.signal(signal.SIGTERM, lambda a, b: os._exit(0))
            # generate pure cpu load
            while True: 
               pass
    os.wait()
$$ LANGUAGE plpython3u;
``` 
SELECT * FROM gp_dist_random('gp_id') WHERE busy() IS NULL;
When we execute the above SQL, call busy in QEs and each QE will fork 15 processes.
The call stack and memory values of the 15 processes are the same as QE's.
In one segment now there are 16 QEs( one original QE and 15 QEs forked),
and they belong to one MPP session.

Some struct related to MPP session is shared between all QEs. Such as MySessionState.
The filed MySessionState->activeProcessCount should be increased by calling 
IdleTracker_ActivateProcess. And decreased by calling IdleTracker_DeactivateProcess.
However, the other 15 QEs are forked and the value of activeProcessCount is the same as QE(now it is 1).

But after the process is forked and before setting signal handler to
signal.signal(signal.SIGINT,  lambda a, b: os._exit(0))
The forked QE has the same signal handler with parent. And now when we receive
SIGINT we will call IdleTracker_DeactivateProcess to reduce the value of activeProcessCount.
This value will be reduced more than once. And hit Assert Error.

Resolution:
Remove fork in busy, Use the same mode in resgroup_cpuset.sql to simulate busy.

backport from https://github.com/greenplum-db/gpdb/pull/16252