### PR TITLE
Fix test case explain_format about Extra Text

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1124,7 +1124,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 		 * from all of the nodes in the slice.  But only if that worker stands
 		 * out more than 5% above the average.
 		 */
-		if (peakmemused.agg.vmax > 1.05 * cdbexplain_agg_avg(&peakmemused.agg))
+		//if (peakmemused.agg.vmax > 1.01 * cdbexplain_agg_avg(&peakmemused.agg))
 			cdbexplain_depStatAcc_saveText(&peakmemused, ctx->extratextbuf, &saved);
 
 		/*

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1124,7 +1124,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 		 * from all of the nodes in the slice.  But only if that worker stands
 		 * out more than 5% above the average.
 		 */
-		//if (peakmemused.agg.vmax > 1.01 * cdbexplain_agg_avg(&peakmemused.agg))
+		if (peakmemused.agg.vmax > 1.05 * cdbexplain_agg_avg(&peakmemused.agg))
 			cdbexplain_depStatAcc_saveText(&peakmemused, ctx->extratextbuf, &saved);
 
 		/*

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -926,8 +926,8 @@ WITH query_plan (et) AS
     'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-epln_info
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
 Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
 Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
 (2 rows)

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -920,56 +920,34 @@ CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=8.948..21.656 rows=10000 loops=1)
-  ->  HashAggregate (actual time=13.950..15.183 rows=3386 loops=1)
-        Group Key: a
-        Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 1024KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
-
-        ->  HashAggregate (actual time=12.113..12.658 rows=3386 loops=1)
-              Group Key: a, b
-              Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
-
-              ->  Seq Scan on test_src_tbl (actual time=0.015..1.748 rows=16930 loops=1)
-Optimizer: Postgres-based planner
-Planning Time: 0.167 ms
-  (slice0)    Executor memory: 236K bytes.
-* (slice1)    Executor memory: 657K bytes avg x 3 workers, 722K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
-Memory used:  1000kB
-Memory wanted:  1640kB
-Execution Time: 22.346 ms
-(17 rows)
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+epln_info
+Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
+Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
+(2 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=57.360..82.135 rows=20000 loops=1)
-  ->  Finalize HashAggregate (actual time=57.788..78.873 rows=6769 loops=1)
-        Group Key: a, b, (GROUPINGSET_ID())
-        Extra Text: (seg0)   hash table(s): 1; 6570 groups total in 16 batches, 20604 spill partitions; disk usage: 1824KB; chain length 2.7 avg, 10 max; using 6570 of 34816 buckets; total 0 expansions.
-
-        ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=14.477..54.576 rows=6769 loops=1)
-              Hash Key: a, b, (GROUPINGSET_ID())
-              ->  Partial HashAggregate (actual time=21.224..38.700 rows=6772 loops=1)
-                    Hash Key: a
-                    Hash Key: b
-                    Extra Text: (seg1)   hash table(s): 2; 6772 groups total in 40 batches, 121260 spill partitions; disk usage: 2912KB; chain length 2.1 avg, 6 max; using 3386 of 83968 buckets; total 0 expansions.
-
-                    ->  Seq Scan on test_src_tbl (actual time=0.043..3.471 rows=16930 loops=1)
-Optimizer: Postgres-based planner
-Planning Time: 0.202 ms
-  (slice0)    Executor memory: 205K bytes.
-* (slice1)    Executor memory: 467K bytes avg x 3 workers, 467K bytes max (seg1).  Work_mem: 705K bytes max, 1921K bytes wanted.
-* (slice2)    Executor memory: 610K bytes avg x 3 workers, 631K bytes max (seg0).  Work_mem: 633K bytes max, 2377K bytes wanted.
-Memory used:  1000kB
-Memory wanted:  5052kB
-Execution Time: 84.367 ms
-(21 rows)
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+epln_info
+Extra Text: (seg1)   hash table(s): 1; 6769 groups total in 16 batches, 21400 spill partitions; disk usage: 1120KB; chain length 2.7 avg, 11 max; using 6769 of 34816 buckets; total 0 expansions.
+Extra Text: (seg0)   hash table(s): 2; 6736 groups total in 8 batches, 120508 spill partitions; disk usage: 1920KB; chain length 2.2 avg, 6 max; using 3368 of 18432 buckets; total 0 expansions.
+(2 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Cleanup

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -943,8 +943,8 @@ WITH query_plan (et) AS
     'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-epln_info
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
 Extra Text: (seg1)   hash table(s): 1; 6769 groups total in 16 batches, 21400 spill partitions; disk usage: 1120KB; chain length 2.7 avg, 11 max; using 6769 of 34816 buckets; total 0 expansions.
 Extra Text: (seg0)   hash table(s): 2; 6736 groups total in 8 batches, 120508 spill partitions; disk usage: 1920KB; chain length 2.2 avg, 6 max; using 3368 of 18432 buckets; total 0 expansions.
 (2 rows)

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -856,8 +856,8 @@ WITH query_plan (et) AS
     'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-epln_info
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
 Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 8 batches, 53148 spill partitions; disk usage: 1152KB; chain length 2.2 avg, 5 max; using 3368 of 18432 buckets; total 0 expansions.
 Extra Text: (seg1)   hash table(s): 1; 3385 groups total in 8 batches, 53488 spill partitions; disk usage: 1152KB; chain length 2.1 avg, 4 max; using 3385 of 18432 buckets; total 0 expansions.
 (2 rows)

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -840,8 +840,8 @@ WITH query_plan (et) AS
     'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-epln_info
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
 Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
 Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 800KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
 (2 rows)

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -834,60 +834,33 @@ SET statement_mem = '1000kB';
 CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=9.551..21.820 rows=10000 loops=1)
-  ->  HashAggregate (actual time=9.028..10.280 rows=3386 loops=1)
-        Group Key: a
-        Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 1024KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
-
-        ->  HashAggregate (actual time=7.066..7.628 rows=3386 loops=1)
-              Group Key: a, b
-              Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 1024KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
-
-              ->  Seq Scan on test_src_tbl (actual time=0.020..1.349 rows=16930 loops=1)
-Optimizer: GPORCA
-Planning Time: 5.518 ms
-  (slice0)    Executor memory: 236K bytes.
-* (slice1)    Executor memory: 709K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 753K bytes max, 721K bytes wanted.
-Memory used:  1000kB
-Memory wanted:  1640kB
-Execution Time: 22.843 ms
-(17 rows)
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+epln_info
+Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
+Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 800KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
+(2 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=66.084..124.823 rows=20000 loops=1)
-  ->  Sequence (actual time=63.808..102.762 rows=6771 loops=1)
-        ->  Shared Scan (share slice:id 1:0) (actual time=10.481..17.729 rows=16930 loops=1)
-              ->  Seq Scan on test_src_tbl (actual time=0.020..1.319 rows=16930 loops=1)
-        ->  Append (actual time=45.590..84.119 rows=6771 loops=1)
-              ->  HashAggregate (actual time=14.125..27.481 rows=3385 loops=1)
-                    Group Key: share0_ref2.b
-                    Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 2016KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
-
-                    ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=0.023..38.616 rows=16925 loops=1)
-                          Hash Key: share0_ref2.b
-                          ->  Result (actual time=7.251..15.668 rows=16930 loops=1)
-                                ->  Shared Scan (share slice:id 2:0) (actual time=10.668..14.900 rows=16930 loops=1)
-              ->  HashAggregate (actual time=11.722..22.117 rows=3386 loops=1)
-                    Group Key: share0_ref3.a
-                    Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 20 batches, 60280 spill partitions; disk usage: 1888KB; chain length 1.9 avg, 3 max; using 3368 of 43008 buckets; total 0 expansions.
-
-                    ->  Shared Scan (share slice:id 1:0) (actual time=0.009..5.775 rows=16930 loops=1)
-Optimizer: GPORCA
-Planning Time: 11.209 ms
-  (slice0)    Executor memory: 224K bytes.
-* (slice1)    Executor memory: 574K bytes avg x 3 workers, 576K bytes max (seg2).  Work_mem: 353K bytes max, 1137K bytes wanted.
-  (slice2)    Executor memory: 161K bytes avg x 3 workers, 161K bytes max (seg0).
-Memory used:  1000kB
-Memory wanted:  6600kB
-Execution Time: 126.275 ms
-(26 rows)
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+epln_info
+Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 8 batches, 53148 spill partitions; disk usage: 1152KB; chain length 2.2 avg, 5 max; using 3368 of 18432 buckets; total 0 expansions.
+Extra Text: (seg1)   hash table(s): 1; 3385 groups total in 8 batches, 53488 spill partitions; disk usage: 1152KB; chain length 2.1 avg, 4 max; using 3385 of 18432 buckets; total 0 expansions.
+(2 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Cleanup

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -255,7 +255,7 @@ WITH query_plan (et) AS
     'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
 
 RESET optimizer_enable_hashagg;
 RESET statement_mem;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -243,7 +243,7 @@ WITH query_plan (et) AS
     'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
     false)
 )
-SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
 
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -237,13 +237,25 @@ SET statement_mem = '1000kB';
 -- Hashagg with spilling
 CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
-EXPLAIN (analyze, costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
 
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-EXPLAIN (analyze, costs off) SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
+WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(
+    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
+    false)
+)
+SELECT BTRIM(et) as epln_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
 
 RESET optimizer_enable_hashagg;
 RESET statement_mem;


### PR DESCRIPTION
By https://github.com/greenplum-db/gpdb/pull/15917, some code was added to test case explain_format to check the EXPLAIN ANALYZE output for hash agg. However, it failed occasionally because there might be an additional line of "Extra Text" like this:
```
@@ -871,6 +871,8 @@
                     Group Key: share0_ref2.b
                     Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions.
+                    Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions.
+
                     ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual time=##.###..##.### rows=# loops=#)
                           Hash Key: share0_ref2.b
                           ->  Result (actual time=##.###..##.### rows=# loops=#)
```
The output is from the code in `cdbexplain_depositStatsToNode()`:
```
1121         /*
1122          * For the worker which had the highest peak executor memory usage
1123          * overall across the whole slice, we'll report the extra message text
1124          * from all of the nodes in the slice.  But only if that worker stands
1125          * out more than 5% above the average.
1126          */
1127         if (peakmemused.agg.vmax > 1.05 * cdbexplain_agg_avg(&peakmemused.agg))
1128             cdbexplain_depStatAcc_saveText(&peakmemused, ctx->extratextbuf, &saved);
```
It means, one than more line might be printed if the condition is qualified, i.e. it works as design.

The fix is to use an existing UDF `test_util.get_explain_output()` to check the result and avoid the failure. 