### PR TITLE
io limit: save oid in catalog instead of tablespace name

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -787,7 +787,7 @@ ResGroupCheckForRole(Oid groupId)
 	/* Load current resource group capabilities */
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
 
-	if (cgroupOpsRoutine != NULL)
+	if (cgroupOpsRoutine != NULL && caps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(caps.io_limit);
 
 	heap_close(pg_resgroupcapability_rel, AccessShareLock);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -502,9 +502,10 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	}
 	else if (limitType == RESGROUP_LIMIT_TYPE_IO_LIMIT)
 	{
-		updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
-									  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
-									  0, cgroupOpsRoutine->dumpio(caps.io_limit));
+		if (caps.io_limit != NIL)
+			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
+										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
+										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 	}
 	else
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -215,20 +215,14 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 		callbackCtx->groupid = groupid;
 		callbackCtx->caps = caps;
 
-		if (caps.io_limit != NULL)
-		{
-			callbackCtx->caps.io_limit = pstrdup(caps.io_limit);
-			callbackCtx->ioLimit = cgroupOpsRoutine->parseio(caps.io_limit);
-		}
-
 		MemoryContextSwitchTo(oldContext);
 		RegisterXactCallbackOnce(createResgroupCallback, callbackCtx);
 
 		/* Create os dependent part for this resource group */
 		cgroupOpsRoutine->createcgroup(groupid);
 
-		if (caps.io_limit != NULL)
-			cgroupOpsRoutine->setio(groupid, callbackCtx->ioLimit);
+		if (caps.io_limit != NIL)
+			cgroupOpsRoutine->setio(groupid, caps.io_limit);
 
 		if (CpusetIsEmpty(caps.cpuset))
 		{
@@ -465,7 +459,15 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			caps.min_cost = value;
 			break;
 		case RESGROUP_LIMIT_TYPE_IO_LIMIT:
-			caps.io_limit = io_limit;
+			oldContext = CurrentMemoryContext;
+			if (cgroupOpsRoutine == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("resource group must be enabled to use io limit feature")));
+
+			MemoryContextSwitchTo(TopMemoryContext);
+			caps.io_limit = cgroupOpsRoutine->parseio(io_limit);
+			MemoryContextSwitchTo(oldContext);
 			break;
 		default:
 			break;
@@ -502,7 +504,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	{
 		updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 									  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
-									  0, caps.io_limit);
+									  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 	}
 	else
 	{
@@ -535,15 +537,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 		callbackCtx->groupid = groupid;
 		callbackCtx->limittype = limitType;
 		callbackCtx->caps = caps;
-
-		if (caps.io_limit != NULL)
-		{
-			callbackCtx->ioLimit = cgroupOpsRoutine->parseio(caps.io_limit);
-			callbackCtx->caps.io_limit = pstrdup(caps.io_limit);
-		}
-
 		callbackCtx->oldCaps = oldCaps;
-		callbackCtx->oldCaps.io_limit = NULL;
 
 		MemoryContextSwitchTo(oldContext);
 		RegisterXactCallbackOnce(alterResgroupCallback, callbackCtx);
@@ -556,6 +550,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 void
 GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 {
+	MemoryContext oldContext;
 	SysScanDesc	sscan;
 	ScanKeyData	key;
 	HeapTuple	tuple;
@@ -631,10 +626,16 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 													getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_IO_LIMIT:
-				if (strcmp(value, DefaultIOLimit) != 0)
-					resgroupCaps->io_limit = value;
+				if (cgroupOpsRoutine != NULL)
+				{
+					oldContext = CurrentMemoryContext;
+					MemoryContextSwitchTo(TopMemoryContext);
+					resgroupCaps->io_limit = cgroupOpsRoutine->parseio(value);
+					MemoryContextSwitchTo(oldContext);
+				}
 				else
-				    resgroupCaps->io_limit = NULL;
+					resgroupCaps->io_limit = NIL;
+				break;
 			default:
 				break;
 		}
@@ -786,6 +787,9 @@ ResGroupCheckForRole(Oid groupId)
 	/* Load current resource group capabilities */
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupId, &caps);
 
+	if (cgroupOpsRoutine != NULL)
+		cgroupOpsRoutine->freeio(caps.io_limit);
+
 	heap_close(pg_resgroupcapability_rel, AccessShareLock);
 }
 
@@ -925,6 +929,7 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 static void
 parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 {
+	MemoryContext oldContext;
 	ListCell *cell;
 	ResGroupCap value;
 	int mask = 0;
@@ -956,7 +961,19 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 			caps->cpuWeight = RESGROUP_DEFAULT_CPU_WEIGHT;
 		}
 		else if (type == RESGROUP_LIMIT_TYPE_IO_LIMIT)
