### PR TITLE
Disable resource group helper functions on non-Linux systems

### DIFF
--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -1,7 +1,11 @@
 EXTENSION = gp_toolkit
 DATA = gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql
 MODULE_big = gp_toolkit
+ifeq ($(PORTNAME),linux)
 OBJS = resgroup.o
+else
+OBJS = resgroup-dummy.o
+endif
 
 REGRESS = resource_manager_restore_to_none gp_toolkit resource_manager_switch_to_queue gp_toolkit_resqueue gp_toolkit_ao_funcs
 

--- a/gpcontrib/gp_toolkit/resgroup-dummy.c
+++ b/gpcontrib/gp_toolkit/resgroup-dummy.c
@@ -1,0 +1,14 @@
+#include "postgres.h"
+
+#include "funcapi.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(pg_resgroup_get_iostats);
+
+Datum
+pg_resgroup_get_iostats(PG_FUNCTION_ARGS)
+{
+	elog(WARNING, "resource group is not supported on this system");
+	PG_RETURN_NULL();
+}


### PR DESCRIPTION
The Cgroups, which the resource group depends on, is a Linux kernel feature.

