### PR TITLE
Fix PANIC for EXISTS query in planner

### DIFF
--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3657,3 +3657,17 @@ select * from table_left where exists (select 1 from table_right where l1 = r1);
 -- clean up
 drop table table_left;
 drop table table_right;
+-- test cross params of initplan
+-- https://github.com/greenplum-db/gpdb/issues/16268
+create table tmp (a varchar, b varchar, c varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select (SELECT EXISTS
+                 (SELECT
+                  FROM pg_views
+                  WHERE schemaname = a)) from tmp;
+ exists 
+--------
+(0 rows)
+
+drop table tmp;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3743,3 +3743,17 @@ select * from table_left where exists (select 1 from table_right where l1 = r1);
 -- clean up
 drop table table_left;
 drop table table_right;
+-- test cross params of initplan
+-- https://github.com/greenplum-db/gpdb/issues/16268
+create table tmp (a varchar, b varchar, c varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select (SELECT EXISTS
+                 (SELECT
+                  FROM pg_views
+                  WHERE schemaname = a)) from tmp;
+ exists 
+--------
+(0 rows)
+
+drop table tmp;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1396,3 +1396,11 @@ select * from table_left where exists (select 1 from table_right where l1 = r1);
 -- clean up
 drop table table_left;
 drop table table_right;
+-- test cross params of initplan
+-- https://github.com/greenplum-db/gpdb/issues/16268
+create table tmp (a varchar, b varchar, c varchar);
+select (SELECT EXISTS
+                 (SELECT
+                  FROM pg_views
+                  WHERE schemaname = a)) from tmp;
+drop table tmp;


### PR DESCRIPTION
After path refactoring of the planner in 7x, the path is alive instead of plan once one query block is finished. upstream has
considered this in commit https://github.com/postgres/postgres/commit/68fa28f77146653f1fcaa530d2f2f161bf5de479. So  for Greenplum we also need to consider those changes because subplan/initplan also is important for us especially on MPP.
For this issue, we should set splan->extParam as all plan done rather than just one query block done, so we moved 
splan->extParam work to SS_finalize_plan() which stand for all plans done and we try to finish set param job in last step.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
