### PR TITLE
url.h: Fix ABI breakage in extvar_t

### DIFF
--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -54,7 +54,6 @@ typedef struct extvar_t
 	char* GP_USER;
 	char* GP_SEG_PG_CONF;   /*location of the segments pg_conf file*/
 	char* GP_SEG_DATADIR;   /*location of the segments datadirectory*/
-	char* GP_SEG_LOGDIR;    /*location of the segment's log directory*/
 	char GP_DATE[9];		/* YYYYMMDD */
 	char GP_TIME[7];		/* HHMMSS */
 	char GP_XID[TMGIDSIZE];		/* global transaction id */
@@ -70,6 +69,8 @@ typedef struct extvar_t
  	char* GP_LINE_DELIM_STR;
 	char GP_LINE_DELIM_LENGTH[11];
 	char *GP_QUERY_STRING;
+
+	char *GP_SEG_LOGDIR;    /* location of the segment's log directory */
 } extvar_t;
 
 


### PR DESCRIPTION
e358573762ee35a40f95ba96630f176b0cd795cc introduced a new field in
extvar_t called GP_SEG_LOGDIR. It was done in the middle of the struct.
So we move it to the end of the struct as a mitigation.

Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_extvar