### PR TITLE
Refactor the external table's ftoptions

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -32,7 +32,7 @@ NOTICE:  foreign table "exttabtest_r" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', database 'greenplum', foo 'bar', format_type 't', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', database 'greenplum', foo 'bar', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     \d exttabtest_w
                    Foreign table "exttableext.exttabtest_w"
@@ -42,7 +42,7 @@ FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', databas
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (id)
 
     -- write to WET
@@ -696,7 +696,7 @@ NOTICE:  protocol "demoprot" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     select count(*) from pg_class where relname = 'exttabtest_r_newname';
  count 
@@ -864,7 +864,7 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (id)
 
     \d format_r
@@ -875,7 +875,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     -- Write to WET
     SELECT * FROM clean_exttabtest_files;
@@ -932,7 +932,7 @@ select max(cnt) - min(cnt)  > 20 from t;
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (id)
 
     \d format_r
@@ -943,7 +943,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     -- Write to WET, should fail
     SELECT * FROM clean_exttabtest_files;
@@ -1033,7 +1033,7 @@ NOTICE:  foreign table "format_r_s2" does not exist, skipping
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (id)
 
     \d format_w_s2
@@ -1044,7 +1044,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (id)
 
     \d format_r_s1
@@ -1055,7 +1055,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     \d format_r_s2
                     Foreign table "exttableext.format_r_s2"
