### PR TITLE
[WIP] make QE readers sync snapshot information from QE writers when executing SET command

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2529,7 +2529,6 @@ StartTransaction(void)
 			{
 				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
-				SharedLocalSnapshotSlot->ready = false;
 				SharedLocalSnapshotSlot->fullXid = s->fullTransactionId;
 				SharedLocalSnapshotSlot->startTimestamp = stmtStartTimestamp;
 				SharedLocalSnapshotSlot->distributedXid = QEDtxContextInfo.distributedXid;
@@ -2539,13 +2538,12 @@ StartTransaction(void)
 				ereportif(Debug_print_full_dtm, LOG,
 						  (errmsg(
 							  "qExec writer setting distributedXid: "UINT64_FORMAT
-							  " sharedQDxid (shared xid " UINT64_FORMAT " -> " UINT64_FORMAT ") ready %s"
+							  " sharedQDxid (shared xid " UINT64_FORMAT " -> " UINT64_FORMAT ")"
 							  " (shared timeStamp = " INT64_FORMAT " -> "
 							  INT64_FORMAT ")",
 							  SharedLocalSnapshotSlot->distributedXid,
 							  U64FromFullTransactionId(SharedLocalSnapshotSlot->fullXid),
 							  U64FromFullTransactionId(s->fullTransactionId),
-							  SharedLocalSnapshotSlot->ready ? "true" : "false",
 							  SharedLocalSnapshotSlot->startTimestamp,
 							  xactStartTimestamp)));
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -330,7 +330,6 @@ cdbdisp_makeDispatcherState(bool isExtendedQuery)
 	handle->dispatcherState->allocatedGangs = NIL;
 	handle->dispatcherState->largestGangSize = 0;
 	handle->dispatcherState->rootGangSize = 0;
-	handle->dispatcherState->destroyIdleReaderGang = false;
 
 	return handle->dispatcherState;
 }
@@ -406,12 +405,6 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 
 		RecycleGang(gp, ds->forceDestroyGang);
 	}
-
-	/*
-	 * Destroy all the idle reader gangs when flag destroyIdleReaderGang is true
-	 */
-	if (ds->destroyIdleReaderGang)
-		cdbcomponent_cleanupIdleQEs(false);
 
 	ds->allocatedGangs = NIL;
 	ds->dispatchParams = NULL;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -464,23 +464,6 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	 */
 	ds = cdbdisp_makeDispatcherState(false);
 
-	/*
-	 * Reader gangs use local snapshot to access catalog, as a result, it will
-	 * not synchronize with the global snapshot from write gang which will lead
-	 * to inconsistent visibilty of catalog table. Considering the case:
-	 * 
-	 * select * from t, t t1; -- create a reader gang.
-	 * begin;
-	 * create role r1;
-	 * set role r1;  -- set command will also dispatched to idle reader gang
-	 *
-	 * When set role command dispatched to reader gang, reader gang cannot see
-	 * the new tuple t1 in catalog table pg_auth.
-	 * To fix this issue, we should drop the idle reader gangs after each
-	 * utility statement which may modify the catalog table.
-	 */
-	ds->destroyIdleReaderGang = true;
-
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
 
 	/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -86,6 +86,7 @@
 #include "utils/snapmgr.h"
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
+#include "utils/sharedsnapshot.h"
 #include "mb/pg_wchar.h"
 
 #include "cdb/cdbutil.h"
@@ -1832,6 +1833,29 @@ exec_simple_query(const char *query_string)
 		{
 			PushActiveSnapshot(GetTransactionSnapshot());
 			snapshot_set = true;
+		}
+		else
+		{
+			if (Gp_is_writer)
+			{
+				/*
+				 * For QE writer, if current query doesn't need a snapshot, then we can make
+				 * sure that all QE writers will not change its transaction state, we can update
+				 * segmateSync safely for QE readers could read snapshot from SharedLocalSnapshot.
+				 */
+				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
+				SharedLocalSnapshotSlot->segmateSync = QEDtxContextInfo.segmateSync;
+				SharedLocalSnapshotSlot->snapshot.curcid = GetCurrentCommandId(false);
+				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+			}
+			else
+			{
+				/*
+				 * For QE reader, we drop current CatalogSnapshot, and fetch one if it needs
+				 * during query execution.
+				 */
+				InvalidateCatalogSnapshot();
+			}
 		}
 
 		/*

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -493,6 +493,8 @@ GetCatalogSnapshot(Oid relid)
 	 */
 	if (HistoricSnapshotActive())
 		return HistoricSnapshot;
