### PR TITLE
[6X] Abort rebalance if replay lag is big on mirror

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -52,6 +52,11 @@ DEFAULT_MASTER_NUM_WORKERS=16
 #max batch size of thread pool on master
 MAX_MASTER_NUM_WORKERS=64
 
+# Maximum replay lag (in GBs) allowed on mirror when rebalancing the segments
+# The default value for ALLOWED_REPLAY_LAG has been decided to be 10 GBs as mirror
+# took 5 mins to replay 10 GB lag on a local demo cluster.
+ALLOWED_REPLAY_LAG = 10
+
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.

--- a/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
+++ b/gpMgmt/bin/gppylib/operations/rebalanceSegments.py
@@ -1,5 +1,6 @@
 import sys
 import signal
+from contextlib import closing
 from gppylib.gparray import GpArray
 from gppylib.db import dbconn
 from gppylib.commands.gp import GpSegStopCmd
@@ -8,7 +9,32 @@ from gppylib import gplog
 
 from gppylib.operations.segment_reconfigurer import SegmentReconfigurer
 
-MIRROR_PROMOTION_TIMEOUT=600
+MIRROR_PROMOTION_TIMEOUT = 600
+
+logger = gplog.get_default_logger()
+
+
+def replay_lag(primary_db):
+    """
+    This function returns replay lag (diff of flush_lsn and replay_lsn) on mirror segment. Goal being if there is a
+    lot to catchup on mirror the user should be warned about that and rebalance opertion should be aborted.
+    params: primary segment info
+    return value: replay lag in bytes
+    replay lag in bytes: diff of flush_lsn and replay_lsn on mirror
+    """
+    port = primary_db.getSegmentPort()
+    host = primary_db.getSegmentHostName()
+    logger.debug('Get replay lag on mirror of primary segment with host:{}, port:{}'.format(host, port))
+    sql = "select pg_xlog_location_diff(flush_location, replay_location) from pg_stat_replication;"
+
+    try:
+        dburl = dbconn.DbURL(hostname=host, port=port)
+        with closing(dbconn.connect(dburl, utility=True, encoding='UTF8')) as conn:
+            replay_lag = dbconn.execSQLForSingleton(conn, sql)
+    except Exception as ex:
+        raise Exception("Failed to query pg_stat_replication for host:{}, port:{}, error: {}".
+                        format(host, port, str(ex)))
+    return replay_lag
 
 
 class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
@@ -26,11 +52,13 @@ class ReconfigDetectionSQLQueryCommand(base.SQLCommand):
 
 
 class GpSegmentRebalanceOperation:
-    def __init__(self, gpEnv, gpArray, batch_size, segment_batch_size):
+    def __init__(self, gpEnv, gpArray, batch_size, segment_batch_size, disable_replay_lag, replay_lag):
         self.gpEnv = gpEnv
         self.gpArray = gpArray
         self.batch_size = batch_size
         self.segment_batch_size = segment_batch_size
+        self.disable_replay_lag = disable_replay_lag
+        self.replay_lag = replay_lag
         self.logger = gplog.get_default_logger()
 
     def rebalance(self):
@@ -45,10 +73,20 @@ class GpSegmentRebalanceOperation:
                 continue
 
             if segmentPair.up() and segmentPair.reachable() and segmentPair.synchronized():
+                if not self.disable_replay_lag:
+                    self.logger.info("Allowed replay lag during rebalance is {} GB".format(self.replay_lag))
+                    replay_lag_in_bytes = replay_lag(segmentPair.primaryDB)
+                    if float(replay_lag_in_bytes) >= (self.replay_lag * 1024 * 1024 * 1024):
+                        raise Exception("{} bytes of xlog is still to be replayed on mirror with dbid {}, let "
+                                        "mirror catchup on replay then trigger rebalance. Use --replay-lag to "
+                                        "configure the allowed replay lag limit or --disable-replay-lag to disable"
+                                        " the check completely if you wish to continue with rebalance anyway"
+                                        .format(replay_lag_in_bytes, segmentPair.primaryDB.getSegmentDbId()))
                 unbalanced_primary_segs.append(segmentPair.primaryDB)
             else:
                 self.logger.warning(
-                    "Not rebalancing primary segment dbid %d with its mirror dbid %d because one is either down, unreachable, or not synchronized" \
+                    "Not rebalancing primary segment dbid %d with its mirror dbid %d because one is either down, "
+                    "unreachable, or not synchronized" \
                     % (segmentPair.primaryDB.dbid, segmentPair.mirrorDB.dbid))
 
         if not len(unbalanced_primary_segs):
