### PR TITLE
Optimize serialization of IMDId objects in Orca to be lazy

### DIFF
--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdCast.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdCast.h
@@ -47,10 +47,10 @@ private:
 	WCHAR m_mdid_buffer[GPDXL_MDID_LENGTH];
 
 	// string representation of the mdid
-	CWStringStatic m_str;
+	mutable CWStringStatic m_str;
 
 	// serialize mdid
-	void Serialize();
+	void Serialize() const;
 
 public:
 	CMDIdCast(const CMDIdCast &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdColStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdColStats.h
@@ -48,10 +48,10 @@ private:
 	WCHAR m_mdid_buffer[GPDXL_MDID_LENGTH];
 
 	// string representation of the mdid
-	CWStringStatic m_str;
+	mutable CWStringStatic m_str;
 
 	// serialize mdid
-	void Serialize();
+	void Serialize() const;
 
 public:
 	CMDIdColStats(const CMDIdColStats &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdGPDB.h
@@ -58,10 +58,10 @@ protected:
 	WCHAR m_mdid_array[GPDXL_MDID_LENGTH];
 
 	// string representation of the mdid
-	CWStringStatic m_str;
+	mutable CWStringStatic m_str;
 
 	// serialize mdid
-	virtual void Serialize();
+	virtual void Serialize() const;
 
 public:
 	// ctors

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdRelStats.h
@@ -45,10 +45,10 @@ private:
 	WCHAR m_mdid_array[GPDXL_MDID_LENGTH];
 
 	// string representation of the mdid
-	CWStringStatic m_str;
+	mutable CWStringStatic m_str;
 
 	// serialize mdid
-	void Serialize();
+	void Serialize() const;
 
 public:
 	CMDIdRelStats(const CMDIdRelStats &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdScCmp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIdScCmp.h
@@ -46,10 +46,10 @@ private:
 	WCHAR m_mdid_array[GPDXL_MDID_LENGTH];
 
 	// string representation of the mdid
-	CWStringStatic m_str;
+	mutable CWStringStatic m_str;
 
 	// serialize mdid
-	void Serialize();
+	void Serialize() const;
 
 public:
 	CMDIdScCmp(const CMDIdScCmp &) = delete;

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdCast.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdCast.cpp
@@ -32,9 +32,6 @@ CMDIdCast::CMDIdCast(CMDIdGPDB *mdid_src, CMDIdGPDB *mdid_dest)
 {
 	GPOS_ASSERT(mdid_src->IsValid());
 	GPOS_ASSERT(mdid_dest->IsValid());
-
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -60,8 +57,14 @@ CMDIdCast::~CMDIdCast()
 //
 //---------------------------------------------------------------------------
 void
-CMDIdCast::Serialize()
+CMDIdCast::Serialize() const
 {
+	if (m_str.Length() > 0)
+	{
+		return;
+	}
+
+	m_str.Reset();
 	// serialize mdid as SystemType.mdidSrc.mdidDest
 	m_str.AppendFormat(GPOS_WSZ_LIT("%d.%d.%d.%d;%d.%d.%d"), MdidType(),
 					   m_mdid_src->Oid(), m_mdid_src->VersionMajor(),
@@ -81,6 +84,7 @@ CMDIdCast::Serialize()
 const WCHAR *
 CMDIdCast::GetBuffer() const
 {
+	Serialize();
 	return m_str.GetBuffer();
 }
 
@@ -146,6 +150,7 @@ void
 CMDIdCast::Serialize(CXMLSerializer *xml_serializer,
 					 const CWStringConst *pstrAttribute) const
 {
+	Serialize();
 	xml_serializer->AddAttribute(pstrAttribute, &m_str);
 }
 
@@ -160,7 +165,7 @@ CMDIdCast::Serialize(CXMLSerializer *xml_serializer,
 IOstream &
 CMDIdCast::OsPrint(IOstream &os) const
 {
-	os << "(" << m_str.GetBuffer() << ")";
+	os << "(" << GetBuffer() << ")";
 	return os;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdColStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdColStats.cpp
@@ -31,9 +31,6 @@ CMDIdColStats::CMDIdColStats(CMDIdGPDB *rel_mdid, ULONG pos)
 	  m_str(m_mdid_buffer, GPOS_ARRAY_SIZE(m_mdid_buffer))
 {
 	GPOS_ASSERT(rel_mdid->IsValid());
-
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -58,8 +55,14 @@ CMDIdColStats::~CMDIdColStats()
 //
 //---------------------------------------------------------------------------
 void
-CMDIdColStats::Serialize()
+CMDIdColStats::Serialize() const
 {
+	if (m_str.Length() > 0)
+	{
+		return;
+	}
+
+	m_str.Reset();
 	// serialize mdid as SystemType.Oid.Major.Minor.Attno
 	m_str.AppendFormat(GPOS_WSZ_LIT("%d.%d.%d.%d.%d"), MdidType(),
 					   m_rel_mdid->Oid(), m_rel_mdid->VersionMajor(),
@@ -77,6 +80,7 @@ CMDIdColStats::Serialize()
 const WCHAR *
 CMDIdColStats::GetBuffer() const
 {
+	Serialize();
 	return m_str.GetBuffer();
 }
 
@@ -142,6 +146,7 @@ void
 CMDIdColStats::Serialize(CXMLSerializer *xml_serializer,
 						 const CWStringConst *attribute_str) const
 {
+	Serialize();
 	xml_serializer->AddAttribute(attribute_str, &m_str);
 }
 
@@ -156,7 +161,7 @@ CMDIdColStats::Serialize(CXMLSerializer *xml_serializer,
 IOstream &
 CMDIdColStats::OsPrint(IOstream &os) const
 {
-	os << "(" << m_str.GetBuffer() << ")";
+	os << "(" << GetBuffer() << ")";
 	return os;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdGPDB.cpp
@@ -133,9 +133,6 @@ CMDIdGPDB::CMDIdGPDB(CSystemId sysid, OID oid)
 		// construct an invalid mdid 0.0.0
 		m_major_version = 0;
 	}
-
-	// serialize mdid into static string
-	Serialize();
 }
 
 CMDIdGPDB::CMDIdGPDB(EMDIdType mdIdType, OID oid, ULONG version_major,
@@ -154,8 +151,6 @@ CMDIdGPDB::CMDIdGPDB(EMDIdType mdIdType, OID oid, ULONG version_major,
 		// construct an invalid mdid 0.0.0
 		m_major_version = 0;
 	}
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -174,8 +169,6 @@ CMDIdGPDB::CMDIdGPDB(const CMDIdGPDB &mdid_source)
 	  m_minor_version(mdid_source.VersionMinor()),
 	  m_str(m_mdid_array, GPOS_ARRAY_SIZE(m_mdid_array))
 {
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -187,8 +180,13 @@ CMDIdGPDB::CMDIdGPDB(const CMDIdGPDB &mdid_source)
 //
 //---------------------------------------------------------------------------
 void
-CMDIdGPDB::Serialize()
+CMDIdGPDB::Serialize() const
 {
+	if (m_str.Length() > 0)
+	{
+		return;
+	}
+
 	m_str.Reset();
 	// serialize mdid as SystemType.Oid.Major.Minor
 	m_str.AppendFormat(GPOS_WSZ_LIT("%d.%d.%d.%d"), MdidType(), m_oid,
@@ -206,6 +204,7 @@ CMDIdGPDB::Serialize()
 const WCHAR *
 CMDIdGPDB::GetBuffer() const
 {
+	Serialize();
 	return m_str.GetBuffer();
 }
 
@@ -220,6 +219,7 @@ CMDIdGPDB::GetBuffer() const
 OID
 CMDIdGPDB::Oid() const
 {
+	Serialize();
 	return m_oid;
 }
 
@@ -307,6 +307,7 @@ void
 CMDIdGPDB::Serialize(CXMLSerializer *xml_serializer,
 					 const CWStringConst *attribute_str) const
 {
+	Serialize();
 	xml_serializer->AddAttribute(attribute_str, &m_str);
 }
 
@@ -321,7 +322,7 @@ CMDIdGPDB::Serialize(CXMLSerializer *xml_serializer,
 IOstream &
 CMDIdGPDB::OsPrint(IOstream &os) const
 {
-	os << "(" << m_str.GetBuffer() << ")";
+	os << "(" << GetBuffer() << ")";
 	return os;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdGPDBCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdGPDBCtas.cpp
@@ -32,7 +32,6 @@ CMDIdGPDBCtas CMDIdGPDBCtas::m_mdid_invalid_key(0);
 CMDIdGPDBCtas::CMDIdGPDBCtas(OID oid)
 	: CMDIdGPDB(CSystemId(IMDId::EmdidGeneral, GPMD_GPDB_CTAS_SYSID), oid)
 {
-	Serialize();
 }
 
 
@@ -49,7 +48,6 @@ CMDIdGPDBCtas::CMDIdGPDBCtas(const CMDIdGPDBCtas &mdid_source)
 {
 	GPOS_ASSERT(mdid_source.IsValid());
 	GPOS_ASSERT(IMDId::EmdidGPDBCtas == mdid_source.MdidType());
-	Serialize();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdRelStats.cpp
@@ -28,8 +28,6 @@ using namespace gpmd;
 CMDIdRelStats::CMDIdRelStats(CMDIdGPDB *rel_mdid)
 	: m_rel_mdid(rel_mdid), m_str(m_mdid_array, GPOS_ARRAY_SIZE(m_mdid_array))
 {
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -54,8 +52,14 @@ CMDIdRelStats::~CMDIdRelStats()
 //
 //---------------------------------------------------------------------------
 void
-CMDIdRelStats::Serialize()
+CMDIdRelStats::Serialize() const
 {
+	if (m_str.Length() > 0)
+	{
+		return;
+	}
+
+	m_str.Reset();
 	// serialize mdid as SystemType.Oid.Major.Minor
 	m_str.AppendFormat(GPOS_WSZ_LIT("%d.%d.%d.%d"), MdidType(),
 					   m_rel_mdid->Oid(), m_rel_mdid->VersionMajor(),
@@ -73,6 +77,7 @@ CMDIdRelStats::Serialize()
 const WCHAR *
 CMDIdRelStats::GetBuffer() const
 {
+	Serialize();
 	return m_str.GetBuffer();
 }
 
@@ -123,6 +128,7 @@ void
 CMDIdRelStats::Serialize(CXMLSerializer *xml_serializer,
 						 const CWStringConst *attribute_str) const
 {
+	Serialize();
 	xml_serializer->AddAttribute(attribute_str, &m_str);
 }
 
@@ -137,7 +143,7 @@ CMDIdRelStats::Serialize(CXMLSerializer *xml_serializer,
 IOstream &
 CMDIdRelStats::OsPrint(IOstream &os) const
 {
-	os << "(" << m_str.GetBuffer() << ")";
+	os << "(" << GetBuffer() << ")";
 	return os;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDIdScCmp.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIdScCmp.cpp
@@ -36,9 +36,6 @@ CMDIdScCmp::CMDIdScCmp(CMDIdGPDB *left_mdid, CMDIdGPDB *right_mdid,
 	GPOS_ASSERT(IMDType::EcmptOther != cmp_type);
 
 	GPOS_ASSERT(left_mdid->Sysid().Equals(right_mdid->Sysid()));
-
-	// serialize mdid into static string
-	Serialize();
 }
 
 //---------------------------------------------------------------------------
@@ -64,8 +61,13 @@ CMDIdScCmp::~CMDIdScCmp()
 //
 //---------------------------------------------------------------------------
 void
-CMDIdScCmp::Serialize()
+CMDIdScCmp::Serialize() const
 {
+	if (m_str.Length() > 0)
+	{
+		return;
+	}
+
 	// serialize mdid as SystemType.mdidLeft;mdidRight;CmpType
 	m_str.AppendFormat(GPOS_WSZ_LIT("%d.%d.%d.%d;%d.%d.%d;%d"), MdidType(),
 					   m_mdid_left->Oid(), m_mdid_left->VersionMajor(),
@@ -167,6 +169,7 @@ void
 CMDIdScCmp::Serialize(CXMLSerializer *xml_serializer,
 					  const CWStringConst *attribute_str) const
 {
+	Serialize();
 	xml_serializer->AddAttribute(attribute_str, &m_str);
 }
 
@@ -181,7 +184,7 @@ CMDIdScCmp::Serialize(CXMLSerializer *xml_serializer,
 IOstream &
 CMDIdScCmp::OsPrint(IOstream &os) const
 {
-	os << "(" << m_str.GetBuffer() << ")";
+	os << "(" << GetBuffer() << ")";
 	return os;
 }
 


### PR DESCRIPTION
This is a follow up to commit https://github.com/greenplum-db/gpdb/commit/b90e0e5b84f6e539eaedd7da9fd2b71a2283507d,
which optimized many objects to do their serialization only when needed.
This commit modifies the rest of the objects. This serialization is
primarily used when there is an error, so there's no need to serialize
it in the vast majority of cases.

This improves optimization time when loading objects into the relcache
by 11%, and for queries when the relcache is already populated by 6% in
a complex sample query involving large and wide partition tables.