### PR TITLE
Fix int overflow in printTableAddCell()

### DIFF
--- a/src/fe_utils/Makefile
+++ b/src/fe_utils/Makefile
@@ -51,3 +51,6 @@ clean distclean:
 # so do not clean it in the clean/distclean rules
 maintainer-clean: distclean
 	rm -f psqlscan.c
+
+unittest-check:
+	$(MAKE) -C test check

--- a/src/fe_utils/test/Makefile
+++ b/src/fe_utils/test/Makefile
@@ -1,0 +1,14 @@
+subdir=src/fe_utils
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=print
+PG_LIBS=-lpgcommon -lpgport -lpq -lm
+
+include $(top_srcdir)/src/backend/mock.mk
+
+# This test case doesn't follow all UT guides, because current the infrastructure of UT
+# is for backend test only. Using it leads to many weird link errors, let's keep it
+# simple here.
+print.t: print_test.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -Wl,--wrap=exit $< ../mbprint.o $(CMOCKERY_OBJS) $(PG_LIBS) -o print.t

--- a/src/fe_utils/test/print_test.c
+++ b/src/fe_utils/test/print_test.c
@@ -1,0 +1,58 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdbool.h>
+#include "cmockery.h"
+
+#include "../print.c" // the file which we want to test
+
+// wrap function for exit() of printTableAddCell
+void __wrap_exit(int code);
+void
+__wrap_exit(int code)
+{
+	check_expected(code);
+	mock();
+}
+
+static void
+test_printTableAddCell(void **state)
+{
+    struct printTableContent content;
+    char cell[] = "cell";
+
+    // normal case
+    content.ncolumns = 26;
+    content.nrows = 10;
+    content.cellsadded = 100;
+    printTableAddCell(&content, cell, false, false);
+    assert_true( content.cellsadded == 101 );
+
+    // bigger than int range (2147483647) case
+    const long LONG_VAL = 4000000000L;
+    content.ncolumns = 26;
+    content.nrows = 200000000;
+    content.cellsadded = LONG_VAL;
+    printTableAddCell(&content, cell, false, false);
+    assert_true( content.cellsadded == LONG_VAL+1 );
+
+    // error case (cellsadded > ncolumns*nrows)
+    content.ncolumns = 26;
+    content.nrows = 200000000;
+    content.cellsadded = 6000000000L;
+    expect_value(__wrap_exit, code, 1);
+    will_be_called(__wrap_exit);
+    printTableAddCell(&content, cell, false, false); 
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const		UnitTest tests[] = {
+		unit_test(test_printTableAddCell)
+	};
+
+	return run_tests(tests);
+}


### PR DESCRIPTION
When user try to select a big number of rows via PSQL, they may encounter the following error:
`ERROR: "Cannot add cell to table content: total cell count of XXX exceeded`. 

The root cause is the overflow of int type in `printTableAddCell()`. 
And this issue also exists in upstream, I have reported it (with repro steps) at:
https://www.postgresql.org/message-id/flat/TYBP286MB0351B057B101C90D7C1239E6B4E2A%40TYBP286MB0351.JPNP286.PROD.OUTLOOK.COM

Let's fix it in GP first since it takes a bit long time on the upstream side.
(needs to port to 6X later)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
