### PR TITLE
add a new GUC of gp_detect_data_correctness to detect data correctness during OS upgrade

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -154,10 +154,14 @@ makeCdbHashForRelation(Relation rel)
 }
 
 /* release all memory of CdbHash */
-void freeCdbHash(CdbHash *h)
+void freeCdbHash(CdbHash *hash)
 {
-	pfree(h->hashfuncs);
-	pfree(h);
+	if (hash)
+	{
+		if (hash->hashfuncs)
+			pfree(hash->hashfuncs);
+		pfree(hash);
+	}
 }
 
 /*

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -128,6 +128,7 @@ makeCdbHash(int numsegs, int natts, Oid *hashfuncs)
 CdbHash *
 makeCdbHashForRelation(Relation rel)
 {
+	CdbHash    *h;
 	GpPolicy   *policy = rel->rd_cdbpolicy;
 	Oid		   *hashfuncs;
 	int			i;
@@ -146,7 +147,17 @@ makeCdbHashForRelation(Relation rel)
 		hashfuncs[i] = cdb_hashproc_in_opfamily(opfamily, typeoid);
 	}
 
-	return makeCdbHash(policy->numsegments, policy->nattrs, hashfuncs);
+	h = makeCdbHash(policy->numsegments, policy->nattrs, hashfuncs);
+
+	pfree(hashfuncs);
+	return h;
+}
+
+/* release all memory of CdbHash */
+void freeCdbHash(CdbHash *h)
+{
+	pfree(h->hashfuncs);
+	pfree(h);
 }
 
 /*

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -101,6 +101,8 @@ int         gp_segment_connect_timeout = 180;  /* Maximum time (in seconds) allo
 												* or a mirror to respond.
 												*/
 