@@ -1065,7 +1065,7 @@ FDW options: (formatter 'formatter_import_s', format 'custom', format_type 'b', 
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', format_type 'b', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     -- Write to WET    
     INSERT INTO format_w_s1 (SELECT * FROM formatsource);
@@ -1606,7 +1606,7 @@ NOTICE:  foreign table "exttabtest_r" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
     -- Create a new ext table using the new protocol name
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w_new;

--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -32,7 +32,7 @@ NOTICE:  foreign table "exttabtest_r" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', database 'greenplum', foo 'bar', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', database 'greenplum', foo 'bar', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     \d exttabtest_w
                    Foreign table "exttableext.exttabtest_w"
@@ -42,7 +42,7 @@ FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', databas
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (id)
 
     -- write to WET
@@ -696,7 +696,7 @@ NOTICE:  protocol "demoprot" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     select count(*) from pg_class where relname = 'exttabtest_r_newname';
  count 
@@ -864,7 +864,7 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (id)
 
     \d format_r
@@ -875,7 +875,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     -- Write to WET
     SELECT * FROM clean_exttabtest_files;
@@ -932,7 +932,7 @@ select max(cnt) - min(cnt)  > 20 from t;
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (id)
 
     \d format_r
@@ -943,7 +943,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test63', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     -- Write to WET, should fail
     SELECT * FROM clean_exttabtest_files;
@@ -1033,7 +1033,7 @@ NOTICE:  foreign table "format_r_s2" does not exist, skipping
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (id)
 
     \d format_w_s2
@@ -1044,7 +1044,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (formatter 'formatter_export_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (id)
 
     \d format_r_s1
@@ -1055,7 +1055,7 @@ Distributed by: (id)
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     \d format_r_s2
                     Foreign table "exttableext.format_r_s2"
@@ -1065,7 +1065,7 @@ FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'de
  id     | double precision      |           |          |         | 
  value1 | double precision      |           |          |         | 
  value2 | double precision      |           |          |         | 
-FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'formatter_import_s', format 'custom', location_uris 'demoprot://exttabtest_test67_s2', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     -- Write to WET    
     INSERT INTO format_w_s1 (SELECT * FROM formatsource);
@@ -1606,7 +1606,7 @@ NOTICE:  foreign table "exttabtest_r" does not exist, skipping
  name   | character varying(20) |           |          |         | 
  value1 | integer               |           |          |         | 
  value2 | integer               |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'demoprot://exttabtest.txt', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
     -- Create a new ext table using the new protocol name
     DROP EXTERNAL TABLE IF EXISTS exttabtest_w_new;

--- a/contrib/formatter_fixedwidth/output/readable_query02.source
+++ b/contrib/formatter_fixedwidth/output/readable_query02.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query02.source
+++ b/contrib/formatter_fixedwidth/output/readable_query02.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query03.source
+++ b/contrib/formatter_fixedwidth/output/readable_query03.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl.gz', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl.gz', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query03.source
+++ b/contrib/formatter_fixedwidth/output/readable_query03.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl.gz', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl.gz', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query04.source
+++ b/contrib/formatter_fixedwidth/output/readable_query04.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct2.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct2.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query04.source
+++ b/contrib/formatter_fixedwidth/output/readable_query04.source
@@ -26,7 +26,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct2.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl|file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct2.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query10.source
+++ b/contrib/formatter_fixedwidth/output/readable_query10.source
@@ -51,7 +51,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
  s3        | text                  |           |          |         | 
  col_empty | character(5)          |           |          |         | 
  col_null  | character varying(5)  |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', col_empty '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_miss_col_null.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', col_empty '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_miss_col_null.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 -- Note field "col_null" is loaded with null value
 select * from tbl_ext_fixedwidth where col_null is null order by s1;

--- a/contrib/formatter_fixedwidth/output/readable_query10.source
+++ b/contrib/formatter_fixedwidth/output/readable_query10.source
@@ -51,7 +51,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
  s3        | text                  |           |          |         | 
  col_empty | character(5)          |           |          |         | 
  col_null  | character varying(5)  |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', col_empty '5', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_miss_col_null.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', col_empty '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_miss_col_null.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 -- Note field "col_null" is loaded with null value
 select * from tbl_ext_fixedwidth where col_null is null order by s1;

--- a/contrib/formatter_fixedwidth/output/readable_query14.source
+++ b/contrib/formatter_fixedwidth/output/readable_query14.source
@@ -25,7 +25,7 @@ FORMAT 'CUSTOM' (formatter=fixedwidth_in, s1=10,
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query14.source
+++ b/contrib/formatter_fixedwidth/output/readable_query14.source
@@ -25,7 +25,7 @@ FORMAT 'CUSTOM' (formatter=fixedwidth_in, s1=10,
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1;
      s1     |  s2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query17.source
+++ b/contrib/formatter_fixedwidth/output/readable_query17.source
@@ -24,7 +24,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', "s 2" '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', "s 2" '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 select * from tbl_ext_fixedwidth order by s1;
      s1     | s 2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query17.source
+++ b/contrib/formatter_fixedwidth/output/readable_query17.source
@@ -24,7 +24,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10',
  n5     | numeric                     |           |          |         | 
  n6     | real                        |           |          |         | 
  n7     | double precision            |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', "s 2" '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', "s 2" '10', s3 '10', dt '20', n1 '5', n2 '10', n3 '10', n4 '10', n5 '10', n6 '10', n7 '15', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_small_correct.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 select * from tbl_ext_fixedwidth order by s1;
      s1     | s 2  |   s3   |         dt          | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/contrib/formatter_fixedwidth/output/readable_query20.source
+++ b/contrib/formatter_fixedwidth/output/readable_query20.source
@@ -20,7 +20,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
  n1     | smallint             |           |          |         | 
  n2     | integer              |           |          |         | 
  n3     | bigint               |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', col_b '5', col_a '5', col_d '5', col_c '5', n3 '5', n1 '5', n2 '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_field_sequence.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', col_b '5', col_a '5', col_d '5', col_c '5', n3 '5', n1 '5', n2 '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_field_sequence.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 -- Can successfully query the ext table, as long as the different column data types are compatible.
 -- However notice the switch between col_a and col_b, col_c and col_d, and n1, n2, and n3.

--- a/contrib/formatter_fixedwidth/output/readable_query20.source
+++ b/contrib/formatter_fixedwidth/output/readable_query20.source
@@ -20,7 +20,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in',
  n1     | smallint             |           |          |         | 
  n2     | integer              |           |          |         | 
  n3     | bigint               |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', col_b '5', col_a '5', col_d '5', col_c '5', n3 '5', n1 '5', n2 '5', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_field_sequence.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', col_b '5', col_a '5', col_d '5', col_c '5', n3 '5', n1 '5', n2 '5', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_field_sequence.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 -- Can successfully query the ext table, as long as the different column data types are compatible.
 -- However notice the switch between col_a and col_b, col_c and col_d, and n1, n2, and n3.

--- a/contrib/formatter_fixedwidth/output/readable_query32.source
+++ b/contrib/formatter_fixedwidth/output/readable_query32.source
@@ -11,7 +11,7 @@ FORMAT 'TEXT';
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(10) |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/single_field_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/single_field_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'PER_HOST', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 select * from tbl_dataset_gen ORDER BY s1 desc limit 10;
      s1     
@@ -43,7 +43,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10');
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(10) |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1 desc limit 10;
      s1     

--- a/contrib/formatter_fixedwidth/output/readable_query32.source
+++ b/contrib/formatter_fixedwidth/output/readable_query32.source
@@ -11,7 +11,7 @@ FORMAT 'TEXT';
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(10) |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', command '$(SHELL) @abs_srcdir@/scripts/single_field_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/single_field_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
 
 select * from tbl_dataset_gen ORDER BY s1 desc limit 10;
      s1     
@@ -43,7 +43,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10');
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(10) |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_single_field.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1 desc limit 10;
      s1     

--- a/contrib/formatter_fixedwidth/output/readable_query33.source
+++ b/contrib/formatter_fixedwidth/output/readable_query33.source
@@ -11,7 +11,7 @@ FORMAT 'TEXT';
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(25) |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/multi_fields_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/multi_fields_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'PER_HOST', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 select * from tbl_dataset_gen ORDER BY s1 desc limit 10;
             s1             
@@ -45,7 +45,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', s2='5', s3='9', s4='1');
  s2     | real             |           |          |         | 
  s3     | double precision |           |          |         | 
  s4     | integer          |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '5', s3 '9', s4 '1', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '5', s3 '9', s4 '1', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1 desc limit 10;
      s1     |  s2   |    s3     | s4 

--- a/contrib/formatter_fixedwidth/output/readable_query33.source
+++ b/contrib/formatter_fixedwidth/output/readable_query33.source
@@ -11,7 +11,7 @@ FORMAT 'TEXT';
  Column |     Type      | Collation | Nullable | Default | FDW options 
 --------+---------------+-----------+----------+---------+-------------
  s1     | character(25) |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', command '$(SHELL) @abs_srcdir@/scripts/multi_fields_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', command '$(SHELL) @abs_srcdir@/scripts/multi_fields_generator.sh | tee @abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'PER_HOST', log_errors 'f', encoding '6', is_writable 'false')
 
 select * from tbl_dataset_gen ORDER BY s1 desc limit 10;
             s1             
@@ -45,7 +45,7 @@ FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1='10', s2='5', s3='9', s4='1');
  s2     | real             |           |          |         | 
  s3     | double precision |           |          |         | 
  s4     | integer          |           |          |         | 
-FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '5', s3 '9', s4 '1', format 'custom', format_type 'b', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (formatter 'fixedwidth_in', s1 '10', s2 '5', s3 '9', s4 '1', format 'custom', location_uris 'file://@hostname@@abs_srcdir@/data/fixedwidth_large_multi_fields.tbl', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT * FROM tbl_ext_fixedwidth ORDER BY s1 desc limit 10;
      s1     |  s2   |    s3     | s4 

--- a/gpcontrib/gp_exttable_fdw/.gitignore
+++ b/gpcontrib/gp_exttable_fdw/.gitignore
@@ -1,2 +1,3 @@
+expected
 results
-
+sql

--- a/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
@@ -9,60 +9,60 @@ CREATE SERVER IF NOT EXISTS gp_exttable_server FOREIGN DATA WRAPPER gp_exttable_
 -- ===================================================================
 -- tests for validator
 -- ===================================================================
--- Error, miss format_type option
+-- Error, miss format option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
--- Error, invalid format_type
+-- Error, invalid format
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'invalid_format_type', delimiter ',',
+OPTIONS (format 'invalid_format_type', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
 -- Error, miss both location_uris and command option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',');
+OPTIONS (format 'csv', delimiter ',');
 
 -- Error, conflict location_uris and command option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          command 'command');
 
 -- Error, invalid reject_limit_type option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'invalid_reject_limit_type');
 
 -- Error, invalid reject_limit option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'r', reject_limit '-1');
 
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'p', reject_limit '120');
 
 -- Error, invalid encoding
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',', encoding '-1',
+OPTIONS (format 'csv', delimiter ',', encoding '-1',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
 SELECT * FROM tableless_ext_fdw;

--- a/gpcontrib/gp_exttable_fdw/option.c
+++ b/gpcontrib/gp_exttable_fdw/option.c
@@ -40,7 +40,7 @@ typedef struct GpExttableFdwMustOption
 static const GpExttableFdwMustOption gp_exttable_fdw_must_options[] = {
 	{"location_uris", ForeignTableRelationId},
 	{"command", ForeignTableRelationId},
-	{"format_type", ForeignTableRelationId},
+	{"format", ForeignTableRelationId},
 	{NULL, InvalidOid}
 };
 
@@ -72,7 +72,7 @@ gp_exttable_permission_check(PG_FUNCTION_ARGS)
 	/* default reject_limit_type is r(ROW)*/
 	char		*reject_limit_type = "r";
 	int32		reject_limit = -1;
-	bool		formattype_found = false;
+	bool		format_found = false;
 	bool		locationuris_found = false;
 	bool		command_found = false;
 	bool		rejectlimit_found = false;
@@ -107,18 +107,18 @@ gp_exttable_permission_check(PG_FUNCTION_ARGS)
 			location_list = TokenizeLocationUris(defGetString(def));
 			locationuris_found = true;
 		}
