### PR TITLE
[6x]: Fix failed jobs for rocky9/oel9/rhel9

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1026,12 +1026,11 @@ class GpVersion(Command):
         # requires further investigation.
 
         self.gphome=gphome
-        #self.cmdStr="%s/bin/postgres --gp-version" % gphome
         self.cmdStr="echo 'START_CMD_OUTPUT';$GPHOME/bin/postgres --gp-version"
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
     def get_version(self):
-        return self.results.stdout.strip().split('START_CMD_OUTPUT\n')[1]
+        return self.get_stdout().split('START_CMD_OUTPUT\n')[1]
 
     @staticmethod
     def local(name,gphome):

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1027,11 +1027,11 @@ class GpVersion(Command):
 
         self.gphome=gphome
         #self.cmdStr="%s/bin/postgres --gp-version" % gphome
-        self.cmdStr="$GPHOME/bin/postgres --gp-version"
+        self.cmdStr="echo 'START_CMD_OUTPUT';$GPHOME/bin/postgres --gp-version"
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
     def get_version(self):
-        return self.results.stdout.strip()
+        return self.results.stdout.strip().split('START_CMD_OUTPUT\n')[1]
 
     @staticmethod
     def local(name,gphome):

--- a/gpMgmt/bin/lib/multidd
+++ b/gpMgmt/bin/lib/multidd
@@ -23,7 +23,7 @@ import sys
 
 
 def usage(exitarg):
-    print __doc__
+    print(__doc__)
     sys.exit(exitarg)
 
 
@@ -132,20 +132,20 @@ pfile = []
 blocksz = opt['-B']
 cnt = int(math.ceil(opt['-S'] / blocksz))
 totalBytes = 0
-for i in xrange(len(opt['-i'])):
+for i in range(len(opt['-i'])):
     ifile = opt['-i'][i]
     ofile = opt['-o'][i]
     cmd.append('dd if=%s of=%s count=%d bs=%d' % (ifile, ofile, cnt, blocksz))
     totalBytes += cnt * blocksz
 
 for c in cmd:
-    print c
+    print(c)
     pfile.append(os.popen(c))
 
 for f in pfile:
     ok = False
     try:
-        print f.read()
+        print(f.read())
         ok = not f.close()
         f = None
     except:
@@ -157,4 +157,4 @@ for f in pfile:
         sys.exit(1)
 
 os.system('sync')
-print 'multidd total bytes ', totalBytes
+print('multidd total bytes {0}' .format(totalBytes))


### PR DESCRIPTION
Support for 6x has been introduced for rocky9/oel9/rhel9, but there are some jobs experiencing failures.

**Failure 1:** gpcheckperf Failure
**Root Cause** - This failure is attributed to the absence of Python 2, as these operating systems exclusively
support Python 3. The code relied on Python 2-specific syntax, including the "print" statement.
**Solution** - To rectify this, we have diligently updated the affected code sections to be compatible with
Python 2 and Python 3 both. Instances of Python 2-specific syntax, such as the "print" statement, have
been replaced with Python 3-compatible alternatives like "print()".

**Failure 2:** gpinitsystem failure
**Root Cause** - The gpinitsystem failure was primarily caused by the presence of a banner in the command output,
making it challenging to identify and parse the necessary version information.
**Solution** - To overcome this issue, we have introduced a delimiter that effectively separates the banners from
the version information. This delimiter, 'START_CMD_OUTPUT\n', allows us to extract the version information by splitting the command's stdout.

**Failure 3**: unit_test_gpmgmt failure
**Root Cause** - The failure in unit_test occurred due to discrepancies between the expected and actual output.
Specifically, the error message format for invalid bash commands was inconsistent
**Solution** - To address this issue, we have implemented a solution using a regular expression (regex) pattern.
This pattern accommodates varying formats of error messages for invalid bash commands, whether or not they include ": line".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