+	if (Gp_is_writer)
+		return GetNonHistoricCatalogSnapshot(relid, DTX_CONTEXT_LOCAL_ONLY);
 	return GetNonHistoricCatalogSnapshot(relid, DistributedTransactionContext);
 }
 

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -493,8 +493,7 @@ GetCatalogSnapshot(Oid relid)
 	 */
 	if (HistoricSnapshotActive())
 		return HistoricSnapshot;
-
-	return GetNonHistoricCatalogSnapshot(relid, DTX_CONTEXT_LOCAL_ONLY);
+	return GetNonHistoricCatalogSnapshot(relid, DistributedTransactionContext);
 }
 
 /*

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -50,7 +50,6 @@ typedef struct CdbDispatcherState
 #ifdef USE_ASSERT_CHECKING
 	bool isGangDestroying;
 #endif
-	bool destroyIdleReaderGang;
 } CdbDispatcherState;
 
 typedef struct DispatcherInternalFuncs

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -39,7 +39,6 @@ typedef struct SharedSnapshotSlot
 	/* only used by cursor dump identification, dose not always set */
 	volatile DistributedTransactionId distributedXid;
 
-	volatile bool			ready;
 	volatile uint32			segmateSync;
 	SnapshotData	snapshot;
 	LWLock		   *slotLock;

--- a/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
+++ b/src/test/isolation2/output/pg_basebackup_with_tablespaces.source
@@ -181,7 +181,7 @@ select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace_
 select count_of_items_in_directory('@testtablespace@/some_basebackup_tablespace');
  count_of_items_in_directory 
 -----------------------------
- 6                           
+ 3                           
 (1 row)
 
 -- Then we should have the tablespace symlink link to the mapped tablespace directory

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1575,7 +1575,7 @@ alter table atacc1 drop column value;
 alter table atacc1 add column value int check (value < 10);
 insert into atacc1(value) values (100);
 ERROR:  new row for relation "atacc1" violates check constraint "atacc1_value_check"
-DETAIL:  Failing row contains (21, 100).
+DETAIL:  Failing row contains (2, 100).
 insert into atacc1(id, value) values (null, 0);
 ERROR:  null value in column "id" violates not-null constraint
 DETAIL:  Failing row contains (null, 0).
@@ -3232,19 +3232,19 @@ insert into alter2.t1(f2) values(14);
 select * from alter2.t1;
  f1 | f2 
 ----+----
-  1 | 11
   2 | 12
- 21 | 13
- 22 | 14
+  3 | 13
+  4 | 14
+  1 | 11
 (4 rows)
 
 select * from alter2.v1;
  f1 | f2 
 ----+----
-  1 | 11
   2 | 12
- 21 | 13
- 22 | 14
+  3 | 13
+  4 | 14
+  1 | 11
 (4 rows)
 
 select alter2.plus1(41);

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -604,13 +604,13 @@ create table t_rep2 as select i from generate_series(5, 15) as i group by i havi
 select count(*) from gp_dist_random('t_rep2');
  count 
 -------
-    33
+    27
 (1 row)
 
 select count(distinct i) from gp_dist_random('t_rep2');
  count 
 -------
-    11
+     9
 (1 row)
 
 drop table t_rep2;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -255,11 +255,7 @@ select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
  Success:
  Success:
  Success:
- Success:
- Success:
- Success:
- Success:
-(8 rows)
+(4 rows)
 
 set allow_segment_DML to off;
 --
@@ -299,75 +295,6 @@ NOTICE:  command without clusterwide effect
 HINT:  Consider alternatives as DEALLOCATE ALL, or DISCARD TEMP if a clusterwide effect is desired.
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
 ERROR:  relation "reset_test" already exists  (seg0 127.0.1.1:7002 pid=26153)