-		else if(pg_strcasecmp(def->defname, "format_type") == 0)
+		else if(pg_strcasecmp(def->defname, "format") == 0)
 		{
 			char *format = (char *) defGetString(def);
-			if(pg_strcasecmp(format, "t") != 0 && pg_strcasecmp(format, "c") != 0 
-			   && pg_strcasecmp(format, "b") != 0)
+			if(pg_strcasecmp(format, "text") != 0 && pg_strcasecmp(format, "csv") != 0
+			   && pg_strcasecmp(format, "custom") != 0)
 			{
 				ereport(ERROR,
 				        (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-				         errmsg("format_type must be [t | c | b], t(text), c(csv), b(custom)")));
+				         errmsg("format must be [text | csv | custom]")));
 			} 
 
-			formattype_found = true;   
+			format_found = true;
 		}
 		else if(pg_strcasecmp(def->defname, "reject_limit_type") == 0)
 		{
@@ -143,11 +143,11 @@ gp_exttable_permission_check(PG_FUNCTION_ARGS)
 		}
 	}
 
-	if(!formattype_found && is_must_option("format_type", catalog))
+	if(!format_found && is_must_option("format", catalog))
 	{
 		ereport(ERROR,
 		        (errcode(ERRCODE_UNDEFINED_OBJECT),
-		         errmsg("must specify format_type option([t | c | b], t(text), c(csv), b(custom))")));
+		         errmsg("must specify format option([text | csv | custom])")));
 	}
 
 	if(locationuris_found && command_found)

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -8,60 +8,60 @@ NOTICE:  server "gp_exttable_server" already exists, skipping
 -- ===================================================================
 -- tests for validator
 -- ===================================================================
