### PR TITLE
Don't use PGC_S_OVERRIDE for setting gp_role GUC

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1019,14 +1019,13 @@ PostmasterMain(int argc, char *argv[])
 	}
 
 	/*
-	 * If gp_role is not set, use utility role instead, and it could not be
-	 * changed by GUC commands because the source is PGC_S_OVERRIDE.
+	 * If gp_role is not set, use utility role instead.
 	 *
 	 * A single node coordinator or segment is set to utility, which is not
 	 * before Greenplum 7.
 	 */
 	if (Gp_role == GP_ROLE_UNDEFINED)
-		SetConfigOption("gp_role", "utility", PGC_POSTMASTER, PGC_S_OVERRIDE);
+		SetConfigOption("gp_role", "utility", PGC_POSTMASTER, PGC_S_DYNAMIC_DEFAULT);
 
 	/*
 	 * Locate the proper configuration files and data directory, and read


### PR DESCRIPTION
If gp_role value is not specified then internally "utility" is set as default. This is mainly for single node coordinator or segments. Changing that setting to use PGC_S_DYNAMIC_DEFAULT instead of PGC_S_OVERRIDE.

The problem with using PGC_S_OVERRIDE is GUC value can't be set later. Since commit 260710, we rely on assign_gp_role() hook to set should_reject_connection. If PGC_S_OVERRIDE is used to SetConfigOption() while setting the default in PostmasterMain(), then later setting gp_role via PGOPTIONS or any other mechanism will not call the assign hook and hence misses to set
should_reject_connection. The reason for change being safe is check_gp_role() only allows "utility" mode to set as value for this GUC and any other values like "execute" or "dispatch" are already banned from PGOPTIONS or postgresql.conf followed by reload.

This problem was exposed by src/test/gpdb_pitr/test_gpdb_pitr.sh tests which gets fixed now.
