### PR TITLE
Fixing column width of partitioned tables

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -751,18 +751,6 @@ gpdb::GetAttStats(Oid relid, AttrNumber attnum)
 	return nullptr;
 }
 
-int32
-gpdb::GetAttAvgWidth(Oid relid, AttrNumber attnum)
-{
-	GP_WRAP_START;
-	{
-		/* catalog tables: pg_statistic */
-		return get_attavgwidth(relid, attnum);
-	}
-	GP_WRAP_END;
-	return 0;
-}
-
 List *
 gpdb::GetExtStats(Relation rel)
 {

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -210,9 +210,6 @@ void FreeAttrStatsSlot(AttStatsSlot *sslot);
 // attribute statistics
 HeapTuple GetAttStats(Oid relid, AttrNumber attnum);
 
-// attribute width
-int32 GetAttAvgWidth(Oid relid, AttrNumber attnum);
-
 List *GetExtStats(Relation rel);
 
 char *GetExtStatsName(Oid statOid);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14499,3 +14499,46 @@ explain select * from baz where baz.a::bpchar='b' or baz.a='c';
 (4 rows)
 
 drop table baz;
+-- While retrieving the columns width in partitioned tables, inherited stats i.e.
+-- stats that cover all the child tables should be used
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+create or replace function check_col_width(query text, operator text, width text) returns int as
+$$
+rv = plpy.execute('EXPLAIN '+ query)
+search_text_1 = operator
+search_text_2 = width
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text_1 in cur_line and search_text_2 in cur_line:
+        result = result+1
+return result
+$$
+language plpython3u;
+create table testPartWidth (a numeric(7,2), b numeric(7,2)) distributed by (a)
+partition by range(a) (start(0.0) end(4.0) every(2.0));
+insert into testPartWidth values (0.001,0.001),(2.123,2.123);
+analyze testPartWidth;
+--------------------------------------------------------------------------------
+-- The below query shows the column width of 'a' and 'b'
+-- select attname,avg_width from pg_stats where tablename='testPartWidth';
+-- attname | avg_width
+-- ---------+-----------
+--  a       |         5
+--  b       |         5
+--------------------------------------------------------------------------------
+select check_col_width('select a from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+ ?column? 
+----------
+ f
+(1 row)
+
+select check_col_width('select b from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+ ?column? 
+----------
+ f
+(1 row)
+
+drop function check_col_width(query text, operator text, width text);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14541,4 +14541,16 @@ select check_col_width('select b from testPartWidth;','Dynamic Seq Scan','width=
  f
 (1 row)
 
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
+ ?column? 
+----------
+ t
+(1 row)
+
 drop function check_col_width(query text, operator text, width text);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14667,4 +14667,20 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
  t
 (1 row)
 
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+ ?column? 
+----------
+ f
+(1 row)
+
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+ ?column? 
+----------
+ f
+(1 row)
+
 drop function check_col_width(query text, operator text, width text);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14621,3 +14621,50 @@ explain select * from baz where baz.a::bpchar='b' or baz.a='c';
 (4 rows)
 
 drop table baz;
+-- While retrieving the columns width in partitioned tables, inherited stats i.e.
+-- stats that cover all the child tables should be used
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+create or replace function check_col_width(query text, operator text, width text) returns int as
+$$
+rv = plpy.execute('EXPLAIN '+ query)
+search_text_1 = operator
+search_text_2 = width
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text_1 in cur_line and search_text_2 in cur_line:
+        result = result+1
+return result
+$$
+language plpython3u;
+create table testPartWidth (a numeric(7,2), b numeric(7,2)) distributed by (a)
+partition by range(a) (start(0.0) end(4.0) every(2.0));
+insert into testPartWidth values (0.001,0.001),(2.123,2.123);
+analyze testPartWidth;
+--------------------------------------------------------------------------------
+-- The below query shows the column width of 'a' and 'b'
+-- select attname,avg_width from pg_stats where tablename='testPartWidth';
+-- attname | avg_width
+-- ---------+-----------
+--  a       |         5
+--  b       |         5
+--------------------------------------------------------------------------------
+select check_col_width('select a from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+ ?column? 
+----------
+ t
+(1 row)
+
+select check_col_width('select b from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+ ?column? 
+----------
+ t
+(1 row)
+
+drop function check_col_width(query text, operator text, width text);

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3510,6 +3510,44 @@ create table baz ( a varchar);
 explain select * from baz where baz.a::bpchar='b' or baz.a='c';
 drop table baz;
 
+-- While retrieving the columns width in partitioned tables, inherited stats i.e.
+-- stats that cover all the child tables should be used
+
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+create or replace function check_col_width(query text, operator text, width text) returns int as
+$$
+rv = plpy.execute('EXPLAIN '+ query)
+search_text_1 = operator
+search_text_2 = width
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text_1 in cur_line and search_text_2 in cur_line:
+        result = result+1
+return result
+$$
+language plpython3u;
+
+create table testPartWidth (a numeric(7,2), b numeric(7,2)) distributed by (a)
+partition by range(a) (start(0.0) end(4.0) every(2.0));
+insert into testPartWidth values (0.001,0.001),(2.123,2.123);
+analyze testPartWidth;
+
+--------------------------------------------------------------------------------
+-- The below query shows the column width of 'a' and 'b'
+-- select attname,avg_width from pg_stats where tablename='testPartWidth';
+-- attname | avg_width
+-- ---------+-----------
+--  a       |         5
+--  b       |         5
+--------------------------------------------------------------------------------
+
+select check_col_width('select a from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+select check_col_width('select b from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+drop function check_col_width(query text, operator text, width text);
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3543,9 +3543,10 @@ analyze testPartWidth;
 --  a       |         5
 --  b       |         5
 --------------------------------------------------------------------------------
-
 select check_col_width('select a from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
 select check_col_width('select b from testPartWidth;','Dynamic Seq Scan','width=5') = 1;
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
+select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
 drop function check_col_width(query text, operator text, width text);
 
 -- start_ignore


### PR DESCRIPTION
In 6X while retrieving the column widths of a partitioned table, inherited stats i.e. stats that cover all the child tables are used. This is done by using method gpdb::GetAttStats. But in 7X the inherited stats are not used. In 7X the method gpdb::GetAttAvgWidth is getting used which generates stats for individual tables and not for inheritance trees. This PR makes the behaviour of 7X similar to 6X by using inherited stats for partitioned tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
