### PR TITLE
[7x]gprecoverseg: Raise exception when -F option is used in rebalance and recovery to new host options

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -497,6 +497,20 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    Scenario: rebalance and recovery to new host with -F option shows error and exits
+      Given the database is running
+        And user stops all primary processes
+        And user can start transactions
+       When the user runs "gprecoverseg -a -F -r"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "-F option is not supported with -r option" to stdout
+       When the user runs "gprecoverseg -a -p localhost -F"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "-F option is not supported with -p option" to stdout
+       When the user runs "gprecoverseg -a"
+       Then gprecoverseg should return a return code of 0
+        And the segments are synchronized
+        And the cluster is rebalanced
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
**Issue:**
Currently, gprecoverseg performs rebalance operation (-r option) which is an incremental operation. To recover segments to a new host (-p option) operation is always a full recovery operation. 
Providing the `-F `flag along with the` -r `or -p option makes no sense. 

**Solution:**
To raise the exception when the Full Recovery option (-F)  is specified along with:
1. Recovery to new host (-p option)
2. Rebalance Operation (-r option)

Changes in this PR: 

- Raise error when -F option is passed with -r or -p
- Moved gprecoverseg flags validation to a separate function. 
- Added tests to verify rebalance and new host options.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
