### PR TITLE
Fix awk script for Gawk 5.0~.

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -86,14 +86,14 @@ SYMBOL_MAPPING_FLAGS =
 ifeq ($(PORTNAME), darwin)
 SYMBOL_MAP_FILE = hide_symbols.list
 $(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
-	$(AWK) '/^[^\#]/ {printf "_%s\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN) >$@
+	$(AWK) '/^[^#]/ {printf "_%s\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN) >$@
 SYMBOL_MAPPING_FLAGS = -unexported_symbols_list $(SYMBOL_MAP_FILE)
 endif
 
 ifeq ($(PORTNAME), linux)
 SYMBOL_MAP_FILE = postgres_symbols.map
 $(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
-	( echo '{ global: *; '; echo ' local:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN); echo '};' ) >$@
+	( echo '{ global: *; '; echo ' local:'; $(AWK) '/^[^#]/ {printf "%s;\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN); echo '};' ) >$@
 SYMBOL_MAPPING_FLAGS = -Wl,--version-script=$(SYMBOL_MAP_FILE)
 endif
 


### PR DESCRIPTION
In Gawk 5.0, regexp routines are replaced by Gnulib implementation, which only allows escaping specific characters. This patch fix the warning introduced in b3ad725.

Upstream PostgreSQL seems having the same issue.
