### PR TITLE
Fix ABI breaking of BufFilePledgeSequential()

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1494,7 +1494,7 @@ ExecHashJoinSaveTuple(PlanState *ps, MinimalTuple tuple, uint32 hashvalue,
 		Assert(hashtable->work_set != NULL);
 		file = BufFileCreateTempInSet("HashJoin", false /* interXact */,
 									  hashtable->work_set);
-		BufFilePledgeSequential(file, hashtable->work_set);	/* allow compression */
+		BufFilePledgeSequential(file);	/* allow compression */
 		*fileptr = file;
 
 		elog(gp_workfile_caching_loglevel, "create batch file %s",

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -1244,8 +1244,10 @@ bool gp_workfile_compression;		/* GUC */
  * that use buffiles across processes pledge sequential access, though.)
  */
 void
-BufFilePledgeSequential(BufFile *buffile, workfile_set *work_set)
+BufFilePledgeSequential(BufFile *buffile)
 {
+	workfile_set *work_set = buffile->work_set;
+
 	if (BufFileSize(buffile) != 0)
 		elog(ERROR, "cannot pledge sequential access to a temporary file after writing it");
 

--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -68,7 +68,7 @@ extern void BufFileSuspend(BufFile *buffile);
 extern void BufFileResume(BufFile *buffile);
 
 extern bool gp_workfile_compression;
-extern void BufFilePledgeSequential(BufFile *buffile, workfile_set *work_set);
+extern void BufFilePledgeSequential(BufFile *buffile);
 extern void BufFileSetIsTempFile(BufFile *file, bool isTempFile);
 
 #endif							/* BUFFILE_H */


### PR DESCRIPTION
The PR https://github.com/greenplum-db/gpdb/pull/16243 caused ABI breaking in BufFilePledgeSequential():
```
buffile.h, postgres
[−] BufFilePledgeSequential ( BufFile* buffile )  1
⇣
BufFilePledgeSequential ( BufFile* buffile, workfile_set* work_set )
```
However, because `BufFile` has a pointer of `workfile_set`, we don't need to change the interface of `BufFilePledgeSequential()` at all. The fix is simply to use `buffile->work_set` and avoid the change of `BufFilePledgeSequential()` interface.
