### PR TITLE
Remove a FIXME in tupser.c

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -379,11 +379,6 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	tcList->serialized_data_length = 0;
 	tcList->max_chunk_length = Gp_max_tuple_chunk_size;
 
-	/*
-	 * GPDB_12_MERGE_FIXME: This used to support serializing memtuples directly.
-	 * That got removed with MinimalTuples in the merge. Resurrect the MemtUple
-	 * support if there's a performance benefit.
-	 */
 	/* Check if the slot has external attribute */
 	for (int i = 0; i < natts; i++)
 	{


### PR DESCRIPTION
The benefit from this optimization idea is plausible (basically, avoiding one memcpy of the memtuple), but the changes incurred by this are just too backwards and invasive for the effort to be worthy:

1. There is no memtuple to directly serialize from. The `PRIVATE_tts_memtuple` field in `TupleTableSlot` is gone after the FIXME was added (d20e071e879). Basically we do not store the memtuple outside of the AM layer anymore (like in the executor memory). I think bringing `PRIVATE_tts_memtuple` back to `TupleTableSlot` and utilize it everywhere is a clear backward change.
2. Assuming we somehow pass the memtuple into `SerializeTuple` as a function argument. But on the deserialization side, we would still need to deserialize it back to minimal tuple because all the deserilization logic and else utilizes minimal tuple now. The only way to avoid that is to carry memtuple around and use it, which is basically same as bringing `PRIVATE_tts_memtuple` back to `TupleTableSlot`. We also might have to bring back the concept of `GenericTuple`, and revert a lot of the changes that we have made to bring GPDB aligned with the AM framework which is a big milestone in 7X. Not very worthwhile IMO.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
