### PR TITLE
 Fix ssl test for gpfdist6

### DIFF
--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -5,11 +5,18 @@ default: installcheck
 
 REGRESS = exttab1 custom_format gpfdist2 gpfdist_path
 
+OS_VERSION := $(shell cat /etc/*release)
+
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
-	REGRESS += gpfdist_ssl gpfdists_multiCA
+	ifneq (,$(findstring release 9,$(OS_VERSION)))
+		REGRESS += gpfdist_ssl gpfdists_multiCA
+	else
+		REGRESS += gpfdist_ssl gpfdists_multiCA gpfdist_old_ssl
+	endif
 endif
 endif
+$(info $(REGRESS))
 
 PSQLDIR = $(prefix)/bin
 REGRESS_OPTS = --init-file=init_file

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -5,15 +5,22 @@ default: installcheck
 
 REGRESS = exttab1 custom_format gpfdist2 gpfdist_path
 
-OS_VERSION := $(shell cat /etc/*release)
+# Get the OpenSSL version
+OPENSSL_VERSION := $(shell openssl version 2>/dev/null)
+$(info $(OPENSSL_VERSION))
+
+# Extract the major, minor, and fix version numbers
+OPENSSL_MAJOR_VERSION := $(shell echo '$(OPENSSL_VERSION)' | cut -d' ' -f2 | cut -d. -f1)
+OPENSSL_MINOR_VERSION := $(shell echo '$(OPENSSL_VERSION)' | cut -d' ' -f2 | cut -d. -f2)
+OPENSSL_FIX_VERSION := $(shell echo '$(OPENSSL_VERSION)' | cut -d' ' -f2 | cut -d. -f3 | sed 's/[^0-9]*//g')
 
 ifeq ($(enable_gpfdist),yes)
-ifeq ($(with_openssl),yes)
-	ifneq (,$(findstring release 9,$(OS_VERSION)))
-		REGRESS += gpfdist_ssl gpfdists_multiCA
-	else
-		REGRESS += gpfdist_ssl gpfdists_multiCA gpfdist_old_ssl
-	endif
+ifeq ($(with_openssl),yes)	
+    ifeq (1,$(shell [ $(OPENSSL_MAJOR_VERSION) -gt 1 ] || ( [ $(OPENSSL_MAJOR_VERSION) -eq 1 ] && [ $(OPENSSL_MINOR_VERSION) -ge 1 ] && [ $(OPENSSL_FIX_VERSION) -ge 1 ] ) && echo 1 ))
+        REGRESS += gpfdist_ssl gpfdists_multiCA
+    else
+        REGRESS += gpfdist_ssl gpfdists_multiCA gpfdist_old_ssl
+    endif
 endif
 endif
 $(info $(REGRESS))

--- a/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
@@ -1,0 +1,27 @@
+-- test disable tls1.0 and tls1.1
+CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
+execute E'
+curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
+curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 $max_tls >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
+execute E'
+curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.1";fi;
+curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 $max_tls >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
+on SEGMENT 0
+FORMAT 'text';
+select * from curl_with_tls10;
+select * from curl_with_tls11;
+drop external table if exists curl_with_tls10;
+drop external table if exists curl_with_tls11;

--- a/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
@@ -1,4 +1,3 @@
--- test disable tls1.0 and tls1.1
 CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -76,29 +76,7 @@ LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
--- test disable tls1.0 and tls1.1
-CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
-execute E'
-curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 $max_tls >/dev/null 2>&1;ret=$?;
-if [ $ret -eq 35 ];then
-    echo "success";
-else
-    echo $ret;
-fi'
-on SEGMENT 0
-FORMAT 'text';
-CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
-execute E'
-curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.1";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 $max_tls >/dev/null 2>&1;ret=$?;
-if [ $ret -eq 35 ];then
-    echo "success";
-else
-    echo $ret;
-fi'
-on SEGMENT 0
-FORMAT 'text';
+-- test  tls1.2
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
@@ -110,11 +88,9 @@ else
 fi'
 on SEGMENT 0
 FORMAT 'text';
-select * from curl_with_tls10;
-select * from curl_with_tls11;
+
 select * from curl_with_tls12;
-drop external table if exists curl_with_tls10;
-drop external table if exists curl_with_tls11;
+
 drop external table if exists curl_with_tls12;
 -- end test disable tls1.0 and tls1.1
 

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -76,7 +76,7 @@ LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
--- test  tls1.2
+-- test tls1.2
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
@@ -88,9 +88,7 @@ else
 fi'
 on SEGMENT 0
 FORMAT 'text';
-
 select * from curl_with_tls12;
-
 drop external table if exists curl_with_tls12;
 -- end test disable tls1.0 and tls1.1
 

--- a/src/bin/gpfdist/regress/output/gpfdist_old_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_old_ssl.source
@@ -1,0 +1,36 @@
+CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
+execute E'
+curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
+curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 $max_tls >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
+on SEGMENT 0
+FORMAT 'text';
+CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
+execute E'
+curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.1";fi;
+curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 $max_tls >/dev/null 2>&1;ret=$?;
+if [ $ret -eq 35 ];then
+    echo "success";
+else
+    echo $ret;
+fi'
+on SEGMENT 0
+FORMAT 'text';
+select * from curl_with_tls10;
+    x    
+---------
+ success
+(1 row)
+
+select * from curl_with_tls11;
+    x    
+---------
+ success
+(1 row)
+
+drop external table if exists curl_with_tls10;
+drop external table if exists curl_with_tls11;

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -70,8 +70,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
  ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (3 rows)
 
--- test disable tls1.0 and tls1.1
-
+-- test tls1.2
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
@@ -89,8 +88,6 @@ select * from curl_with_tls12;
  success
 (1 row)
 
-drop external table if exists curl_with_tls10;
-drop external table if exists curl_with_tls11;
 drop external table if exists curl_with_tls12;
 -- end test disable tls1.0 and tls1.1
 -- gpfdist_ssl case 2

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -71,28 +71,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 (3 rows)
 
 -- test disable tls1.0 and tls1.1
-CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
-execute E'
-curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.0 $max_tls >/dev/null 2>&1;ret=$?;
-if [ $ret -eq 35 ];then
-    echo "success";
-else
-    echo $ret;
-fi'
-on SEGMENT 0
-FORMAT 'text';
-CREATE EXTERNAL WEB TABLE curl_with_tls11 (x text)
-execute E'
-curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.1";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.1 $max_tls >/dev/null 2>&1;ret=$?;
-if [ $ret -eq 35 ];then
-    echo "success";
-else
-    echo $ret;
-fi'
-on SEGMENT 0
-FORMAT 'text';
+
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
@@ -104,18 +83,6 @@ else
 fi'
 on SEGMENT 0
 FORMAT 'text';
-select * from curl_with_tls10;
-    x    
----------
- success
-(1 row)
-
-select * from curl_with_tls11;
-    x    
----------
- success
-(1 row)
-
 select * from curl_with_tls12;
     x    
 ---------


### PR DESCRIPTION
Gpdb is going to support rocky9/rhel9/oel9. In this operation system, the default openssl version is 3.*, which doesn't support tls 1.0 and tls 1.1. Thus, we have to do some adjustments for gpfdist regression tests.
