### PR TITLE
Disallow non-standalone ALTER distribution

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -542,6 +542,9 @@ static void prepare_AlterTableStmt_for_dispatch(AlterTableStmt *stmt);
 static List *strip_gpdb_part_commands(List *cmds);
 static void populate_rel_col_encodings(Relation rel, List *stenc, List *withOptions);
 
+static void checkATSetDistributedByStandalone(AlteredTableInfo *tab, Relation rel);
+
+
 /* ----------------------------------------------------------------
  *		DefineRelation
  *				Creates a new relation.
@@ -5794,6 +5797,7 @@ ATExecCmd(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			ATExecGenericOptions(rel, (List *) cmd->def);
 			break;
 		case AT_SetDistributedBy:	/* SET DISTRIBUTED BY */
+			checkATSetDistributedByStandalone(tab, rel);
 			ATExecSetDistributedBy(rel, (Node *) cmd->def, cmd);
 			break;
 		case AT_ExpandTable:	/* EXPAND TABLE */
@@ -21868,4 +21872,36 @@ ATDetachCheckNoForeignKeyRefs(Relation partition)
 
 		table_close(rel, NoLock);
 	}
+}
+
+/*
+ * Check if AT SET DISTRIBUTED BY for this relation was specified in isolation.
+ * Currently, we don't allow AT SET DISTRIBUTED BY to be specified with other
+ * subcommands. This is due to the way that AT SET DISTRIBUTED BY is currently
+ * implemented: ATExecSetDistributedBy dispatches a CTAS, outside the regular
+ * AT dispatch workflow, which results in an inconsistent view of the catalog on
+ * the QEs.
+ */
+static void
+checkATSetDistributedByStandalone(AlteredTableInfo *tab, Relation rel)
+{
+	bool standalone = true;
+
+	for (int i = 0; i < AT_NUM_PASSES; ++i)
+	{
+		if (i != AT_PASS_MISC && list_length(tab->subcmds[i]) > 0)
+		{
+			standalone = false;
+			break;
+		}
+	}
+	if (list_length(tab->subcmds[AT_PASS_MISC]) > 1)
+		standalone = false;
+
+	if (!standalone)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("cannot alter distribution with other subcommands for relation \"%s\"",
+						   RelationGetRelationName(rel)),
+					errhint("consider separating into multiple statements")));
 }

--- a/src/test/isolation2/expected/aoco_column_rewrite.out
+++ b/src/test/isolation2/expected/aoco_column_rewrite.out
@@ -1568,31 +1568,6 @@ ALTER TABLE
 alter table atsetenc set access method heap, alter column c8 set encoding (compresstype=zlib,compresslevel=9);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
 DETAIL:  New access method for "atsetenc" is not ao_column
--- reorganize, should rewrite
-execute capturerelfilenodebefore('set encoding - reorg', 'atsetenc');
-INSERT 0 4
-alter table atsetenc set with (reorganize=true), alter column c8 set encoding (compresstype=zlib,compresslevel=9);
-ALTER TABLE
-execute checkrelfilenodediff('set encoding - reorg', 'atsetenc');
- segid | casename             | relname  | rewritten 
--------+----------------------+----------+-----------
- 2     | set encoding - reorg | atsetenc | t         
- -1    | set encoding - reorg | atsetenc | t         
- 0     | set encoding - reorg | atsetenc | t         
- 1     | set encoding - reorg | atsetenc | t         
-(4 rows)
-execute attribute_encoding_check('atsetenc');
- relname  | attname                      | filenum | attoptions                                                  
-----------+------------------------------+---------+-------------------------------------------------------------
- atsetenc | c1                           | 1       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
- atsetenc | c2                           | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
- atsetenc | c4                           | 4       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
- atsetenc | c5                           | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
- atsetenc | c6                           | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- atsetenc | c7                           | 7       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
- atsetenc | c8                           | 8       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
- atsetenc | ........pg.dropped.3........ | 3       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
-(8 rows)
 
 -- 5. multiple SET ENCODING commands
 -- not rewrite
