### PR TITLE
Formalize assert build high mem alloc protection

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -46,6 +46,7 @@
 #include "storage/proc.h"
 #include "utils/builtins.h"
 #include "utils/gdd.h"
+#include "utils/gp_alloc.h"
 #include "utils/guc_tables.h"
 #include "utils/inval.h"
 #include "utils/resscheduler.h"
@@ -4242,6 +4243,19 @@ struct config_int ConfigureNamesInt_gp[] =
 		-1, -1, 1024,
 		NULL, NULL, NULL
 	},
+
+#ifdef GP_ALLOC_DEBUG
+	{
+		{"gp_max_alloc_size", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Sets the max size of a memory allocation request in the backend."),
+		 NULL,
+		 GUC_UNIT_MB
+		},
+		&gp_max_alloc_size_mb,
+		GP_MAX_ALLOC_SIZE_MB_DEFAULT, 1, MAX_KILOBYTES,
+		NULL, NULL, NULL
+	},
+#endif
 
 	/* End-of-list marker */
 	{

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -41,7 +41,10 @@
 #include "utils/guc.h"
 
 #define SHMEM_OOM_TIME "last vmem oom time"
-#define MAX_REQUESTABLE_SIZE 0x7fffffff
+
+#ifdef GP_ALLOC_DEBUG
+int 		gp_max_alloc_size_mb = GP_MAX_ALLOC_SIZE_MB_DEFAULT;
+#endif
 
 static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz);
 
@@ -437,7 +440,13 @@ static void *gp_malloc_internal(int64 requested_size)
 	Assert(requested_size > 0);
 	size_t size_with_overhead = UserPtrSize_GetVmemPtrSize(requested_size);
 
-	Assert(size_with_overhead <= MAX_REQUESTABLE_SIZE);
+#ifdef GP_ALLOC_DEBUG
+	/*
+	 * Added protection for debug builds, to catch bugs leading to unusually
+	 * high memory allocation requests.
+	 */
+	Assert(size_with_overhead <= gp_max_alloc_size_mb * 1024L * 1024L);
+#endif
 
 	MemoryAllocationStatus stat = VmemTracker_ReserveVmem(size_with_overhead);
 	if (MemoryAllocation_Success == stat)

--- a/src/backend/utils/mmgr/test/memprot_test.c
+++ b/src/backend/utils/mmgr/test/memprot_test.c
@@ -96,9 +96,9 @@ static size_t CalculateReallocSize(size_t original_size, float ratio)
 	size_t new_size = ((float)original_size) * ratio;
 
 	/* Overflow or exceeding the max allowed allocation size */
-	if ((ratio > 1.0 && new_size < original_size) || (new_size > MAX_REQUESTABLE_SIZE))
+	if ((ratio > 1.0 && new_size < original_size) || (new_size > gp_max_alloc_size_mb * 1024L * 1024L))
 	{
-		return MAX_REQUESTABLE_SIZE;
+		return gp_max_alloc_size_mb * 1024L * 1024L;
 	}
 
 	return new_size;
@@ -117,7 +117,7 @@ static void* AllocateWithCheck(size_t size)
 	size_t chosen_vmem_size = CalculateVmemSizeFromUserSize(size);
 
 	/* Too big allocation should fail assert checking */
-	if (is_assert_checking && chosen_vmem_size > MAX_REQUESTABLE_SIZE)
+	if (is_assert_checking && chosen_vmem_size > gp_max_alloc_size_mb * 1024L * 1024L)
 	{
 		EXPECT_EXCEPTION();
 	}
@@ -133,7 +133,7 @@ static void* AllocateWithCheck(size_t size)
 		void *ptr = gp_malloc(size);
 
 		/* size limit is only checked in assert build */
-		if (is_assert_checking && chosen_vmem_size > MAX_REQUESTABLE_SIZE)
+		if (is_assert_checking && chosen_vmem_size > gp_max_alloc_size_mb * 1024L * 1024L)
 		{
 			assert_true(false);
 		}
@@ -334,7 +334,7 @@ test__gp_malloc_calls_vmem_tracker_when_mp_init_true(void **state)
 static void
 test__gp_malloc_and_free__basic_tests(void **state)
 {
-	size_t sizes[] = {50, 1024, MAX_REQUESTABLE_SIZE - sizeof(VmemHeader) - FOOTER_CHECKSUM_SIZE,
+	size_t sizes[] = {50, 1024, gp_max_alloc_size_mb * 1024L * 1024L - sizeof(VmemHeader) - FOOTER_CHECKSUM_SIZE,
 			1024L * 1024L * 1024L * 2L, 1024L * 1024L * 1024L * 5L};
 
 	for (int idx = 0; idx < sizeof(sizes)/sizeof(sizes[0]); idx++)
@@ -351,7 +351,7 @@ test__gp_malloc_and_free__basic_tests(void **state)
 static void
 test__gp_realloc__basic_tests(void **state)
 {
-	size_t sizes[] = {50, 1024, MAX_REQUESTABLE_SIZE - sizeof(VmemHeader) - FOOTER_CHECKSUM_SIZE};
+	size_t sizes[] = {50, 1024, gp_max_alloc_size_mb * 1024L * 1024L - sizeof(VmemHeader) - FOOTER_CHECKSUM_SIZE};
 	/* Ratio of new size to original size for realloc calls */
 	float fractions[] = {0, 0.1, 0.5, 1, 1.5, 2};
 

--- a/src/include/utils/gp_alloc.h
+++ b/src/include/utils/gp_alloc.h
@@ -30,6 +30,9 @@ typedef int64 FooterChecksumType;
 
 #define FOOTER_CHECKSUM_SIZE (sizeof(FooterChecksumType))
 
+#define GP_MAX_ALLOC_SIZE_MB_DEFAULT 	(2048)
+extern int gp_max_alloc_size_mb;
+
 #else
 
 #define FOOTER_CHECKSUM_SIZE 0

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -76,6 +76,7 @@
 		"gp_log_resqueue_memory",
 		"gp_log_stack_trace_lines",
 		"gp_log_suboverflow_statement",
+		"gp_max_alloc_size",
 		"gp_max_packet_size",
 		"gp_motion_slice_noop",
 		"gp_quicklz_fallback",


### PR DESCRIPTION
This commit formalizes the long existing 2GB upper bound for memory
allocations inside gp_malloc_internal(). Historically, this limit has
always been imposed only on debug builds - it doesn't apply to retail
builds. We make that slightly more apparent here in this commit.

Also, we turn the bound into a GUC for greater developer flexibility.

For instance, this GUC can be quite useful when running experiments with
high work_mem: a good rule of thumb would be to set this GUC to a value
higher than 2 * work_mem (internal routines often try to allocate 2 *
work_mem or more, such as tidbitmap growth. See:
tbm_get_pageentry->pagetable_insert()).

Eg: Q4 (at TPC-H scale 30, with work_mem='1GB', and with B-tree indexes
would BRIN indexes created overt the tables) would fail this assert.
Now, setting the GUC upwards of '2GB' would enable the query to succeed.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/debug_highmem_protect?group=all
