### PR TITLE
6X: Fix recursive CTE mergejoin having motion on WTS

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1493,14 +1493,17 @@ cdbpath_motion_for_join(PlannerInfo *root,
 			CdbPathLocus_MakeReplicated(&large_rel->move_to,
 										CdbPathLocus_NumSegments(small_rel->locus));
 
-		/* Last resort: Move both rels to a single qExec. */
-		else
+		/* Last resort: Move both rels to a single qExec
+		 * only if there is no wts on either rels*/
+		else if (!outer.has_wts && !inner.has_wts)
 		{
 			int numsegments = CdbPathLocus_CommonSegments(outer.locus,
 														  inner.locus);
 			CdbPathLocus_MakeSingleQE(&outer.move_to, numsegments);
 			CdbPathLocus_MakeSingleQE(&inner.move_to, numsegments);
 		}
+		else
+			goto fail;
 	}							/* partitioned */
 
 	/*

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -620,3 +620,41 @@ select * from the_cte_here;
  4
 (4 rows)
 
+-- Test recursive CTE doesnt create a plan with motion on top of worktablescan
+CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
+SET enable_nestloop = off;
+SET enable_hashjoin = off;
+SET enable_mergejoin = on;
+explain (costs off) with recursive rcte as
+   (
+      ( select a, b, 1::integer recursion_level from t1 order by 1 )
+      union all
+      select parent_table.a, parent_table.b, rcte.recursion_level + 1
+      from
+      ( select a, b from t1 order by 1 ) parent_table
+      join rcte on rcte.b = parent_table.a
+   )
+select count(*) from rcte;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Recursive Union
+                     ->  Sort
+                           Sort Key: t1.a
+                           ->  Seq Scan on t1
+                     ->  Nested Loop
+                           Join Filter: (t1_1.a = rcte.b)
+                           ->  WorkTable Scan on rcte
+                           ->  Materialize
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                       ->  Sort
+                                             Sort Key: t1_1.a
+                                             ->  Seq Scan on t1 t1_1
+ Optimizer: Postgres-based planner
+(16 rows)
+
+RESET enable_nestloop;
+RESET enable_hashjoin;
+RESET enable_mergejoin;

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -432,3 +432,25 @@ with recursive the_cte_here(n) as (
   select n+1 from the_cte_here join t_rand_test_rcte
 	              on t_rand_test_rcte.c = the_cte_here.n)
 select * from the_cte_here;
+
+-- Test recursive CTE doesnt create a plan with motion on top of worktablescan
+CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
+SET enable_nestloop = off;
+SET enable_hashjoin = off;
+SET enable_mergejoin = on;
+
+explain (costs off) with recursive rcte as
+   (
+      ( select a, b, 1::integer recursion_level from t1 order by 1 )
+      union all
+
+      select parent_table.a, parent_table.b, rcte.recursion_level + 1
+      from
+      ( select a, b from t1 order by 1 ) parent_table
+      join rcte on rcte.b = parent_table.a
+   )
+select count(*) from rcte;
+
+RESET enable_nestloop;
+RESET enable_hashjoin;
+RESET enable_mergejoin;


### PR DESCRIPTION
For a recursive CTE, planner currently creates a mergejoin plan which moves the WorkTableScan results to a singleQE using CdbPathLocus_MakeSingleQE
That would introduce motion in between Union and WorkTableScan. The WorkTableScan results should be local to each segment and shouldn't be broadcasted/moved to other segments. We shouldn't be allowing any motion in between Union and WorkTableScan. This commit adds a check for the last resort case to avoid adding that motion. If there is a WTS on any side in the last resort case, we should just fail (no possible plan using mergejoin)

Added simplified test to force a mergejoin for such recursive CTE, the test shouldn't create a mergejoin plan.

Co-authored-by: Zhenghua Lyu <zlv@pivotal.io>
Co-authored-by: Alexandra Wang<lewang@pivotal.io>
(cherry picked from commit d033d93a3019a8c59019e06908bed98de18b99cb)