@@ -1611,13 +1586,13 @@ execute checkrelfilenodediff('set encoding - multiple', 'atsetenc');
 execute attribute_encoding_check('atsetenc');
  relname  | attname                      | filenum | attoptions                                                      
 ----------+------------------------------+---------+-----------------------------------------------------------------
- atsetenc | c1                           | 1       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
+ atsetenc | c1                           | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
  atsetenc | c2                           | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1']     
- atsetenc | c4                           | 4       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
+ atsetenc | c4                           | 1604    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
  atsetenc | c5                           | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1']     
- atsetenc | ........pg.dropped.3........ | 3       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
  atsetenc | c6                           | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
- atsetenc | c7                           | 1607    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=3'] 
+ atsetenc | c7                           | 7       | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=3'] 
+ atsetenc | ........pg.dropped.3........ | 1603    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
  atsetenc | c8                           | 1608    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=4'] 
 (8 rows)
 

--- a/src/test/isolation2/sql/aoco_column_rewrite.sql
+++ b/src/test/isolation2/sql/aoco_column_rewrite.sql
@@ -571,11 +571,6 @@ select c7 from atsetenc;
 alter table atsetenc add column c8 int default 8;
 -- changing to another AM, should complaint
 alter table atsetenc set access method heap, alter column c8 set encoding (compresstype=zlib,compresslevel=9);
--- reorganize, should rewrite
-execute capturerelfilenodebefore('set encoding - reorg', 'atsetenc');
-alter table atsetenc set with (reorganize=true), alter column c8 set encoding (compresstype=zlib,compresslevel=9);
-execute checkrelfilenodediff('set encoding - reorg', 'atsetenc');
-execute attribute_encoding_check('atsetenc');
 
 -- 5. multiple SET ENCODING commands
 -- not rewrite

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1770,3 +1770,14 @@ select check_redistributed('insert into t_distbya select * from t_reorganize', '
 
 reset optimizer;
 reset gp_force_random_redistribution;
+-- Check that AT SET DISTRIBUTED BY cannot be combined with other subcommands
+-- on the same table
+CREATE TABLE atsdby_multiple(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE atsdby_multiple SET DISTRIBUTED BY(j), ADD COLUMN k int;
+ERROR:  cannot alter distribution with other subcommands for relation "atsdby_multiple"
+HINT:  consider separating into multiple statements
+ALTER TABLE atsdby_multiple SET WITH (reorganize=true), ADD COLUMN k int;
+ERROR:  cannot alter distribution with other subcommands for relation "atsdby_multiple"
+HINT:  consider separating into multiple statements

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -616,3 +616,9 @@ select check_redistributed('insert into t_distbya select * from t_reorganize', '
 
 reset optimizer;
 reset gp_force_random_redistribution;
+
+-- Check that AT SET DISTRIBUTED BY cannot be combined with other subcommands
+-- on the same table
+CREATE TABLE atsdby_multiple(i int, j int);
+ALTER TABLE atsdby_multiple SET DISTRIBUTED BY(j), ADD COLUMN k int;
+ALTER TABLE atsdby_multiple SET WITH (reorganize=true), ADD COLUMN k int;


### PR DESCRIPTION
If AT SET DISTRIBUTED BY, or AT SET WITH (reorganize=true|false) is run
today along with another subcommand, it will result in ERRORs such as:

ALTER TABLE foo ADD COLUMN c int, SET DISTRIBUTED BY(b);
ERROR: attribute number 3 exceeds number of columns 2

This kind of error results when the CTAS for the temp table is
dispatched as part of ATExecSetDistributedBy(). Since SET DISTRIBUTED BY
is run in the last pass, the ADD COLUMN takes effect on the QD and is
considered as part of the dispatched QueryDesc for the CTAS. However,
since the AT command has not been dispatched yet to the QEs (which only
happens after ATController()), the QE hasn't yet applied the results of
the ADD COLUMN operation.  Thus, the QEs cannot reconcile the reference
to the added column, and an ERROR results.

Other ERRORs can also result from having an inconsistent view of the
catalog on the QEs in the CTAS.

Supporting AT SET DISTRIBUTED BY with other subcommands would require
abandoning the current approach, and aligining it with regular AT
workflow. Since, that is a larger change, we ban such usage at the
moment.


Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/ban_setdby