-CREATE TABLE guc_gp_t1(i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO guc_gp_t1 VALUES(1),(2);
--- generate an idle redaer gang by the following query
-SELECT count(*) FROM guc_gp_t1, guc_gp_t1 t;
- count 
--------
-     4
-(1 row)
-
--- test create role and set role in the same transaction
-BEGIN;
-DROP ROLE IF EXISTS guc_gp_test_role1;
-NOTICE:  role "guc_gp_test_role1" does not exist, skipping
-CREATE ROLE guc_gp_test_role1;
-SET ROLE guc_gp_test_role1;
-RESET ROLE;
-END;
--- generate an idle redaer gang by the following query
-SELECT count(*) FROM guc_gp_t1, guc_gp_t1 t;
- count 
--------
-     4
-(1 row)
-
-BEGIN ISOLATION LEVEL REPEATABLE READ;
-DROP ROLE IF EXISTS guc_gp_test_role2;
-NOTICE:  role "guc_gp_test_role2" does not exist, skipping
-CREATE ROLE guc_gp_test_role2;
-SET ROLE guc_gp_test_role2;
-RESET ROLE;
-END;
--- test cursor case
--- cursors are also reader gangs, but they are not idle, thus will not be
--- destroyed by utility statement.
-BEGIN;
-DECLARE c1 CURSOR FOR SELECT * FROM guc_gp_t1 a, guc_gp_t1 b order by a.i, b.i;
-DECLARE c2 CURSOR FOR SELECT * FROM guc_gp_t1 a, guc_gp_t1 b order by a.i, b.i;
-FETCH c1;
- i | i 
----+---
- 1 | 1
-(1 row)
-
-DROP ROLE IF EXISTS guc_gp_test_role1;
-CREATE ROLE guc_gp_test_role1;
-SET ROLE guc_gp_test_role1;
-RESET ROLE;
-FETCH c2;
- i | i 
----+---
- 1 | 1
-(1 row)
-
-FETCH c1;
- i | i 
----+---
- 1 | 2
-(1 row)
-
-FETCH c2;
- i | i 
----+---
- 1 | 2
-(1 row)
-
-END;
-DROP TABLE guc_gp_t1;
 -- test for string guc is quoted correctly
 SET search_path = "'";
 SHOW search_path;

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -2195,7 +2195,7 @@ select sp_add_user('user1');
 select sp_add_user('user2');
  sp_add_user 
 -------------
-          21
+           2
 (1 row)
 
 select sp_add_user('user2');
@@ -2207,7 +2207,7 @@ select sp_add_user('user2');
 select sp_add_user('user3');
  sp_add_user 
 -------------
-          22
+           3
 (1 row)
 
 select sp_add_user('user3');

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -1597,10 +1597,10 @@ select insert_tt('fool');
 select * from tt;
  f1 |   data   
 ----+----------
- 22 | foolfool
   1 | foo
   2 | bar
- 21 | fool
+  4 | foolfool
+  3 | fool
 (4 rows)
 
 -- setof does what's expected
@@ -1610,28 +1610,28 @@ language sql;
 select insert_tt2('foolish','barrish');
  insert_tt2 
 ------------
-         41
-         42
+          6
+          5
 (2 rows)
 
 select * from insert_tt2('baz','quux');
  insert_tt2 
 ------------
-         43
-         44
+          7
+          8
 (2 rows)
 
 select * from tt;
  f1 |   data   
 ----+----------
- 22 | foolfool
- 41 | foolish
- 42 | barrish
- 43 | baz
- 44 | quux
   1 | foo
   2 | bar
- 21 | fool
+  7 | baz
+  8 | quux
+  4 | foolfool
+  5 | foolish
+  3 | fool
+  6 | barrish
 (8 rows)
 
 -- limit doesn't prevent execution to completion
@@ -1644,16 +1644,16 @@ select 1 from insert_tt2('foolish','barrish') limit 1;
 select * from tt;
  f1 |   data   
 ----+----------
- 43 | baz
- 44 | quux
- 45 | foolish
- 22 | foolfool
- 41 | foolish
- 42 | barrish
+  4 | foolfool
+  5 | foolish
   1 | foo
   2 | bar
- 21 | fool
- 46 | barrish
+  7 | baz
+  8 | quux
+  9 | foolish
+ 10 | barrish
+  3 | fool
+  6 | barrish
 (10 rows)
 
 -- triggers will fire, too
@@ -1665,8 +1665,8 @@ end $$ language plpgsql;
 create trigger tnoticetrigger after insert on tt for each row
 execute procedure noticetrigger();
 select 1 from insert_tt2('foolme','barme') limit 1;
-NOTICE:  noticetrigger 61 foolme  (seg2 slice1 127.0.1.1:7004 pid=2003065)
-NOTICE:  noticetrigger 62 barme  (seg2 slice1 127.0.1.1:7004 pid=2003065)
+NOTICE:  noticetrigger 11 foolme  (seg0 slice1 127.0.1.1:7002 pid=2626322)
+NOTICE:  noticetrigger 12 barme  (seg0 slice1 127.0.1.1:7002 pid=2626322)
  ?column? 
 ----------
         1
@@ -1675,18 +1675,18 @@ NOTICE:  noticetrigger 62 barme  (seg2 slice1 127.0.1.1:7004 pid=2003065)
 select * from tt;
  f1 |   data   
 ----+----------
- 43 | baz
- 44 | quux
- 45 | foolish
- 22 | foolfool
- 41 | foolish
- 42 | barrish
- 61 | foolme
- 62 | barme
+  3 | fool
+  6 | barrish
+  4 | foolfool
+  5 | foolish
   1 | foo
   2 | bar
- 21 | fool
- 46 | barrish
+  7 | baz
+  8 | quux
+  9 | foolish
+ 10 | barrish
+ 11 | foolme
+ 12 | barme
 (12 rows)
 
 -- and rules work
@@ -1694,31 +1694,31 @@ create temp table tt_log(f1 int, data text);
 create rule insert_tt_rule as on insert to tt do also
   insert into tt_log values(new.*);
 select * from insert_tt2('foollog','barlog');
-NOTICE:  noticetrigger 82 barlog  (seg2 slice1 127.0.1.1:7004 pid=2003065)
-NOTICE:  noticetrigger 81 foollog  (seg1 slice1 127.0.1.1:7003 pid=2003066)
+NOTICE:  noticetrigger 13 foollog  (seg0 slice1 127.0.1.1:7002 pid=2626322)
+NOTICE:  noticetrigger 14 barlog  (seg0 slice1 127.0.1.1:7002 pid=2626322)
  insert_tt2 
 ------------
-         81
-         82
+         13
+         14
 (2 rows)
 
 select * from tt;
  f1 |   data   
 ----+----------
- 43 | baz
- 44 | quux
- 45 | foolish
- 81 | foollog
- 22 | foolfool
- 41 | foolish
- 42 | barrish
- 61 | foolme
- 62 | barme
- 82 | barlog
+  3 | fool
+  6 | barrish
   1 | foo
   2 | bar
- 21 | fool
- 46 | barrish
+  7 | baz
+  8 | quux
+  9 | foolish
+ 10 | barrish
+ 11 | foolme
+ 12 | barme
+ 13 | foollog
+ 14 | barlog
+  4 | foolfool
+  5 | foolish
 (14 rows)
 
 -- note that nextval() gets executed a second time in the rule expansion,
@@ -1726,8 +1726,8 @@ select * from tt;
 select * from tt_log;
  f1 |  data   
 ----+---------
- 83 | foollog
- 84 | barlog
+ 16 | barlog
+ 15 | foollog
 (2 rows)
 
 -- test case for a whole-row-variable bug

--- a/src/test/regress/expected/returning.out
+++ b/src/test/regress/expected/returning.out
@@ -338,7 +338,7 @@ SELECT * FROM voo;
 INSERT INTO foo AS bar DEFAULT VALUES RETURNING *; -- ok
  f1 | f2 | f3 | f4 
 ----+----+----+----
- 21 |    | 42 | 99
+  4 |    | 42 | 99
 (1 row)
 
 INSERT INTO foo AS bar DEFAULT VALUES RETURNING foo.*; -- fails, wrong name
@@ -349,7 +349,7 @@ HINT:  Perhaps you meant to reference the table alias "bar".
 INSERT INTO foo AS bar DEFAULT VALUES RETURNING bar.*; -- ok
  f1 | f2 | f3 | f4 
 ----+----+----+----
- 22 |    | 42 | 99
+  5 |    | 42 | 99
 (1 row)
 
 INSERT INTO foo AS bar DEFAULT VALUES RETURNING bar.f3; -- ok

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -103,8 +103,8 @@ alter table f_star reset (parallel_workers);
 set enable_parallel_append to off;
 explain (costs off)
   select round(avg(aa)), sum(aa) from a_star;
-                     QUERY PLAN                      
------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
@@ -213,8 +213,8 @@ alter table tenk1 set (parallel_workers = 4);
 explain (verbose, costs off)
 select sp_parallel_restricted(unique1) from tenk1
   where stringu1 = 'GRAAAA' order by 1;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: (sp_parallel_restricted(unique1))
    Merge Key: (sp_parallel_restricted(unique1))
@@ -231,7 +231,7 @@ select sp_parallel_restricted(unique1) from tenk1
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
-                         QUERY PLAN
+                         QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -266,7 +266,7 @@ explain (costs off)
                            Group Key: stringu1
                            ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 -- test that parallel plan for aggregates is not selected when
 -- target list contains parallel restricted clause.
@@ -627,7 +627,7 @@ select * from explain_parallel_sort_stats();
                      ->  Seq Scan on tenk1 (actual rows=3386 loops=1)
                            Filter: (ten < 100)
  Optimizer: Postgres query optimizer
-(11 rows)
+(12 rows)
 
 reset enable_indexscan;
 reset enable_hashjoin;
@@ -714,8 +714,8 @@ end;
 $$ language plpgsql PARALLEL SAFE;
 explain (costs off, verbose)
     select ten, sp_simple_func(ten) from tenk1 where ten < 100 order by ten;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: ten, (sp_simple_func(ten))
    Merge Key: ten
@@ -1027,21 +1027,6 @@ SELECT make_record(x) FROM (SELECT generate_series(1, 5) x) ss ORDER BY x;
 
 ROLLBACK TO SAVEPOINT settings;
 DROP function make_record(n int);
--- test the sanity of parallel query after the active role is dropped.
-drop role if exists regress_parallel_worker;
-create role regress_parallel_worker;
-set role regress_parallel_worker;
-reset session authorization;
-drop role regress_parallel_worker;
-set force_parallel_mode = 1;
-select count(*) from tenk1;
- count 
--------
- 10000
-(1 row)
-
-reset force_parallel_mode;
-reset role;
 -- Window function calculation can't be pushed to workers.
 explain (costs off, verbose)
   select count(*) from tenk1 a where (unique1, two) in

--- a/src/test/regress/expected/sequence.out
+++ b/src/test/regress/expected/sequence.out
@@ -264,10 +264,10 @@ INSERT INTO serialTest1 VALUES ('more');
 SELECT * FROM serialTest1;
   f1   | f2  
 -------+-----
+ more  |   3
  foo   |   1
  bar   |   2
  force | 100
- more  |  21
 (4 rows)
 
 --
@@ -511,7 +511,7 @@ WHERE sequencename ~ ANY(ARRAY['sequence_test', 'serialtest'])
  public     | sequence_test7     |           1 |                    1 | 9223372036854775807 |            1 | f     |         20 |           
  public     | sequence_test8     |           1 |                    1 |               20000 |            1 | f     |         20 |           
  public     | sequence_test9     |          -1 |               -32768 |                  -1 |           -1 | f     |         20 |           
- public     | serialtest1_f2_foo |           1 |                    1 |          2147483647 |            1 | f     |         20 |         40
+ public     | serialtest1_f2_foo |           1 |                    1 |          2147483647 |            1 | f     |         20 |         20
  public     | serialtest2_f2_seq |           1 |                    1 |          2147483647 |            1 | f     |         20 |         40
  public     | serialtest2_f3_seq |           1 |                    1 |               32767 |            1 | f     |         20 |         40
  public     | serialtest2_f4_seq |           1 |                    1 |               32767 |            1 | f     |         20 |         40

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -750,15 +750,14 @@ select * from trigtest2;
 -- ensure we still insert, even when all triggers are disabled
 insert into trigtest default values;
 select *  from trigtest;
-  i  
------
-  41
-  81
- 101
-  61
-  21
-  62
-(6 rows)
+ i 
+---
+ 3
+ 4
+ 7
+ 5
+ 6
+(5 rows)
 
 drop table trigtest2;
 drop table trigtest;

--- a/src/test/regress/expected/truncate.out
+++ b/src/test/regress/expected/truncate.out
@@ -358,8 +358,8 @@ INSERT INTO truncate_a DEFAULT VALUES;
 SELECT * FROM truncate_a;
  id | id1 
 ----+-----
- 21 |  35
- 22 |  36
+  3 |  35
+  4 |  36
 (2 rows)
 
 TRUNCATE truncate_a RESTART IDENTITY;
@@ -388,8 +388,8 @@ INSERT INTO truncate_b DEFAULT VALUES;
 SELECT * FROM truncate_b;
  id 
 ----
- 65
- 64
+ 46
+ 47
 (2 rows)
 
 TRUNCATE truncate_b RESTART IDENTITY;
@@ -418,10 +418,10 @@ INSERT INTO truncate_a DEFAULT VALUES;
 SELECT * FROM truncate_a;
  id | id1 
 ----+-----
-  1 |  33
   2 |  34
- 21 |  35
  22 |  36
+ 21 |  35
+  1 |  33
 (4 rows)
 
 DROP TABLE truncate_a;

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1238,13 +1238,13 @@ ALTER VIEW rw_view1 ALTER COLUMN bb SET DEFAULT 'View default';
 INSERT INTO rw_view1 VALUES (4, 'Row 4');
 INSERT INTO rw_view1 (aa) VALUES (5);
 SELECT * FROM base_tbl;
- a |      b       | c  
----+--------------+----
- 2 | Row 2        |  2
- 3 | Unspecified  |  3
- 4 | Row 4        | 21
- 1 | Row 1        |  1
- 5 | View default | 22
+ a |      b       | c 
+---+--------------+---
+ 2 | Row 2        | 2
+ 3 | Unspecified  | 3
+ 4 | Row 4        | 4
+ 1 | Row 1        | 1
+ 5 | View default | 5
 (5 rows)
 
 DROP TABLE base_tbl CASCADE;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -162,9 +162,9 @@ WITH a1 as (select * from tts_foo),
            FROM a1
              INNER JOIN a2 ON a2.i = a1.i
 distributed by(xx);
-NOTICE:  sisc_xslice: Use default tablespace  (seg0 slice1 172.17.0.2:7002 pid=2945819)
-NOTICE:  sisc_xslice: Use default tablespace  (seg1 slice1 172.17.0.2:7003 pid=2945820)
-NOTICE:  sisc_xslice: Use default tablespace  (seg2 slice1 172.17.0.2:7004 pid=2945821)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg1 slice2 127.0.1.1:7003 pid=2879969)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg2 slice2 127.0.1.1:7004 pid=2879973)
+NOTICE:  sisc_xslice: Use temp tablespace  (seg0 slice2 127.0.1.1:7002 pid=2879971)
 -- Make sure the following fault injector is triggered.
 select gp_wait_until_triggered_fault('sisc_xslice_temp_files', 1, dbid)
   from gp_segment_configuration where role='p' and content>=0;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -189,48 +189,6 @@ SELECT * FROM reset_test;
 DISCARD ALL;
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
 
