### PR TITLE
Fix ABI breakage

### DIFF
--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -565,19 +565,6 @@ typedef struct TableAmRoutine
 											  double *tups_vacuumed,
 											  double *tups_recently_dead);
 
-	/* See table_relation_copy_for_repack() */
-	void		(*relation_copy_for_repack) (Relation origTable,
-											 Relation newTable,
-											 int nkeys,
-											 AttrNumber *attNums,
-											 Oid *sortOperators,
-											 Oid *sortCollations,
-											 bool *nullsFirstFlags, 
-											 TransactionId *xid_cutoff,
-											 MultiXactId *multi_cutoff,
-											 TransactionId OldestXmin,
-											 double *num_tuples);
-									 
 	/*
 	 * React to VACUUM command on the relation. The VACUUM can be
 	 * triggered by a user or by autovacuum. The specific actions
@@ -816,6 +803,24 @@ typedef struct TableAmRoutine
 										   struct SampleScanState *scanstate,
 										   TupleTableSlot *slot);
 
+	/* 
+	 * See table_relation_copy_for_repack()
+	 *
+	 * This is kept at the bottom of the struct to avoid ABI breakage within 
+	 * a major version.
+	 */
+	void		(*relation_copy_for_repack) (Relation origTable,
+											 Relation newTable,
+											 int nkeys,
+											 AttrNumber *attNums,
+											 Oid *sortOperators,
+											 Oid *sortCollations,
+											 bool *nullsFirstFlags, 
+											 TransactionId *xid_cutoff,
+											 MultiXactId *multi_cutoff,
+											 TransactionId OldestXmin,
+											 double *num_tuples);
+									 
 } TableAmRoutine;
 
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2007,7 +2007,6 @@ typedef enum AlterTableType
 	AT_SetDistributedBy,		/* SET DISTRIBUTED BY */
 	AT_ExpandTable,          /* EXPAND DISTRIBUTED */
 	AT_ExpandPartitionTablePrepare,	/* EXPAND PARTITION PREPARE */
-	AT_RepackTable,				/* REPACK TABLE */
 
 	/* GPDB: Legacy commands to manipulate partitions */
 	AT_PartAdd,					/* Add */
@@ -2017,7 +2016,10 @@ typedef enum AlterTableType
 	AT_PartRename,				/* Rename */
 	AT_PartSetTemplate,			/* Set Subpartition Template */
 	AT_PartSplit,				/* Split */
-	AT_PartTruncate				/* Truncate */
+	AT_PartTruncate,			/* Truncate */
+
+	/* kept at end for ABI hygiene */
+	AT_RepackTable				/* REPACK TABLE */
 } AlterTableType;
 
 typedef struct ReplicaIdentityStmt


### PR DESCRIPTION
A recent commit caused ABI changes after the beta-5 ABI freeze. Reorganize those changes to fix that:
* move relation_copy_for_repack to end of the  TableAmRoutine struct
* move AT_RepackTable to end of AlterTableType enum