-			caps->io_limit = defGetString(defel);
+		{
+			char *io_limit_str = defGetString(defel);
+
+			oldContext = CurrentMemoryContext;
+			if (cgroupOpsRoutine == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("resource group must be enabled to use io limit feature")));
+
+			MemoryContextSwitchTo(TopMemoryContext);
+			caps->io_limit = cgroupOpsRoutine->parseio(io_limit_str);
+			MemoryContextSwitchTo(oldContext);
+		}
 		else
 		{
 			value = getResgroupOptionValue(defel);
@@ -1031,11 +1048,8 @@ createResgroupCallback(XactEvent event, void *arg)
 		ResGroupCreateOnAbort(callbackCtx);
 	}
 
-	if (callbackCtx->caps.io_limit != NULL)
-	{
-		cgroupOpsRoutine->freeio(callbackCtx->ioLimit);
-		pfree(callbackCtx->caps.io_limit);
-	}
+	if (callbackCtx->caps.io_limit != NIL)
+		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
 	pfree(callbackCtx);
 }
 
@@ -1068,11 +1082,12 @@ alterResgroupCallback(XactEvent event, void *arg)
 	if (event == XACT_EVENT_COMMIT)
 		ResGroupAlterOnCommit(callbackCtx);
 
-	if (callbackCtx->caps.io_limit != NULL)
-	{
-		cgroupOpsRoutine->freeio(callbackCtx->ioLimit);
-		pfree(callbackCtx->caps.io_limit);
-	}
+	if (callbackCtx->caps.io_limit != NIL)
+		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
+
+	if (callbackCtx->caps.io_limit != NIL)
+		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);
+
 	pfree(callbackCtx);
 }
 
@@ -1118,9 +1133,10 @@ insertResgroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *caps)
 	insertResgroupCapabilityEntry(rel, groupId,
 								  RESGROUP_LIMIT_TYPE_MIN_COST, value);
 
-	if (caps->io_limit != NULL)
+	if (caps->io_limit != NIL)
 		insertResgroupCapabilityEntry(rel, groupId,
-									  RESGROUP_LIMIT_TYPE_IO_LIMIT, caps->io_limit);
+									  RESGROUP_LIMIT_TYPE_IO_LIMIT,
+									  cgroupOpsRoutine->dumpio((caps->io_limit)));
 	else
 		insertResgroupCapabilityEntry(rel, groupId,
 									  RESGROUP_LIMIT_TYPE_IO_LIMIT, DefaultIOLimit);

--- a/src/backend/utils/resgroup/cgroup-ops-dummy.c
+++ b/src/backend/utils/resgroup/cgroup-ops-dummy.c
@@ -14,6 +14,7 @@
 
 #include "postgres.h"
 
+#include "utils/resgroup.h"
 #include "utils/cgroup.h"
 #include "utils/cgroup-ops-dummy.h"
 
@@ -221,7 +222,7 @@ static List *
 parseio_dummy(const char *io_limit)
 {
 	unsupported_system();
-	return NULL;
+	return NIL;
 }
 
 static void
