### PR TITLE
Bring work_mem out of deprecation

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2316,7 +2316,7 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"work_mem", PGC_USERSET, DEPRECATED_OPTIONS,
+		{"work_mem", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum memory to be used for query workspaces."),
 			gettext_noop("This much memory can be used by each internal "
 						 "sort operation and hash table before switching to "

--- a/src/pl/plpgsql/src/expected/plpgsql_transaction.out
+++ b/src/pl/plpgsql/src/expected/plpgsql_transaction.out
@@ -127,10 +127,7 @@ BEGIN
     COMMIT;
 END;
 $$;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 CALL transaction_test5();
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 ERROR:  invalid transaction termination
 CONTEXT:  PL/pgSQL function transaction_test5() line 3 at COMMIT
 -- SECURITY DEFINER currently disallow transaction statements

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -2976,7 +2976,6 @@ explain (costs off)
 --
 set enable_sort=false;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select unique1, count(*), sum(twothousand) from tenk1
 group by unique1
 having sum(fivethous) > 4975
@@ -3034,14 +3033,12 @@ order by sum(twothousand);
 (48 rows)
 
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set enable_sort to default;
 --
 -- Compare results between plans using sorting and plans using hash
 -- aggregation. Force spilling in both cases by setting work_mem low.
 --
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
@@ -3125,7 +3122,6 @@ select (g/2)::numeric as c1, array_agg(g::numeric) as c2, count(*) as c3
   group by g/2;
 set enable_sort = true;
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare group aggregation results to hash aggregation results
 (select * from agg_hash_1 except select * from agg_group_1)
   union all

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3279,7 +3279,6 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 --
 set enable_sort=false;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select unique1, count(*), sum(twothousand) from tenk1
 group by unique1
 having sum(fivethous) > 4975
@@ -3337,14 +3336,12 @@ order by sum(twothousand);
 (48 rows)
 
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set enable_sort to default;
 --
 -- Compare results between plans using sorting and plans using hash
 -- aggregation. Force spilling in both cases by setting work_mem low.
 --
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
@@ -3434,7 +3431,6 @@ select (g/2)::numeric as c1, array_agg(g::numeric) as c2, count(*) as c3
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 set enable_sort = true;
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare group aggregation results to hash aggregation results
 (select * from agg_hash_1 except select * from agg_group_1)
   union all

--- a/src/test/regress/expected/bitmapops.out
+++ b/src/test/regress/expected/bitmapops.out
@@ -23,7 +23,6 @@ set enable_indexscan=false;
 set enable_seqscan=false;
 -- Lower work_mem to trigger use of lossy bitmaps
 set work_mem = 64;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Test bitmap-and.
 SELECT count(*) FROM bmscantest WHERE a = 1 AND b = 1;
  count 

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -25,7 +25,6 @@ set enable_indexscan=false;
 set enable_seqscan=false;
 -- Lower work_mem to trigger use of lossy bitmaps
 set work_mem = 64;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Test bitmap-and.
 SELECT count(*) FROM bmscantest WHERE a = 1 AND b = 1;
  count 

--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1861,7 +1861,6 @@ select array(select row(v.a,s1.*) from (select two,four, count(*) from onek grou
 -- test the knapsack
 set enable_indexscan = false;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select unique1,
          count(two), count(four), count(ten),
@@ -1911,7 +1910,6 @@ explain (costs off)
 (12 rows)
 
 set work_mem = '384kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select unique1,
          count(two), count(four), count(ten),
@@ -2017,7 +2015,6 @@ UPDATE pg_class SET reltuples = 10 WHERE relname='bug_16784';
 SET allow_system_table_mods=false;
 INSERT INTO bug_16784 SELECT g/10, g FROM generate_series(1,40) g;
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off) select * from
   (values (1),(2)) v(a),
   lateral (select v.a, i, j, count(*) from
@@ -2229,7 +2226,6 @@ select * from
 --
 SET enable_groupingsets_hash_disk = true;
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
@@ -2276,7 +2272,6 @@ group by grouping sets (g100,g10) distributed by (g100);
 set enable_hashagg = true;
 set enable_sort = false;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set jit_above_cost = 0;
 explain (costs off)
 select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
@@ -2315,7 +2310,6 @@ select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
 group by grouping sets (g100,g10) distributed by (g100);
 set enable_sort = true;
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare results of ORCA plan that relies on "IS NOT DISTINCT FROM" HASH Join
 (select * from gs_hash_1 except select * from gs_group_1)
   union all

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -2044,7 +2044,6 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 -- test the knapsack
 set enable_indexscan = false;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select unique1,
          count(two), count(four), count(ten),
@@ -2153,7 +2152,6 @@ explain (costs off)
 (37 rows)
 
 set work_mem = '384kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select unique1,
          count(two), count(four), count(ten),
@@ -2310,7 +2308,6 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 SET allow_system_table_mods=false;
 INSERT INTO bug_16784 SELECT g/10, g FROM generate_series(1,40) g;
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off) select * from
   (values (1),(2)) v(a),
   lateral (select v.a, i, j, count(*) from
@@ -2526,7 +2523,6 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 --
 SET enable_groupingsets_hash_disk = true;
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
@@ -2587,7 +2583,6 @@ group by grouping sets (g100,g10) distributed by (g100);
 set enable_hashagg = true;
 set enable_sort = false;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set jit_above_cost = 0;
 explain (costs off)
 select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
@@ -2644,7 +2639,6 @@ select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
 group by grouping sets (g100,g10) distributed by (g100);
 set enable_sort = true;
 set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare results of ORCA plan that relies on "IS NOT DISTINCT FROM" HASH Join
 (select * from gs_hash_1 except select * from gs_group_1)
   union all

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -642,23 +642,17 @@ reset search_path;
 -- Tests for function-local GUC settings
 --
 set work_mem = '3MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 create function report_guc(text) returns text as
 $$ select current_setting($1) $$ language sql
 set work_mem = '1MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select report_guc('work_mem'), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  report_guc | current_setting 
 ------------+-----------------
  1MB        | 3MB
 (1 row)
 
 alter function report_guc(text) set work_mem = '2MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select report_guc('work_mem'), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  report_guc | current_setting 
 ------------+-----------------
  2MB        | 3MB
@@ -679,11 +673,7 @@ begin
 end $$
 language plpgsql
 set work_mem = '1MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select myfunc(0), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  myfunc | current_setting 
 --------+-----------------
  2MB    | 3MB
@@ -691,14 +681,12 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 
 alter function myfunc(int) reset all;
 select myfunc(0), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  myfunc | current_setting 
 --------+-----------------
  2MB    | 2MB
 (1 row)
 
 set work_mem = '3MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- but SET isn't
 create or replace function myfunc(int) returns text as $$
 begin
@@ -707,18 +695,13 @@ begin
 end $$
 language plpgsql
 set work_mem = '1MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select myfunc(0), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  myfunc | current_setting 
 --------+-----------------
  2MB    | 2MB
 (1 row)
 
 set work_mem = '3MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- it should roll back on error, though
 create or replace function myfunc(int) returns text as $$
 begin
@@ -728,12 +711,8 @@ begin
 end $$
 language plpgsql
 set work_mem = '1MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select myfunc(0);
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 ERROR:  division by zero
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 CONTEXT:  SQL statement "SELECT 1/$1"
 PL/pgSQL function myfunc(integer) line 4 at PERFORM
 select current_setting('work_mem');
@@ -743,8 +722,6 @@ select current_setting('work_mem');
 (1 row)
 
 select myfunc(1), current_setting('work_mem');
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
  myfunc | current_setting 
 --------+-----------------
  2MB    | 2MB

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -101,9 +101,7 @@ DROP FUNCTION if exists test_call_set_command();
 -- a SET command. If this stops emitting a WARNING in the future, we'll need
 -- another way to detect that the GUC's assign-hook is called only once.
 set work_mem='1MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 --
 -- Test if RESET timezone is dispatched to all slices
 --

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2544,7 +2544,6 @@ reset enable_nestloop;
 -- like it does on PostgreSQL?
 -- end_ignore
 set work_mem to '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set enable_mergejoin to off;
 explain (costs off)
 select count(*) from tenk1 a, tenk1 b
@@ -2572,7 +2571,6 @@ select count(*) from tenk1 a, tenk1 b
 (1 row)
 
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 reset enable_mergejoin;
 --
 -- regression test for 8.2 bug with improper re-ordering of left joins

--- a/src/test/regress/expected/join_hash.out
+++ b/src/test/regress/expected/join_hash.out
@@ -94,7 +94,6 @@ ANALYZE wide;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from simple r join simple s using (id);
                      QUERY PLAN                     
@@ -131,7 +130,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local enable_parallel_hash = off;
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -169,7 +167,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local enable_parallel_hash = on;
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -210,7 +207,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -248,7 +244,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -287,7 +282,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '192kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -330,7 +324,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) FROM simple r JOIN bigger_than_it_looks s USING (id);
@@ -368,7 +361,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -407,7 +399,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 1;
 set local work_mem = '192kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -451,7 +442,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from simple r join extremely_skewed s using (id);
@@ -488,7 +478,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -526,7 +515,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 1;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -565,7 +553,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local parallel_leader_participation = off;
 select * from hash_join_batches(
 $$
@@ -596,7 +583,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from join_foo
@@ -652,7 +638,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from join_foo
     left join (select b1.id, b1.t from join_bar b1 join join_bar b2 using (id)) ss
@@ -707,7 +692,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from join_foo
@@ -763,7 +747,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from join_foo
     left join (select b1.id, b1.t from join_bar b1 join join_bar b2 using (id)) ss
@@ -928,7 +911,6 @@ savepoint settings;
 set max_parallel_workers_per_gather = 2;
 set enable_parallel_hash = on;
 set work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 insert into wide select generate_series(3, 100) as id, rpad('', 320000, 'x') as t;
 explain (costs off)
   select length(max(s.t))

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -99,7 +99,6 @@ ANALYZE wide;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from simple r join simple s using (id);
                                   QUERY PLAN                                  
@@ -140,7 +139,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local enable_parallel_hash = off;
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -182,7 +180,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local enable_parallel_hash = on;
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -227,7 +224,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from simple r join simple s using (id);
@@ -269,7 +265,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -312,7 +307,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '192kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -359,7 +353,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) FROM simple r JOIN bigger_than_it_looks s USING (id);
@@ -398,7 +391,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -438,7 +430,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 1;
 set local work_mem = '192kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -483,7 +474,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 0;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from simple r join extremely_skewed s using (id);
@@ -527,7 +517,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = off;
 explain (costs off)
@@ -572,7 +561,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 1;
 set local work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 set local enable_parallel_hash = on;
 explain (costs off)
@@ -618,7 +606,6 @@ rollback to settings;
 savepoint settings;
 set local max_parallel_workers_per_gather = 2;
 set local work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local parallel_leader_participation = off;
 select * from hash_join_batches(
 $$
@@ -651,7 +638,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from join_foo
@@ -711,7 +697,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from join_foo
     left join (select b1.id, b1.t from join_bar b1 join join_bar b2 using (id)) ss
@@ -770,7 +755,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set local statement_mem = '1000kB'; -- GPDB uses statement_mem instead of work_mem
 explain (costs off)
   select count(*) from join_foo
@@ -830,7 +814,6 @@ set max_parallel_workers_per_gather = 2;
 set enable_material = off;
 set enable_mergejoin = off;
 set work_mem = '4MB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
   select count(*) from join_foo
     left join (select b1.id, b1.t from join_bar b1 join join_bar b2 using (id)) ss
@@ -1017,7 +1000,6 @@ savepoint settings;
 set max_parallel_workers_per_gather = 2;
 set enable_parallel_hash = on;
 set work_mem = '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 insert into wide select generate_series(3, 100) as id, rpad('', 320000, 'x') as t;
 explain (costs off)
   select length(max(s.t))

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2577,7 +2577,6 @@ reset enable_nestloop;
 -- regression test for bug #13908 (hash join with skew tuples & nbatch increase)
 --
 set work_mem to '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 set enable_mergejoin to off;
 explain (costs off)
 select count(*) from tenk1 a, tenk1 b
@@ -2608,7 +2607,6 @@ select count(*) from tenk1 a, tenk1 b
 (1 row)
 
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 reset enable_mergejoin;
 --
 -- regression test for 8.2 bug with improper re-ordering of left joins

--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -1736,7 +1736,6 @@ create function rngfunc1(n integer, out a text, out b text)
   language sql
   as $$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $$;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select t.a, t, t.a from rngfunc1(10000) t limit 1;
    a   |         t         |   a   
 -------+-------------------+-------
@@ -1744,7 +1743,6 @@ select t.a, t, t.a from rngfunc1(10000) t limit 1;
 (1 row)
 
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select t.a, t, t.a from rngfunc1(10000) t limit 1;
    a   |         t         |   a   
 -------+-------------------+-------

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -1738,7 +1738,6 @@ create function rngfunc1(n integer, out a text, out b text)
   language sql
   as $$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $$;
 set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select t.a, t, t.a from rngfunc1(10000) t limit 1;
    a   |         t         |   a   
 -------+-------------------+-------
@@ -1746,7 +1745,6 @@ select t.a, t, t.a from rngfunc1(10000) t limit 1;
 (1 row)
 
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select t.a, t, t.a from rngfunc1(10000) t limit 1;
    a   |         t         |   a   
 -------+-------------------+-------

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -165,7 +165,6 @@ SELECT count(*) FROM
 -- aggregation. Force spilling in both cases by setting work_mem low.
 --
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 SET enable_hashagg=FALSE;
 SET optimizer_enable_hashagg=FALSE;
@@ -207,7 +206,6 @@ CREATE TABLE distinct_hash_2 AS
 SELECT DISTINCT (g%1000)::text FROM generate_series(0,9999) g;
 SET enable_sort=TRUE;
 SET work_mem TO DEFAULT;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare results
 (SELECT * FROM distinct_hash_1 EXCEPT SELECT * FROM distinct_group_1)
   UNION ALL

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -163,7 +163,6 @@ SELECT count(*) FROM
 -- aggregation. Force spilling in both cases by setting work_mem low.
 --
 SET work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 SET enable_hashagg=FALSE;
 SET optimizer_enable_hashagg=FALSE;
@@ -211,7 +210,6 @@ SELECT DISTINCT (g%1000)::text FROM generate_series(0,9999) g;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SET enable_sort=TRUE;
 SET work_mem TO DEFAULT;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare results
 (SELECT * FROM distinct_hash_1 EXCEPT SELECT * FROM distinct_group_1)
   UNION ALL

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -535,7 +535,6 @@ BEGIN
 EXCEPTION WHEN invalid_parameter_value THEN
 END $$;
 set work_mem='64kB';  --set small work mem to force lossy pages
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
 	select count(*) from tenk1, tenk2 where tenk1.hundred > 1 and tenk2.thousand=0;
                                   QUERY PLAN                                  
@@ -595,7 +594,6 @@ explain (analyze, timing off, summary off, costs off)
 
 alter table tenk2 reset (parallel_workers);
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 create function explain_parallel_sort_stats() returns setof text
 language plpgsql as
 $$

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -540,7 +540,6 @@ BEGIN
 EXCEPTION WHEN invalid_parameter_value THEN
 END $$;
 set work_mem='64kB';  --set small work mem to force lossy pages
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 explain (costs off)
 	select count(*) from tenk1, tenk2 where tenk1.hundred > 1 and tenk2.thousand=0;
                              QUERY PLAN                              
@@ -600,7 +599,6 @@ explain (analyze, timing off, summary off, costs off)
 
 alter table tenk2 reset (parallel_workers);
 reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 create function explain_parallel_sort_stats() returns setof text
 language plpgsql as
 $$

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1228,7 +1228,6 @@ insert into bms_ao_bug select 1, 1, a.c1::char(100) from generate_series(1, 2000
 create index bms_ao_bug_ix1 on bms_ao_bug (c2);
 set enable_seqscan=off;
 set work_mem=256;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select
 a.c1,
 count(*) row_cnt

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1665,7 +1665,6 @@ insert into bms_ao_bug select 1, 1, a.c1::char(100) from generate_series(1, 2000
 create index bms_ao_bug_ix1 on bms_ao_bug (c2);
 set enable_seqscan=off;
 set work_mem=256;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 select
 a.c1,
 count(*) row_cnt


### PR DESCRIPTION
work_mem still enjoys abundant use in our codebase. Although, we would
like to replace it with operatorMemKB, that kind of change will require
significant investment and a careful strategy. So, bring it out of
deprecation for now.

Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/GgOxTgaMJsA/m/004-RkHDFAAJ

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/undep_work_mem