### PR TITLE
[6x]: Fix gpcheckperf discrepancy in network test results (v6.23 vs v6.25)

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -666,10 +666,11 @@ def setupNetPerfTest():
     print '-------------------'
 
     hostlist = ssh_utils.HostList()
-    for h in GV.opt['-h']:
-        hostlist.add(h)
     if GV.opt['-f']:
         hostlist.parseFile(GV.opt['-f'])
+    else:
+        for h in GV.opt['-h']:
+            hostlist.add(h)
 
     h = hostlist.get()
     if len(h) == 0:
@@ -1000,13 +1001,11 @@ def getHostList():
     :return: returns a list of hosts
     """
     hostlist = ssh_utils.HostList()
-
     if GV.opt['-f']:
         hostlist.parseFile(GV.opt['-f'])
     else:
         for h in GV.opt['-h']:
             hostlist.add(h)
-
 
     try:
         hostlist.checkSSH()

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -149,7 +149,8 @@ def gpsync(src, dst):
     -P : print information showing the progress of the transfer
     """
     proc = []
-    for peer in GV.opt['-h']:
+    host_list = getHostList()
+    for peer in host_list:
         cmd = 'rsync -P -a -c -e "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" {0} {1}:{2}' \
             .format(src, unix.canonicalize(peer), dst)
         if GV.opt['-v']:
@@ -999,20 +1000,23 @@ def getHostList():
     :return: returns a list of hosts
     """
     hostlist = ssh_utils.HostList()
-    for h in GV.opt['-h']:
-        hostlist.add(h)
+
     if GV.opt['-f']:
         hostlist.parseFile(GV.opt['-f'])
+    else:
+        for h in GV.opt['-h']:
+            hostlist.add(h)
+
 
     try:
         hostlist.checkSSH()
     except ssh_utils.SSHError, e:
         sys.exit('[Error] {0}' .format(str(e)))
 
-    GV.opt['-h'] = hostlist.filterMultiHomedHosts()
-    if len(GV.opt['-h']) == 0:
+    host_list = hostlist.filterMultiHomedHosts()
+    if len(host_list) == 0:
         usage('Error: missing hosts in -h and/or -f arguments')
-    return GV.opt['-h']
+    return host_list
 
 
 def main():

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
@@ -83,10 +83,10 @@ class GpCheckPerf(GpTestCase):
         self.subject.main()
         mock_gpscp.assert_called_with(src, target)
 
-    def test_gpsync_failed_to_copy(self):
+    @patch('gpcheckperf.getHostList', return_value=['localhost', "invalid_host"])
+    def test_gpsync_failed_to_copy(self, mock_hostlist):
         src = '%s/lib/multidd' % os.path.abspath(os.path.dirname(__file__) + "/../../../")
         target = '=:tmp/'
-        self.subject.GV.opt['-h'] = ['localhost', "invalid_host"]
         with self.assertRaises(SystemExit) as e:
             self.subject.gpsync(src, target)
         self.assertIn('[Error] command failed for host:invalid_host', e.exception.code)

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -134,7 +134,7 @@ Feature: Tests for gpcheckperf
     Given the user runs command "echo -e "cdw\nsdw1" > /tmp/hostfile_gpchecknet"
     When  the user runs "gpcheckperf -f /tmp/hostfile_gpchecknet -d /data/gpdata/ -r n"
     Then  gpcheckperf should return a return code of 0
-    And   the following lines should appear exactly once to stdout
+    And   gpcheckperf should print the following lines 1 times to stdout
       """
       cdw -> sdw1
       sdw1 -> cdw

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -126,3 +126,16 @@ Feature: Tests for gpcheckperf
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "--buffer-size value is not specified or invalid. Using default \(32 kilobytes\)" to stdout
     And   gpcheckperf should print "avg = " to stdout
+
+
+  @concourse_cluster
+  Scenario: gpcheckperf runs sequential network test with hostfile
+    Given the database is running
+    Given the user runs command "echo -e "cdw\nsdw1" > /tmp/hostfile_gpchecknet"
+    When  the user runs "gpcheckperf -f /tmp/hostfile_gpchecknet -d /data/gpdata/ -r n"
+    Then  gpcheckperf should return a return code of 0
+    And   the following lines should appear exactly once to stdout
+      """
+      cdw -> sdw1
+      sdw1 -> cdw
+      """

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4266,15 +4266,15 @@ def impl(context, table, dbname, count):
         raise Exception(
             "%s table in %s has %d rows, expected %d rows." % (table, dbname, sum(current_row_count), int(count)))
 
-@then('the following lines should appear exactly once to stdout')
-def impl(context):
+@then('{command} should print the following lines {num} times to stdout')
+def impl(context, command, num):
     """
-    to verify that each pattern occurs only once in the output
+    Verify that each pattern occurs a specific number of times in the output.
     """
     expected_lines = context.text.strip().split('\n')
     for expected_pattern in expected_lines:
         match_count = len(re.findall(re.escape(expected_pattern), context.stdout_message))
-        if match_count > 1:
+        if match_count != int(num):
             raise Exception(
-                "Pattern %s matched more than once" % expected_pattern)
+                "Expected %s to occur %s times but Found %d times" .format(expected_pattern, num, match_count))
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4265,3 +4265,16 @@ def impl(context, table, dbname, count):
     if int(count) != sum(current_row_count):
         raise Exception(
             "%s table in %s has %d rows, expected %d rows." % (table, dbname, sum(current_row_count), int(count)))
+
+@then('the following lines should appear exactly once to stdout')
+def impl(context):
+    """
+    to verify that each pattern occurs only once in the output
+    """
+    expected_lines = context.text.strip().split('\n')
+    for expected_pattern in expected_lines:
+        match_count = len(re.findall(re.escape(expected_pattern), context.stdout_message))
+        if match_count > 1:
+            raise Exception(
+                "Pattern %s matched more than once" % expected_pattern)
+


### PR DESCRIPTION
Fixes - https://github.com/greenplum-db/gpdb/issues/16356

**Problem** - gpcheckperf provides different results when executing a sequential network test with a specified hostfile between versions 6.23 and 6.25.

**RCA** - The problem arises from the getHostList function, which assigns GV.opt['-h'] with a list of hosts because of which the code interprets that the -h option is set with the host list. As GV.opt['-h'] is already assigned during network testing, the code incorrectly combines hosts from both the GV.opt['-f'] option and GV.opt['-h'], when it should exclusively retrieve hosts from either GV.opt['-f'] or GV.opt['-h']. It leads to redundant host list data, resulting in the observed issue

**Solution** - Omit the assignment of the global variable GV.opt['-h'] within the "getHostList" function.Instead, utilize a function call to retrieve the host list when it is required in other parts of the code.

Added behave test case for the fix.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