-CREATE TABLE guc_gp_t1(i int);
-INSERT INTO guc_gp_t1 VALUES(1),(2);
-
--- generate an idle redaer gang by the following query
-SELECT count(*) FROM guc_gp_t1, guc_gp_t1 t;
-
--- test create role and set role in the same transaction
-BEGIN;
-DROP ROLE IF EXISTS guc_gp_test_role1;
-CREATE ROLE guc_gp_test_role1;
-SET ROLE guc_gp_test_role1;
-RESET ROLE;
-END;
-
--- generate an idle redaer gang by the following query
-SELECT count(*) FROM guc_gp_t1, guc_gp_t1 t;
-
-BEGIN ISOLATION LEVEL REPEATABLE READ;
-DROP ROLE IF EXISTS guc_gp_test_role2;
-CREATE ROLE guc_gp_test_role2;
-SET ROLE guc_gp_test_role2;
-RESET ROLE;
-END;
-
--- test cursor case
--- cursors are also reader gangs, but they are not idle, thus will not be
--- destroyed by utility statement.
-BEGIN;
-DECLARE c1 CURSOR FOR SELECT * FROM guc_gp_t1 a, guc_gp_t1 b order by a.i, b.i;
-DECLARE c2 CURSOR FOR SELECT * FROM guc_gp_t1 a, guc_gp_t1 b order by a.i, b.i;
-FETCH c1;
-DROP ROLE IF EXISTS guc_gp_test_role1;
-CREATE ROLE guc_gp_test_role1;
-SET ROLE guc_gp_test_role1;
-RESET ROLE;
-FETCH c2;
-FETCH c1;
-FETCH c2;
-END;
-
-DROP TABLE guc_gp_t1;
-
 -- test for string guc is quoted correctly
 SET search_path = "'";
 SHOW search_path;