@@ -76,7 +114,7 @@ class GpSegmentRebalanceOperation:
                 pool.addCommand(cmd)
 
             base.join_and_indicate_progress(pool)
-            
+
             failed_count = 0
             completed = pool.getCompletedItems()
             for res in completed:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -98,7 +98,7 @@ class GpRecoverSegmentProgram:
 
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
-            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
+            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.disableReplayLag, self.__options.replayLag)
         else:
             instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
             segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
@@ -252,6 +252,9 @@ class GpRecoverSegmentProgram:
         # verify differential supported options
         if self.__options.differentialResynchronization and self.__options.outputSampleConfigFile:
             raise ProgramArgumentValidationException("Invalid -o provided with --differential argument")
+
+        if self.__options.disableReplayLag and not self.__options.rebalanceSegments:
+            raise ProgramArgumentValidationException("--disable-replay-lag should be used only with -r")
 
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getMasterPort())
 
@@ -461,6 +464,11 @@ class GpRecoverSegmentProgram:
 
         addTo.add_option("-r", None, default=False, action='store_true',
                          dest='rebalanceSegments', help='Rebalance synchronized segments.')
+        addTo.add_option("--replay-lag", None, type="float", default=gp.ALLOWED_REPLAY_LAG,
+                         dest="replayLag",
+                         metavar="<replayLag>", help='Allowed replay lag on mirror, lag should be provided in GBs')
+        addTo.add_option("--disable-replay-lag", None, default=False, action='store_true',
+                         dest='disableReplayLag', help='Disable replay lag check when rebalancing segments')
         addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',
                          help='use hostnames instead of CIDR in pg_hba.conf')
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -24,6 +24,8 @@ class Options:
         self.recoveryConfigFile = None
         self.outputSpareDataDirectoryFile = None
         self.rebalanceSegments = None
+        self.disableReplayLag = None
+        self.replayLag = None
 
         self.outputSampleConfigFile = None
         self.parallelDegree = 1

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_rebalance_segment.py
@@ -4,6 +4,7 @@ from gp_unittest import *
 from gppylib.gparray import GpArray, Segment
 from gppylib.commands.base import CommandResult
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+from gppylib.operations.rebalanceSegments import replay_lag
 
 
 class RebalanceSegmentsTestCase(GpTestCase):
@@ -11,10 +12,15 @@ class RebalanceSegmentsTestCase(GpTestCase):
         self.pool = Mock()
         self.pool.getCompletedItems.return_value = []
 
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
         self.apply_patches([
             patch("gppylib.commands.base.WorkerPool.__init__", return_value=None),
             patch("gppylib.commands.base.WorkerPool", return_value=self.pool),
             patch('gppylib.programs.clsRecoverSegment.GpRecoverSegmentProgram'),
+            patch('gppylib.operations.rebalanceSegments.logger', return_value=mock_logger),
+            patch('gppylib.db.dbconn.connect', autospec=True),
+            patch('gppylib.db.dbconn.execSQLForSingleton', return_value='5678')
         ])
 
         self.mock_gp_recover_segment_prog_class = self.get_mock_from_apply_patch('GpRecoverSegmentProgram')
@@ -32,8 +38,11 @@ class RebalanceSegmentsTestCase(GpTestCase):
         self.success_command_mock.get_results.return_value = CommandResult(
             0, "stdout success text", "stderr text", True, False)
 
-        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors(), 1, 1)
-        self.subject.logger = Mock()
+        self.subject = GpSegmentRebalanceOperation(Mock(), self._create_gparray_with_2_primary_2_mirrors(), 1, 1, False,
+                                                   10)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
 
     def tearDown(self):
         super(RebalanceSegmentsTestCase, self).tearDown()
