### PR TITLE
(7x) gpexpand: replace DELETE of coordinator-only tables with TRUNCATE

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -654,7 +654,6 @@ class SegmentTemplate:
         """Deploys the template tar file and configures the new segments"""
         self.statusLogger.set_status('BUILD_SEGMENTS_STARTED', self.segTarFile)
         self._distribute_template()
-        # FIXME: truncate the qd only tables' underlying files instead of delete the tuples
         self._configure_new_segments()
         numNewSegments = len(self.gparray.getExpansionSegDbList())
         self.statusLogger.set_status('BUILD_SEGMENTS_DONE', numNewSegments)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1416,7 +1416,7 @@ class gpexpand:
         Build the list of delete statements based on the COORDINATOR_ONLY_TABLES
         defined in gpcatalog.py
         """
-        statements = ["delete from pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES]
+        statements = ["truncate pg_catalog.%s" % tab for tab in COORDINATOR_ONLY_TABLES]
 
         """
           Connect to each database in the new segments, and clean up the catalog tables.


### PR DESCRIPTION
On one of our production clusters phase 'gpexpand execute segment cleanup commands' took 46 minutes and did not free up the disk space needed for further manipulations. We do not need MVCC safety at this point of expand, thus can save a lot of work by simply replcaing DELETE with TRUNCATE.

GP7 version of #16303.