--- a/src/test/regress/sql/select_parallel.sql
+++ b/src/test/regress/sql/select_parallel.sql
@@ -377,17 +377,6 @@ SELECT make_record(x) FROM (SELECT generate_series(1, 5) x) ss ORDER BY x;
 ROLLBACK TO SAVEPOINT settings;
 DROP function make_record(n int);
 
--- test the sanity of parallel query after the active role is dropped.
-drop role if exists regress_parallel_worker;
-create role regress_parallel_worker;
-set role regress_parallel_worker;
-reset session authorization;
-drop role regress_parallel_worker;
-set force_parallel_mode = 1;
-select count(*) from tenk1;
-reset force_parallel_mode;
-reset role;
-
 -- Window function calculation can't be pushed to workers.
 explain (costs off, verbose)
   select count(*) from tenk1 a where (unique1, two) in


### PR DESCRIPTION
This PR is based on PR #10400, and trying to fix the same issue which has been
fixed by #10456 in a different way.

------

## Problems

```
postgres=# create table t(a int);
postgres=# create table s(a int);

postgres=# select * from t, s;          -- create reader gangs
 a | b | a | b 
---+---+---+---
(0 rows)

postgres=# begin;
postgres=# create role r1;                -- modify catalog 
CREATE ROLE
postgres=# set role r1;
ERROR:  role "r1" does not exist  (seg0 127.0.1.1:6002 pid=2227573)
```

