### PR TITLE
Sort out isolation_schedule

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3643,7 +3643,7 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 	if (!IS_QUERY_DISPATCHER())
 		return false;
 
-	if (!gp_enable_global_deadlock_detector)
+	if (!gp_enable_global_deadlock_detector && Gp_role != GP_ROLE_UTILITY)
 		return false;
 
 	/*

--- a/src/test/isolation/expected/alter-table-2.out
+++ b/src/test/isolation/expected/alter-table-2.out
@@ -2,6 +2,7 @@ Parsed test spec with 2 sessions
 
 starting permutation: s1a s1b s1c s2a s2b s2c s2d s2e s2f
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2a: BEGIN;
@@ -23,6 +24,7 @@ step s2f: COMMIT;
 
 starting permutation: s1a s1b s2a s1c s2b s2c s2d s2e s2f
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2a: BEGIN;
 step s1c: COMMIT;
@@ -44,6 +46,7 @@ step s2f: COMMIT;
 
 starting permutation: s1a s1b s2a s2b s1c s2c s2d s2e s2f
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2a: BEGIN;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
@@ -65,6 +68,7 @@ step s2f: COMMIT;
 
 starting permutation: s1a s1b s2a s2b s2c s1c s2d s2e s2f
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2a: BEGIN;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
@@ -86,6 +90,7 @@ step s2f: COMMIT;
 
 starting permutation: s1a s1b s2a s2b s2c s2d s1c s2e s2f
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2a: BEGIN;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
@@ -109,6 +114,7 @@ step s2f: COMMIT;
 starting permutation: s1a s2a s1b s1c s2b s2c s2d s2e s2f
 step s1a: BEGIN;
 step s2a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
@@ -130,6 +136,7 @@ step s2f: COMMIT;
 starting permutation: s1a s2a s1b s2b s1c s2c s2d s2e s2f
 step s1a: BEGIN;
 step s2a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -151,6 +158,7 @@ step s2f: COMMIT;
 starting permutation: s1a s2a s1b s2b s2c s1c s2d s2e s2f
 step s1a: BEGIN;
 step s2a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -172,6 +180,7 @@ step s2f: COMMIT;
 starting permutation: s1a s2a s1b s2b s2c s2d s1c s2e s2f
 step s1a: BEGIN;
 step s2a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -200,6 +209,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
@@ -221,6 +231,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -242,6 +253,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -270,6 +282,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2d: INSERT INTO b VALUES (0);
@@ -291,6 +304,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2d: INSERT INTO b VALUES (0); <waiting ...>
 step s1c: COMMIT;
@@ -317,6 +331,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -339,6 +354,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -360,12 +376,14 @@ a_id
 step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
 starting permutation: s2a s1a s1b s1c s2b s2c s2d s2e s2f
 step s2a: BEGIN;
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
@@ -387,6 +405,7 @@ step s2f: COMMIT;
 starting permutation: s2a s1a s1b s2b s1c s2c s2d s2e s2f
 step s2a: BEGIN;
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -408,6 +427,7 @@ step s2f: COMMIT;
 starting permutation: s2a s1a s1b s2b s2c s1c s2d s2e s2f
 step s2a: BEGIN;
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -429,6 +449,7 @@ step s2f: COMMIT;
 starting permutation: s2a s1a s1b s2b s2c s2d s1c s2e s2f
 step s2a: BEGIN;
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2b: SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE;
 i
@@ -457,6 +478,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
@@ -478,6 +500,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -499,6 +522,7 @@ i
 1
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -527,6 +551,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2d: INSERT INTO b VALUES (0);
@@ -548,6 +573,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2d: INSERT INTO b VALUES (0); <waiting ...>
 step s1c: COMMIT;
@@ -574,6 +600,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -596,6 +623,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -617,6 +645,7 @@ a_id
 step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
@@ -629,6 +658,7 @@ i
 (1 row)
 
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
@@ -650,6 +680,7 @@ i
 (1 row)
 
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -671,6 +702,7 @@ i
 (1 row)
 
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2c: SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE;
 a_id
@@ -699,6 +731,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2d: INSERT INTO b VALUES (0);
@@ -720,6 +753,7 @@ a_id
    3
 (1 row)
 
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2d: INSERT INTO b VALUES (0); <waiting ...>
 step s1c: COMMIT;
@@ -746,6 +780,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -768,6 +803,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -789,6 +825,7 @@ a_id
 step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
@@ -807,6 +844,7 @@ a_id
 (1 row)
 
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 step s2d: INSERT INTO b VALUES (0);
@@ -828,6 +866,7 @@ a_id
 (1 row)
 
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s2d: INSERT INTO b VALUES (0); <waiting ...>
 step s1c: COMMIT;
@@ -854,6 +893,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -876,6 +916,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -897,6 +938,7 @@ step s1a: BEGIN;
 step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
@@ -919,6 +961,7 @@ step s1a: BEGIN;
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -941,6 +984,7 @@ step s1a: BEGIN;
 step s2e: INSERT INTO a VALUES (4);
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -962,6 +1006,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s1a: BEGIN;
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
@@ -984,6 +1029,7 @@ step s2e: INSERT INTO a VALUES (4);
 step s1a: BEGIN;
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID; <waiting ...>
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: <... completed>
 step s1c: COMMIT;
 
@@ -1005,6 +1051,7 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s1a: BEGIN;
 step s2f: COMMIT;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;
 
@@ -1026,5 +1073,6 @@ step s2d: INSERT INTO b VALUES (0);
 step s2e: INSERT INTO a VALUES (4);
 step s2f: COMMIT;
 step s1a: BEGIN;
+s1: WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 step s1b: ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) NOT VALID;
 step s1c: COMMIT;

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -26,19 +26,10 @@
 #   4. No sublink and no subquery
 #   5. No set operations (union, intersect, …)
 
-# GPDB_95_MERGE_FIXME: Tests insert-conflict-do-update-3,
-# nowait, nowait-2, nowait-3, nowait-4, nowait-5, skip-locked, skip-locked-2,
-# skip-locked-3, skip-locked-4, tuplelock-conflict, alter-table-2,
-# alter-table-2, create-trigger. If GDD is enabled, it will then take
-# RowExclusiveLock and the tests can probably be enabled back.
 # Additionally, skip-locked-4 uses pg_advisory_lock() which only takes the lock
 # on QD, but it needs to take it on QE segments as well.
 # insert-conflict-do-update-3 related to issue https://github.com/greenplum-db/gpdb/issues/15635
 
-#
-# GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: tuplelock-upgrade-no-deadlock, freeze-the-dead
-# don't pass in normal mode for GPDB as SELECT..FOR SHARE/UPDATE can
-# block each other in gpdb if GDD does not open.
 #
 # GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disable test predicate-lock-hot-tuple, update-conflict-out
 # because Greenplum does not support serializable transactions.
@@ -80,8 +71,8 @@ test: deadlock-soft-2
 #test: fk-partitioned-2
 #test: eval-plan-qual
 #test: eval-plan-qual-trigger
-#test: lock-update-delete
-#test: lock-update-traversal
+test: lock-update-delete
+test: lock-update-traversal
 test: inherit-temp
 test: temp-schema-cleanup
 test: insert-conflict-do-nothing
@@ -92,33 +83,33 @@ test: insert-conflict-do-update-2
 test: insert-conflict-toast
 test: insert-conflict-specconflict
 test: delete-abort-savept
-#test: delete-abort-savept-2
-#test: aborted-keyrevoke
-#test: multixact-no-deadlock
-#test: multixact-no-forget
-#test: lock-committed-update
-#test: lock-committed-keyupdate
+test: delete-abort-savept-2
+test: aborted-keyrevoke
+test: multixact-no-deadlock
+test: multixact-no-forget
+test: lock-committed-update
+test: lock-committed-keyupdate
 test: update-locked-tuple
 #test: reindex-concurrently
 #test: propagate-lock-delete
-#test: tuplelock-conflict
+test: tuplelock-conflict
 #test: tuplelock-update
-#test: tuplelock-upgrade-no-deadlock
+test: tuplelock-upgrade-no-deadlock
 #test: tuplelock-partition
-#test: freeze-the-dead
-#test: nowait
-#test: nowait-2
-#test: nowait-3
-#test: nowait-4
-#test: nowait-5
-#test: skip-locked
-#test: skip-locked-2
-#test: skip-locked-3
-#test: skip-locked-4
+test: freeze-the-dead
+test: nowait
+test: nowait-2
+test: nowait-3
+test: nowait-4
+test: nowait-5
+test: skip-locked
+test: skip-locked-2
+test: skip-locked-3
+test: skip-locked-4
 test: drop-index-concurrently-1
 #test: multiple-cic
 test: alter-table-1
-#test: alter-table-2
+test: alter-table-2
 #test: alter-table-3
 #test: alter-table-4
 #test: create-trigger

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -1,45 +1,39 @@
-# GPDB_91_MERGE_FIXME: GPDB acquires ExclusiveLock for update and delete SQL
-# statements.  This invalidates most of the isolation tests from upstream below.
-# E.g. an UPDATE step executed by isolationtester never returns because another
-# session run in the same permutation holds ExclusiveLock that blocks the step.
-# GPDB_94_MERGE_FIXME: Since the introduction of Global Deadlock Detector, an
-# UPDATE/DELETE no longer acquires ExclusiveLock. So we could perhaps enable
-# some of these now. 
-# A GUC gp_enable_global_deadlock_detector is introduced to control GDD.
-# When GDD is enabled, update|delete on heap tables will lock the table in
-# RowExclusiveLock mode. Otherwise, it locks the whole table in ExlusiveLock mode.
-# By default, GDD is set distabled and most the cases are tested under this
-# condition.
-# Greenplum's logic for Select-Statement with locking clause (for update|no key update|share|key share)
-# is different from upstream:
-#   - For all kinds of select-statement with locking clause, Greenplum locks the entire table in ExclusiveLock
-#   mode, and does not generate LockRows plannode in the plan.
-#   - For very simple cases (defined below), Greenplum behaves just like Postgres:
-#     1. Hold RowShareLock on the table
-#     2. Generate LockRows plannode in the plan
-#     3. Lock tuples during executing
-
-# Simple cases should meet all the following conditions:
-#   1. GDD(global deadlock detector) is enabled
-#   2. Top level select statements with locking clause
-#   3. FromList in the parse tree contains and only contains one rangeVar
-#   4. No sublink and no subquery
-#   5. No set operations (union, intersect, …)
-
-# Additionally, skip-locked-4 uses pg_advisory_lock() which only takes the lock
-# on QD, but it needs to take it on QE segments as well.
-# insert-conflict-do-update-3 related to issue https://github.com/greenplum-db/gpdb/issues/15635
-
-#
-# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disable test predicate-lock-hot-tuple, update-conflict-out
-# because Greenplum does not support serializable transactions.
-#
 #############################################################
 #
 # IMPORTANT: Isolation tests are run with gp_role=utility
 # currently in GPDB. Refer isolation_init()
 #
+# Global deadlock detector (gp_enable_global_deadlock_detector)
+# is default to OFF currently. Enable it when we enable these
+# tests in non-utility mode.
+#
 #############################################################
+
+# GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: disabled these tests because Greenplum
+# does not enforce foreign key constraints:
+# fk-contention, fk-partitioned-1, fk-partitioned-2, propagate-lock-delete
+#
+# GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: disabled these tests because Greenplum
+# does not support statement trigger:
+# alter-table-3, create-trigger
+#
+# GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: disabled these tests because Greenplum
+# does not support CREATE INDEX CONCURRENTLY or REINDEX CONCURRENTLY:
+# reindex-concurrently, multiple-cic
+#
+# GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: disabled these tests because Greenplum
+# does not support serializable transactions:
+# read-only-anomaly-2, read-only-anomaly-3, read-write-unique, read-write-unique-2,
+# read-write-unique-3, read-write-unique-4, simple-write-skew, receipt-report, 
+# temporal-range-integrity, project-manager, classroom-scheduling, total-cash, 
+# referential-integrity, ri-trigger, partial-index, two-ids, multiple-row-versions,
+# index-only-scan, predicate-lock-hot-tuple, update-conflict-out, predicate-hash,
+# predicate-gist, predicate-gin, serializable-parallel, serializable-parallel-2,
+# prepared-transactions
+#
+# XXX: these tests are failed due to unknown reasons: eval-plan-qual, tuplelock-update,
+# tuplelock-partition, alter-table-4
+#
 
 test: read-only-anomaly
 #test: read-only-anomaly-2
@@ -65,12 +59,12 @@ test: deadlock-hard
 test: deadlock-soft
 test: deadlock-soft-2
 #test: fk-contention
-#test: fk-deadlock
-#test: fk-deadlock2
+test: fk-deadlock
+test: fk-deadlock2
 #test: fk-partitioned-1
 #test: fk-partitioned-2
 #test: eval-plan-qual
-#test: eval-plan-qual-trigger
+test: eval-plan-qual-trigger
 test: lock-update-delete
 test: lock-update-traversal
 test: inherit-temp
@@ -79,6 +73,7 @@ test: insert-conflict-do-nothing
 test: insert-conflict-do-nothing-2
 test: insert-conflict-do-update
 test: insert-conflict-do-update-2
+# insert-conflict-do-update-3 is disabled related to issue https://github.com/greenplum-db/gpdb/issues/15635
 #test: insert-conflict-do-update-3
 test: insert-conflict-toast
 test: insert-conflict-specconflict

--- a/src/test/isolation/specs/aborted-keyrevoke.spec
+++ b/src/test/isolation/specs/aborted-keyrevoke.spec
@@ -1,6 +1,9 @@
 # When a tuple that has been updated is locked, the locking command
 # should traverse the update chain; thus, a DELETE should not be able
 # to proceed until the lock has been released.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -18,7 +21,7 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1s	{ SAVEPOINT f; }
 step s1u	{ UPDATE foo SET key = 2; }	# obtain KEY REVOKE
 step s1r	{ ROLLBACK TO f; } # lose KEY REVOKE
@@ -26,7 +29,7 @@ step s1l	{ SELECT * FROM foo FOR KEY SHARE; }
 step s1c	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2l	{ SELECT * FROM foo FOR KEY SHARE; }
 step s2c	{ COMMIT; }
 

--- a/src/test/isolation/specs/alter-table-2.spec
+++ b/src/test/isolation/specs/alter-table-2.spec
@@ -2,6 +2,8 @@
 #
 # ADD CONSTRAINT uses ShareRowExclusiveLock so we mix writes with it
 # to see what works or waits.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -22,6 +24,7 @@ step s1b { ALTER TABLE b ADD CONSTRAINT bfk FOREIGN KEY (a_id) REFERENCES a (i) 
 step s1c { COMMIT; }
 
 session s2
+setup { SET optimizer=off; }
 step s2a { BEGIN; }
 step s2b { SELECT * FROM a WHERE i = 1 LIMIT 1 FOR UPDATE; }
 step s2c { SELECT * FROM b WHERE a_id = 3 LIMIT 1 FOR UPDATE; }

--- a/src/test/isolation/specs/delete-abort-savept-2.spec
+++ b/src/test/isolation/specs/delete-abort-savept-2.spec
@@ -1,4 +1,6 @@
 # A funkier version of delete-abort-savept
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 setup
 {
   CREATE TABLE foo (
@@ -15,7 +17,7 @@ teardown
 }
 
 session s1
-setup			{ BEGIN; }
+setup			{ SET optimizer=off; BEGIN; }
 step s1l		{ SELECT * FROM foo FOR KEY SHARE; }
 step s1svp		{ SAVEPOINT f; }
 step s1d		{ SELECT * FROM foo FOR NO KEY UPDATE; }
@@ -23,7 +25,7 @@ step s1r		{ ROLLBACK TO f; }
 step s1c		{ COMMIT; }
 
 session s2
-setup			{ BEGIN; }
+setup			{ SET optimizer=off; BEGIN; }
 step s2l		{ SELECT * FROM foo FOR UPDATE; }
 step s2l2		{ SELECT * FROM foo FOR NO KEY UPDATE; }
 step s2c		{ COMMIT; }

--- a/src/test/isolation/specs/freeze-the-dead.spec
+++ b/src/test/isolation/specs/freeze-the-dead.spec
@@ -1,5 +1,8 @@
 # Test for interactions of tuple freezing with dead, as well as recently-dead
 # tuples using multixacts via FOR KEY SHARE.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 setup
 {
   CREATE TABLE tab_freeze (
@@ -29,12 +32,14 @@ step s1_selectone	{
 step s1_selectall	{ SELECT * FROM tab_freeze ORDER BY name, id; }
 
 session s2
+setup { SET optimizer=off; }
 step s2_begin		{ BEGIN; }
 step s2_key_share	{ SELECT id FROM tab_freeze WHERE id = 3 FOR KEY SHARE; }
 step s2_commit		{ COMMIT; }
 step s2_vacuum		{ VACUUM FREEZE tab_freeze; }
 
 session s3
+setup { SET optimizer=off; }
 step s3_begin		{ BEGIN; }
 step s3_key_share	{ SELECT id FROM tab_freeze WHERE id = 3 FOR KEY SHARE; }
 step s3_commit		{ COMMIT; }

--- a/src/test/isolation/specs/lock-committed-keyupdate.spec
+++ b/src/test/isolation/specs/lock-committed-keyupdate.spec
@@ -4,6 +4,9 @@
 #
 # Some of the permutations are commented out that work fine in the
 # lock-committed-update test, because in this case the update blocks.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -28,6 +31,7 @@ step s1c      { COMMIT; }
 teardown      { SELECT pg_advisory_unlock_all(); }
 
 session s2
+setup { SET optimizer=off; }
 step s2b1     { BEGIN ISOLATION LEVEL READ COMMITTED; }
 step s2b2     { BEGIN ISOLATION LEVEL REPEATABLE READ; }
 step s2b3     { BEGIN ISOLATION LEVEL SERIALIZABLE; }

--- a/src/test/isolation/specs/lock-committed-update.spec
+++ b/src/test/isolation/specs/lock-committed-update.spec
@@ -1,6 +1,9 @@
 # Test locking of a tuple with a committed update.  When the lock does not
 # conflict with the update, no blocking and no serializability errors should
 # occur.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -24,6 +27,7 @@ step s1c    { COMMIT; }
 teardown      { SELECT pg_advisory_unlock_all(); }
 
 session s2
+setup { SET optimizer=off; }
 step s2b1    { BEGIN ISOLATION LEVEL READ COMMITTED; }
 step s2b2    { BEGIN ISOLATION LEVEL REPEATABLE READ; }
 step s2b3    { BEGIN ISOLATION LEVEL SERIALIZABLE; }

--- a/src/test/isolation/specs/lock-update-delete.spec
+++ b/src/test/isolation/specs/lock-update-delete.spec
@@ -14,6 +14,9 @@
 # We use an advisory lock (which is locked during s1's setup) to let s2 obtain
 # its snapshot early and only allow it to actually traverse the update chain
 # when s1 is done creating it.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -32,6 +35,7 @@ teardown
 }
 
 session s1
+setup { SET optimizer=off; }
 # obtain lock on the tuple, traversing its update chain
 step s1l	{ SELECT * FROM foo WHERE pg_advisory_xact_lock(0) IS NOT NULL AND key = 1 FOR KEY SHARE; }
 

--- a/src/test/isolation/specs/lock-update-traversal.spec
+++ b/src/test/isolation/specs/lock-update-traversal.spec
@@ -3,6 +3,9 @@
 # should not be able to proceed until the lock has been released.  An UPDATE
 # that changes the key should not be allowed to continue either; but an UPDATE
 # that doesn't modify the key should be able to continue immediately.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -21,6 +24,7 @@ teardown
 }
 
 session s1
+setup 		{ SET optimizer=off; }
 step s1b	{ BEGIN ISOLATION LEVEL REPEATABLE READ; }
 step s1s	{ SELECT * FROM foo; }	# obtain snapshot
 step s1l	{ SELECT * FROM foo FOR KEY SHARE; } # obtain lock

--- a/src/test/isolation/specs/multixact-no-deadlock.spec
+++ b/src/test/isolation/specs/multixact-no-deadlock.spec
@@ -1,6 +1,9 @@
 # If we already hold a lock of a given strength, do not deadlock when
 # some other transaction is waiting for a conflicting lock and we try
 # to acquire the same lock we already held.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 setup
 {
   CREATE TABLE justthis (
@@ -16,19 +19,19 @@ teardown
 }
 
 session s1
-setup			{ BEGIN; }
+setup			{ SET optimizer=off; BEGIN; }
 step s1lock		{ SELECT * FROM justthis FOR SHARE; }
 step s1svpt		{ SAVEPOINT foo; }
 step s1lock2	{ SELECT * FROM justthis FOR SHARE; }
 step s1c		{ COMMIT; }
 
 session s2
-setup			{ BEGIN; }
+setup			{ SET optimizer=off; BEGIN; }
 step s2lock		{ SELECT * FROM justthis FOR SHARE; }	# ensure it's a multi
 step s2c		{ COMMIT; }
 
 session s3
-setup			{ BEGIN; }
+setup			{ SET optimizer=off; BEGIN; }
 step s3lock		{ SELECT * FROM justthis FOR UPDATE; }
 step s3c		{ COMMIT; }
 

--- a/src/test/isolation/specs/nowait-2.spec
+++ b/src/test/isolation/specs/nowait-2.spec
@@ -1,4 +1,6 @@
 # Test NOWAIT with multixact locks.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -15,12 +17,12 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=false; BEGIN; }
 step s1a	{ SELECT * FROM foo FOR SHARE NOWAIT; }
 step s1b	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=false; BEGIN; }
 step s2a	{ SELECT * FROM foo FOR SHARE NOWAIT; }
 step s2b	{ SELECT * FROM foo FOR UPDATE NOWAIT; }
 step s2c	{ COMMIT; }

--- a/src/test/isolation/specs/nowait-3.spec
+++ b/src/test/isolation/specs/nowait-3.spec
@@ -1,4 +1,6 @@
 # Test NOWAIT with tuple locks.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -15,17 +17,17 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM foo FOR UPDATE; }
 step s1b	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2a	{ SELECT * FROM foo FOR UPDATE; }
 step s2b	{ COMMIT; }
 
 session s3
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s3a	{ SELECT * FROM foo FOR UPDATE NOWAIT; }
 step s3b	{ COMMIT; }
 

--- a/src/test/isolation/specs/nowait-4.spec
+++ b/src/test/isolation/specs/nowait-4.spec
@@ -1,4 +1,6 @@
 # Test NOWAIT with an updated tuple chain.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -15,7 +17,7 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM foo WHERE pg_advisory_lock(0) IS NOT NULL FOR UPDATE NOWAIT; }
 step s1b	{ COMMIT; }
 

--- a/src/test/isolation/specs/nowait-5.spec
+++ b/src/test/isolation/specs/nowait-5.spec
@@ -1,4 +1,6 @@
 # Test NOWAIT on an updated tuple chain
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -19,6 +21,7 @@ teardown
 }
 
 session sl1
+setup { SET optimizer=off; }
 step sl1_prep {
 	PREPARE sl1_run AS SELECT id FROM test_nowait WHERE pg_advisory_lock(0) is not null FOR UPDATE NOWAIT;
 }
@@ -46,6 +49,7 @@ step upd_releaselock {
 
 # A session that acquires locks that sl1 is supposed to avoid blocking on
 session lk1
+setup { SET optimizer=off; }
 step lk1_doforshare {
 	BEGIN ISOLATION LEVEL READ COMMITTED;
 	SELECT id FROM test_nowait WHERE id % 2 = 0 FOR SHARE;

--- a/src/test/isolation/specs/nowait.spec
+++ b/src/test/isolation/specs/nowait.spec
@@ -1,4 +1,6 @@
 # Test NOWAIT when regular row locks can't be acquired.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -15,11 +17,11 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM foo FOR UPDATE NOWAIT; }
 step s1b	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2a	{ SELECT * FROM foo FOR UPDATE NOWAIT; }
 step s2b	{ COMMIT; }

--- a/src/test/isolation/specs/skip-locked-2.spec
+++ b/src/test/isolation/specs/skip-locked-2.spec
@@ -1,4 +1,6 @@
 # Test SKIP LOCKED with multixact locks.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -16,12 +18,12 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM queue ORDER BY id FOR SHARE SKIP LOCKED LIMIT 1; }
 step s1b	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2a	{ SELECT * FROM queue ORDER BY id FOR SHARE SKIP LOCKED LIMIT 1; }
 step s2b	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s2c	{ COMMIT; }

--- a/src/test/isolation/specs/skip-locked-3.spec
+++ b/src/test/isolation/specs/skip-locked-3.spec
@@ -1,4 +1,6 @@
 # Test SKIP LOCKED with tuple locks.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -16,17 +18,17 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM queue ORDER BY id FOR UPDATE LIMIT 1; }
 step s1b	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2a	{ SELECT * FROM queue ORDER BY id FOR UPDATE LIMIT 1; }
 step s2b	{ COMMIT; }
 
 session s3
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s3a	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s3b	{ COMMIT; }
 

--- a/src/test/isolation/specs/skip-locked-4.spec
+++ b/src/test/isolation/specs/skip-locked-4.spec
@@ -1,4 +1,6 @@
 # Test SKIP LOCKED with an updated tuple chain.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -15,7 +17,7 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM foo WHERE pg_advisory_lock(0) IS NOT NULL ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED; }
 step s1b	{ COMMIT; }
 

--- a/src/test/isolation/specs/skip-locked.spec
+++ b/src/test/isolation/specs/skip-locked.spec
@@ -1,4 +1,6 @@
 # Test SKIP LOCKED when regular row locks can't be acquired.
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -16,13 +18,13 @@ teardown
 }
 
 session s1
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s1a	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s1b	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s1c	{ COMMIT; }
 
 session s2
-setup		{ BEGIN; }
+setup		{ SET optimizer=off; BEGIN; }
 step s2a	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s2b	{ SELECT * FROM queue ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1; }
 step s2c	{ COMMIT; }

--- a/src/test/isolation/specs/tuplelock-conflict.spec
+++ b/src/test/isolation/specs/tuplelock-conflict.spec
@@ -1,5 +1,8 @@
 # Here we verify that tuple lock levels conform to their documented
 # conflict tables.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup {
 	DROP TABLE IF EXISTS multixact_conflict;
@@ -12,6 +15,7 @@ teardown {
 }
 
 session s1
+setup { SET optimizer=off; }
 step s1_begin { BEGIN; }
 step s1_lcksvpt { SELECT * FROM multixact_conflict FOR KEY SHARE; SAVEPOINT foo; }
 step s1_tuplock1 { SELECT * FROM multixact_conflict FOR KEY SHARE; }
@@ -21,6 +25,7 @@ step s1_tuplock4 { SELECT * FROM multixact_conflict FOR UPDATE; }
 step s1_commit { COMMIT; }
 
 session s2
+setup { SET optimizer=off; }
 step s2_tuplock1 { SELECT * FROM multixact_conflict FOR KEY SHARE; }
 step s2_tuplock2 { SELECT * FROM multixact_conflict FOR SHARE; }
 step s2_tuplock3 { SELECT * FROM multixact_conflict FOR NO KEY UPDATE; }

--- a/src/test/isolation/specs/tuplelock-upgrade-no-deadlock.spec
+++ b/src/test/isolation/specs/tuplelock-upgrade-no-deadlock.spec
@@ -1,6 +1,9 @@
 # This test checks that multiple sessions locking a single row in a table
 # do not deadlock each other when one of them upgrades its existing lock
 # while the others are waiting for it.
+#
+# GPDB: have to run sessions that have SELECT ... FOR ... w/ planner because 
+# ORCA would upgrade lock to ExclusiveLock.
 
 setup
 {
@@ -17,12 +20,13 @@ teardown
 }
 
 session s0
+setup { SET optimizer=off; }
 step s0_begin { begin; }
 step s0_keyshare { select id from tlu_job where id = 1 for key share;}
 step s0_rollback { rollback; }
 
 session s1
-setup { begin; }
+setup { SET optimizer=off; begin; }
 step s1_keyshare { select id from tlu_job where id = 1 for key share;}
 step s1_share { select id from tlu_job where id = 1 for share; }
 step s1_fornokeyupd { select id from tlu_job where id = 1 for no key update; }
@@ -35,7 +39,7 @@ step s1_rollback { rollback; }
 step s1_commit { commit; }
 
 session s2
-setup { begin; }
+setup { SET optimizer=off; begin; }
 step s2_for_keyshare { select id from tlu_job where id = 1 for key share; }
 step s2_fornokeyupd { select id from tlu_job where id = 1 for no key update; }
 step s2_for_update { select id from tlu_job where id = 1 for update; }
@@ -44,7 +48,7 @@ step s2_delete { delete from tlu_job where id = 1; }
 step s2_rollback { rollback; }
 
 session s3
-setup { begin; }
+setup { SET optimizer=off; begin; }
 step s3_keyshare { select id from tlu_job where id = 1 for key share; }
 step s3_share { select id from tlu_job where id = 1 for share; }
 step s3_for_update { select id from tlu_job where id = 1 for update; }


### PR DESCRIPTION
Currently the isolation_schedule is quite messy as it contains too many FIXMEs and has too many tests disabled w/o a reason. This PR tries to sort them out. It mainly includes two changes:
1. Fixed an issue with upgrading lock for SELECT under utility mode on coordinator. With that, enable tests that can be enabled now, and remove FIXMEs;
```
In https://github.com/greenplum-db/gpdb/commit/6ebce73331773d7cf71cfd109d1d7617453c738e 
we allow that when the right conditions meet, we do not upgrade
lock for a SELECT statement.

This commit fixes a corner case with utility mode: when we are connecting the
coordinator in utility mode, and when we do not enable global deadlock detector
(GDD) but all the other conditions meet, we should not need to upgrade lock as
well because we are not going to acquire any locks on the segments, so we will
not cause any global deadlock. In fact utility mode on any segment seems won't
cause global deaklock, but we are making a conservative change here to meet our
current need: we can now allow many isolation tests to be run w/o GDD. Note
that we still need to turn off optimizer for them to be run, so add test cases to
do that and reset it back after those tests are done.
```
2. Went over all tests in isolation suite. Add comments for tests failed reasons (if known). Enable tests if we can. Remove more FIXMEs.
Failed tests summarized here:
```
# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disabled these tests because Greenplum
# does not enforce foreign key constraints:
# fk-contention, fk-partitioned-1, fk-partitioned-2, propagate-lock-delete
#
# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disabled these tests because Greenplum
# does not support statement trigger:
# alter-table-3, create-trigger
#
# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disabled these tests because Greenplum
# does not support CREATE INDEX CONCURRENTLY or REINDEX CONCURRENTLY:
# reindex-concurrently, multiple-cic
#
# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disabled these tests because Greenplum
# does not support serializable transactions:
# read-only-anomaly-2, read-only-anomaly-3, read-write-unique, read-write-unique-2,
# read-write-unique-3, read-write-unique-4, simple-write-skew, receipt-report, 
# temporal-range-integrity, project-manager, classroom-scheduling, total-cash, 
# referential-integrity, ri-trigger, partial-index, two-ids, multiple-row-versions,
# index-only-scan, predicate-lock-hot-tuple, update-conflict-out, predicate-hash,
# predicate-gist, predicate-gin, serializable-parallel, serializable-parallel-2,
# prepared-transactions
#
# XXX: these tests are failed due to unknown reasons: eval-plan-qual, tuplelock-update,
# tuplelock-partition, alter-table-4
```

Note that, however, currently all isolation tests are run in utility mode, which probably isn't ideal. We should enable them in normal mode someday, and once we do that, we need to turn on GDD which is not very easy in isolation framework because it needs server restart, so some facility needs to be added to support that.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fixme-isolatoin-test

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