+bool		gp_detect_data_correctness;		/* Detect if the current data distribution is correct */
+
 /*
  * Configurable timeout for snapshot add: exceptionally busy systems may take
  * longer than our old hard-coded version -- so here is a tuneable version.

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -62,6 +62,7 @@
 #include "catalog/aocatalog.h"
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbhash.h"
 #include "cdb/cdbvars.h"
 #include "parser/parsetree.h"
 #include "utils/lsyscache.h"
@@ -529,6 +530,55 @@ ExecInsert(ModifyTableState *mtstate,
 			 (resultRelInfo->ri_TrigDesc &&
 			  resultRelInfo->ri_TrigDesc->trig_insert_before_row)))
 			ExecPartitionCheck(resultRelInfo, slot, estate, true);
+
+		/*
+		 * Everything has been checked, if we set the GUC gp_detect_data_correctness to true,
+		 * we just verify the data belongs to current partition and segment, we'll not insert
+		 * the data really, so just return NULL.
+		 *
+		 * Above ExecPartitionCheck has already checked the partition correctness, so we just
+		 * need check distribution correctness.
+		 */
+		if (gp_detect_data_correctness)
+		{
+			/* Initialize hash function and structure */
+			CdbHash  *hash;
+			Relation rel = resultRelInfo->ri_RelationDesc;
+			GpPolicy *policy = rel->rd_cdbpolicy;
+
+			/* Skip randomly and replicated distributed relation */
+			if (GpPolicyIsRandomPartitioned(policy) || GpPolicyIsReplicated(policy))
+				return NULL;
+
+			hash = makeCdbHashForRelation(rel);
+
+			cdbhashinit(hash);
+
+			/* Add every attribute in the distribution policy to the hash */
+			for (int i = 0; i < policy->nattrs; i++)
+			{
+				int			attnum = policy->attrs[i];
+				bool		isNull;
+				Datum		attr;
+
+				attr = slot_getattr(slot, attnum, &isNull);
+
+				cdbhash(hash, i + 1, attr, isNull);
+			}
+
+			/* End check if one tuple is in the wrong segment */
+			if (cdbhashreduce(hash) != GpIdentity.segindex)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_CHECK_VIOLATION),
+								errmsg("trying to insert row into wrong segment")));
+			}
+
+			freeCdbHash(hash);
+
+			/* Do nothing */
+			return NULL;
+		}
 
 		if (onconflict != ONCONFLICT_NONE && resultRelInfo->ri_NumIndices > 0)
 		{

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -547,7 +547,7 @@ ExecInsert(ModifyTableState *mtstate,
 			GpPolicy *policy = rel->rd_cdbpolicy;
 
 			/* Skip randomly and replicated distributed relation */
-			if (GpPolicyIsRandomPartitioned(policy) || GpPolicyIsReplicated(policy))
+			if (!GpPolicyIsHashPartitioned(policy))
 				return NULL;
 
 			hash = makeCdbHashForRelation(rel);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2984,6 +2984,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+	{
+		{"gp_detect_data_correctness", PGC_USERSET, UNGROUPED,
+		gettext_noop("Detect if the current partitioning of the table or data distribution is correct."),
+		NULL,
+		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_detect_data_correctness,
+		false,
+		NULL, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -50,6 +50,7 @@ typedef struct CdbHash
  */
 extern CdbHash *makeCdbHash(int numsegs, int natts, Oid *typeoids);
 extern CdbHash *makeCdbHashForRelation(Relation rel);
+extern void freeCdbHash(CdbHash *h);
 
 /*
  * Initialize CdbHash for hashing the next tuple values.

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -122,6 +122,9 @@ extern int			gp_reject_percent_threshold;
  */
 extern bool           gp_select_invisible;
 
+/* Detect if the current partitioning of the table or data distribution is correct */
+extern bool			gp_detect_data_correctness;
+
 /*
  * Used to set the maximum length of the current query which is displayed
  * when the user queries pg_stat_activty table.

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -43,6 +43,7 @@
 		"gp_blockdirectory_minipage_size",
 		"gp_debug_linger",
 		"gp_default_storage_options",
+		"gp_detect_data_correctness",
 		"gp_disable_tuple_hints",
 		"gp_enable_interconnect_aggressive_retry",
 		"gp_enable_segment_copy_checking",

--- a/src/test/isolation2/expected/guc_gp.out
+++ b/src/test/isolation2/expected/guc_gp.out
@@ -1,0 +1,61 @@
+-- case 1: test gp_detect_data_correctness
+create table data_correctness_detect(a int, b int);
+CREATE TABLE
+create table data_correctness_detect_randomly(a int, b int) distributed randomly;
+CREATE TABLE
+create table data_correctness_detect_replicated(a int, b int) distributed replicated;
+CREATE TABLE
+
+set gp_detect_data_correctness = on;
+SET
+-- should no data insert
+insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+INSERT 0 0
+select count(*) from data_correctness_detect;
+ count 
+-------
+ 0     
+(1 row)
+insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+INSERT 0 0
+select count(*) from data_correctness_detect_randomly;
+ count 
+-------
+ 0     
+(1 row)
+insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+INSERT 0 0
+select count(*) from data_correctness_detect_replicated;
+ count 
+-------
+ 0     
+(1 row)
+set gp_detect_data_correctness = off;
+SET
+
+-- insert some data that not belongs to it
+1U: insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+INSERT 0 100
+1U: insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+INSERT 0 100
+1U: insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+INSERT 0 100
+set gp_detect_data_correctness = on;
+SET
+insert into data_correctness_detect select * from data_correctness_detect;
+ERROR:  trying to insert row into wrong segment  (seg1 127.0.1.1:7003 pid=618729)
+insert into data_correctness_detect select * from data_correctness_detect_randomly;
+INSERT 0 0
+insert into data_correctness_detect select * from data_correctness_detect_replicated;
+INSERT 0 0
+
+-- clean up
+set gp_detect_data_correctness = off;
+SET
+drop table data_correctness_detect;
+DROP TABLE
+drop table data_correctness_detect_randomly;
+DROP TABLE
+drop table data_correctness_detect_replicated;
+DROP TABLE
+

--- a/src/test/isolation2/sql/guc_gp.sql
+++ b/src/test/isolation2/sql/guc_gp.sql
@@ -1,0 +1,30 @@
+-- case 1: test gp_detect_data_correctness
+create table data_correctness_detect(a int, b int);
+create table data_correctness_detect_randomly(a int, b int) distributed randomly;
+create table data_correctness_detect_replicated(a int, b int) distributed replicated;
+
+set gp_detect_data_correctness = on;
+-- should no data insert
+insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect;
+insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect_randomly;
+insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect_replicated;
+set gp_detect_data_correctness = off;
+
+-- insert some data that not belongs to it
+1U: insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+1U: insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+1U: insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+set gp_detect_data_correctness = on;
+insert into data_correctness_detect select * from data_correctness_detect;
+insert into data_correctness_detect select * from data_correctness_detect_randomly;
+insert into data_correctness_detect select * from data_correctness_detect_replicated;
+
+-- clean up
+set gp_detect_data_correctness = off;
+drop table data_correctness_detect;
+drop table data_correctness_detect_randomly;
+drop table data_correctness_detect_replicated;
+


### PR DESCRIPTION
During OS upgrades, such as an upgrade from CentOS 7 to CentOS 8, there could be some
locale changes happen that lead to the data distribution or data partition position change.

In order to detect it, we add a new GUC of `gp_detect_data_correctness`, if it sets to on,
we will not insert data actually, we just check whether the data belongs to this segment or
this partition table or not.