@@ -241,6 +242,14 @@ getiostat_dummy(Oid group, List *io_limit)
 {
 	unsupported_system();
 	return NIL;
+}
+
+static char *
+dumpio_dummy(List *limit_list)
+{
+	unsupported_system();
+
+	return DefaultIOLimit;
 }
 
 static CGroupOpsRoutine cGroupOpsRoutineDummy = {
@@ -270,7 +279,8 @@ static CGroupOpsRoutine cGroupOpsRoutineDummy = {
 		.parseio = parseio_dummy,
 		.setio = setio_dummy,
 		.freeio = freeio_dummy,
-		.getiostat = getiostat_dummy
+		.getiostat = getiostat_dummy,
+		.dumpio = dumpio_dummy
 };
 
 CGroupOpsRoutine *get_cgroup_routine_dummy(void)

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
@@ -175,6 +175,7 @@ static List *parseio_v1(const char *io_limit);
 static void setio_v1(Oid group, List *limit_list);
 static void freeio_v1(List *limit_list);
 static List* getiostat_v1(Oid group, List *io_limit);
+static char *dumpio_v1(List *limit_list);
 
 /*
  * Detect gpdb cgroup component dirs.
@@ -1111,10 +1112,16 @@ getmemoryusage_v1(Oid group)
 static List *
 parseio_v1(const char *io_limit)
 {
+	if (io_limit == NULL)
+		return NIL;
+
+	if (strcmp(io_limit, DefaultIOLimit) == 0)
+		return NIL;
+
 	ereport(WARNING,
 			(errcode(ERRCODE_SYSTEM_ERROR),
-			 errmsg("resource group io limit only can be used in cgroup v2.")));
-	return NULL;
+			errmsg("resource group io limit only can be used in cgroup v2.")));
+	return NIL;
 }
 
 static void
@@ -1140,6 +1147,15 @@ getiostat_v1(Oid group, List *io_limit)
 			(errcode(ERRCODE_SYSTEM_ERROR),
 			 errmsg("resource group io limit only can be used in cgroup v2.")));
 	return NIL;
+}
+
+static char *
+dumpio_v1(List *limit_list)
+{
+	ereport(WARNING,
+			(errcode(ERRCODE_SYSTEM_ERROR),
+			 errmsg("resource group io limit only can be used in cgroup v2.")));
+	return DefaultIOLimit;
 }
 
 static CGroupOpsRoutine cGroupOpsRoutineV1 = {
@@ -1170,7 +1186,8 @@ static CGroupOpsRoutine cGroupOpsRoutineV1 = {
 		.parseio = parseio_v1,
 		.setio = setio_v1,
 		.freeio = freeio_v1,
-		.getiostat = getiostat_v1
+		.getiostat = getiostat_v1,
+		.dumpio = dumpio_v1
 };
 
 CGroupOpsRoutine *get_group_routine_v1(void)

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -166,6 +166,7 @@ static List *parseio_v2(const char *io_limit);
 static void setio_v2(Oid group, List *limit_list);
 static void freeio_v2(List *limit_list);
 static List	*getiostat_v2(Oid group, List *io_limit);
+static char *dumpio_v2(List *limit_list);
 
 /*
  * Dump component dir to the log.
@@ -827,6 +828,9 @@ parseio_v2(const char *io_limit)
 	if (io_limit == NULL)
 		return NIL;
 
+	if (strcmp(io_limit, DefaultIOLimit) == 0)
+		return NIL;
+
 	result = io_limit_parse(io_limit);
 	io_limit_validate(result);
 
@@ -897,6 +901,12 @@ getiostat_v2(Oid groupid, List *io_limit)
 	return get_iostat(groupid, io_limit);
 }
 
+static char *
+dumpio_v2(List *limit_list)
+{
+	return io_limit_dump(limit_list);
+}
+
 static CGroupOpsRoutine cGroupOpsRoutineV2 = {
 		.getcgroupname = getcgroupname_v2,
 		.probecgroup = probecgroup_v2,
@@ -925,7 +935,8 @@ static CGroupOpsRoutine cGroupOpsRoutineV2 = {
 		.parseio = parseio_v2,
 		.setio = setio_v2,
 		.freeio = freeio_v2,
-		.getiostat = getiostat_v2
+		.getiostat = getiostat_v2,
+		.dumpio = dumpio_v2
 };
 
 CGroupOpsRoutine *get_group_routine_v2(void)

--- a/src/backend/utils/resgroup/cgroup_io_limit.c
+++ b/src/backend/utils/resgroup/cgroup_io_limit.c
@@ -514,3 +514,37 @@ compare_iostat(const void *x, const void *y)
 
 	return 0;
 }
+
+char *
+io_limit_dump(List *limit_list)
+{
+	ListCell *cell;
+
+	StringInfo result = makeStringInfo();
+
+	foreach(cell, limit_list)
+	{
+		int i;
+		int fields_length = lengthof(IOconfigFields);
+		TblSpcIOLimit *limit = (TblSpcIOLimit *) lfirst(cell);
+		uint64 *value = (uint64 *) limit->ioconfig;
+
+		if (limit->tablespace_oid != InvalidOid)
+			appendStringInfo(result, "%u:", limit->tablespace_oid);
+		else
+			appendStringInfo(result, "*:");
+
+		for(i = 0; i < fields_length; i++)
+		{
+			appendStringInfo(result, "%s=%lu", IOconfigFields[i], *(value + i));
+
+			if (i + 1 != fields_length)
+				appendStringInfo(result, ",");
+		}
+
+		if (cell != limit_list->tail)
+			appendStringInfo(result, ";");
+	}
+
+	return result->data;
+}

--- a/src/backend/utils/resgroup/io_limit_scanner.l
+++ b/src/backend/utils/resgroup/io_limit_scanner.l
@@ -38,7 +38,7 @@ max          {
 
 [[:digit:]]+ {
                 yylval->integer = strtoull(yytext, NULL, 10);
-                return VALUE;
+                return NUMBER;
              }
 
 {wildcard}   {

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -495,8 +495,11 @@ InitResGroups(void)
 
 		cgroupOpsRoutine->createcgroup(groupId);
 
-		if (caps.io_limit != NULL)
-			cgroupOpsRoutine->setio(groupId, cgroupOpsRoutine->parseio(caps.io_limit));
+		if (caps.io_limit != NIL)
+		{
+			cgroupOpsRoutine->setio(groupId, caps.io_limit);
+			cgroupOpsRoutine->freeio(caps.io_limit);
+		}
 
 		if (CpusetIsEmpty(caps.cpuset))
 		{
@@ -802,7 +805,7 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 		}
 		else if (callbackCtx->limittype == RESGROUP_LIMIT_TYPE_IO_LIMIT)
 		{
-			cgroupOpsRoutine->setio(callbackCtx->groupid, callbackCtx->ioLimit);
+			cgroupOpsRoutine->setio(callbackCtx->groupid, callbackCtx->caps.io_limit);
 		}
 
 		/* reset default group if cpuset has changed */
@@ -974,7 +977,7 @@ createGroup(Oid groupId, const ResGroupCaps *caps)
 	group->caps = *caps;
 
 	/* remove local pointers */
-	group->caps.io_limit = NULL;
+	group->caps.io_limit = NIL;
 
 	group->nRunning = 0;
 	group->nRunningBypassed = 0;

--- a/src/include/utils/cgroup.h
+++ b/src/include/utils/cgroup.h
@@ -232,6 +232,7 @@ typedef List* (*parseio_function) (const char *io_limit);
 typedef void (*setio_function) (Oid group, List *limit_list);
 typedef void (*freeio_function) (List *limit_list);
 typedef List* (*getiostat_function) (Oid groupid, List *io_limit);
+typedef char* (*dumpio_function) (List *limit_list);
 
 
 typedef struct CGroupOpsRoutine
@@ -270,6 +271,7 @@ typedef struct CGroupOpsRoutine
 	setio_function			setio;
 	freeio_function			freeio;
 	getiostat_function		getiostat;
+	dumpio_function			dumpio;
 } CGroupOpsRoutine;
 
 /* The global function handler. */

