### PR TITLE
Allocate histogram sample array on heap

### DIFF
--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -144,7 +144,7 @@ private:
 	CBucket *operator[](ULONG) const;
 
 	// Populate sample ratio within each bucket
-	void GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE sample_rate[],
+	void GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE *sample_rate,
 					   ULONG index);
 
 	// compute skew estimate

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -2081,10 +2081,10 @@ CHistogram::GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE *sample_rate,
 		return;
 	}
 
-	sample_rate[index + 1] = (left + right) / 2;
+	sample_rate[index] = (left + right) / 2;
 
-	GetSampleRate(left, (left + right) / 2, sample_rate, index * 2);
-	GetSampleRate((left + right) / 2, right, sample_rate, index * 2 + 1);
+	GetSampleRate(left, (left + right) / 2, sample_rate, index * 2 - 1);
+	GetSampleRate((left + right) / 2, right, sample_rate, index * 2);
 }
 
 // estimate data skew by sampling histogram buckets,
@@ -2115,12 +2115,12 @@ CHistogram::ComputeSkew()
 
 	// generate a sample from histogram data, and compute sample mean
 	DOUBLE sample_mean = 0;
-	DOUBLE samples[GPOPT_SKEW_SAMPLE_SIZE];
-	DOUBLE sample_rate[GPOPT_SKEW_SAMPLE_SIZE];
+	DOUBLE *samples = GPOS_NEW_ARRAY(m_mp, DOUBLE, GPOPT_SKEW_SAMPLE_SIZE);
+	DOUBLE *sample_rate = GPOS_NEW_ARRAY(m_mp, DOUBLE, GPOPT_SKEW_SAMPLE_SIZE);
 	sample_rate[0] = 0;
 	sample_rate[1] = 1;
-	ULONG index = 1;
-	GetSampleRate(sample_rate[0], sample_rate[1], sample_rate, index);
+	// populate the sample rate array from the 3rd (index = 2) element onward
+	GetSampleRate(sample_rate[0], sample_rate[1], sample_rate, 2 /*index*/);
 
 	// start with the lowest frequency bucket
 	ULONG bucket_index = m_histogram_buckets->Size() - 1;
@@ -2157,6 +2157,10 @@ CHistogram::ComputeSkew()
 		num2 = num2 + pow((samples[ul] - sample_mean), 2.0);
 		num3 = num3 + pow((samples[ul] - sample_mean), 3.0);
 	}
+
+	GPOS_DELETE_ARRAY(samples);
+	GPOS_DELETE_ARRAY(sample_rate);
+
 	// second moment: variance
 	DOUBLE moment2 = (DOUBLE)(num2 / GPOPT_SKEW_SAMPLE_SIZE);
 	// third moment: a/symmetry


### PR DESCRIPTION
Issue:
Sample array used for skew stats collection caused stack overflow in address sanitizer environment.

Solution:
Allocate the array on heap memory. Also simplified the math in the sample rate populator for better readability --

GetSampleRate populates a 1000-element array. It uses the existing elements as lower/higher bounds and appends the medium as the next element. The first two elements are predefined as 0 and 1. The function populates the 3rd element onward. The array goes:

0, 1, 0.5, 0.25, 0.75, 0.125, 0.375, 0.625, 0.875, ...

Previously, we recursively assign the value for sample_rate[index+1]. Since we start from the 3rd element, we pass in index = 1, so the 3rd element becomes sample_rate[1+1] = 0.5. The next two elements to be populated are the 4th and 5th element. Therefore, we pass index*2 to the first recursive call, and index*2+1 to the second recursive call. The first recursive call populates the 4th element sample_rate[1*2+1] = 0.25, and the second recursive call populates the 5th element sample_rate[1*2+1+1] = 0.75.

Apparently, having sample_rate[index+1] as LHS is less intuitive and thence error prone (accessing address outside array bounds). This PR changed it to sample_rate[index]. Accordingly, we pass in index = 2, so the 3rd element becomes sample_rate[2] = 0.5. Going forward, we pass index*2-1 and index*2 to the two recursive calls. The first recursive call populates the 4th element sample_rate[2*2-1] = 0.25, and the second recursive call populates the 5th element sample_rate[2*2] = 0.75.

Fix #16021

(cherry picked from commit 420cbeb67b6f0c443de53f9983aeecaf5c198a56)