--- Error, miss format_type option
+-- Error, miss format option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
-ERROR:  must specify format_type option([t | c | b], t(text), c(csv), b(custom))  (seg1 127.0.0.1:7003 pid=5173)
--- Error, invalid format_type
+ERROR:  must specify format option([text | csv | custom])  (seg1 127.0.0.1:7003 pid=5173)
+-- Error, invalid format
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'invalid_format_type', delimiter ',',
+OPTIONS (format 'invalid_format_type', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
-ERROR:  format_type must be [t | c | b], t(text), c(csv), b(custom)  (seg2 127.0.0.1:7004 pid=5174)
+ERROR:  format must be [text | csv | custom]  (seg2 127.0.0.1:7004 pid=5174)
 -- Error, miss both location_uris and command option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',');
+OPTIONS (format 'csv', delimiter ',');
 ERROR:  must specify one of location_uris and command option  (seg1 127.0.0.1:7003 pid=5173)
 -- Error, conflict location_uris and command option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          command 'command');
 ERROR:  location_uris and command options conflict with each other  (seg1 127.0.0.1:7003 pid=5173)
 -- Error, invalid reject_limit_type option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'invalid_reject_limit_type');
 ERROR:  reject_limit_type must be [r | p], r(ROW) or p(PERCENT)  (seg1 127.0.0.1:7003 pid=5173)
 -- Error, invalid reject_limit option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'r', reject_limit '-1');
 ERROR:  segment reject limit in ROWS must be 2 or larger (got -1)  (seg1 127.0.0.1:7003 pid=5173)
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'p', reject_limit '120');
 ERROR:  segment reject limit in PERCENT must be between 1 and 100 (got 120)  (seg1 127.0.0.1:7003 pid=5173)
 -- Error, invalid encoding
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',', encoding '-1',
+OPTIONS (format 'csv', delimiter ',', encoding '-1',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 ERROR:  -1 is not a valid encoding code  (seg0 127.0.0.1:7002 pid=8289)
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
-OPTIONS (format_type 'c', delimiter ',',
+OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 SELECT * FROM tableless_ext_fdw;
  a | b  

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -38,26 +38,26 @@ SERVER gp_exttable_server
 OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'invalid_reject_limit_type');
-ERROR:  reject_limit_type must be [r | p], r(ROW) or p(PERCENT)  (seg1 127.0.0.1:7003 pid=5173)
+ERROR:  reject_limit_type must be 'rows' or 'percentage'  (seg0 127.0.1.1:40000 pid=85668)
 -- Error, invalid reject_limit option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'r', reject_limit '-1');
