### PR TITLE
Refine the document of resource groups

### DIFF
--- a/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
@@ -542,9 +542,6 @@ probecgroup_v1(void)
 
 	detect_component_dirs_v1();
 
-	if (!normalPermissionCheck(permlists, CGROUP_ROOT_ID, false))
-		return false;
-
 	return true;
 }
 

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -289,9 +289,6 @@ probecgroup_v2(void)
 	if (!getCgroupMountDir())
 		return false;
 
-	if (!normalPermissionCheck(permlists, CGROUP_ROOT_ID, false))
-		return false;
-
 	return true;
 }
 


### PR DESCRIPTION
The most important changes of this commit are:

1. Notice the user that cgroup2 doesn't yet support control of real-time
processes, the possible "Invalid argument" error is expected when there are
real-time processes in non-root cgroups.

2. Greenplum has to have the write permission of `/sys/fs/cgroup/cgroup.procs`
to manipulate the cgroups since it currently not spawned by Systemd or other
managers that take over cgroups management.

Reference: https://docs.kernel.org/admin-guide/cgroup-v2.html#controlling-controllers