### PR TITLE
[6X] Fix Flow structure copying, comparison, serialization and deserialization

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2321,6 +2321,7 @@ _copyFlow(const Flow *from)
 	COPY_SCALAR_FIELD(numsegments);
 	COPY_NODE_FIELD(hashExprs);
 	COPY_NODE_FIELD(hashOpfamilies);
+	COPY_SCALAR_FIELD(segidColIdx);
 	COPY_NODE_FIELD(flow_before_req_move);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -769,6 +769,7 @@ _equalFlow(const Flow *a, const Flow *b)
 	COMPARE_SCALAR_FIELD(numsegments);
 	COMPARE_NODE_FIELD(hashExprs);
 	COMPARE_NODE_FIELD(hashOpfamilies);
+	COMPARE_SCALAR_FIELD(segidColIdx);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -60,6 +60,8 @@
 #define WRITE_INT_FIELD(fldname) \
 	appendStringInfo(str, " :" CppAsString(fldname) " %d", node->fldname)
 
+#define WRITE_INT16_FIELD(fldname) WRITE_INT_FIELD(fldname)
+
 /* Write an unsigned integer field (anything written as ":fldname %u") */
 #define WRITE_UINT_FIELD(fldname) \
 	appendStringInfo(str, " :" CppAsString(fldname) " %u", node->fldname)
@@ -1955,7 +1957,7 @@ _outFlow(StringInfo str, const Flow *node)
 
 	WRITE_NODE_FIELD(hashExprs);
 	WRITE_NODE_FIELD(hashOpfamilies);
-
+	WRITE_INT16_FIELD(segidColIdx);
 	WRITE_NODE_FIELD(flow_before_req_move);
 }
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2187,6 +2187,7 @@ _readFlow(void)
 
 	READ_NODE_FIELD(hashExprs);
 	READ_NODE_FIELD(hashOpfamilies);
+	READ_INT16_FIELD(segidColIdx);
 	READ_NODE_FIELD(flow_before_req_move);
 
 	READ_DONE();

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3112,3 +3112,65 @@ select * from r where b in (select b from s where c=10 order by c limit 2);
  1 | 2 | 3
 (1 row)
 
+-- Test that Explicit Redistribute Motion is applied properly for
+-- queries that have modifying operation inside a SubPlan. That
+-- requires the ModifyTable's top Flow node to be copied correctly inside
+-- ParallelizeSubPlan function.
+--start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+--end_ignore
+create table t1 (i int) distributed randomly;
+create table t2 (i int) distributed by (i);
+insert into t1 values (1);
+insert into t2 values (1);
+explain (costs off)
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Result
+         One-Time Filter: $1
+         InitPlan 1 (returns $1)  (slice5)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                       ->  Limit
+                             ->  Delete on t1
+                                   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+                                         ->  Hash Join
+                                               Hash Cond: (t1.i = t2_1.i)
+                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                     Hash Key: t1.i
+                                                     ->  Seq Scan on t1
+                                               ->  Hash
+                                                     ->  Seq Scan on t2 t2_1
+         ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+drop table t2;
+drop table t1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3253,3 +3253,65 @@ select * from r where b in (select b from s where c=10 order by c limit 2);
  1 | 2 | 3
 (1 row)
 
+-- Test that Explicit Redistribute Motion is applied properly for
+-- queries that have modifying operation inside a SubPlan. That
+-- requires the ModifyTable's top Flow node to be copied correctly inside
+-- ParallelizeSubPlan function.
+--start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+--end_ignore
+create table t1 (i int) distributed randomly;
+create table t2 (i int) distributed by (i);
+insert into t1 values (1);
+insert into t2 values (1);
+explain (costs off)
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Result
+         One-Time Filter: $1
+         InitPlan 1 (returns $1)  (slice5)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                       ->  Limit
+                             ->  Delete on t1
+                                   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+                                         ->  Hash Join
+                                               Hash Cond: (t1.i = t2_1.i)
+                                               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                     Hash Key: t1.i
+                                                     ->  Seq Scan on t1
+                                               ->  Hash
+                                                     ->  Seq Scan on t2 t2_1
+         ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+drop table t2;
+drop table t1;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1215,3 +1215,36 @@ explain (costs off) select * from r where b in (select b from s where c=10 order
 select * from r where b in (select b from s where c=10 order by c);
 explain (costs off) select * from r where b in (select b from s where c=10 order by c limit 2);
 select * from r where b in (select b from s where c=10 order by c limit 2);
+
+-- Test that Explicit Redistribute Motion is applied properly for
+-- queries that have modifying operation inside a SubPlan. That
+-- requires the ModifyTable's top Flow node to be copied correctly inside
+-- ParallelizeSubPlan function.
+--start_ignore
+drop table if exists t1;
+drop table if exists t2;
+--end_ignore
+create table t1 (i int) distributed randomly;
+create table t2 (i int) distributed by (i);
+insert into t1 values (1);
+insert into t2 values (1);
+
+explain (costs off)
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+
+with cte as
+(delete from t1
+ using t2 where t2.i = t1.i
+ returning t1.i)
+select i from t2
+where exists (select i from cte);
+
+select count(*) from t1;
+
+drop table t2;
+drop table t1;


### PR DESCRIPTION
Flow structure has a segidColIdx field, which referencing a gp_segment_id column in plan's targetList when the Explicit Redistribute Motion is requested. There was a problem, that _copyFlow, _equalFlow, _outFlow and _readFlow functions did not handle the segidColIdx field. Therefore, the Flow node could not be serialized and deserialized, or copied correctly.

The problem manifested itself when a query had UPDATE/DELETE operation, that required Explicit Redistribute, inside the SubPlan (or InitPlan). The Explicit Redistribute did not applied correctly inside the apply_motion_mutator function because by that moment the value segidColIdx had been lost. The problem occured because previously SubPlans had been mutated inside the ParallelizeSubplan function, where the SubPlan's plan had been copied via copyObject function. This function copies the whole plan including the Flow node, which is copied via _copyFlow function. However the Flow node copying did not include the copying of segidColIdx Flow field, which is used for valid performance of Explicit Redistribute Motion.

Therefore, this patch solves the issue by adding segidColIdx to the list of fields to copy, serialize, deserialize and compare in the _copyFlow, _outFlow, _readFlow and _equalFlow functions respectively.