-ERROR:  segment reject limit in ROWS must be 2 or larger (got -1)  (seg1 127.0.0.1:7003 pid=5173)
+ERROR:  reject_limit_type must be 'rows' or 'percentage'  (seg1 127.0.1.1:40001 pid=85669)
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (format 'csv', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'p', reject_limit '120');
-ERROR:  segment reject limit in PERCENT must be between 1 and 100 (got 120)  (seg1 127.0.0.1:7003 pid=5173)
+ERROR:  reject_limit_type must be 'rows' or 'percentage'  (seg2 127.0.1.1:40002 pid=85670)
 -- Error, invalid encoding
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (format 'csv', delimiter ',', encoding '-1',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
-ERROR:  -1 is not a valid encoding code  (seg0 127.0.0.1:7002 pid=8289)
+ERROR:  -1 is not a valid encoding name  (seg2 127.0.1.1:40002 pid=85670)
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server

--- a/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
+++ b/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
@@ -10,7 +10,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -31,7 +31,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -52,7 +52,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -73,7 +73,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -94,7 +94,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -115,7 +115,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -136,7 +136,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -157,7 +157,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -178,7 +178,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -199,7 +199,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -220,7 +220,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  

--- a/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
+++ b/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
@@ -10,7 +10,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -31,7 +31,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -52,7 +52,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -73,7 +73,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -94,7 +94,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -115,7 +115,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -136,7 +136,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -157,7 +157,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -178,7 +178,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -199,7 +199,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -220,7 +220,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open
  high   | double precision |           |          |         | 
  low    | double precision |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  

--- a/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
+++ b/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
@@ -10,7 +10,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -31,7 +31,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-2', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -52,7 +52,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-west-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -73,7 +73,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-south-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-south-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -94,7 +94,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-2', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -115,7 +115,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -136,7 +136,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-2', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -157,7 +157,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -178,7 +178,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-central-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-central-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -199,7 +199,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-west-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -220,7 +220,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=sa-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=sa-east-1', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  

--- a/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
+++ b/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
@@ -10,7 +10,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -31,7 +31,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -52,7 +52,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -73,7 +73,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-south-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-south-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -94,7 +94,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -115,7 +115,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -136,7 +136,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -157,7 +157,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -178,7 +178,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-central-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-central-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -199,7 +199,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -220,7 +220,7 @@ CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time t
  open   | double precision |           |          |         | 
  time   | text             |           |          |         | 
  volume | integer          |           |          |         | 
-FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=sa-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=sa-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -171,16 +171,15 @@ GetExtFromForeignTableOptions(List *ftoptons, Oid relid)
 			continue;
 		}
 
