### PR TITLE
Fix test case explain_format

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -932,7 +932,7 @@ Gather Motion 3:1  (slice1; segments: 3) (actual time=8.948..21.656 rows=10000 l
               Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
 
               ->  Seq Scan on test_src_tbl (actual time=0.015..1.748 rows=16930 loops=1)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 Planning Time: 0.167 ms
   (slice0)    Executor memory: 236K bytes.
 * (slice1)    Executor memory: 657K bytes avg x 3 workers, 722K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
@@ -961,7 +961,7 @@ Gather Motion 3:1  (slice1; segments: 3) (actual time=57.360..82.135 rows=20000 
                     Extra Text: (seg1)   hash table(s): 2; 6772 groups total in 40 batches, 121260 spill partitions; disk usage: 2912KB; chain length 2.1 avg, 6 max; using 3386 of 83968 buckets; total 0 expansions.
 
                     ->  Seq Scan on test_src_tbl (actual time=0.043..3.471 rows=16930 loops=1)
-Optimizer: Postgres query optimizer
+Optimizer: Postgres-based planner
 Planning Time: 0.202 ms
   (slice0)    Executor memory: 205K bytes.
 * (slice1)    Executor memory: 467K bytes avg x 3 workers, 467K bytes max (seg1).  Work_mem: 705K bytes max, 1921K bytes wanted.

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -846,7 +846,7 @@ Gather Motion 3:1  (slice1; segments: 3) (actual time=9.551..21.820 rows=10000 l
               Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 1024KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
 
               ->  Seq Scan on test_src_tbl (actual time=0.020..1.349 rows=16930 loops=1)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 Planning Time: 5.518 ms
   (slice0)    Executor memory: 236K bytes.
 * (slice1)    Executor memory: 709K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
@@ -879,7 +879,7 @@ Gather Motion 3:1  (slice1; segments: 3) (actual time=66.084..124.823 rows=20000
                     Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 1888KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
 
                     ->  Shared Scan (share slice:id 1:0) (actual time=0.009..5.775 rows=16930 loops=1)
-Optimizer: Pivotal Optimizer (GPORCA)
+Optimizer: GPORCA
 Planning Time: 11.209 ms
   (slice0)    Executor memory: 224K bytes.
 * (slice1)    Executor memory: 574K bytes avg x 3 workers, 576K bytes max (seg2).  Work_mem: 353K bytes max, 1137K bytes wanted.


### PR DESCRIPTION
The PR https://github.com/greenplum-db/gpdb/pull/15917/ imported a mistake about mismatch in test case explain_format, which dues to some output string of optimizer in latest code. The fix is simply to update the string.
