### PR TITLE
[6X] add a new GUC of gp_detect_data_correctness to detect data correctness during OS upgrade

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -131,6 +131,7 @@ makeCdbHash(int numsegs, int natts, Oid *hashfuncs)
 CdbHash *
 makeCdbHashForRelation(Relation rel)
 {
+	CdbHash    *h;
 	GpPolicy   *policy = rel->rd_cdbpolicy;
 	Oid		   *hashfuncs;
 	int			i;
@@ -149,7 +150,20 @@ makeCdbHashForRelation(Relation rel)
 		hashfuncs[i] = cdb_hashproc_in_opfamily(opfamily, typeoid);
 	}
 
-	return makeCdbHash(policy->numsegments, policy->nattrs, hashfuncs);
+	h = makeCdbHash(policy->numsegments, policy->nattrs, hashfuncs);
+	pfree(hashfuncs);
+	return h;
+}
+
+/* release all memory of CdbHash */
+void freeCdbHash(CdbHash *hash)
+{
+	if (hash)
+	{
+		if (hash->hashfuncs)
+			pfree(hash->hashfuncs);
+		pfree(hash);
+	}
 }
 
 /*

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -104,6 +104,8 @@ int			gp_reject_percent_threshold;	/* SREH reject % kicks off only
 bool		gp_select_invisible = false;	/* debug mode to allow select to
 											 * see "invisible" rows */
 
+bool 		gp_detect_data_correctness; /* Detect if the current data distribution is correct */
+
 /*
  * Configurable timeout for snapshot add: exceptionally busy systems may take
  * longer than our old hard-coded version -- so here is a tuneable version.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3297,6 +3297,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 
+	{
+			{"gp_detect_data_correctness", PGC_USERSET, UNGROUPED,
+			 gettext_noop("Detect if the current partitioning of the table or data distribution is correct."),
+			 NULL,
+			 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			},
+			&gp_detect_data_correctness,
+			false,
+			NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -50,6 +50,7 @@ typedef struct CdbHash
  */
 extern CdbHash *makeCdbHash(int numsegs, int natts, Oid *typeoids);
 extern CdbHash *makeCdbHashForRelation(Relation rel);
+extern void freeCdbHash(CdbHash *h);
 
 /*
  * Initialize CdbHash for hashing the next tuple values.

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -183,6 +183,9 @@ extern int			gp_reject_percent_threshold;
  */
 extern bool           gp_select_invisible;
 
+/* Detect if the current partitioning of the table or data distribution is correct */
+extern bool			gp_detect_data_correctness;
+
 /*
  * Used to set the maximum length of the current query which is displayed
  * when the user queries pg_stat_activty table.

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -18,6 +18,7 @@
 		"gp_blockdirectory_minipage_size",
 		"gp_debug_linger",
 		"gp_default_storage_options",
+		"gp_detect_data_correctness",
 		"gp_disable_tuple_hints",
 		"gp_enable_mk_sort",
 		"gp_enable_motion_mk_sort",

--- a/src/test/isolation2/expected/guc_gp.out
+++ b/src/test/isolation2/expected/guc_gp.out
@@ -1,0 +1,61 @@
+-- case 1: test gp_detect_data_correctness
+create table data_correctness_detect(a int, b int);
+CREATE
+create table data_correctness_detect_randomly(a int, b int) distributed randomly;
+CREATE
+create table data_correctness_detect_replicated(a int, b int) distributed replicated;
+CREATE
+
+set gp_detect_data_correctness = on;
+SET
+-- should no data insert
+insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+INSERT 0
+select count(*) from data_correctness_detect;
+ count 
+-------
+ 0     
+(1 row)
+insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+INSERT 0
+select count(*) from data_correctness_detect_randomly;
+ count 
+-------
+ 0     
+(1 row)
+insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+INSERT 0
+select count(*) from data_correctness_detect_replicated;
+ count 
+-------
+ 0     
+(1 row)
+set gp_detect_data_correctness = off;
+SET
+
+-- insert some data that not belongs to it
+1U: insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+INSERT 100
+1U: insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+INSERT 100
+1U: insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+INSERT 100
+set gp_detect_data_correctness = on;
+SET
+insert into data_correctness_detect select * from data_correctness_detect;
+ERROR:  trying to insert row into wrong segment  (seg1 127.0.1.1:6003 pid=3027104)
+insert into data_correctness_detect select * from data_correctness_detect_randomly;
+INSERT 0
+insert into data_correctness_detect select * from data_correctness_detect_replicated;
+INSERT 0
+
+-- clean up
+set gp_detect_data_correctness = off;
+SET
+drop table data_correctness_detect;
+DROP
+drop table data_correctness_detect_randomly;
+DROP
+drop table data_correctness_detect_replicated;
+DROP
+

--- a/src/test/isolation2/sql/guc_gp.sql
+++ b/src/test/isolation2/sql/guc_gp.sql
@@ -1,0 +1,30 @@
+-- case 1: test gp_detect_data_correctness
+create table data_correctness_detect(a int, b int);
+create table data_correctness_detect_randomly(a int, b int) distributed randomly;
+create table data_correctness_detect_replicated(a int, b int) distributed replicated;
+
+set gp_detect_data_correctness = on;
+-- should no data insert
+insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect;
+insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect_randomly;
+insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+select count(*) from data_correctness_detect_replicated;
+set gp_detect_data_correctness = off;
+
+-- insert some data that not belongs to it
+1U: insert into data_correctness_detect select i, i from generate_series(1, 100) i;
+1U: insert into data_correctness_detect_randomly select i, i from generate_series(1, 100) i;
+1U: insert into data_correctness_detect_replicated select i, i from generate_series(1, 100) i;
+set gp_detect_data_correctness = on;
+insert into data_correctness_detect select * from data_correctness_detect;
+insert into data_correctness_detect select * from data_correctness_detect_randomly;
+insert into data_correctness_detect select * from data_correctness_detect_replicated;
+
+-- clean up
+set gp_detect_data_correctness = off;
+drop table data_correctness_detect;
+drop table data_correctness_detect_randomly;
+drop table data_correctness_detect_replicated;
+


### PR DESCRIPTION
This is the backport of #16333

----

During OS upgrades, such as an upgrade from CentOS 7 to CentOS 8, there could be some
locale changes happen that lead to the data distribution or data partition position change.

In order to detect it, we add a new GUC of gp_detect_data_correctness, if it sets to on,
we will not insert data actually, we just check whether the data belongs to this segment or
this partition table or not.
