### PR TITLE
[6X] gprecoverseg differential: Data integrity scenario

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -34,7 +34,7 @@ curr_platform = platform.uname()[0].lower()
 GPHOME = os.environ.get('GPHOME', None)
 
 # ---------------command path--------------------
-CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
+CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/usr/local/bin', '/bin',
            '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
 
 if GPHOME:

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -192,3 +192,9 @@ def after_scenario(context, scenario):
     if os.getenv('SUSPEND_PG_REWIND') is not None:
         del os.environ['SUSPEND_PG_REWIND']
 
+    if "remove_rsync_bash" in scenario.effective_tags:
+        for host in context.hosts_with_rsync_bash:
+            cmd = Command(name='remove /usr/local/bin/rsync', cmdStr="sudo rm /usr/local/bin/rsync", remoteHost=host,
+                          ctxt=REMOTE)
+            cmd.run(validateAfter=True)
+

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1876,3 +1876,24 @@ Feature: gprecoverseg tests
     And the user runs "gprecoverseg -a -v"
     Then gprecoverseg should return a return code of 0
     And the cluster is rebalanced
+
+    @remove_rsync_bash
+    @concourse_cluster
+    Scenario: None of the accumulated wal (after running pg_start_backup and before copying the pg_control file) is lost during differential
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,1000) AS a;" is executed in "postgres" db
+        And user immediately stops all mirror processes for content 0
+        And the user waits until mirror on content 0 is down
+        And user can start transactions
+        And user creates a new executable rsync script which inserts data into table and runs checkpoint along with doing rsync
+       When the user runs "gprecoverseg -av --differential"
+       Then gprecoverseg should return a return code of 0
+        And verify that mirror on content 0 is up
+       Then the row count of table test_recoverseg in "postgres" should be 2000
+      Given user immediately stops all primary processes for content 0
+        And user can start transactions
+       Then the row count of table test_recoverseg in "postgres" should be 2000
+       And the cluster is recovered in full and rebalanced


### PR DESCRIPTION
Added a behave test scenario which tests the data integrity property of differential recovery. In this scenario we assert that any data inserted in database during the execution of recovery can be seen even after the completion of recovery and no data loss happens.

Steps:

- Create a table test_recoverseg with 1000 rows
- Stop one primary segment and wait for it to marked down in gp_segment_configuration
- Create a rsync bash script which will (1st and 2nd steps will be performed only if pg_wal is being synced)
- 1. insert 1000 extra rows in test_recoverseg
- 2. execute a checkpoint (just to make sure the latest_checkpoint is updated in pg_control file)
- 3. executes actual (/usr/bin/rsync) rsync to sync the source and target provided
- Run differential recovery and make sure it uses new rsync script whenever rsync is called during recovery
- After recovery is completed, check if number of rows in test_recoverseg are 2000
- Stop the primary segment with same content id which was stopped previously and wait for it to be marked down
- number of rows in test_recoverseg should be 2000, this means the rows inserted during recovery are not lost

Reason for no data loss:

- When more rows were inserted during recovery, the wal files were present on primary which were synced to mirror during pg_wal sync step.
- Also in differential recovery the starting point for wal replay is determined by backup_label file not pg_control file. As pg_control has no role here so updating the latest_checkpoint in pg_control will not impact anything.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
