### PR TITLE
Make 'plan_create_index_workersr' always to return 0

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7110,6 +7110,8 @@ getSimplyUpdatableRel(Query *query)
 int
 plan_create_index_workers(Oid tableOid, Oid indexOid)
 {
+	/* parallel worker is disabled on gpdb */
+	return 0;
 	PlannerInfo *root;
 	Query	   *query;
 	PlannerGlobal *glob;


### PR DESCRIPTION
'plan_create_index_workers' could be called by extension such as pgvector to create parallel workers to scan the base table when building index. As gpdb doesn't support the parallel workers, make this function always to return 0.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
