### PR TITLE
Fix flaky test case vacuum_stats

### DIFF
--- a/src/test/regress/expected/vacuum_stats.out
+++ b/src/test/regress/expected/vacuum_stats.out
@@ -1,3 +1,56 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+NOTICE:  extension "gp_inject_fault" already exists, skipping
+-- Make sure backgroud process dtx recover and FTS is not working
+-- before running the test, because they will create gang, which
+-- will start transaction on segment. And concurrent transacion
+-- will affect the behavior of vacuum, which will result in relallvisible
+-- could be 0.
+--
+-- The following scenario could cuase relallvisible be 0 in segment:
+--   1. CREATE TABLE vacstat_test `start transaction with xid =5`;
+--   2. FTS create gang `start transaction with snapshot's xmin = 5`;
+--   3. CREATE TABLE vacstat_test `commit transacion`;
+--   4. INSERT vacstat_test `start transaction with xid =6`;
+--   5. INSERT vacstat_test `commit`;
+--   6. VACUUM vacstat_test `start transaction with snapshot (xmin=7, xmax=7, xcnt=0)
+--      and current globalxmin = 5`;
+--   7. When computing the `all_visible` in `lazy_scan_heap`, the `all_visible`
+--      will be set to false, since `TransactionIdPrecedes(xmin, OldestXmin)`
+--      (xmin=6, OldestXmin=5) is not true.
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid)
+FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
 CREATE TABLE vacstat_test (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -28,4 +81,18 @@ AND relallvisible =
  t
 (1 row)
 
-DROP TABLE vacstat_test
+DROP TABLE vacstat_test;
+SELECT gp_inject_fault('before_orphaned_check', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('fts_probe', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/sql/vacuum_stats.sql
+++ b/src/test/regress/sql/vacuum_stats.sql
@@ -1,3 +1,38 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Make sure backgroud process dtx recover and FTS is not working
+-- before running the test, because they will create gang, which
+-- will start transaction on segment. And concurrent transacion
+-- will affect the behavior of vacuum, which will result in relallvisible
+-- could be 0.
+--
+-- The following scenario could cuase relallvisible be 0 in segment:
+--   1. CREATE TABLE vacstat_test `start transaction with xid =5`;
+--   2. FTS create gang `start transaction with snapshot's xmin = 5`;
+--   3. CREATE TABLE vacstat_test `commit transacion`;
+--   4. INSERT vacstat_test `start transaction with xid =6`;
+--   5. INSERT vacstat_test `commit`;
+--   6. VACUUM vacstat_test `start transaction with snapshot (xmin=7, xmax=7, xcnt=0)
+--      and current globalxmin = 5`;
+--   7. When computing the `all_visible` in `lazy_scan_heap`, the `all_visible`
+--      will be set to false, since `TransactionIdPrecedes(xmin, OldestXmin)`
+--      (xmin=6, OldestXmin=5) is not true.
+
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_request_fts_probe_scan();
+
+SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid)
+FROM gp_segment_configuration WHERE role='p' AND content=-1;
+
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+FROM gp_segment_configuration WHERE role='p' AND content=-1;
+
+
 CREATE TABLE vacstat_test (a int);
 INSERT INTO vacstat_test SELECT i FROM generate_series(1,10) i ;
 VACUUM vacstat_test;
@@ -19,4 +54,10 @@ AND relallvisible =
     (SELECT SUM(relallvisible) FROM gp_dist_random('pg_class')
      WHERE oid='vacstat_test'::regclass);
 
-DROP TABLE vacstat_test
+DROP TABLE vacstat_test;
+
+SELECT gp_inject_fault('before_orphaned_check', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_inject_fault('fts_probe', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;


### PR DESCRIPTION
During the test, backgroup process like dtx recover and FTS will create gang, which will start transaction on segment. And concurrent transacion will affect the behavior of vacuum (OldestXmin), which will result in that relallvisible could be 0.

In this commit, we make sure that dtx recover and FTS are not working in the test.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