-		if (pg_strcasecmp(def->defname, "format_type") == 0)
-		{
-			arg = defGetString(def);
-			extentry->fmtcode = arg[0];
-			continue;
-		}
-
-		/* only CSV format needs this for ProcessCopyOptions(), will do it later */
 		if (pg_strcasecmp(def->defname, "format") == 0)
 		{
+			arg = defGetString(def);
+			if (pg_strcasecmp(arg, "text") == 0)
+				extentry->fmtcode = 't';
+			else if (pg_strcasecmp(arg, "csv") == 0)
+				extentry->fmtcode = 'c';
+			else if (pg_strcasecmp(arg, "custom") == 0)
+				extentry->fmtcode = 'b';
 			continue;
 		}
 

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -47,7 +47,6 @@ static bool ExtractErrorLogPersistent(List **options);
 static List * GenerateExtTableEntryOptions(Oid tbloid,
 										   bool iswritable,
 										   bool issreh,
-										   char formattype,
 										   char rejectlimittype,
 										   char* commandString,
 										   int rejectlimit,
@@ -293,7 +292,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	entryOptions = GenerateExtTableEntryOptions(reloid,
 										   iswritable,
 										   issreh,
-										   formattype,
 										   rejectlimittype,
 										   commandString,
 										   rejectlimit,
@@ -821,7 +819,6 @@ static List*
 GenerateExtTableEntryOptions(Oid 	tbloid,
 							 bool 	iswritable,
 							 bool	issreh,
-							 char	formattype,
 							 char	rejectlimittype,
 							 char*	commandString,
 							 int	rejectlimit,
@@ -831,8 +828,6 @@ GenerateExtTableEntryOptions(Oid 	tbloid,
 							 char*	locationUris)
 {
 	List		*entryOptions = NIL;
-
-	entryOptions = lappend(entryOptions, makeDefElem("format_type", (Node *) makeString(psprintf("%c", formattype)), -1));
 
 	if (commandString)
 	{

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -655,7 +655,7 @@ create writable external table wet_pos1(a text, b text) location('gpfdist://@hos
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed randomly
 
 create writable external table wet_pos2(a text, b text) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(b);
@@ -665,7 +665,7 @@ create writable external table wet_pos2(a text, b text) location('gpfdist://@hos
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (b)
 
 create writable external table wet_pos3(like wet_pos2) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(a,b);
@@ -675,7 +675,7 @@ create writable external table wet_pos3(like wet_pos2) location('gpfdist://@host
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
 Distributed by: (a, b)
 
 create writable external table wet_region(like reg_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -655,7 +655,7 @@ create writable external table wet_pos1(a text, b text) location('gpfdist://@hos
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed randomly
 
 create writable external table wet_pos2(a text, b text) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(b);
@@ -665,7 +665,7 @@ create writable external table wet_pos2(a text, b text) location('gpfdist://@hos
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (b)
 
 create writable external table wet_pos3(like wet_pos2) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(a,b);
@@ -675,7 +675,7 @@ create writable external table wet_pos3(like wet_pos2) location('gpfdist://@host
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'true')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://@hostname@:7070/wet.out', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
 Distributed by: (a, b)
 
 create writable external table wet_region(like reg_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -1756,7 +1756,6 @@ my %tests = (
 		\n\s+\Qescape E'\\',\E
 		\n\s+\Qexecute_on 'ALL_SEGMENTS',\E
 		\n\s+\Qformat 'text',\E
-		\n\s+\Qformat_type 't',\E
 		\n\s+\Qis_writable 'false',\E
 		\n\s+\Qlog_errors 'f',\E
 		\n\s+\Q"null" E'\\N'\E

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -1752,12 +1752,12 @@ my %tests = (
 		\n\QOPTIONS (\E
 		\n\s+\Qcommand 'echo foo',\E
 		\n\s+\Qdelimiter '\E\s+\Q',\E
-		\n\s+\Qencoding '\E\d\Q',\E
+		\n\s+\Qencoding 'UTF8',\E
 		\n\s+\Qescape E'\\',\E
 		\n\s+\Qexecute_on 'ALL_SEGMENTS',\E
 		\n\s+\Qformat 'text',\E
 		\n\s+\Qis_writable 'false',\E
-		\n\s+\Qlog_errors 'f',\E
+		\n\s+\Qlog_errors 'disable',\E
 		\n\s+\Q"null" E'\\N'\E
 		\n\Q);\E
 		/xm,

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1734,7 +1734,7 @@ NOTICE:  skipping foreign table "at_external" for ALTER operation
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | integer |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 -- Should be a no-op.
 ALTER TABLE at_external SET (compresstype=zlib);
@@ -1745,7 +1745,7 @@ NOTICE:  skipping foreign table "at_external" for ALTER operation
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | integer |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 -- Now make the table an external partition.
 CREATE TABLE at_part_w_external(i int, j int) DISTRIBUTED BY (i)

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1734,7 +1734,7 @@ NOTICE:  skipping foreign table "at_external" for ALTER operation
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | integer |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 -- Should be a no-op.
 ALTER TABLE at_external SET (compresstype=zlib);
@@ -1745,7 +1745,7 @@ NOTICE:  skipping foreign table "at_external" for ALTER operation
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | integer |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://host.invalid:8000/file', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 -- Now make the table an external partition.
 CREATE TABLE at_part_w_external(i int, j int) DISTRIBUTED BY (i)

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -272,11 +272,11 @@ FROM
 		LEFT OUTER JOIN pg_catalog.pg_foreign_table f ON (c.oid = f.ftrelid)
 WHERE
 	c.relname LIKE 't_ext%';
- relname | relkind |                                                                                        ftoptions                                                                                         
----------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- t_ext   | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",format_type=t,location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
- t_ext_b | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",format_type=t,location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
- t_ext_r | f       | {format=csv,"delimiter= ",null=,"escape=\"","quote=\"",format_type=c,location_uris=gpfdist://127.0.0.1:8080/tmp/dummy,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
+ relname | relkind |                                                                                 ftoptions                                                                                  
+---------+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ t_ext   | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
+ t_ext_b | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
+ t_ext_r | f       | {format=csv,"delimiter= ",null=,"escape=\"","quote=\"",location_uris=gpfdist://127.0.0.1:8080/tmp/dummy,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
 (3 rows)
 
 -- TEMP TABLE WITH COMMENTS

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -272,11 +272,11 @@ FROM
 		LEFT OUTER JOIN pg_catalog.pg_foreign_table f ON (c.oid = f.ftrelid)
 WHERE
 	c.relname LIKE 't_ext%';
- relname | relkind |                                                                                 ftoptions                                                                                  
----------+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- t_ext   | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
- t_ext_b | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
- t_ext_r | f       | {format=csv,"delimiter= ",null=,"escape=\"","quote=\"",location_uris=gpfdist://127.0.0.1:8080/tmp/dummy,execute_on=ALL_SEGMENTS,log_errors=f,encoding=6,is_writable=false}
+ relname | relkind |                                                                                      ftoptions                                                                                      
+---------+---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ t_ext   | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=disable,encoding=UTF8,is_writable=false}
+ t_ext_b | f       | {format=text,"delimiter=        ","null=\\N","escape=\\",location_uris=file://127.0.0.1/tmp/foo,execute_on=ALL_SEGMENTS,log_errors=disable,encoding=UTF8,is_writable=false}
+ t_ext_r | f       | {format=csv,"delimiter= ",null=,"escape=\"","quote=\"",location_uris=gpfdist://127.0.0.1:8080/tmp/dummy,execute_on=ALL_SEGMENTS,log_errors=disable,encoding=UTF8,is_writable=false}
 (3 rows)
 
 -- TEMP TABLE WITH COMMENTS

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -869,7 +869,7 @@ create external table ext_t1 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t1';
  amname 
@@ -886,7 +886,7 @@ create external table ext_error_logging_off (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_error_logging_off';
  amname 
@@ -903,7 +903,7 @@ create external table ext_t2 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 't', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 't', encoding '6', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t2';
  amname 
@@ -920,7 +920,7 @@ create external table ext_t3 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'p', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'p', encoding '6', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t3';
  amname 

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -869,7 +869,7 @@ create external table ext_t1 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t1';
  amname 
@@ -886,7 +886,7 @@ create external table ext_error_logging_off (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'rows', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_error_logging_off';
  amname 
@@ -903,7 +903,7 @@ create external table ext_t2 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 't', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'rows', log_errors 'enable', encoding 'UTF8', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t2';
  amname 
@@ -920,7 +920,7 @@ create external table ext_t3 (a int, b int)
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           |          |         |             | plain   |              | 
  b      | integer |           |          |         |             | plain   |              | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'r', log_errors 'p', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'file:///tmp/test.txt', execute_on 'ALL_SEGMENTS', reject_limit '100', reject_limit_type 'rows', log_errors 'persistently', encoding 'UTF8', is_writable 'false')
 
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 'ext_t3';
  amname 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -578,7 +578,7 @@ create external table ret_too_many_uris(a text, b text) location(
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 select * from ret_too_many_uris;
 ERROR:  there are more external files (URLs) than primary segments that can read them
@@ -2679,7 +2679,7 @@ OPTIONS (hello 'world', bonjour 'again', nihao 'again and again' );
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 \d exttab_with_option_empty
          Foreign table "public.exttab_with_option_empty"
@@ -2687,7 +2687,7 @@ FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello '
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_1;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -578,7 +578,7 @@ create external table ret_too_many_uris(a text, b text) location(
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 select * from ret_too_many_uris;
 ERROR:  there are more external files (URLs) than primary segments that can read them
@@ -2679,7 +2679,7 @@ OPTIONS (hello 'world', bonjour 'again', nihao 'again and again' );
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', format_type 't', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 \d exttab_with_option_empty
          Foreign table "public.exttab_with_option_empty"
@@ -2687,7 +2687,7 @@ FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello '
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_1;

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -578,7 +578,7 @@ create external table ret_too_many_uris(a text, b text) location(
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 select * from ret_too_many_uris;
 ERROR:  there are more external files (URLs) than primary segments that can read them
@@ -2679,7 +2679,7 @@ OPTIONS (hello 'world', bonjour 'again', nihao 'again and again' );
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 \d exttab_with_option_empty
          Foreign table "public.exttab_with_option_empty"
@@ -2687,7 +2687,7 @@ FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello '
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'false')
 
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_1;

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -578,7 +578,7 @@ create external table ret_too_many_uris(a text, b text) location(
 --------+------+-----------+----------+---------+-------------
  a      | text |           |          |         | 
  b      | text |           |          |         | 
-FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', format_type 't', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '	', "null" E'\\N', escape E'\\', location_uris 'gpfdist://foo.invalid:7070/ret.tbl1|gpfdist://foo.invalid:7070/ret.tbl2|gpfdist://foo.invalid:7070/ret.tbl3|gpfdist://foo.invalid:7070/ret.tbl4|gpfdist://foo.invalid:7070/ret.tbl5|gpfdist://foo.invalid:7070/ret.tbl6|gpfdist://foo.invalid:7070/ret.tbl7|gpfdist://foo.invalid:7070/ret.tbl8|gpfdist://foo.invalid:7070/ret.tbl9|gpfdist://foo.invalid:7070/ret.tbl10|gpfdist://foo.invalid:7070/ret.tbl11|gpfdist://foo.invalid:7070/ret.tbl12|gpfdist://foo.invalid:7070/ret.tbl13|gpfdist://foo.invalid:7070/ret.tbl14|gpfdist://foo.invalid:7070/ret.tbl15|gpfdist://foo.invalid:7070/ret.tbl16|gpfdist://foo.invalid:7070/ret.tbl17|gpfdist://foo.invalid:7070/ret.tbl18|gpfdist://foo.invalid:7070/ret.tbl19|gpfdist://foo.invalid:7070/ret.tbl20', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 select * from ret_too_many_uris;
 ERROR:  there are more external files (URLs) than primary segments that can read them
@@ -2679,7 +2679,7 @@ OPTIONS (hello 'world', bonjour 'again', nihao 'again and again' );
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', format_type 't', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello 'world', bonjour 'again', nihao 'again and again', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 \d exttab_with_option_empty
          Foreign table "public.exttab_with_option_empty"
@@ -2687,7 +2687,7 @@ FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', hello '
 --------+---------+-----------+----------+---------+-------------
  i      | integer |           |          |         | 
  j      | text    |           |          |         | 
-FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', format_type 't', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+FDW options: (format 'text', delimiter '|', "null" E'\\N', escape E'\\', location_uris 'file://@hostname@@abs_srcdir@/data/exttab_few_errors.data', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_1;


### PR DESCRIPTION
### Commit 1:

Greenplum had both `format` and `format_type` in the external table's
`ftoptions` because the `ExtTableEntry` had both (one is for the catalog,
the other is for COPY), which made the `ftoptions` confusing.

This PR refactor to remove the `format_type` option.

### Commit 2:

Before, the external table's ftoptions member stored values directly
from the `ExtTableEntry`, for instance, `log_errors` could be 'p',
`encoding` could be '6', which is kind of not human-friendly.

This commit changes:
1, the key `encoding`'s values to the real names, like 'UTF8'.
2, the key `log_errors`'s values to 'enable', 'disable', or 'persistently'.
   'true', 'false', or 'persistent' also work to be tolerant.
3, the key `reject_limit_type`'s values to 'rows' or 'percentage'.
   'row' or 'percent' also work because the external table syntax uses them.

Ref: https://github.com/greenplum-db/gpdb/pull/10015
