### PR TITLE
Fix resource group io limit flaky case

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -138,7 +138,7 @@ CREATE FUNCTION
 
 0: CREATE OR REPLACE FUNCTION mkdir(dirname text) RETURNS BOOL AS $$ import os 
 if os.path.exists(dirname): return True 
-try: os.makedirs(dirname) except Exception as e: plpy.error("cannot create dir {}".format(e)) else: return True $$ LANGUAGE plpython3u;
+try: os.makedirs(dirname) except FileExistsError: return True except Exception as e: plpy.error("cannot create dir {}".format(e)) else: return True $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
 0: CREATE OR REPLACE FUNCTION rmdir(dirname text) RETURNS BOOL AS $$ import shutil import fcntl import os 

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -320,6 +320,8 @@ $$ LANGUAGE plpython3u;
 
     try:
         os.makedirs(dirname)
+    except FileExistsError:
+        return True
     except Exception as e:
         plpy.error("cannot create dir {}".format(e))
     else:


### PR DESCRIPTION
The flaky case caused by running `mkdir` on multi segments at the same host.

Just catch `FileExistsError` and ignore it is ok, the `mkdir` function just need the dir exists.