### PR TITLE
Refactor gppylib's check_results

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -353,8 +353,6 @@ def do_change(options):
                 LOGGER.error('failed updating the postgresql.conf files on host: %s msg:%s' %
                              (i.remoteHost, i.get_results().stderr))
                 failure = True
-
-        pool.check_results()
     except Exception as err:
         failure = True
         LOGGER.error('errors in job:')
@@ -485,7 +483,7 @@ def get_gucs_from_files(guc):
                 FileSegmentGuc([cmd.segInfo.getSegmentContentId(), guc, cmd.get_value(),
                                 cmd.segInfo.getSegmentDbId()]))
 
-    pool.check_results()
+    pool.empty_completed_items(throw_on_error=True)
     pool.haltWork()
     pool.joinWorkers()
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -783,8 +783,7 @@ class SegmentTemplate:
                         whole_file=True)
             self.pool.addCommand(cpCmd)
 
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
     def _start_new_primary_segments(self):
         newSegments = self.gparray.getExpansionSegDbList()
@@ -805,8 +804,7 @@ class SegmentTemplate:
                 , pg_ctl_wait=True
                 , timeout=SEGMENT_TIMEOUT_DEFAULT)
             self.pool.addCommand(segStartCmd)
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
     def _stop_new_primary_segments(self):
         newSegments = self.gparray.getExpansionSegDbList()
@@ -822,8 +820,7 @@ class SegmentTemplate:
                 , remoteHost=seg.getSegmentHostName()
             )
             self.pool.addCommand(segStopCmd)
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
     def _configure_new_segments(self):
         """Configures new segments.  This includes modifying the postgresql.conf file
@@ -842,8 +839,7 @@ class SegmentTemplate:
                                             ctxt=REMOTE, remoteHost=host)
             self.pool.addCommand(segCfgCmd)
 
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
         # Map primary and mirror hostnames to expanded segment's contentid
         expanded_host_content = defaultdict(lambda: [])
@@ -917,8 +913,7 @@ class SegmentTemplate:
                 rmCmd = RemoveDirectory('gpexpand remove new segment data directory: %s:%s' % (hostname, datadir),
                                         datadir, ctxt=REMOTE, remoteHost=hostname)
                 pool.addCommand(rmCmd)
-        pool.join()
-        pool.check_results()
+        pool.join_and_check_results()
 
     def cleanup(self):
         """Cleans up temporary files from the local system and new segment hosts"""
@@ -1409,8 +1404,7 @@ class gpexpand:
                 , pg_ctl_wait=True
                 , timeout=SEGMENT_TIMEOUT_DEFAULT)
             self.pool.addCommand(segStartCmd)
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
         """
         Build the list of delete statements based on the COORDINATOR_ONLY_TABLES
@@ -1439,10 +1433,7 @@ class gpexpand:
                                                          )
                 self.pool.addCommand(execSQLCmd)
 
-        self.pool.join()
-        ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
-        self.pool.check_results()
-        self.pool.getCompletedItems()
+        self.pool.join_and_check_results()
 
     # --------------------------------------------------------------------------
     def restore_coordinator(self):

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -325,7 +325,7 @@ def remove_standby_datadir(array):
 
         pool.join()
         try:
-            pool.check_results()
+            pool.empty_completed_items(throw_on_error=True)
         except Exception as ex:
             logger.error('Failed to remove data directory on standby coordinator.')
             raise GpInitStandbyException(ex)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1169,8 +1169,7 @@ def distribute_tarball(queue,list,tarball):
             (head,tail)=os.path.split(datadir)
             rsync_cmd=Rsync(name="copy coordinator",srcFile=tarball,dstHost=hostname,dstFile=head, ignore_times=True, whole_file=True)
             queue.addCommand(rsync_cmd)
-        queue.join()
-        queue.check_results()
+        queue.join_and_check_results()
         logger.debug("distributeTarBall finished")
 
 

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -498,12 +498,7 @@ class GpMirrorListToBuild:
         else:
             base.join_and_indicate_progress(self.__pool)
 
-        if not suppressErrorCheck:
-            self.__pool.check_results()
-
-        completed_cmds = list(set(self.__pool.getCompletedItems()) & set(cmds))
-
-        self.__pool.empty_completed_items()
+        completed_cmds = list(set(self.__pool.getCompletedItems(throw_on_error=not suppressErrorCheck)) & set(cmds))
 
         return completed_cmds
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_workerpool.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_workerpool.py
@@ -82,8 +82,7 @@ class WorkerPoolTest(unittest.TestCase):
         result.wasSuccessful.return_value = True
 
         self.pool.addCommand(cmd)
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
     def test_check_results_throws_exception_at_first_failure(self):
         cmd = mock.Mock(spec=Command)
@@ -95,10 +94,9 @@ class WorkerPoolTest(unittest.TestCase):
         result.wasSuccessful.return_value = False
 
         self.pool.addCommand(cmd)
-        self.pool.join()
 
         with self.assertRaises(ExecutionError):
-            self.pool.check_results()
+            self.pool.join_and_check_results()
 
     def test_join_with_timeout_returns_done_immediately_if_there_is_nothing_to_do(self):
         start = time.time()
@@ -195,8 +193,7 @@ class WorkerPoolTest(unittest.TestCase):
 
         self.pool.addCommand(cmd)
 
-        self.pool.join()
-        self.pool.check_results()
+        self.pool.join_and_check_results()
 
         self.assertEqual(self.pool.assigned, 0)
 

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -804,8 +804,7 @@ class GpStop:
         else:
             base.join_and_indicate_progress(self.pool)
 
-        self.pool.check_results()
-        self.pool.empty_completed_items()
+        self.pool.empty_completed_items(throw_on_error=True)
 
         if len(self.pool.failed) < 1:
             return 0

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -409,7 +409,7 @@ try:
         else: sys.exit(0)
     else:
         try:
-            pool.check_results()
+            pool.empty_completed_items(throw_on_error=True)
         except Exception as e:
             if options.verbose:
                 logger.exception(e)


### PR DESCRIPTION
I was wondering why check_results() seems pure but mutates state. So I've found out few bugs in error handling and decided to refactor that stuff.