--- a/src/include/utils/cgroup_io_limit.h
+++ b/src/include/utils/cgroup_io_limit.h
@@ -107,5 +107,6 @@ extern void io_limit_validate(List *limit_list);
 
 extern List  *get_iostat(Oid groupid, List *io_limit);
 extern int  compare_iostat(const void *a, const void *b);
+extern char *io_limit_dump(List *limit_list);
 
 #endif

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -78,10 +78,10 @@ typedef struct ResGroupCaps
 	volatile ResGroupCap	min_cost;
 
 	/*
-	 * io_limit are local pointers,
-	 * do not use it for cross MemoryContext.
+	 * io_limit is a pointer in TopMemoryContext,
+	 * This cell of list should be converted to TblSpcIOLimit when use.
 	 */
-	char			*io_limit;
+	List			*io_limit;
 
 	char			cpuset[MaxCpuSetLength];
 } ResGroupCaps;

--- a/src/test/isolation2/output/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_io_limit.source
@@ -2,9 +2,9 @@
 CREATE RESOURCE GROUP rg_test_group1 WITH (concurrency=10, cpu_max_percent=10, io_limit='pg_default:rbps=1000,wbps=1000,riops=1000,wiops=1000');
 CREATE RESOURCE GROUP
 SELECT io_limit FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group1';
- io_limit                                             
-------------------------------------------------------
- pg_default:rbps=1000,wbps=1000,riops=1000,wiops=1000 
+ io_limit                                       
+------------------------------------------------
+ 1663:rbps=1000,wbps=1000,riops=1000,wiops=1000 
 (1 row)
 
 SELECT check_cgroup_io_max('rg_test_group1', 'pg_default', 'rbps=1048576000 wbps=1048576000 riops=1000 wiops=1000');


### PR DESCRIPTION
Use tablespace name in catalog will cause some wrong exceptions, for example, the tablespace has been renamed.

Use oid in catalog like:
```
1663:rbps=5,wbps=5,riops=1000,wiops=1000
```
can eliminate errors caused by rename.

io limit also support write tablespace oid directly in this pr. Both
```
1663:rbps=5,wbps=5,riops=1000,wiops=1000
```
and 
```
pg_default:rbps=5,wbps=5,riops=1000,wiops=1000
```
is legal.

