### PR TITLE
6X: Support FIELDSELECT node from ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -262,7 +262,6 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes(Query *query)
 	static const SUnsupportedFeature unsupported_features[] = {
 		{T_RowExpr, GPOS_WSZ_LIT("ROW EXPRESSION")},
 		{T_RowCompareExpr, GPOS_WSZ_LIT("ROW COMPARE")},
-		{T_FieldSelect, GPOS_WSZ_LIT("FIELDSELECT")},
 		{T_FieldStore, GPOS_WSZ_LIT("FIELDSTORE")},
 		{T_CoerceToDomainValue, GPOS_WSZ_LIT("COERCETODOMAINVALUE")},
 		{T_GroupId, GPOS_WSZ_LIT("GROUPID")},

--- a/src/backend/gporca/data/dxl/minidump/FieldSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FieldSelect.mdp
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+       Objective:Orca should generate a plan when extracting a field from a composite datatype
+       setup:
+         CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
+         CREATE TABLE foo (item inventory_item, count integer);
+         INSERT INTO foo VALUES (ROW('fuzzy dice', 42, 1.99), 1000);
+         explain select (item).name from foo where (item).price > 0;
+                                       QUERY PLAN
+         ------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                 Filter: ((item).price > '0'::numeric)
+         Optimizer: Pivotal Optimizer (GPORCA)
+     ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.38001.1.0.1" Name="count" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.38001.1.0.0" Name="item" Width="44.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:RelationStatistics Mdid="2.38001.1.0" Name="foo" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.38001.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="item" Attno="1" Mdid="0.38000.1.0" Nullable="true" ColWidth="44">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="count" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.1756.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.1700.1.0"/>
+        <dxl:RightType Mdid="0.1700.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1720.1.0"/>
+        <dxl:Commutator Mdid="0.1754.1.0"/>
+        <dxl:InverseOp Mdid="0.1755.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1988.1.0"/>
+          <dxl:Opfamily Mdid="0.7032.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.38000.1.0" Name="inventory_item" IsRedistributable="false" IsHashable="false" IsMergeJoinable="true" IsComposite="true" BaseRelationMdid="6.37998.1.0" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.2988.1.0"/>
+        <dxl:InequalityOp Mdid="0.2989.1.0"/>
+        <dxl:LessThanOp Mdid="0.2990.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2992.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2991.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2993.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2987.1.0"/>
+        <dxl:ArrayType Mdid="0.37999.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="10" ColName="name" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="10" Alias="name">
+            <dxl:FIELDSELECT FieldType="0.25.1.0" FieldCollation="0.100.1.0" TypeModifier="-1" FieldNumber="1">
+              <dxl:Ident ColId="1" ColName="item" TypeMdid="0.38000.1.0"/>
+            </dxl:FIELDSELECT>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalSelect>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
+            <dxl:FIELDSELECT FieldType="0.1700.1.0" FieldCollation="0.0.0.0" TypeModifier="-1" FieldNumber="3">
+              <dxl:Ident ColId="1" ColName="item" TypeMdid="0.38000.1.0"/>
+            </dxl:FIELDSELECT>
+            <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAABgCA" DoubleValue="0.000000"/>
+          </dxl:Comparison>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.38001.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="item" TypeMdid="0.38000.1.0" ColWidth="44"/>
+                <dxl:Column ColId="2" Attno="2" ColName="count" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="9" Alias="name">
+            <dxl:Ident ColId="9" ColName="name" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="name">
+              <dxl:FIELDSELECT FieldType="0.25.1.0" FieldCollation="0.100.1.0" TypeModifier="-1" FieldNumber="1">
+                <dxl:Ident ColId="0" ColName="item" TypeMdid="0.38000.1.0"/>
+              </dxl:FIELDSELECT>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="1.000000" Width="44"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="item">
+                <dxl:Ident ColId="0" ColName="item" TypeMdid="0.38000.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
+                <dxl:FIELDSELECT FieldType="0.1700.1.0" FieldCollation="0.0.0.0" TypeModifier="-1" FieldNumber="3">
+                  <dxl:Ident ColId="0" ColName="item" TypeMdid="0.38000.1.0"/>
+                </dxl:FIELDSELECT>
+                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAABgCA" DoubleValue="0.000000"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="6.38001.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="item" TypeMdid="0.38000.1.0" ColWidth="44"/>
+                <dxl:Column ColId="1" Attno="2" ColName="count" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -186,6 +186,8 @@ public:
 		EopScalarBitmapIndexProbe,
 		EopScalarBitmapBoolOp,
 
+		EopScalarFieldSelect,
+
 		EopPhysicalTableScan,
 		EopPhysicalExternalScan,
 		EopPhysicalIndexScan,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarFieldSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarFieldSelect.h
@@ -1,0 +1,139 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CScalarFieldSelect.h
+//
+//	@doc:
+//		Class for representing FIELDSELECT
+//---------------------------------------------------------------------------
+
+#ifndef GPOPT_CSCALARFIELDSELECT_H
+#define GPOPT_CSCALARFIELDSELECT_H
+
+#include "gpos/base.h"
+
+#include "gpopt/operators/CScalar.h"
+#include "naucrates/md/IMDId.h"
+
+namespace gpopt
+{
+using namespace gpos;
+using namespace gpmd;
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CScalarFieldSelect
+//
+//	@doc:
+//		Class for representing scalar FieldSelect
+//
+//---------------------------------------------------------------------------
+class CScalarFieldSelect : public CScalar
+{
+private:
+	// type of the field
+	IMDId *m_field_type;
+
+	// collation OID of the field
+	IMDId *m_field_collation;
+
+	// output typmod (usually -1)
+	INT m_type_modifier;
+
+	// attribute number of field to extract
+	SINT m_field_number;
+
+	// private copy ctor
+	CScalarFieldSelect(const CScalarFieldSelect &);
+
+public:
+	// ctor/dtor
+	CScalarFieldSelect(CMemoryPool *mp, IMDId *field_type,
+					   IMDId *field_collation, INT type_modifier,
+					   SINT field_number);
+
+	virtual ~CScalarFieldSelect();
+
+	// ident accessors
+	virtual EOperatorId
+	Eopid() const
+	{
+		return EopScalarFieldSelect;
+	}
+
+	// operator name
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CScalarFieldSelect";
+	}
+
+	// operator specific hash function
+	virtual ULONG HashValue() const;
+
+	// match function
+	virtual BOOL Matches(COperator *pop) const;
+
+
+	// mdid of the field
+	virtual IMDId *
+	MdidType() const
+	{
+		return m_field_type;
+	}
+
+	// field collation mdid
+	IMDId *
+	FieldCollation() const
+	{
+		return m_field_collation;
+	}
+
+	// output mode type
+	virtual INT
+	TypeModifier() const
+	{
+		return m_type_modifier;
+	}
+
+	// attribute number of field
+	SINT
+	FieldNumber() const
+	{
+		return m_field_number;
+	}
+
+	// conversion function
+	static CScalarFieldSelect *
+	PopConvert(COperator *pop)
+	{
+		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(EopScalarFieldSelect == pop->Eopid());
+
+		return dynamic_cast<CScalarFieldSelect *>(pop);
+	}
+
+	// sensitivity to order of inputs
+	virtual BOOL
+	FInputOrderSensitive() const
+	{
+		return true;
+	}
+
+	// return a copy of the operator with remapped columns
+	virtual COperator *
+	PopCopyWithRemappedColumns(CMemoryPool *,		//mp,
+							   UlongToColRefMap *,	//colref_mapping,
+							   BOOL					//must_exist
+	)
+	{
+		return PopCopyDefault();
+	}
+};
+}  // namespace gpopt
+
+#endif	// !GPDB_CSCALARFIELDSELECT_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/ops.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/ops.h
@@ -36,6 +36,7 @@
 #include "gpopt/operators/CScalarCoerceViaIO.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CScalarDMLAction.h"
