### PR TITLE
docs - use resource groups to limit greenplum_fdw concurrency

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/greenplum_fdw.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/greenplum_fdw.html.md
@@ -203,7 +203,7 @@ Remote cluster (1) configuration:
     ALTER ROLE gpcluster2_users RESOURCE GROUP rg_gpcluster2_users;
     ```
 
-    When you configure the remote cluster as described below, the `rg_gpcluster2_users` resource group manages the resources used by all queries that are initiated by `gpcluster2_users`.
+    When you configure the remote cluster as described above, the `rg_gpcluster2_users` resource group manages the resources used by all queries that are initiated by `gpcluster2_users`.
 
 Local cluster (2) configuration:
 


### PR DESCRIPTION
in this PR:  add a topic named "About Using Resource Groups to Limit Concurrency" to the greenplum_fdw module docs.  also changed some master refs -> coordinator.

questions:  are the CREATE RESOURCE GROUP statements correct and reasonable for this scenario?  is there any other info that would be helpful to the user?

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Greenplum/gp2gp-resgroups/greenplum-database/GUID-ref_guide-modules-greenplum_fdw.html#about-using-resource-groups-to-limit-concurrency
