### PR TITLE
[ORCA] Add fallback on relations with 'hnsw' index type

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2776,9 +2776,15 @@ CTranslatorRelcacheToDXL::IsIndexSupported(Relation index_rel)
 		return true;
 	}
 
-	// Fall back if query is on a relation with a pgvector index (ivfflat)
-	// Orca currently does not generate index scan alternatives here
-	// Fall back to ensure users can get better performing index plans using planner
+	// Fall back if query is on a relation with a pgvector index (ivfflat) or
+	// pg_embedding index (hnsw). Orca currently does not generate index scan
+	// alternatives here. Fall back to ensure users can get better performing
+	// index plans using planner.
+	//
+	// An alternative approach was considered to fall back for any unsupported
+	// index. However, the downside of that is that it will lead to many more
+	// fall backs when a table has an unsupported index. That could severely
+	// limit ORCA's ability to operate on that table.
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 	CWStringDynamic *am_name_str = CDXLUtils::CreateDynamicStringFromCharArray(

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2784,14 +2784,14 @@ CTranslatorRelcacheToDXL::IsIndexSupported(Relation index_rel)
 	CWStringDynamic *am_name_str = CDXLUtils::CreateDynamicStringFromCharArray(
 		mp, gpdb::GetRelAmName(index_rel->rd_rel->relam));
 
-	CWStringConst str_pgvector_am(GPOS_WSZ_LIT("ivfflat"));
-	if (am_name_str->Equals(&str_pgvector_am))
+	if (am_name_str->Equals(GPOS_WSZ_LIT("ivfflat")) ||
+		am_name_str->Equals(GPOS_WSZ_LIT("hnsw")))
 	{
 		GPOS_DELETE(am_name_str);
 		GPOS_RAISE(
 			gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
 			GPOS_WSZ_LIT(
-				"Queries on relations with pgvector indexes (ivfflat) are not supported"));
+				"Queries on relations with pgvector indexes (ivfflat) or pg_embedding indexes (hnsw) are not supported"));
 	}
 	GPOS_DELETE(am_name_str);
 	return false;

--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
@@ -74,6 +74,9 @@ public:
 	// checks whether the string is byte-wise equal to another string
 	virtual BOOL Equals(const CWStringBase *str) const;
 
+	// checks whether the string is equal to a string literal
+	virtual BOOL Equals(const WCHAR *str) const;
+
 	// checks whether the string contains any characters
 	virtual BOOL IsEmpty() const;
 

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/string/CWStringTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/string/CWStringTest.cpp
@@ -376,6 +376,8 @@ CWStringTest::EresUnittest_Equals()
 	GPOS_ASSERT(str1->Equals(str2));
 	GPOS_ASSERT(!str1->Equals(str3));
 	GPOS_ASSERT(!str3->Equals(str1));
+	GPOS_ASSERT(str3->Equals(GPOS_WSZ_LIT("12")));
+	GPOS_ASSERT(!str3->Equals(GPOS_WSZ_LIT("123")));
 
 	// static strings
 	WCHAR buffer1[8];

--- a/src/backend/gporca/libgpos/src/string/CWStringBase.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringBase.cpp
@@ -95,6 +95,22 @@ CWStringBase::Equals(const CWStringBase *str) const
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CWStringBase::Equals
+//
+//	@doc:
+//		Checks whether the string is equal to a string literal
+//
+//---------------------------------------------------------------------------
+BOOL
+CWStringBase::Equals(const WCHAR *str) const
+{
+	GPOS_ASSERT(nullptr != str);
+	return Length() == GPOS_WSZ_LENGTH(str) &&
+		   0 == clib::Wcsncmp(GetBuffer(), str, Length());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CWStringBase::IsEmpty
 //
 //	@doc:

--- a/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
@@ -143,7 +143,6 @@ BOOL
 CWStringConst::Equals(const CWStringBase *str) const
 {
 	GPOS_ASSERT(nullptr != str);
-	GPOS_ASSERT(nullptr != str);
 	return Length() == str->Length() &&
 		   0 == clib::Wcsncmp(GetBuffer(), str->GetBuffer(), Length());
 }


### PR DESCRIPTION
Extension of commit https://github.com/greenplum-db/gpdb/commit/26c3382759b3ec526fc715f4f78617f88b9f17e9 that falls back to planner for queries
using 'ivfflat' indexes from pgvector. However, there is another similar
index 'hnsw' added in pgvector 0.5.0. Add 'hnsw' to the list of indexes
ORCA will fall back when it encounters.

An alternative approach was considered to fallback for any unsupported
index. However, the downside of that is that it will lead to many more
fallbacks when a table has an unsupported index. That could severely
limit ORCA's ability to operate on that table.

NB: This is intended as a temporary hack to avoid ORCA from picking bad
plans until ORCA is able to support these indexes.

Following test falls back to PLANNER:
  ```sql
  CREATE EXTENSION embedding;
  CREATE TABLE documents(id INTEGER, embedding REAL[]);
  CREATE INDEX ON documents USING hnsw(embedding) WITH (maxelements=1000, dims=3, m=8);

  EXPLAIN SELECT id FROM documents ORDER BY embedding <-> array[1.1, 2.2, 3.3] LIMIT 1;
```

```  
INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on relations with pgvector indexes (ivfflat) or pg_embedding indexes (hnsw) are not supported
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 Limit  (cost=1.03..1.04 rows=1 width=8)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.03..1.07 rows=3 width=8)
         Merge Key: ((embedding <-> '{1.1,2.2,3.3}'::real[]))
         ->  Limit  (cost=1.03..1.03 rows=1 width=8)
               ->  Sort  (cost=1.02..1.03 rows=1 width=8)
                     Sort Key: ((embedding <-> '{1.1,2.2,3.3}'::real[]))
                     ->  Seq Scan on documents  (cost=0.00..1.01 rows=1 width=8)
 Optimizer: Postgres-based planner
(8 rows)

  ```