### PR TITLE
[6X] Disallow non-standalone ALTER distribution

### DIFF
--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1681,3 +1681,14 @@ SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 (1 row)
 
 DROP TABLE t_reorganize_false;
+-- Check that AT SET DISTRIBUTED BY cannot be combined with other subcommands
+-- on the same table
+CREATE TABLE atsdby_multiple(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE atsdby_multiple SET DISTRIBUTED BY(j), ADD COLUMN k int;
+ERROR:  cannot alter distribution with other subcommands for relation "atsdby_multiple"
+HINT:  consider separating into multiple statements
+ALTER TABLE atsdby_multiple SET WITH (reorganize=true), ADD COLUMN k int;
+ERROR:  cannot alter distribution with other subcommands for relation "atsdby_multiple"
+HINT:  consider separating into multiple statements

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -539,3 +539,9 @@ SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
 SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
 DROP TABLE t_reorganize_false;
+
+-- Check that AT SET DISTRIBUTED BY cannot be combined with other subcommands
+-- on the same table
+CREATE TABLE atsdby_multiple(i int, j int);
+ALTER TABLE atsdby_multiple SET DISTRIBUTED BY(j), ADD COLUMN k int;
+ALTER TABLE atsdby_multiple SET WITH (reorganize=true), ADD COLUMN k int;


### PR DESCRIPTION
This is a 6X backport of 20f39c76f3dd03b0feb8b05011c1e0637df6c77e, with
trivial conflicts resolved (there was no test case for
gp_force_random_redistribution and the aoco_column_rewrite test file
doesn't exist in 6X).

Also, in 6X the ERROR message is slightly different from the one
described in the original commit message:
ERROR:  invalid attribute number 3 (heaptuple.c:1231)

Original commit message follows:

If AT SET DISTRIBUTED BY, or AT SET WITH (reorganize=true|false) is run
today along with another subcommand, it will result in ERRORs such as:

ALTER TABLE foo ADD COLUMN c int, SET DISTRIBUTED BY(b);
ERROR: attribute number 3 exceeds number of columns 2

This kind of error results when the CTAS for the temp table is
dispatched as part of ATExecSetDistributedBy(). Since SET DISTRIBUTED BY
is run in the last pass, the ADD COLUMN takes effect on the QD and is
considered as part of the dispatched QueryDesc for the CTAS. However,
since the AT command has not been dispatched yet to the QEs (which only
happens after ATController()), the QE hasn't yet applied the results of
the ADD COLUMN operation.  Thus, the QEs cannot reconcile the reference
to the added column, and an ERROR results.

Other ERRORs can also result from having an inconsistent view of the
catalog on the QEs in the CTAS.

Supporting AT SET DISTRIBUTED BY with other subcommands would require
abandoning the current approach, and aligining it with regular AT
workflow. Since, that is a larger change, we ban such usage at the
moment.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_fix_setdby
