### PR TITLE
Fix ANALYZE bug in expand_vacuum_rels

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1027,7 +1027,7 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 		 * If current table is skipped, no need to merge stats for it's parent
 		 * since current table's stats is not get updated.
 		 */
-		if (optimizer_analyze_root_partition && !skip_this)
+		if ((options & VACOPT_ANALYZE) && optimizer_analyze_root_partition && !skip_this)
 		{
 			Oid			child_relid = relid;
 


### PR DESCRIPTION
With `optimizer_analyze_root_partition` enabled, `VACUUM` commands with a relation list would check leaf partition stats even when `VACUUM (ANALYZE)` was not specified.

Instead, check for `VACOPT_ANALYZE` before updating parent partition stats in `expand_vacuum_rel`. There is no reason to check `leaf_parts_analyzed` or add to the vacuum list if `ANALYZE` wasn't specified.

The existing comment explains the intended behavior:
```
* GPDB: If you explicitly ANALYZE a partition, also update the
* parent's stats after the partition has been ANALYZEd. (Thanks to
* the code to merge leaf statistics, it should be fast.)
```

The fix results in a large performance improvement when issuing `VACUUM` with a relation list and `optimizer_analyze_root_partition` enabled.

Authored-by: Brent Doil <bdoil@vmware.com>
