### PR TITLE
Remove check restricting some array casts by orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1282,14 +1282,6 @@ CTranslatorScalarToDXL::TranslateArrayCoerceExprToDXL(
 	GPOS_ASSERT(nullptr != child_node);
 	GPOS_ASSERT(nullptr != elemexpr_node);
 
-	if (!(IsA(array_coerce_expr->elemexpr, FuncExpr) ||
-		  IsA(array_coerce_expr->elemexpr, RelabelType)))
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("ArrayCoerceExpr with elemexpr that is neither "
-								"FuncExpr or RelabelType"));
-	}
-
 	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(
 		m_mp, GPOS_NEW(m_mp) CDXLScalarArrayCoerceExpr(
 				  m_mp,

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14761,3 +14761,23 @@ select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
 (1 row)
 
 drop function check_col_width(query text, operator text, width text);
+---------------------------------------------------------------------------------
+-- Test cast from INT[] to TEXT[]
+CREATE TABLE array_coerceviaio(a INT[]) distributed randomly;
+INSERT INTO array_coerceviaio values(ARRAY[1, 2, 3]);
+EXPLAIN SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1882.00 rows=52800 width=32)
+   ->  Seq Scan on array_coerceviaio  (cost=0.00..1178.00 rows=17600 width=32)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+    a    
+---------
+ {1,2,3}
+(1 row)
+
+DROP TABLE array_coerceviaio;
+---------------------------------------------------------------------------------

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14779,5 +14779,4 @@ SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
  {1,2,3}
 (1 row)
 
-DROP TABLE array_coerceviaio;
 ---------------------------------------------------------------------------------

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14877,5 +14877,4 @@ SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
  {1,2,3}
 (1 row)
 
-DROP TABLE array_coerceviaio;
 ---------------------------------------------------------------------------------

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14859,3 +14859,23 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 (1 row)
 
 drop function check_col_width(query text, operator text, width text);
+---------------------------------------------------------------------------------
+-- Test cast from INT[] to TEXT[]
+CREATE TABLE array_coerceviaio(a INT[]) distributed randomly;
+INSERT INTO array_coerceviaio values(ARRAY[1, 2, 3]);
+EXPLAIN SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Seq Scan on array_coerceviaio  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(3 rows)
+
+SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+    a    
+---------
+ {1,2,3}
+(1 row)
+
+DROP TABLE array_coerceviaio;
+---------------------------------------------------------------------------------

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3599,6 +3599,16 @@ select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
 select check_col_width('select a from testPartWidth;','Append','width=5') = 1;
 drop function check_col_width(query text, operator text, width text);
 
+---------------------------------------------------------------------------------
+-- Test cast from INT[] to TEXT[]
+CREATE TABLE array_coerceviaio(a INT[]) distributed randomly;
+INSERT INTO array_coerceviaio values(ARRAY[1, 2, 3]);
+
+EXPLAIN SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
+DROP TABLE array_coerceviaio;
+---------------------------------------------------------------------------------
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3606,7 +3606,6 @@ INSERT INTO array_coerceviaio values(ARRAY[1, 2, 3]);
 
 EXPLAIN SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
 SELECT CAST(a AS TEXT[]) FROM array_coerceviaio;
-DROP TABLE array_coerceviaio;
 ---------------------------------------------------------------------------------
 
 -- start_ignore


### PR DESCRIPTION
**Issue:**
Gporca failed to produce plan for casting int[] to text[].
Example query with plan result:
```
-- setup
create table foo(a int, b int[]);
-- query
explain select CAST(b as text[]) FROM foo;
INFO:  GPORCA failed to produce a plan, falling back to planner
DETAIL:  Feature not supported: ArrayCoerceExpr with elemexpr that is neither FuncExpr or RelabelType
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1770.00 rows=49600 width=32)
   ->  Seq Scan on foo  (cost=0.00..1108.67 rows=16533 width=32)
 Optimizer: Postgres query optimizer
(3 rows)
```

**RCA:**
In function `CTranslatorScalarToDXL::TranslateArrayCoerceExprToDXL`,
there is a condition restricting the plan dxl to be generated if
`elemexpr` of `ArrayCoerceExpr` is not of type `RelabelType` and
`FuncExpr`.
The condition was added in commit
https://github.com/greenplum-db/gpdb-postgres-merge/commit/256b11929f349c27b86e754e4664d3a63426a6e4.
It was added as DXL was not ready to accept `elemexpr` of type `CoerceViaIO`.

**Fix:**
This condition is now redundant, since DXL is working well with elemexpr
of type `CoerceViaIO` and plan is being generated and result is being
computed without issues.
So the condition is now removed.

**Tests:**
Added a regression test case in `gporca.sql` to verify that ORCA now generates plan without falling back to planner.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