+#include "gpopt/operators/CScalarFieldSelect.h"
 #include "gpopt/operators/CScalarFunc.h"
 #include "gpopt/operators/CScalarIdent.h"
 #include "gpopt/operators/CScalarIf.h"

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -338,6 +338,9 @@ private:
 
 	CExpression *PexprSortGroupClause(const CDXLNode *pdxlnSortGroupClause);
 
+	// translate a DXL FieldSelect node into a FieldSelect expression
+	CExpression *PexprFieldSelect(const CDXLNode *pdxlnConst);
+
 	// translate a DXL project list node into a project list expression
 	CExpression *PexprScalarProjList(const CDXLNode *proj_list_dxlnode);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -624,6 +624,9 @@ private:
 	// translate an arrayref
 	CDXLNode *PdxlnArrayRef(CExpression *pexpr);
 
+	// translate a FieldSelect expr
+	CDXLNode *PdxlnFieldSelect(CExpression *pexpr);
+
 	// translate an arrayref index list
 	CDXLNode *PdxlnArrayRefIndexList(CExpression *pexpr);
 

--- a/src/backend/gporca/libgpopt/src/operators/CScalarFieldSelect.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarFieldSelect.cpp
@@ -1,0 +1,96 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CScalarFieldSelect.cpp
+//
+//	@doc:
+//		Implementation of scalar FIELDSELECT
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/CScalarFieldSelect.h"
+
+#include "gpos/base.h"
+
+using namespace gpopt;
+using namespace gpmd;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarFieldSelect::CScalarFieldSelect
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CScalarFieldSelect::CScalarFieldSelect(CMemoryPool *mp, IMDId *field_type,
+									   IMDId *field_collation,
+									   INT type_modifier, SINT field_number)
+	: CScalar(mp),
+	  m_field_type(field_type),
+	  m_field_collation(field_collation),
+	  m_type_modifier(type_modifier),
+	  m_field_number(field_number)
+{
+	GPOS_ASSERT(m_field_type->IsValid());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarFieldSelect::~CScalarFieldSelect
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CScalarFieldSelect::~CScalarFieldSelect()
+{
+	m_field_type->Release();
+	m_field_collation->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarFieldSelect::HashValue
+//
+//	@doc:
+//		Operator specific hash function
+//
+//---------------------------------------------------------------------------
+ULONG
+CScalarFieldSelect::HashValue() const
+{
+	return gpos::CombineHashes(
+		COperator::HashValue(),
+		CombineHashes(CombineHashes(m_field_type->HashValue(),
+									m_field_collation->HashValue()),
+					  gpos::HashValue<SINT>(&m_field_number)));
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarFieldSelect::Matches
+//
+//	@doc:
+//		Match function on operator level
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarFieldSelect::Matches(COperator *pop) const
+{
+	if (pop->Eopid() != Eopid())
+	{
+		return false;
+	}
+	CScalarFieldSelect *popFieldSelect = CScalarFieldSelect::PopConvert(pop);
+
+	// match attribute field number and type of the field
+	return popFieldSelect->MdidType()->Equals(MdidType()) &&
+		   popFieldSelect->FieldCollation()->Equals(FieldCollation()) &&
+		   popFieldSelect->FieldNumber() == FieldNumber();
+}
+
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -166,6 +166,7 @@ OBJS        = CExpression.o \
               CScalarCoerceViaIO.o \
               CScalarConst.o \
               CScalarDMLAction.o \
+              CScalarFieldSelect.o \
               CScalarFunc.o \
               CScalarIdent.o \
               CScalarIf.o \

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -200,6 +200,8 @@ CTranslatorDXLToExpr::InitTranslators()
 		{EdxlopScalarValuesList, &gpopt::CTranslatorDXLToExpr::PexprValuesList},
 		{EdxlopScalarSortGroupClause,
 		 &gpopt::CTranslatorDXLToExpr::PexprSortGroupClause},
+		{EdxlopScalarFieldSelect,
+		 &gpopt::CTranslatorDXLToExpr::PexprFieldSelect},
 	};
 
 	const ULONG translators_mapping_len = GPOS_ARRAY_SIZE(translators_mapping);
@@ -3244,6 +3246,35 @@ CTranslatorDXLToExpr::PexprValuesList(const CDXLNode *dxlnode)
 
 	return GPOS_NEW(m_mp)
 		CExpression(m_mp, popScalarValuesList, pdrgpexprChildren);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorDXLToExpr::PexprFieldSelect
+//
+//	@doc:
+// 		Create a scalar FieldSelect operator expression from a DXL FieldSelect node
+//
+//---------------------------------------------------------------------------
+CExpression *
+CTranslatorDXLToExpr::PexprFieldSelect(const CDXLNode *dxlnode)
+{
+	CDXLScalarFieldSelect *dxl_op =
+		CDXLScalarFieldSelect::Cast(dxlnode->GetOperator());
+
+	IMDId *field_type = dxl_op->GetDXLFieldType();
+	field_type->AddRef();
+	IMDId *field_collation = dxl_op->GetDXLFieldCollation();
+	field_collation->AddRef();
+	INT type_modifier = dxl_op->GetDXLTypeModifier();
+	SINT field_number = dxl_op->GetDXLFieldNumber();
+
+	CScalarFieldSelect *popFieldSelect = GPOS_NEW(m_mp) CScalarFieldSelect(
+		m_mp, field_type, field_collation, type_modifier, field_number);
+	CExpressionArray *pdrgpexprChildren = PdrgpexprChildren(dxlnode);
+
+	return GPOS_NEW(m_mp) CExpression(m_mp, popFieldSelect, pdrgpexprChildren);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
@@ -68,6 +68,7 @@ enum Edxlopid
 	EdxlopScalarHashCondList,
 	EdxlopScalarArray,
 	EdxlopScalarArrayRef,
+	EdxlopScalarFieldSelect,
 	EdxlopScalarArrayRefIndexList,
 
 	EdxlopScalarAssertConstraintList,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -262,6 +262,10 @@ public:
 	static CDXLScalar *MakeDXLArrayCoerceExpr(
 		CDXLMemoryManager *dxl_memory_manager, const Attributes &attrs);
 
+	// create a FieldSelectExpr
+	static CDXLScalar *MakeDXLFieldSelect(CDXLMemoryManager *dxl_memory_manager,
+										  const Attributes &attrs);
+
 	// create a scalar identifier operator
 	static CDXLScalar *MakeDXLScalarIdent(CDXLMemoryManager *dxl_memory_manager,
 										  const Attributes &attrs);

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarFieldSelect.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarFieldSelect.h
@@ -1,0 +1,110 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CDXLScalarFieldSelect.cpp
+//
+//	@doc:
+//		Implementation of DXL Scalar FIELDSELECT operator
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CDXLSCALARFIELDSELECT_H
+#define GPDXL_CDXLSCALARFIELDSELECT_H
+
+#include "gpos/base.h"
+
+#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/md/IMDId.h"
+
+namespace gpdxl
+{
+using namespace gpos;
+using namespace gpmd;
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CDXLScalarAggref
+//
+//	@doc:
+//		Class for representing DXL FIELDSELECT
+//
+//---------------------------------------------------------------------------
+class CDXLScalarFieldSelect : public CDXLScalar
+{
+private:
+	// type of the field
+	IMDId *m_dxl_field_type;
+
+	// collation OID of the field
+	IMDId *m_dxl_field_collation;
+
+	// output typmod (usually -1)
+	INT m_dxl_type_modifier;
+
+	// attribute number of field to extract
+	SINT m_dxl_field_number;
+
+	// private copy ctor
+	CDXLScalarFieldSelect(const CDXLScalarFieldSelect &);
+
+public:
+	// ctor/dtor
+	CDXLScalarFieldSelect(CMemoryPool *mp, IMDId *field_type,
+						  IMDId *field_collation, INT type_modifier,
+						  SINT field_number);
+
+	virtual ~CDXLScalarFieldSelect();
+
+	// ident accessors
+	virtual Edxlopid GetDXLOperator() const;
+
+	// DXL operator name
+	virtual const CWStringConst *GetOpNameStr() const;
+
+	// serialize operator in DXL format
+	virtual void SerializeToDXL(CXMLSerializer *xml_serializer,
+								const CDXLNode *dxlnode) const;
+
+	// mdid of the field
+	IMDId *GetDXLFieldType() const;
+
+	// collation mdid of the field
+	IMDId *GetDXLFieldCollation() const;
+
+	// output type mode
+	INT GetDXLTypeModifier() const;
+
+	// attribute number of the field
+	SINT GetDXLFieldNumber() const;
+
+	// conversion function
+	static CDXLScalarFieldSelect *
+	Cast(CDXLOperator *dxl_op)
+	{
+		GPOS_ASSERT(NULL != dxl_op);
+		GPOS_ASSERT(EdxlopScalarFieldSelect == dxl_op->GetDXLOperator());
+
+		return dynamic_cast<CDXLScalarFieldSelect *>(dxl_op);
+	}
+
+	// does the operator return a boolean result
+	virtual BOOL
+	HasBoolResult(CMDAccessor *	 //md_accessor
+	) const
+	{
+		return true;
+	}
+
+#ifdef GPOS_DEBUG
+	// checks whether the operator has valid structure, i.e. number and
+	// types of child nodes
+	virtual void AssertValid(const CDXLNode *dxlnode,
+							 BOOL validate_children) const;
+#endif	// GPOS_DEBUG
+};
+}  // namespace gpdxl
+
+#endif	// !GPDB_CDXLSCALARFIELDSELECT_H
+
+// EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/dxlops.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/dxlops.h
@@ -92,6 +92,7 @@
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLScalarDMLAction.h"
 #include "naucrates/dxl/operators/CDXLScalarDistinctComp.h"
+#include "naucrates/dxl/operators/CDXLScalarFieldSelect.h"
 #include "naucrates/dxl/operators/CDXLScalarFilter.h"
 #include "naucrates/dxl/operators/CDXLScalarFuncExpr.h"
 #include "naucrates/dxl/operators/CDXLScalarHashCondList.h"

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -371,6 +371,11 @@ private:
 		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
 		CParseHandlerBase *parse_handler_root);
 
+	// construct an FieldSelect parse handler
+	static CParseHandlerBase *CreateScalarFieldSelectParseHandler(
+		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+		CParseHandlerBase *parse_handler_root);
+
 	// construct an arrayref index list parse handler
 	static CParseHandlerBase *CreateScArrayRefIdxListParseHandler(
 		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarFieldSelect.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarFieldSelect.h
@@ -1,0 +1,67 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CParseHandlerScalarFieldSelect.h
+//
+//	@doc:
+//		SAX parse handler class for parsing scalar FieldSelect operator nodes
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CParseHandlerScalarFieldSelect_H
+#define GPDXL_CParseHandlerScalarFieldSelect_H
+
+#include "gpos/base.h"
+
+#include "naucrates/dxl/operators/CDXLScalarFieldSelect.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+
+namespace gpdxl
+{
+using namespace gpos;
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CParseHandlerScalarFieldSelect
+//
+//	@doc:
+//		Parse handler class for parsing scalar FieldSelect
+//
+//---------------------------------------------------------------------------
+class CParseHandlerScalarFieldSelect : public CParseHandlerScalarOp
+{
+private:
+	// private copy ctor
+	CParseHandlerScalarFieldSelect(const CParseHandlerScalarFieldSelect &);
+
+	// process the start of an element
+	void StartElement(
+		const XMLCh *const element_uri,			// URI of element's namespace
+		const XMLCh *const element_local_name,	// local part of element's name
+		const XMLCh *const element_qname,		// element's qname
+		const Attributes &attr					// element's attributes
+	);
+
+	// process the end of an element
+	void EndElement(
+		const XMLCh *const element_uri,			// URI of element's namespace
+		const XMLCh *const element_local_name,	// local part of element's name
+		const XMLCh *const element_qname		// element's qname
+	);
+
+public:
+	// ctor/dtor
+	CParseHandlerScalarFieldSelect(CMemoryPool *mp,
+								   CParseHandlerManager *parse_handler_mgr,
+								   CParseHandlerBase *parse_handler_root);
+
+	virtual ~CParseHandlerScalarFieldSelect(){};
+};
+}  // namespace gpdxl
+
+#endif	// !GPDXL_CParseHandlerScalarFieldSelect_H
+
+// EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
@@ -135,6 +135,7 @@
 #include "naucrates/dxl/parser/CParseHandlerScalarConstValue.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarDMLAction.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarExpr.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarFieldSelect.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarFuncExpr.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarIdent.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarIfStmt.h"

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -269,6 +269,13 @@ enum Edxltoken
 	EdxltokenWindowrefStageRowKey,
 	EdxltokenWindowrefWinSpecPos,
 
+	// FIELDSELECT
+	EdxltokenScalarFieldSelect,
+	EdxltokenScalarFieldSelectFieldType,
+	EdxltokenScalarFieldSelectFieldCollation,
+	EdxltokenScalarFieldSelectFieldNumber,
+	EdxltokenScalarFieldSelectTypeModifier,
+
 	EdxltokenValue,
 	EdxltokenTypeId,
 	EdxltokenTypeIds,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -922,6 +922,37 @@ CDXLOperatorFactory::MakeDXLArrayCoerceExpr(
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CDXLOperatorFactory::MakeDXLFieldSelectExpr
+//
+//	@doc:
+//		Construct a scalar FieldSelect expression
+//
+//---------------------------------------------------------------------------
+CDXLScalar *
+CDXLOperatorFactory::MakeDXLFieldSelect(CDXLMemoryManager *dxl_memory_manager,
+										const Attributes &attrs)
+{
+	CMemoryPool *mp = dxl_memory_manager->Pmp();
+
+	IMDId *field_type = ExtractConvertAttrValueToMdId(
+		dxl_memory_manager, attrs, EdxltokenScalarFieldSelectFieldType,
+		EdxltokenScalarFieldSelect);
+	IMDId *field_collation = ExtractConvertAttrValueToMdId(
+		dxl_memory_manager, attrs, EdxltokenScalarFieldSelectFieldCollation,
+		EdxltokenScalarFieldSelect);
+	INT type_modifier = ExtractConvertAttrValueToInt(
+		dxl_memory_manager, attrs, EdxltokenScalarFieldSelectTypeModifier,
+		EdxltokenScalarFieldSelect);
+	SINT field_number = ExtractConvertAttrValueToInt(
+		dxl_memory_manager, attrs, EdxltokenScalarFieldSelectFieldNumber,
+		EdxltokenScalarFieldSelect);
+
+	return GPOS_NEW(mp) CDXLScalarFieldSelect(mp, field_type, field_collation,
+											  type_modifier, field_number);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CDXLOperatorFactory::MakeDXLConstValue
 //
 //	@doc:

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarFieldSelect.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarFieldSelect.cpp
@@ -1,0 +1,205 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CDXLScalarFieldSelect.cpp
+//
+//	@doc:
+//		Implementation of DXL Scalar FIELDSELECT operator
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/operators/CDXLScalarFieldSelect.h"
+
+#include "gpopt/mdcache/CMDAccessor.h"
+#include "naucrates/dxl/operators/CDXLNode.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+using namespace gpos;
+using namespace gpdxl;
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::CDXLScalarFieldSelect
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CDXLScalarFieldSelect::CDXLScalarFieldSelect(CMemoryPool *mp, IMDId *field_type,
+											 IMDId *field_collation,
+											 INT type_modifier,
+											 SINT field_number)
+	: CDXLScalar(mp),
+	  m_dxl_field_type(field_type),
+	  m_dxl_field_collation(field_collation),
+	  m_dxl_type_modifier(type_modifier),
+	  m_dxl_field_number(field_number)
+{
+	GPOS_ASSERT(m_dxl_field_type->IsValid());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::~CDXLScalarFieldSelect
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CDXLScalarFieldSelect::~CDXLScalarFieldSelect()
+{
+	m_dxl_field_type->Release();
+	m_dxl_field_collation->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetDXLOperator
+//
+//	@doc:
+//		Operator type
+//
+//---------------------------------------------------------------------------
+Edxlopid
+CDXLScalarFieldSelect::GetDXLOperator() const
+{
+	return EdxlopScalarFieldSelect;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetDXLFieldType
+//
+//	@doc:
+//		Returns mdid of the field
+//
+//---------------------------------------------------------------------------
+IMDId *
+CDXLScalarFieldSelect::GetDXLFieldType() const
+{
+	return m_dxl_field_type;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetDXLFieldCollation
+//
+//	@doc:
+//		Returns collation mdid of the field
+//
+//---------------------------------------------------------------------------
+IMDId *
+CDXLScalarFieldSelect::GetDXLFieldCollation() const
+{
+	return m_dxl_field_collation;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetDXLFieldTypeModifier
+//
+//	@doc:
+//		Returns output type mode
+//
+//---------------------------------------------------------------------------
+INT
+CDXLScalarFieldSelect::GetDXLTypeModifier() const
+{
+	return m_dxl_type_modifier;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetDXLFieldNumber()
+//
+//	@doc:
+//		Returns attribute number of the field to extract
+//
+//---------------------------------------------------------------------------
+SINT
+CDXLScalarFieldSelect::GetDXLFieldNumber() const
+{
+	return m_dxl_field_number;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::GetOpNameStr
+//
+//	@doc:
+//		Operator name
+//
+//---------------------------------------------------------------------------
+const CWStringConst *
+CDXLScalarFieldSelect::GetOpNameStr() const
+{
+	return CDXLTokens::GetDXLTokenStr(EdxltokenScalarFieldSelect);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::SerializeToDXL
+//
+//	@doc:
+//		Serialize operator in DXL format
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarFieldSelect::SerializeToDXL(CXMLSerializer *xml_serializer,
+									  const CDXLNode *dxlnode) const
+{
+	const CWStringConst *element_name = GetOpNameStr();
+
+	xml_serializer->OpenElement(
+		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), element_name);
+
+	m_dxl_field_type->Serialize(
+		xml_serializer,
+		CDXLTokens::GetDXLTokenStr(EdxltokenScalarFieldSelectFieldType));
+	m_dxl_field_collation->Serialize(
+		xml_serializer,
+		CDXLTokens::GetDXLTokenStr(EdxltokenScalarFieldSelectFieldCollation));
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(EdxltokenScalarFieldSelectTypeModifier),
+		m_dxl_type_modifier);
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(EdxltokenScalarFieldSelectFieldNumber),
+		m_dxl_field_number);
+
+	dxlnode->SerializeChildrenToDXL(xml_serializer);
+
+	xml_serializer->CloseElement(
+		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), element_name);
+}
+
+#ifdef GPOS_DEBUG
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarFieldSelect::AssertValid
+//
+//	@doc:
+//		Checks whether operator node is well-structured
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarFieldSelect::AssertValid(const CDXLNode *dxlnode,
+								   BOOL validate_children) const
+{
+	const ULONG arity = dxlnode->Arity();
+	for (ULONG ul = 0; ul < arity; ++ul)
+	{
+		CDXLNode *child_dxlnode = (*dxlnode)[ul];
+		GPOS_ASSERT(EdxloptypeScalar ==
+					child_dxlnode->GetOperator()->GetDXLOperatorType());
+
+		if (validate_children)
+		{
+			child_dxlnode->GetOperator()->AssertValid(child_dxlnode,
+													  validate_children);
+		}
+	}
+}
+#endif	// GPOS_DEBUG
+
+// EOF

--- a/src/backend/gporca/libnaucrates/src/operators/Makefile
+++ b/src/backend/gporca/libnaucrates/src/operators/Makefile
@@ -111,6 +111,7 @@ OBJS        = CDXLColDescr.o \
               CDXLScalarConstValue.o \
               CDXLScalarDMLAction.o \
               CDXLScalarDistinctComp.o \
+	      CDXLScalarFieldSelect.o \
               CDXLScalarFilter.o \
               CDXLScalarFuncExpr.o \
               CDXLScalarHashCondList.o \

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -174,6 +174,7 @@ CParseHandlerFactory::Init(CMemoryPool *mp)
 		{EdxltokenScalarCoerceToDomain, CreateScCoerceToDomainParseHandler},
 		{EdxltokenScalarCoerceViaIO, CreateScCoerceViaIOParseHandler},
 		{EdxltokenScalarArrayCoerceExpr, CreateScArrayCoerceExprParseHandler},
+		{EdxltokenScalarFieldSelect, &CreateScalarFieldSelectParseHandler},
 		{EdxltokenScalarHashExpr, &CreateHashExprParseHandler},
 		{EdxltokenScalarHashCondList, &CreateCondListParseHandler},
 		{EdxltokenScalarMergeCondList, &CreateCondListParseHandler},
@@ -1249,6 +1250,16 @@ CParseHandlerFactory::CreateScArrayCoerceExprParseHandler(
 {
 	return GPOS_NEW(mp) CParseHandlerScalarArrayCoerceExpr(
 		mp, parse_handler_mgr, parse_handler_root);
+}
+
+// creates a parse handler for parsing FIELDSELECT operator
+CParseHandlerBase *
+CParseHandlerFactory::CreateScalarFieldSelectParseHandler(
+	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+	CParseHandlerBase *parse_handler_root)
+{
+	return GPOS_NEW(mp) CParseHandlerScalarFieldSelect(mp, parse_handler_mgr,
+													   parse_handler_root);
 }
 
 // creates a parse handler for parsing a SubPlan.

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarFieldSelect.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarFieldSelect.cpp
@@ -1,0 +1,129 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CParseHandlerScalarFieldSelect.cpp
+//
+//	@doc:
+//		Implementation of the SAX parse handler class for FieldSelect
+//		operators
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerScalarFieldSelect.h"
+
+#include "naucrates/dxl/CDXLUtils.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+
+
+using namespace gpdxl;
+
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarFieldSelect::CParseHandlerScalarFieldSelect
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CParseHandlerScalarFieldSelect::CParseHandlerScalarFieldSelect(
+	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+	CParseHandlerBase *parse_handler_root)
+	: CParseHandlerScalarOp(mp, parse_handler_mgr, parse_handler_root)
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarFieldSelect::StartElement
+//
+//	@doc:
+//		Processes a Xerces start element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerScalarFieldSelect::StartElement(
+	const XMLCh *const,	 // element_uri,
+	const XMLCh *const element_local_name,
+	const XMLCh *const,	 // element_qname
+	const Attributes &attrs)
+{
+	if (0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenScalarFieldSelect),
+				 element_local_name))
+	{
+		if (NULL != m_dxl_node)
+		{
+			CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(
+				m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,
+					   str->GetBuffer());
+		}
+
+		// parse and create scalar fieldselect
+		CDXLScalarFieldSelect *dxl_op =
+			(CDXLScalarFieldSelect *) CDXLOperatorFactory::MakeDXLFieldSelect(
+				m_parse_handler_mgr->GetDXLMemoryManager(), attrs);
+
+		m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
+
+		// parse handler for child scalar node
+		CParseHandlerBase *child_parse_handler =
+			CParseHandlerFactory::GetParseHandler(
+				m_mp, CDXLTokens::XmlstrToken(EdxltokenScalar),
+				m_parse_handler_mgr, this);
+		m_parse_handler_mgr->ActivateParseHandler(child_parse_handler);
+
+		// store parse handler
+		this->Append(child_parse_handler);
+	}
+	else
+	{
+		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(
+			m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,
+				   str->GetBuffer());
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarFieldSelect::EndElement
+//
+//	@doc:
+//		Processes a Xerces end element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerScalarFieldSelect::EndElement(
+	const XMLCh *const,	 // element_uri,
+	const XMLCh *const element_local_name,
+	const XMLCh *const	// element_qname
+)
+{
+	if (0 != XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenScalarFieldSelect),
+				 element_local_name))
+	{
+		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(
+			m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,
+				   str->GetBuffer());
+	}
+	GPOS_ASSERT(1 == this->Length());
+
+	// add constructed child from child parse handlers
+	CParseHandlerScalarOp *child_parse_handler =
+		dynamic_cast<CParseHandlerScalarOp *>((*this)[0]);
+	AddChildFromParseHandler(child_parse_handler);
+
+	// deactivate handler
+	m_parse_handler_mgr->DeactivateHandler();
+}
+
+// EOF

--- a/src/backend/gporca/libnaucrates/src/parser/Makefile
+++ b/src/backend/gporca/libnaucrates/src/parser/Makefile
@@ -139,6 +139,7 @@ OBJS        = CParseHandlerAgg.o \
               CParseHandlerScalarConstValue.o \
               CParseHandlerScalarDMLAction.o \
               CParseHandlerScalarExpr.o \
+              CParseHandlerScalarFieldSelect.o \
               CParseHandlerScalarFuncExpr.o \
               CParseHandlerScalarIdent.o \
               CParseHandlerScalarIfStmt.o \

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -220,9 +220,15 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenScalarSortColList, GPOS_WSZ_LIT("SortingColumnList")},
 		{EdxltokenScalarGroupingColList, GPOS_WSZ_LIT("GroupingColumns")},
 		{EdxltokenScalarSortGroupClause, GPOS_WSZ_LIT("SortGroupClause")},
-
 		{EdxltokenScalarBitmapAnd, GPOS_WSZ_LIT("BitmapAnd")},
 		{EdxltokenScalarBitmapOr, GPOS_WSZ_LIT("BitmapOr")},
+
+		{EdxltokenScalarFieldSelect, GPOS_WSZ_LIT("FIELDSELECT")},
+		{EdxltokenScalarFieldSelectFieldType, GPOS_WSZ_LIT("FieldType")},
+		{EdxltokenScalarFieldSelectFieldCollation,
+		 GPOS_WSZ_LIT("FieldCollation")},
+		{EdxltokenScalarFieldSelectFieldNumber, GPOS_WSZ_LIT("FieldNumber")},
+		{EdxltokenScalarFieldSelectTypeModifier, GPOS_WSZ_LIT("TypeModifier")},
 
 		{EdxltokenScalarArray, GPOS_WSZ_LIT("Array")},
 		{EdxltokenScalarArrayRef, GPOS_WSZ_LIT("ArrayRef")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -372,6 +372,9 @@ SqlFuncNullReject SqlFuncPredFactorize SqlFuncDmlScalar SqlFuncDmlTvf CompositeT
 CScalarFuncPushDownTest:
 ScalarFuncPushedBelowGather ConstScalarFuncNotPushedBelowGather;
 
+CScalarTest:
+FieldSelect;
+
 COrderedAggTest:
 CTAS_OrderedAgg_multiple_cols OrderedAgg_multiple_diffcol OrderedAgg_with_groupby OrderedAgg_computed_col
 OrderedAggUsingGroupColumnInDirectArg OrderedAgg_multiple_samecol OrderedAgg_with_nonOrderedAgg OrderedAgg_single

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -136,6 +136,9 @@ private:
 	Expr *TranslateDXLScalarArrayCoerceExprToScalar(
 		const CDXLNode *coerce_node, CMappingColIdVar *colid_var);
 
+	Expr *TranslateDXLFieldSelectToScalar(const CDXLNode *field_select_node,
+										  CMappingColIdVar *colid_var);
+
 	Expr *TranslateDXLScalarNullTestToScalar(
 		const CDXLNode *scalar_null_test_node, CMappingColIdVar *colid_var);
 

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -130,6 +130,10 @@ private:
 	CDXLNode *TranslateScalarArrayOpExprToDXL(
 		const Expr *expr, const CMappingVarColId *var_colid_mapping);
 
+	// create a DXL node for a fieldselect node from gpdb expression
+	CDXLNode *TranslateFieldSelectToDXL(
+		const Expr *expr, const CMappingVarColId *var_colid_mapping);
+
 	// create a DXL scalar array comparison node from a GPDB expression
 	CDXLNode *CreateScalarArrayCompFromExpr(
 		const Expr *expr, const CMappingVarColId *var_colid_mapping);

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3619,24 +3619,28 @@ select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
 create type mytype_prefetch_params as (x int, y int);
 alter table b add column mt_col mytype_prefetch_params;
 explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.19..765906.72 rows=24 width=16)
-   ->  Nested Loop  (cost=0.19..765906.26 rows=8 width=16)
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=36)
-               ->  Seq Scan on b  (cost=0.00..1.01 rows=1 width=36)
-         ->  Materialize  (cost=0.19..255301.72 rows=2 width=12)
-               ->  Nested Loop  (cost=0.19..255301.70 rows=2 width=12)
+NOTICE:  One or more columns in the following table(s) do not have statistics: b
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324038.71 rows=1 width=16)
+   ->  Nested Loop  (cost=0.00..1324038.71 rows=1 width=16)
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..1324032.71 rows=1 width=8)
                      Join Filter: (((b.mt_col).x > a.i) OR (b.i = a.i))
-                     ->  Materialize  (cost=0.00..1.06 rows=1 width=4)
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
-                                 ->  Seq Scan on a  (cost=0.00..1.01 rows=1 width=4)
-                     ->  Index Only Scan using c_i_j_idx on c  (cost=0.19..85100.20 rows=1 width=8)
-                           Index Cond: (j = (a.i + b.i))
- Optimizer: Postgres query optimizer
+                     ->  Seq Scan on b  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..431.00 rows=1 width=4)
+         ->  Index Scan using c_i_j_idx on c  (cost=0.00..6.00 rows=1 width=8)
+               Index Cond: (j = (a.i + b.i))
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+NOTICE:  One or more columns in the following table(s) do not have statistics: b
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
  i | i | i | j 
 ---+---+---+---
  1 | 1 | 2 | 2

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14527,6 +14527,216 @@ select c from mix_func_cast();
  t
 (1 row)
 
+----------------------------------
+-- Test ORCA support for FIELDSELECT
+----------------------------------
+create type comp_type as ( a text, b numeric, c int, d float, e int);
+create table comp_table(id int, item comp_type) distributed by (id);
+create table comp_part (id int, item comp_type) distributed by (id) partition by range(id) (start(1) end(4) every(1));
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_1" for table "comp_part"
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_2" for table "comp_part"
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_3" for table "comp_part"
+insert into comp_table values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+insert into comp_part values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+analyze comp_table;
+analyze comp_part;
+select sum((item).b) from comp_table where (item).c=20;
+ sum  
+------
+ 20.5
+(1 row)
+
+explain (costs off) select sum((item).b) from comp_table where (item).c=20;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Seq Scan on comp_table
+                     Filter: ((item).c = 20)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select distinct (item).b from comp_table where (item).c=20;
+  b   
+------
+ 20.5
+(1 row)
+
+explain (costs off) select distinct (item).b from comp_table where (item).c=20;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  HashAggregate
+         Group Key: ((comp_table.item).b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: ((comp_table.item).b)
+               ->  HashAggregate
+                     Group Key: (comp_table.item).b
+                     ->  Seq Scan on comp_table
+                           Filter: ((item).c = 20)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- verify the query output using predicate with the same composite type
+select (item).a from comp_table where (item).c=20 and (item).e >10;
+ a  
+----
+ VM
+(1 row)
+
+explain (costs off) select (item).a from comp_table where (item).c=20 and (item).e >10;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on comp_table
+         Filter: (((item).e > 10) AND ((item).c = 20))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- verify the query output using predicate with the different composite type
+select * from comp_table where (item).c>(item).d;
+ id |         item         
+----+----------------------
+  2 | (VM,20.5,20,10.5,20)
+(1 row)
+
+explain (costs off) select * from comp_table where (item).c>(item).d ;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on comp_table
+         Filter: (((item).c)::double precision > (item).d)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- verify the query output by using a composite type in a join query
+select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+ a  
+----
+ GP
+ GP
+ DB
+ DB
+ VM
+(5 rows)
+
+explain (costs off) select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((x.item).c = (y.item).c)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (x.item).c
+               ->  Seq Scan on comp_table x
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (y.item).c
+                     ->  Seq Scan on comp_table y
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- verify the query output by using a composite type in a TVF query
+select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+ a  | count 
+----+-------
+ GP |    10
+ VM |    20
+ DB |    10
+(3 rows)
+
+explain (costs off) select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on comp_table x
+         SubPlan 1  (slice1; segments: 1)
+           ->  Aggregate
+                 ->  Function Scan on generate_series
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+-- verify the query output by using a composite type in a cte query
+with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+ id | a  |  b   | c  | e  
+----+----+------+----+----
+  2 | VM | 20.5 | 20 | 20
+(1 row)
+
+explain (costs off) with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Subquery Scan on cte1
+         ->  Seq Scan on comp_table
+               Filter: ((item).c > 10)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- verify the query output by using a composite type in a  subquery
+select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+ a  
+----
+ GP
+ DB
+(2 rows)
+
+explain (costs off) select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((comp_table.item).e = (comp_table_1.item).e)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (comp_table.item).e
+               ->  Seq Scan on comp_table
+                     Filter: ((item).c = 10)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (comp_table_1.item).e
+                     ->  Seq Scan on comp_table comp_table_1
+                           Filter: ((item).c = 10)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+-- verify the query output by using a composite type in a partition table query
+select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+ a  
+----
+ DB
+ DB
+ GP
+ GP
+ VM
+(5 rows)
+
+explain (costs off) select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((x.item).c = (y.item).c)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (x.item).c
+               ->  Append
+                     ->  Seq Scan on comp_part_1_prt_1 x
+                     ->  Seq Scan on comp_part_1_prt_2 x_1
+                     ->  Seq Scan on comp_part_1_prt_3 x_2
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (y.item).c
+                     ->  Append
+                           ->  Seq Scan on comp_part_1_prt_1 y
+                           ->  Seq Scan on comp_part_1_prt_2 y_1
+                           ->  Seq Scan on comp_part_1_prt_3 y_2
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- clean up
+drop table comp_table;
+drop table comp_part;
+drop type comp_type;
 -- the query with empty CTE producer target list should fall back to Postgres
 -- optimizer without any error on build without asserts
 drop table if exists empty_cte_tl_test;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14629,18 +14629,20 @@ explain select c2 from quad_func_cast();
 (3 rows)
 
 explain select (c1).r from quad_func_cast();
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
- Optimizer: Postgres query optimizer
-(2 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=8)
+   ->  Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
 
 explain select (c2).i from quad_func_cast();
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
- Optimizer: Postgres query optimizer
-(2 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=8)
+   ->  Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
 
 select c1 from quad_func_cast();
    c1   
@@ -14710,6 +14712,220 @@ select c from mix_func_cast();
  t
 (1 row)
 
+----------------------------------
+-- Test ORCA support for FIELDSELECT
+----------------------------------
+create type comp_type as ( a text, b numeric, c int, d float, e int);
+create table comp_table(id int, item comp_type) distributed by (id);
+create table comp_part (id int, item comp_type) distributed by (id) partition by range(id) (start(1) end(4) every(1));
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_1" for table "comp_part"
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_2" for table "comp_part"
+NOTICE:  CREATE TABLE will create partition "comp_part_1_prt_3" for table "comp_part"
+insert into comp_table values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+insert into comp_part values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+analyze comp_table;
+analyze comp_part;
+select sum((item).b) from comp_table where (item).c=20;
+ sum  
+------
+ 20.5
+(1 row)
+
+explain (costs off) select sum((item).b) from comp_table where (item).c=20;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Seq Scan on comp_table
+                     Filter: ((item).c = 20)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+select distinct (item).b from comp_table where (item).c=20;
+  b   
+------
+ 20.5
+(1 row)
+
+explain (costs off) select distinct (item).b from comp_table where (item).c=20;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  GroupAggregate
+         Group Key: ((item).b)
+         ->  Sort
+               Sort Key: ((item).b)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: ((item).b)
+                     ->  Result
+                           ->  Seq Scan on comp_table
+                                 Filter: ((item).c = 20)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+-- verify the query output using predicate with the same composite type
+select (item).a from comp_table where (item).c=20 and (item).e >10;
+ a  
+----
+ VM
+(1 row)
+
+explain (costs off) select (item).a from comp_table where (item).c=20 and (item).e >10;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on comp_table
+               Filter: (((item).c = 20) AND ((item).e > 10))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- verify the query output using predicate with the different composite type
+select * from comp_table where (item).c>(item).d;
+ id |         item         
+----+----------------------
+  2 | (VM,20.5,20,10.5,20)
+(1 row)
+
+explain (costs off) select * from comp_table where (item).c>(item).d ;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on comp_table
+         Filter: (((item).c)::double precision > (item).d)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- verify the query output by using a composite type in a join query
+select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+ a  
+----
+ VM
+ GP
+ GP
+ DB
+ DB
+(5 rows)
+
+explain (costs off) select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Result
+         ->  Hash Join
+               Hash Cond: ((comp_table.item).c = (comp_table_1.item).c)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: (comp_table.item).c
+                     ->  Seq Scan on comp_table
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (comp_table_1.item).c
+                           ->  Seq Scan on comp_table comp_table_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- verify the query output by using a composite type in a TVF query
+select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+ a  | count 
+----+-------
+ GP |    10
+ VM |    20
+ DB |    10
+(3 rows)
+
+explain (costs off) select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on comp_table
+         SubPlan 1  (slice1; segments: 3)
+           ->  Aggregate
+                 ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+-- verify the query output by using a composite type in a cte query
+with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+ id | a  |  b   | c  | e  
+----+----+------+----+----
+  2 | VM | 20.5 | 20 | 20
+(1 row)
+
+explain (costs off) with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on comp_table
+               Filter: ((item).c > 10)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- verify the query output by using a composite type in a  subquery
+select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+ a  
+----
+ GP
+ DB
+(2 rows)
+
+explain (costs off) select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Result
+         ->  Hash Semi Join
+               Hash Cond: ((comp_table.item).e = ((comp_table_1.item).e))
+               ->  Seq Scan on comp_table
+                     Filter: ((item).c = 10)
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Result
+                                 ->  Seq Scan on comp_table comp_table_1
+                                       Filter: ((item).c = 10)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- verify the query output by using a composite type in a partition table query
+select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+ a  
+----
+ VM
+ DB
+ DB
+ GP
+ GP
+(5 rows)
+
+explain (costs off) select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Result
+         ->  Hash Join
+               Hash Cond: ((comp_part.item).c = (comp_part_1.item).c)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: (comp_part.item).c
+                     ->  Sequence
+                           ->  Partition Selector for comp_part (dynamic scan id: 1)
+                                 Partitions selected: 3 (out of 3)
+                           ->  Dynamic Seq Scan on comp_part (dynamic scan id: 1)
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (comp_part_1.item).c
+                           ->  Sequence
+                                 ->  Partition Selector for comp_part (dynamic scan id: 2)
+                                       Partitions selected: 3 (out of 3)
+                                 ->  Dynamic Seq Scan on comp_part comp_part_1 (dynamic scan id: 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+-- clean up
+drop table comp_table;
+drop table comp_part;
+drop type comp_type;
 -- the query with empty CTE producer target list should fall back to Postgres
 -- optimizer without any error on build without asserts
 drop table if exists empty_cte_tl_test;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3286,6 +3286,56 @@ select a from mix_func_cast();
 select b from mix_func_cast();
 select c from mix_func_cast();
 
+----------------------------------
+-- Test ORCA support for FIELDSELECT
+----------------------------------
+create type comp_type as ( a text, b numeric, c int, d float, e int);
+create table comp_table(id int, item comp_type) distributed by (id);
+create table comp_part (id int, item comp_type) distributed by (id) partition by range(id) (start(1) end(4) every(1));
+insert into comp_table values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+insert into comp_part values (1, ROW('GP', 10.5, 10, 10.5, 20)), (2, ROW('VM',20.5, 20, 10.5, 20)), (3, ROW('DB',10.5, 10, 10.5, 10));
+analyze comp_table;
+analyze comp_part;
+
+select sum((item).b) from comp_table where (item).c=20;
+explain (costs off) select sum((item).b) from comp_table where (item).c=20;
+
+select distinct (item).b from comp_table where (item).c=20;
+explain (costs off) select distinct (item).b from comp_table where (item).c=20;
+
+-- verify the query output using predicate with the same composite type
+select (item).a from comp_table where (item).c=20 and (item).e >10;
+explain (costs off) select (item).a from comp_table where (item).c=20 and (item).e >10;
+
+-- verify the query output using predicate with the different composite type
+select * from comp_table where (item).c>(item).d;
+explain (costs off) select * from comp_table where (item).c>(item).d ;
+
+-- verify the query output by using a composite type in a join query
+select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+explain (costs off) select (x.item).a from comp_table x join comp_table y on (x.item).c=(y.item).c;
+
+-- verify the query output by using a composite type in a TVF query
+select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+explain (costs off) select (x.item).a, (select count(*) from generate_series(1, (x.item).c)) from comp_table x;
+
+-- verify the query output by using a composite type in a cte query
+with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+explain (costs off) with cte1 as (select * from comp_table where (item).c>10) select id, (item).a, (item).b, (item).c, (item).e from cte1;
+
+-- verify the query output by using a composite type in a  subquery
+select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+explain (costs off) select (item).a from comp_table where (item).c=10 and (item).e IN (SELECT (item).e FROM comp_table WHERE (item).c = 10);
+
+-- verify the query output by using a composite type in a partition table query
+select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+explain (costs off) select (x.item).a from comp_part x join comp_part y on (X.item).c=(Y.item).c;
+
+-- clean up
+drop table comp_table;
+drop table comp_part;
+drop type comp_type;
+
 -- the query with empty CTE producer target list should fall back to Postgres
 -- optimizer without any error on build without asserts
 drop table if exists empty_cte_tl_test;


### PR DESCRIPTION
Currently, ORCA does not support to handle FIELDSELECT nodes. Consequently, when a query involves a FIELDSELECT node, the query fallsback to planner.

Solution:
In order to facilitate FieldSelect nodes within ORCA, several additions have been made. This includes introducing the ScalardxlFieldSelect operator to translate Query's fieldselect nodes to DXLscalarFieldNodes nodes, and the ScalarFieldSelect operator to accommodate fieldSelect nodes during optimization. Additionally, a parse handler (ParseHandlerScalarFieldSelect) is implemented to support the parsing of mdp files containing fieldselect nodes.

What is FIELDSELECT?
In query execution plan, the FIELDSELECT operation is used to extract a specific field (column) from a composite data type. The FIELDSELECT operation takes as input a composite value (usually a column from a table) and specifies the attribute (field) within that composite value that you want to extract and produces the value of the specified attribute from the composite value.

Example:
```

CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
CREATE TABLE foo (item inventory_item, count integer);
INSERT INTO foo VALUES (ROW('fuzzy dice', 42, 1.99), 1000);
Before fix:

explain select (item).name from foo where (item).price > 0;
INFO:  GPORCA failed to produce a plan, falling back to planner
DETAIL:  Feature not supported: FIELDSELECT
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..461.11 rows=16533 width=32)
   ->  Seq Scan on foo  (cost=0.00..240.67 rows=5511 width=32)
         Filter: ((item).price > '0'::numeric)
 Optimizer: Postgres query optimizer
```

After fix:

```
explain select (item).name from foo where (item).price > 0;
                              QUERY PLAN
------------------------------------------------------------------------------
Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
  ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
        Filter: ((item).price > '0'::numeric)
Optimizer: Pivotal Optimizer (GPORCA)
```

Backport of [d04dc43](https://github.com/greenplum-db/gpdb/commit/d04dc43e051b171b4c18d0c2d5768c3cd3ebb67b)
