### PR TITLE
Fix failed pipeline for job icw_planner_jit_rocky8.

### DIFF
--- a/src/test/regress/expected/hba_conf.out
+++ b/src/test/regress/expected/hba_conf.out
@@ -1,4 +1,6 @@
 -- Test ldap
+-- backup pg_hba.conf
+\! cp $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
 \! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
 select type,database,user_name,address,netmask,auth_method,options from pg_hba_file_rules where address = '10.10.100.100';
    type    | database | user_name |    address    |     netmask     | auth_method |                                                                        options                                                                        
@@ -6,3 +8,4 @@ select type,database,user_name,address,netmask,auth_method,options from pg_hba_f
  hostnossl | {all}    | {all}     | 10.10.100.100 | 255.255.255.255 | ldap        | {ldapserver=abc.example.com,ldapport=3268,ldaptls=true,ldapbasedn=DC=COM,"ldapbinddn=OU=Hosting,DC=COM",ldapbindpasswd=ldapbindpasswd111,ldapscope=2}
 (1 row)
 
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf

--- a/src/test/regress/sql/hba_conf.sql
+++ b/src/test/regress/sql/hba_conf.sql
@@ -1,3 +1,6 @@
 -- Test ldap
+-- backup pg_hba.conf
+\! cp $COORDINATOR_DATA_DIRECTORY/pg_hba.conf $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak
 \! echo 'hostnossl       all     all     10.10.100.100/32        ldap ldapserver="abc.example.com" ldapbasedn="DC=COM" ldapbinddn="OU=Hosting,DC=COM" ldapbindpasswd="ldapbindpasswd111" ldapport=3268 ldaptls=1' >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
 select type,database,user_name,address,netmask,auth_method,options from pg_hba_file_rules where address = '10.10.100.100';
+\! mv $COORDINATOR_DATA_DIRECTORY/pg_hba.conf.bak $COORDINATOR_DATA_DIRECTORY/pg_hba.conf


### PR DESCRIPTION
This previous commit https://github.com/greenplum-db/gpdb/commit/b7715f24d7f453c13b74f0a4f05bc4c84f0ebf99 introduced one bad pghba text line for pg_hba.conf and did not clear it after the test. Thus binary swap task to old version of gpdb without fix will cause the cluster crash.

This PR is to fix the binary swap task by adding recovery script when case "hba_conf" has finished.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
