### PR TITLE
Corrected comment mistake about `looks_like_temp_rel_name` function.

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -3236,7 +3236,7 @@ RemovePgTempRelationFilesInDbspace(const char *dbspacedirname)
  * temporary relation are kept in shared buffers, and need to be accessible
  * from multiple backends. So the pattern in GPDB is:
  *
- * t_<digits>, or t<digits>_<digits>_<forkname>
+ * t_<digits>, or t_<digits>_<forkname>
  */
 bool
 looks_like_temp_rel_name(const char *name)


### PR DESCRIPTION
The comment maybe mislead the code readers because we never use ` t<digits>_<digits>_<forkname>` pattern for temporary relation in GPDB.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
