### PR TITLE
docs - gporca now supports backwards index scan

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -54,6 +54,7 @@ These features are unsupported when GPORCA is enabled \(the default\):
     - Partial dynamic index scan
     - Index-only scan on GIST indexes
     - Partial indexes
+    - Forward and backward dynamic index and dynamic index-only scans on partitioned tables
     - Indexed expressions (an index defined as an expression based on one or more columns of the table)
     - Combined indexes
 

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -54,7 +54,6 @@ These features are unsupported when GPORCA is enabled \(the default\):
     - Partial dynamic index scan
     - Index-only scan on GIST indexes
     - Partial indexes
-    - Backward index scan
     - Indexed expressions (an index defined as an expression based on one or more columns of the table)
     - Combined indexes
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/16087.

remove backwards index scan from list of unsupported gporca index features
