### PR TITLE
support gpload test in rocky9

### DIFF
--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -30,9 +30,14 @@ installcheck: gpdiff.pl gpstringsubs.pl
 	@echo "skip gpload test for Red Hat"
 else
 installcheck: gpdiff.pl gpstringsubs.pl
+	# install pytest for python2 and gpload test
+	python2 -m ensurepip --upgrade
+	python2 -m pip install -r pytest_requirements.txt
+	python2 -m pip install pytest-order==0.11.0
+
 	@cd gpload && ./TEST.py
 	@export PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/site-packages/:/usr/lib64/python2.7/site-packages/:/usr/local/greenplum-db-devel/lib/python\
-	&& cd gpload2 && python -m pytest TEST_local_*
+	&& cd gpload2 && python2 -m pytest TEST_local_*
 endif
 
 clean distclean:

--- a/gpMgmt/bin/gpload_test/Makefile
+++ b/gpMgmt/bin/gpload_test/Makefile
@@ -32,8 +32,9 @@ else
 installcheck: gpdiff.pl gpstringsubs.pl
 	# install pytest for python2 and gpload test
 	python2 -m ensurepip --upgrade
-	python2 -m pip install -r pytest_requirements.txt
+	python2 -m pip install -r pytest_requirement.txt
 	python2 -m pip install pytest-order==0.11.0
+	python2 -m pip install lxml
 
 	@cd gpload && ./TEST.py
 	@export PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/site-packages/:/usr/lib64/python2.7/site-packages/:/usr/local/greenplum-db-devel/lib/python\

--- a/gpMgmt/bin/gpload_test/pytest_requirement.txt
+++ b/gpMgmt/bin/gpload_test/pytest_requirement.txt
@@ -1,0 +1,10 @@
+attrs==21.2.0
+wcwidth==0.2.5
+pathlib2==2.3.5
+atomicwrites==1.4.0
+funcsigs==1.0.2
+more_itertools==5.0.0
+packaging==20.9
+pluggy==0.13.1
+importlib-metadata==2.1.0
+pytest==4.6.


### PR DESCRIPTION
install pip2 and other site-packages needed by gpload test in Makefile

gpload_test needs pytest module to run with vendored python2.7.18. in the past, we use os provided python2 and os provided pip2 to install pytest inside the gpdb6-[OS]-test docker image, then during ICW, use vendored python2.7.18 to import pytest inside the gpdb6-[OS]-test docker image.
But this does not work for EL9 platform, because EL9 has dropped python2 and pip2, so there is no way to have pytest installed inside gpdb6-rocky9/rhel9/oel9-test image, so gpload_test will failed on EL9 like the following error
/usr/local/greenplum-db-devel/ext/python/bin/python: No module named pytest

To fix the issue on platform EL9. we use vendored python2.7.18 and its pip to install pytest during the test.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