@@ -57,6 +66,47 @@ class RebalanceSegmentsTestCase(GpTestCase):
 
         result = self.subject.rebalance()
         self.assertFalse(result)
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', return_value='56780000000')
+    def test_rebalance_returns_warning(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.subject.rebalance()
+        self.assertEqual('56780000000 bytes of xlog is still to be replayed on mirror with dbid 2, let mirror catchup '
+                         'on replay then trigger rebalance. Use --replay-lag to configure the allowed replay lag limit '
+                         'or --disable-replay-lag to disable the check completely if you wish to continue with '
+                         'rebalance anyway', str(ex.exception))
+        self.assertEqual([call("Get replay lag on mirror of primary segment with host:sdw1, port:40000")],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual([call("Determining primary and mirror segment pairs to rebalance"),
+                          call('Allowed replay lag during rebalance is 10 GB')],
+                         self.subject.logger.info.call_args_list)
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', return_value='5678000000')
+    def test_rebalance_does_not_return_warning(self, mock1):
+        self.subject.rebalance()
+        self.assertEqual([call("Get replay lag on mirror of primary segment with host:sdw1, port:40000")],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', return_value='56780000000')
+    def test_rebalance_replay_lag_is_disabled(self, mock1):
+        self.subject.disable_replay_lag = True
+        self.subject.rebalance()
+        self.assertNotIn([call("Get replay lag on mirror of primary segment with host:sdw1, port:40000")],
+                         self.mock_logger.debug.call_args_list)
+        self.assertIn([call("Determining primary and mirror segment pairs to rebalance")],
+                      self.subject.logger.info.call_args_list)
+
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_replay_lag_connect_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            replay_lag(self.primary0)
+        self.assertEqual('Failed to query pg_stat_replication for host:sdw1, port:40000, error: ', str(ex.exception))
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', side_effect=Exception())
+    def test_replay_lag_query_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            replay_lag(self.primary0)
+        self.assertEqual('Failed to query pg_stat_replication for host:sdw1, port:40000, error: ', str(ex.exception))
 
     def _create_gparray_with_2_primary_2_mirrors(self):
         master = Segment.initFromString(

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -14,7 +14,7 @@ gprecoverseg [-p <new_recover_host>[,...]]
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
 
-gprecoverseg -r
+gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
 
 
 gprecoverseg -o <output_recover_config_file> 
@@ -242,6 +242,16 @@ This option rebalances primary and mirror segments by returning them to
 their preferred roles. All segments must be valid and synchronized before 
 running gprecoverseg -r. If there are any in progress queries, they will 
 be cancelled and rolled back.
+
+--replay-lag
+Replay lag(in GBs) allowed on mirror when rebalancing the segments. Default is 10 GB. If
+the replay_lag (flush_lsn-replay_lsn) is more than the value provided with this option
+then rebalance will be aborted.
+
+
+--disable-replay-lag
+Disable replay lag check when rebalancing segments
+
 
 -s
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1904,6 +1904,47 @@ Feature: gprecoverseg tests
     Then gprecoverseg should return a return code of 0
     And the cluster is rebalanced
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg rebalance aborts and throws exception if replay lag on mirror is more than or equal to the allowed limit
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And user immediately stops all primary processes for content 0
+        And user can start transactions
+        When the user runs "gprecoverseg -av"
+        Then gprecoverseg should return a return code of 0
+        When the user runs "gprecoverseg -ar --replay-lag 0"
+        Then gprecoverseg should return a return code of 2
+         And gprecoverseg should print ".* bytes of xlog is still to be replayed on mirror with dbid.*, let mirror catchup on replay then trigger rebalance" regex to logfile
+        When the user runs "gprecoverseg -ar --disable-replay-lag"
+        Then gprecoverseg should return a return code of 0
+         And all the segments are running
+         And user can start transactions
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg errors out if invalid options are used with --disable-replay-lag
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And user immediately stops all primary processes for content 0,1,2
+        And user can start transactions
+       When the user runs "gprecoverseg -av"
+       Then gprecoverseg should return a return code of 0
+        And verify that mirror on content 0,1,2 is up
+       When the user runs "gprecoverseg -aF --disable-replay-lag"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "--disable-replay-lag should be used only with -r" to stdout
+        When the user runs "gprecoverseg -ar"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Allowed replay lag during rebalance is 10 GB" to stdout
+        And all the segments are running
+        And user can start transactions
+
+
     @remove_rsync_bash
     @concourse_cluster
     Scenario: None of the accumulated wal (after running pg_start_backup and before copying the pg_control file) is lost during differential

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2883,6 +2883,20 @@ def impl(context, command, target):
     if target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
 
+
+@then('{command} should print "{target}" regex to logfile')
+def impl(context, command, target):
+    log_dir = _get_gpAdminLogs_directory()
+    filename = glob.glob('%s/%s_*.log' % (log_dir, command))[0]
+    contents = ''
+    with open(filename) as fr:
+        for line in fr:
+            contents += line
+
+    pat = re.compile(target)
+    if not pat.search(contents):
+        raise Exception("cannot find %s in %s" % (target, filename))
+
 @given('verify that a role "{role_name}" exists in database "{dbname}"')
 @then('verify that a role "{role_name}" exists in database "{dbname}"')
 def impl(context, role_name, dbname):

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -10,7 +10,7 @@ gprecoverseg [[-p <new_recover_host>[,...]] | -i <recover_config_file>] [-d <coo
 	           [--hba-hostnames <boolean>] 
              [--no-progress] [-l <logfile_directory>]
 
-gprecoverseg -r 
+gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
 
 gprecoverseg -o <output_recover_config_file> 
              [-p <new_recover_host>[,...]]
@@ -167,6 +167,12 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 
 -r \(rebalance segments\)
 :   After a segment recovery, segment instances may not be returned to the preferred role that they were given at system initialization time. This can leave the system in a potentially unbalanced state, as some segment hosts may have more active segments than is optimal for top system performance. This option rebalances primary and mirror segments by returning them to their preferred roles. All segments must be valid and resynchronized before running `gprecoverseg -r`. If there are any in progress queries, they will be cancelled and rolled back.
+
+--replay-lag
+:   Replay lag(in GBs) allowed on mirror when rebalancing the segments. Default is 10 GB. If the replay_lag (flush_lsn-replay_lsn) is more than the value provided with this option then rebalance will be aborted.
+
+--disable-replay-lag
+:   Disable replay lag check when rebalancing segments
 
 -s \(sequential progress\)
 :   Show `pg_basebackup` or `pg_rewind` progress sequentially instead of in-place. Useful when writing to a file, or if a tty does not support escape sequences. The default is to show progress in-place.


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/16220

**Issue:** If there is a big gap between flush_lsn and replay_lsn on mirror then trigerring rebalance will cause a panic.

**Fix:** Added a check to WAL Replay Location of mirror. gprecoverseg rebalance should throw an exception if replay lag (flush_lsn - replay_lsn) on mirror is more than the default allowed limit (10 GB).

The default value for ALLOWED_REPLAY_LAG has been decided based on the experiments performed with different amount of replay lags on mirror. Below are the findings:

Purpose of experiments: Get the rough estimate of time mirror takes to replay different amount of wals
```

Replay_lag in bytes(flush_lsn - replay_lsn) | time taken by mirror to make replay_lag 0
--------------------------------------------|-------------------------------------------
132350280 (0.123 GB)                        |  9 secs
492864416 (0.460 GB)                        |  16 secs 
631452744 (0.588 GB)                        |  35 secs 
835431392 (0.778 GB)                        |  45 secs 
1642613424 (1.529 GB)                       |  50 secs
3284380456 (3.058 GB)                       |  1 min 45 sec
4926554560 (4.588 GB)                       |  2 mins 56 secs 
6891280424 (6.418 GB)                       |  4 min 30 secs
12652128968 (11.783 GB)                     |  6 mins 18 secs
```

ALLOWED_REPLAY_LAG (default value 10 GB) can be configured to any other value using flag --replay-lag with gprecoverseg -r. The check for the replay lag can also be disabled completely using the new flag --disable-replay-lag.

**New flags:**
--disbale-replay-lag: will turn off the replay_lag check during rebalance
Usage:
gprecoverseg -r --disable-replay-lag

--replay-lag: will set the provided value as the new allowed replay lag on mirror
Usage:
gprecoverseg -r --replay-lag 2 



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
