### PR TITLE
Fix "cache lookup failed for foreign table" ERROR when ORCA handles multi-level partition table with foreign tables.

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -1393,6 +1393,67 @@ explain (costs false) update t1 set b = b + 1 where b in (select a from gp_coord
  Optimizer: Postgres query optimizer
 (9 rows)
 
+---
+--- Test for #16376 of multi-level partition table with foreign table
+---
+CREATE TABLE sub_part (
+                          a int,
+                          b int,
+                          c int)
+    DISTRIBUTED BY (a)
+partition by range(b) subpartition by list(c) 
+ SUBPARTITION TEMPLATE 
+  (
+   SUBPARTITION one values (1),
+   SUBPARTITION two values (2)
+  )
+(
+   START (0) INCLUSIVE END (5) EXCLUSIVE EVERY (1)
+);
+-- Create foreign tables
+CREATE FOREIGN TABLE sub_part_1_prt_1_2_prt_one_foreign (
+    a int,
+    b int,
+    c int)
+SERVER loopback;
+CREATE FOREIGN TABLE sub_part_1_prt_1_2_prt_two_foreign (
+    a int,
+    b int,
+    c int)
+SERVER loopback;
+-- change a sub partition's all leaf table to foreign table
+ALTER TABLE sub_part_1_prt_1 EXCHANGE PARTITION for(1) WITH TABLE sub_part_1_prt_1_2_prt_one_foreign;
+ALTER TABLE sub_part_1_prt_1 EXCHANGE PARTITION for(2) WITH TABLE sub_part_1_prt_1_2_prt_two_foreign;
+-- explain with ORCA should fall back to planner, rather than raise ERROR
+explain select * from sub_part;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Append  (cost=100.00..14631.81 rows=641404 width=12)
+   ->  Foreign Scan on sub_part_1_prt_1_2_prt_one  (cost=100.00..383.06 rows=9102 width=12)
+   ->  Foreign Scan on sub_part_1_prt_1_2_prt_two  (cost=100.00..383.06 rows=9102 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_2_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_2_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_3_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_3_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_4_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_4_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_5_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_5_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+--- Clean up
+DROP TABLE sub_part;
+DROP TABLE sub_part_1_prt_1_2_prt_one_foreign;
+DROP TABLE sub_part_1_prt_1_2_prt_two_foreign;
 -- GPDB #16219: validate scram-sha-256 in postgres_fdw
 alter system set password_encryption = 'scram-sha-256';
 -- add created user to pg_hba.conf

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -1438,6 +1438,67 @@ explain (costs false) update t1 set b = b + 1 where b in (select a from gp_coord
  Optimizer: Pivotal Optimizer (GPORCA)
 (23 rows)
 
+---
+--- Test for #16376 of multi-level partition table with foreign table
+---
+CREATE TABLE sub_part (
+                          a int,
+                          b int,
+                          c int)
+    DISTRIBUTED BY (a)
+partition by range(b) subpartition by list(c) 
+ SUBPARTITION TEMPLATE 
+  (
+   SUBPARTITION one values (1),
+   SUBPARTITION two values (2)
+  )
+(
+   START (0) INCLUSIVE END (5) EXCLUSIVE EVERY (1)
+);
+-- Create foreign tables
+CREATE FOREIGN TABLE sub_part_1_prt_1_2_prt_one_foreign (
+    a int,
+    b int,
+    c int)
+SERVER loopback;
+CREATE FOREIGN TABLE sub_part_1_prt_1_2_prt_two_foreign (
+    a int,
+    b int,
+    c int)
+SERVER loopback;
+-- change a sub partition's all leaf table to foreign table
+ALTER TABLE sub_part_1_prt_1 EXCHANGE PARTITION for(1) WITH TABLE sub_part_1_prt_1_2_prt_one_foreign;
+ALTER TABLE sub_part_1_prt_1 EXCHANGE PARTITION for(2) WITH TABLE sub_part_1_prt_1_2_prt_two_foreign;
+-- explain with ORCA should fall back to planner, rather than raise ERROR
+explain select * from sub_part;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Append  (cost=100.00..14631.81 rows=641404 width=12)
+   ->  Foreign Scan on sub_part_1_prt_1_2_prt_one  (cost=100.00..383.06 rows=9102 width=12)
+   ->  Foreign Scan on sub_part_1_prt_1_2_prt_two  (cost=100.00..383.06 rows=9102 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_2_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_2_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_3_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_3_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_4_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_4_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_5_2_prt_one  (cost=0.00..293.67 rows=25967 width=12)
+   ->  Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12)
+         ->  Seq Scan on sub_part_1_prt_5_2_prt_two  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+--- Clean up
+DROP TABLE sub_part;
+DROP TABLE sub_part_1_prt_1_2_prt_one_foreign;
+DROP TABLE sub_part_1_prt_1_2_prt_two_foreign;
 -- GPDB #16219: validate scram-sha-256 in postgres_fdw
 alter system set password_encryption = 'scram-sha-256';
 -- add created user to pg_hba.conf

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -3012,6 +3012,12 @@ CTranslatorRelcacheToDXL::RetrieveStorageTypeForPartitionedTable(Relation rel)
 		gpdb::RelationWrapper child_rel = gpdb::GetRelation(oid);
 		IMDRelation::Erelstoragetype child_storage =
 			RetrieveRelStorageType(child_rel.get());
+		// Child rel with partdesc means it's not leaf partition, we don't care about it
+		if (child_rel->rd_partdesc)
+		{
+			continue;
+		}
+
 		if (child_storage == IMDRelation::ErelstorageForeign)
 		{
 			// for partitioned tables with foreign partitions, we want to ignore the foreign partitions


### PR DESCRIPTION
This issue was introduced by #15706. When ORCA translates multi-level partition table Relcache to DXL, it searches for the storage type of the leaf table and checks if the foreign table is a greenplum_fdw table. However, the none-leaf table is also checked, and an ERROR is thrown because the none-leaf table is not a foreign table.

Fix this issue by checking if the table is a foreign table first to avoid elog ERROR.
