### PR TITLE
Fix ldap crash when ldaptls=1 and ldapscheme is not set.

### DIFF
--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1580,7 +1580,7 @@ parse_hba_line(TokenizedLine *tok_line, int elevel)
 		 * make the connection between database and the LDAP server use TLS
 		 * encryption. The scheme 'ldaps' makes LDAP connections over SSL.
 		 */
-		if (parsedline->ldaptls && strcmp(parsedline->ldapscheme, "ldaps") == 0)
+		if (parsedline->ldaptls && parsedline->ldapscheme && strcmp(parsedline->ldapscheme, "ldaps") == 0)
 		{
 			ereport(LOG,
 					(errcode(ERRCODE_CONFIG_FILE_ERROR),

--- a/src/test/regress/expected/hba_conf.out
+++ b/src/test/regress/expected/hba_conf.out
@@ -1,0 +1,11 @@
+-- Test ldap
+-- backup pg_hba.conf
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
+\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' > $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select * from pg_hba_file_rules;
+ line_number |   type    | database | user_name |    address    |     netmask     | auth_method |                                                                        options                                                                        | error 
+-------------+-----------+----------+-----------+---------------+-----------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
+           1 | hostnossl | {all}    | {all}     | 10.10.100.100 | 255.255.255.255 | ldap        | {ldapserver=abc.example.com,ldapport=3268,ldaptls=true,ldapbasedn=DC=COM,"ldapbinddn=OU=Hosting,DC=COM",ldapbindpasswd=ldapbindpasswd111,ldapscope=2} | 
+(1 row)
+
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf

--- a/src/test/regress/expected/hba_conf.out
+++ b/src/test/regress/expected/hba_conf.out
@@ -1,11 +1,8 @@
 -- Test ldap
--- backup pg_hba.conf
-\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
-\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' > $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
-select * from pg_hba_file_rules;
- line_number |   type    | database | user_name |    address    |     netmask     | auth_method |                                                                        options                                                                        | error 
--------------+-----------+----------+-----------+---------------+-----------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------
-           1 | hostnossl | {all}    | {all}     | 10.10.100.100 | 255.255.255.255 | ldap        | {ldapserver=abc.example.com,ldapport=3268,ldaptls=true,ldapbasedn=DC=COM,"ldapbinddn=OU=Hosting,DC=COM",ldapbindpasswd=ldapbindpasswd111,ldapscope=2} | 
+\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select type,database,user_name,address,netmask,auth_method,options from pg_hba_file_rules where address = '10.10.100.100';
+   type    | database | user_name |    address    |     netmask     | auth_method |                                                                        options                                                                        
+-----------+----------+-----------+---------------+-----------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ hostnossl | {all}    | {all}     | 10.10.100.100 | 255.255.255.255 | ldap        | {ldapserver=abc.example.com,ldapport=3268,ldaptls=true,ldapbasedn=DC=COM,"ldapbinddn=OU=Hosting,DC=COM",ldapbindpasswd=ldapbindpasswd111,ldapscope=2}
 (1 row)
 
-\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -357,4 +357,7 @@ test: quicklz_fallback
 # run this at the end of the schedule for more chance to catch abnormalities
 test: gp_check_files
 
+# run pg_hba raleted testing
+test: hba_conf
+
 # end of tests

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -202,3 +202,4 @@ test: event_trigger
 test: fast_default
 test: stats
 test: createdb
+test: hba_conf

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -202,4 +202,3 @@ test: event_trigger
 test: fast_default
 test: stats
 test: createdb
-test: hba_conf

--- a/src/test/regress/sql/hba_conf.sql
+++ b/src/test/regress/sql/hba_conf.sql
@@ -1,0 +1,6 @@
+-- Test ldap
+-- backup pg_hba.conf
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
+\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' > $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select * from pg_hba_file_rules;
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf

--- a/src/test/regress/sql/hba_conf.sql
+++ b/src/test/regress/sql/hba_conf.sql
@@ -1,6 +1,3 @@
 -- Test ldap
--- backup pg_hba.conf
-\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
-\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' > $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
-select * from pg_hba_file_rules;
-\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+\! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select type,database,user_name,address,netmask,auth_method,options from pg_hba_file_rules where address = '10.10.100.100';


### PR DESCRIPTION
When ldaptls is set to "1", and ldapscheme is not set, when `select from pg_hba_file_rules;`, postgres will crash because of dereference to a null pointer which is the value of ldapscheme.