here is the RCA, thanks @kainwen 's comments [RCA](https://github.com/greenplum-db/gpdb/issues/12916#issuecomment-1057949461):

1. Before the begin block, due to gang cache, there are several idle gangs on segments.
2. Then a create role statement comes to seg, and this will only dispatch to writer gang.
3. The reader gang is still idle.
4. The reader gang got the set role command, and finally it will scan the pg_authid catalog 
fetch the tuple, and use MVCC `HeapTupleSatisfiesMVCC` to test visibility.
6. Reader gang never generate transaction id, so `TransactionIdIsCurrentTransactionId`
returns false.
8. And comes to `TransactionIdIsInProgress` test, this hit, thus the tuple cannot be seen
lead to the bug in this issue.

## Resolution

My resolution is quite direct and simple, since the reader gang could not notice what writer
gang has changed, then let reader gang sync distributed snapshot from it when it executes
the SET command.

Generally speaking, we will not grab a snapshot when we execute SET command, as the
the function `PlannedStmtRequiresSnapshot()` did. But in Greenplum, the reader gang
needs to know what writer gang has done, so when the reader gang is executing the SET
command, it should retrieve `CatalogSnapshot` again, this is why this PR update `segmateSync`
in writer gang and invalid catalog snapshot in the reader gang. Only this way the reader
will invoke `readerFillLocalSnapshot()` to sync snapshot from the writer.


------
## Reference

- [Inconsistent visibilty between reader gang and writer gang for 6X ](https://github.com/greenplum-db/gpdb/issues/12916)
- [Idle reader gangs will be destroyed every time, when execute SELECT statement using extended query protocol.](https://github.com/greenplum-db/gpdb/issues/15413)
