### PR TITLE
Fix compiling failure without USE_ZSTD

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -207,7 +207,9 @@ makeBufFile(File firstfile, const char *operation_name)
 
 	file->operation_name = pstrdup(operation_name);
 
+#ifdef USE_ZSTD
 	file->compressed_buffer_size = 0;
+#endif
 
 	return file;
 }


### PR DESCRIPTION
The issue was imported by https://github.com/greenplum-db/gpdb/pull/16243. Basically, the code in `makeBufFile()` fails to compile if GPDB is compiled without `USE_ZSTD`:
```
file->compressed_buffer_size = 0;
```
The fix is to include the code by `ifdef USE_ZSTD` macro.