### PR TITLE
Optimize string length checks in Orca

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
@@ -53,9 +53,6 @@ protected:
 	// whether string owns its memory and should take care of deallocating it at destruction time
 	BOOL m_owns_memory;
 
-	// checks whether the string is byte-wise equal to a given string literal
-	virtual BOOL Equals(const WCHAR *w_str_buffer) const;
-
 public:
 	CWStringBase(const CWStringBase &) = delete;
 

--- a/src/backend/gporca/libgpos/src/string/CWStringBase.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringBase.cpp
@@ -89,28 +89,8 @@ BOOL
 CWStringBase::Equals(const CWStringBase *str) const
 {
 	GPOS_ASSERT(nullptr != str);
-	return Equals(str->GetBuffer());
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CWStringBase::Equals
-//
-//	@doc:
-//		Checks whether the string is byte-wise equal to a string literal
-//
-//---------------------------------------------------------------------------
-BOOL
-CWStringBase::Equals(const WCHAR *w_str_buffer) const
-{
-	GPOS_ASSERT(nullptr != w_str_buffer);
-	ULONG length = GPOS_WSZ_LENGTH(w_str_buffer);
-	if (Length() == length &&
-		0 == clib::Wcsncmp(GetBuffer(), w_str_buffer, length))
-	{
-		return true;
-	}
-	return false;
+	return Length() == str->Length() &&
+		   0 == clib::Wcsncmp(GetBuffer(), str->GetBuffer(), Length());
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
@@ -124,8 +124,8 @@ BOOL
 CWStringConst::Equals(const CWStringConst *string1,
 					  const CWStringConst *string2)
 {
-	ULONG length = GPOS_WSZ_LENGTH(string1->GetBuffer());
-	return length == GPOS_WSZ_LENGTH(string2->GetBuffer()) &&
+	ULONG length = string1->Length();
+	return length == string2->Length() &&
 		   0 == clib::Wcsncmp(string1->GetBuffer(), string2->GetBuffer(),
 							  length);
 }
@@ -134,9 +134,8 @@ CWStringConst::Equals(const CWStringConst *string1,
 ULONG
 CWStringConst::HashValue(const CWStringConst *string)
 {
-	return gpos::HashByteArray(
-		(BYTE *) string->GetBuffer(),
-		GPOS_WSZ_LENGTH(string->GetBuffer()) * GPOS_SIZEOF(WCHAR));
+	return gpos::HashByteArray((BYTE *) string->GetBuffer(),
+							   string->Length() * GPOS_SIZEOF(WCHAR));
 }
 
 // checks whether the string is byte-wise equal to another string
@@ -144,6 +143,8 @@ BOOL
 CWStringConst::Equals(const CWStringBase *str) const
 {
 	GPOS_ASSERT(nullptr != str);
-	return CWStringBase::Equals(str->GetBuffer());
+	GPOS_ASSERT(nullptr != str);
+	return Length() == str->Length() &&
+		   0 == clib::Wcsncmp(GetBuffer(), str->GetBuffer(), Length());
 }
 // EOF


### PR DESCRIPTION
Previously, we would use GPOS_WSZ_LENGTH, which is just a wrapper around gpos::clib::Wcslen(x), which checks the length by iterating over the string. We already store the string length within the string, so we should use that instead. This shaves off ~8% of optimization time in my tests when the relcache is populated.