### PR TITLE
Fix ORCA invalid processing of nested SubLinks under aggregates.

### DIFF
--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -605,8 +605,6 @@ LINE 4:                where sum(distinct a.four + b.four) = b.four)...
 select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1)))
 from tenk1 o;
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  max  
 ------
  9999

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -143,26 +143,25 @@ create table part_pa_test_p2 partition of part_pa_test for values from (0) to (m
 explain (costs off)
 	select (select max((select pa1.b from part_pa_test pa1 where pa1.a = pa2.a)))
 	from part_pa_test pa2;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Append
-                     ->  Seq Scan on part_pa_test_p1 pa2
-                     ->  Seq Scan on part_pa_test_p2 pa2_1
+               ->  Dynamic Seq Scan on part_pa_test
+                     Number of partitions to scan: 2 (out of 2)
                SubPlan 1
                  ->  Result
-                       Filter: (pa1.a = pa2.a)
+                       Filter: (part_pa_test_1.a = part_pa_test.a)
                        ->  Materialize
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                   ->  Append
-                                         ->  Seq Scan on part_pa_test_p1 pa1
-                                         ->  Seq Scan on part_pa_test_p2 pa1_1
+                                   ->  Dynamic Seq Scan on part_pa_test part_pa_test_1
+                                         Number of partitions to scan: 2 (out of 2)
    SubPlan 2
      ->  Result
- Optimizer: Postgres query optimizer
-(17 rows)
+           ->  Result
+ Optimizer: GPORCA
+(16 rows)
 
 drop table part_pa_test;
 -- test with leader participation disabled

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2043,4 +2043,35 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   Output: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max((SubPlan 1)))
+         ->  Partial Aggregate
+               Output: PARTIAL max((SubPlan 1))
+               ->  Seq Scan on public.t
+                     Output: t.i, t.j
+               SubPlan 1
+                 ->  Result
+                       Output: t.i
+   SubPlan 2
+     ->  Result
+           Output: max((SubPlan 1))
+ Optimizer: Postgres-based planner
+(15 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2131,4 +2131,37 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   Output: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL max((SubPlan 1)))
+         ->  Partial Aggregate
+               Output: PARTIAL max((SubPlan 1))
+               ->  Seq Scan on public.t
+                     Output: i
+               SubPlan 1
+                 ->  Result
+                       Output: t.i
+   SubPlan 2
+     ->  Result
+           Output: max((SubPlan 1))
+           ->  Result
+                 Output: true
+ Optimizer: GPORCA
+(17 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1016,4 +1016,13 @@ select j, 1 as c,
 from t
 group by j, q1;
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+
+select (select max((select t.i))) from t;
+
 drop table t;


### PR DESCRIPTION
The ORCA optimizer could produce an invalid query plan and fallback to the legacy optimizer due to incorrect processing of nested SubLinks (SubLink contains one more SubLink or rtable subquery inside) during query normalization.

The issue could arise when query had a AggRef inside a Sublink and that AggRef contained one more SubLink inside (see the example of the query in the tests section).

While mutating the SubLink inside RunExtractAggregatesMutator, the Aggref branch is executed for SubLink's query targetList, which mutates args of the AggRef. And if inside this AggRef arg some Var had varlevelsup value greater than the m_agg_levels_up, i.e the Var referenced a relation that is higher than the AggRef (it's important to notice, that Aggref referenced the same relation), the Var was not mutated at all. The varlevelsup field was not modified and because of that, when AggRef was pulled up to the zero query level (by appending it to the context.m_lower_table_tlist), the Var, whose varlevelsup was higher than AggRef's, and which remained unchanged, started referencing the wrong relation. This could lead to the fallback or invalid plan construction when processing attributes at further planning stages.

This patch makes the RunExtractAggregatesMutator modify the varlevelsup of the Var relatively the AggRef level in order to preserve proper query level.