### PR TITLE
[7X] Refactoring. Declare methods as static if they work with static member variables only

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -67,8 +67,7 @@ CColumnFactory::~CColumnFactory()
 	m_sht.Cleanup();
 
 	// destroy mem pool
-	CMemoryPoolManager *pmpm = CMemoryPoolManager::GetMemoryPoolMgr();
-	pmpm->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -40,7 +40,7 @@ static CMemoryPool *mp = nullptr;
 void
 gpopt_init()
 {
-	mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	mp = CMemoryPoolManager::CreateMemoryPool();
 
 	gpopt::EresExceptionInit(mp);
 
@@ -61,7 +61,7 @@ gpopt_terminate()
 #ifdef GPOS_DEBUG
 	CMDCache::Shutdown();
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 
 	CXformFactory::Shutdown();
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
@@ -52,7 +52,7 @@ CSchedulerContext::~CSchedulerContext()
 	// release local memory pool
 	if (FInit())
 	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(PmpLocal());
+		CMemoryPoolManager::Destroy(PmpLocal());
 	}
 }
 
@@ -76,7 +76,7 @@ CSchedulerContext::Init(CMemoryPool *pmpGlobal, CJobFactory *pjf,
 
 	GPOS_ASSERT(!FInit() && "Scheduling context is already initialized");
 
-	m_pmpLocal = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_pmpLocal = CMemoryPoolManager::CreateMemoryPool();
 
 	m_pmpGlobal = pmpGlobal;
 	m_pjf = pjf;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -355,11 +355,10 @@ CXformFactory::IsXformIdUsed(CXform::EXformId exfid)
 void
 CXformFactory::Init()
 {
-	GPOS_ASSERT(nullptr == Pxff() && "Xform factory was already initialized");
+	GPOS_ASSERT(nullptr == m_pxff && "Xform factory was already initialized");
 
 	// create xform factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create xform factory instance
 	m_pxff = GPOS_NEW(mp) CXformFactory(mp);
@@ -380,18 +379,18 @@ CXformFactory::Init()
 void
 CXformFactory::Shutdown()
 {
-	CXformFactory *pxff = CXformFactory::Pxff();
+	CXformFactory *pxff = m_pxff;
 
 	GPOS_ASSERT(nullptr != pxff && "Xform factory has not been initialized");
 
 	CMemoryPool *mp = pxff->m_mp;
 
 	// destroy xform factory
-	CXformFactory::m_pxff = nullptr;
+	m_pxff = nullptr;
 	GPOS_DELETE(pxff);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -39,8 +39,7 @@ struct DbgPrintMixin
 	void
 	DbgPrint() const
 	{
-		CMemoryPool *mp =
-			CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool();
+		CMemoryPool *mp = CMemoryPoolManager::GetGlobalMemoryPool();
 		CAutoTrace at(mp);
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -69,7 +69,7 @@ public:
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();
 
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CMessageRepository
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
@@ -365,7 +365,7 @@ private:
 		// destroy the object before deleting memory pool. This cover the case where object & cacheentry use same memory pool
 		CMemoryPool *mp = entry->Pmp();
 		GPOS_DELETE(entry);
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 
 	// evict entries by making one pass through the hash table buckets

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
@@ -69,7 +69,7 @@ public:
 		// check if a memory pool was created but insertion failed
 		if (nullptr != m_mp && !m_inserted)
 		{
-			CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+			CMemoryPoolManager::Destroy(m_mp);
 		}
 
 		// release entry if one was created
@@ -150,7 +150,7 @@ public:
 		GPOS_ASSERT(nullptr == m_mp);
 
 		// construct a memory pool for cache entry
-		m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+		m_mp = CMemoryPoolManager::CreateMemoryPool();
 
 		return m_mp;
 	}

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -83,10 +83,10 @@ public:
 				typename CCache<T, K>::HashFuncPtr hash_func,
 				typename CCache<T, K>::EqualFuncPtr equal_func)
 	{
-		GPOS_ASSERT(nullptr != GetFactory() &&
+		GPOS_ASSERT(nullptr != m_factory &&
 					"Cache factory has not been initialized");
 
-		CMemoryPool *mp = GetFactory()->Pmp();
+		CMemoryPool *mp = m_factory->Pmp();
 		CCache<T, K> *cache = GPOS_NEW(mp)
 			CCache<T, K>(mp, unique, cache_quota, CCACHE_GCLOCK_INIT_COUNTER,
 						 hash_func, equal_func);

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -63,7 +63,7 @@ private:
 	virtual CMemoryPool *NewMemoryPool();
 
 	// clean-up memory pools
-	void Cleanup();
+	static void Cleanup();
 
 	// destroy a memory pool at shutdown
 	static void DestroyMemoryPoolAtShutdown(CMemoryPool *mp);
@@ -116,10 +116,10 @@ public:
 	CMemoryPoolManager(const CMemoryPoolManager &) = delete;
 
 	// create new memory pool
-	CMemoryPool *CreateMemoryPool();
+	static CMemoryPool *CreateMemoryPool();
 
 	// release memory pool
-	void Destroy(CMemoryPool *);
+	static void Destroy(CMemoryPool *);
 
 #ifdef GPOS_DEBUG
 	// print internal contents of allocated memory pools
@@ -130,13 +130,14 @@ public:
 #endif	// GPOS_DEBUG
 
 	// delete memory pools and release manager
-	void Shutdown();
+	static void Shutdown();
 
 	// accessor of memory pool used in global new allocations
-	CMemoryPool *
+	static CMemoryPool *
 	GetGlobalMemoryPool()
 	{
-		return m_global_memory_pool;
+		GPOS_ASSERT(nullptr != m_memory_pool_mgr);
+		return m_memory_pool_mgr->m_global_memory_pool;
 	}
 
 	virtual ~CMemoryPoolManager() = default;

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -238,10 +238,10 @@ gpos_terminate()
 	CDebugCounter::Shutdown();
 #endif
 #ifdef GPOS_DEBUG
-	CMessageRepository::GetMessageRepository()->Shutdown();
+	CMessageRepository::Shutdown();
 	CWorkerPoolManager::Shutdown();
 	CCacheFactory::Shutdown();
-	CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+	CMemoryPoolManager::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
+++ b/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
@@ -60,8 +60,7 @@ CDebugCounter::Init()
 {
 	GPOS_RTL_ASSERT(NULL == m_instance);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 }
@@ -75,7 +74,7 @@ CDebugCounter::Shutdown()
 
 		GPOS_DELETE(m_instance);
 		m_instance = NULL;
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 }
 

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -129,7 +129,7 @@ CMessageRepository::GetMessageRepository()
 void
 CMessageRepository::Shutdown()
 {
-	GPOS_ASSERT(NULL != m_repository);
+	GPOS_ASSERT(nullptr != m_repository);
 	CMemoryPoolManager::Destroy(m_repository->m_mp);
 	m_repository = nullptr;
 }

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -92,8 +92,7 @@ CMessageRepository::Init()
 {
 	GPOS_ASSERT(nullptr == m_repository);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	m_repository = GPOS_NEW(mp) CMessageRepository(mp);
 	m_repository->InitDirectory(mp);
@@ -130,8 +129,9 @@ CMessageRepository::GetMessageRepository()
 void
 CMessageRepository::Shutdown()
 {
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
-	CMessageRepository::m_repository = nullptr;
+	GPOS_ASSERT(NULL != m_repository);
+	CMemoryPoolManager::Destroy(m_repository->m_mp);
+	m_repository = nullptr;
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
@@ -44,7 +44,7 @@ CAutoMemoryPool::CAutoMemoryPool(ELeakCheck leak_check_type GPOS_ASSERTS_ONLY)
 	: m_leak_check_type(leak_check_type)
 #endif
 {
-	m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_mp = CMemoryPoolManager::CreateMemoryPool();
 }
 
 
@@ -107,7 +107,7 @@ CAutoMemoryPool::~CAutoMemoryPool() noexcept(false)
 		}
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 	}
 	GPOS_CATCH_EX(ex)
 	{
@@ -115,7 +115,7 @@ CAutoMemoryPool::~CAutoMemoryPool() noexcept(false)
 			GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiAssert));
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 
 		GPOS_RETHROW(ex);
 	}
@@ -124,7 +124,7 @@ CAutoMemoryPool::~CAutoMemoryPool() noexcept(false)
 #else  // GPOS_DEBUG
 
 	// hand in pool and return
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 
 #endif	// GPOS_DEBUG
 }

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -60,12 +60,11 @@ CCacheFactory::Pmp() const
 void
 CCacheFactory::Init()
 {
-	GPOS_ASSERT(nullptr == GetFactory() &&
+	GPOS_ASSERT(nullptr == m_factory &&
 				"Cache factory was already initialized");
 
 	// create cache factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create cache factory instance
 	m_factory = GPOS_NEW(mp) CCacheFactory(mp);
@@ -83,17 +82,17 @@ CCacheFactory::Init()
 void
 CCacheFactory::Shutdown()
 {
-	CCacheFactory *factory = CCacheFactory::GetFactory();
+	CCacheFactory *factory = m_factory;
 
 	GPOS_ASSERT(nullptr != factory && "Cache factory has not been initialized");
 
 	CMemoryPool *mp = factory->m_mp;
 
 	// destroy cache factory
-	CCacheFactory::m_factory = nullptr;
+	m_factory = nullptr;
 	GPOS_DELETE(factory);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 // EOF

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -67,7 +67,7 @@ CMemoryPoolManager::Setup()
 void
 CMemoryPoolManager::Init()
 {
-	if (nullptr == CMemoryPoolManager::m_memory_pool_mgr)
+	if (nullptr == m_memory_pool_mgr)
 	{
 		SetupGlobalMemoryPoolManager<CMemoryPoolManager, CMemoryPoolTracker>();
 	}
@@ -77,14 +77,15 @@ CMemoryPoolManager::Init()
 CMemoryPool *
 CMemoryPoolManager::CreateMemoryPool()
 {
-	CMemoryPool *mp = NewMemoryPool();
+	GPOS_ASSERT(nullptr != m_memory_pool_mgr);
+	CMemoryPool *mp = m_memory_pool_mgr->NewMemoryPool();
 
 	// accessor scope
 	{
 		// HERE BE DRAGONS
 		// See comment in CCache::InsertEntry
 		const ULONG_PTR hashKey = mp->GetHashKey();
-		MemoryPoolKeyAccessor acc(*m_ht_all_pools, hashKey);
+		MemoryPoolKeyAccessor acc(*m_memory_pool_mgr->m_ht_all_pools, hashKey);
 		acc.Insert(mp);
 	}
 
@@ -104,6 +105,7 @@ CMemoryPoolManager::NewMemoryPool()
 void
 CMemoryPoolManager::Destroy(CMemoryPool *mp)
 {
+	GPOS_ASSERT(nullptr != m_memory_pool_mgr);
 	GPOS_ASSERT(nullptr != mp);
 
 	// accessor scope
@@ -111,7 +113,7 @@ CMemoryPoolManager::Destroy(CMemoryPool *mp)
 		// HERE BE DRAGONS
 		// See comment in CCache::InsertEntry
 		const ULONG_PTR hashKey = mp->GetHashKey();
-		MemoryPoolKeyAccessor acc(*m_ht_all_pools, hashKey);
+		MemoryPoolKeyAccessor acc(*m_memory_pool_mgr->m_ht_all_pools, hashKey);
 		acc.Remove(mp);
 	}
 
@@ -231,22 +233,24 @@ CMemoryPoolManager::DestroyMemoryPoolAtShutdown(CMemoryPool *mp)
 void
 CMemoryPoolManager::Cleanup()
 {
+	GPOS_ASSERT(nullptr != m_memory_pool_mgr);
+	GPOS_ASSERT(nullptr != m_memory_pool_mgr->m_global_memory_pool);
 #ifdef GPOS_DEBUG
-	if (0 < m_global_memory_pool->TotalAllocatedSize())
+	if (0 < m_memory_pool_mgr->m_global_memory_pool->TotalAllocatedSize())
 	{
 		// allocations made by calling global new operator are not deleted
 		gpos::oswcerr << "Memory leaks detected" << std::endl
-					  << *m_global_memory_pool << std::endl;
+					  << *m_memory_pool_mgr->m_global_memory_pool << std::endl;
 	}
 #endif	// GPOS_DEBUG
 
-	GPOS_ASSERT(nullptr != m_global_memory_pool);
-	Destroy(m_global_memory_pool);
+	Destroy(m_memory_pool_mgr->m_global_memory_pool);
 
 	// cleanup left-over memory pools;
 	// any such pool means that we have a leak
-	m_ht_all_pools->DestroyEntries(DestroyMemoryPoolAtShutdown);
-	GPOS_DELETE(m_ht_all_pools);
+	m_memory_pool_mgr->m_ht_all_pools->DestroyEntries(
+		DestroyMemoryPoolAtShutdown);
+	GPOS_DELETE(m_memory_pool_mgr->m_ht_all_pools);
 }
 
 
@@ -254,14 +258,15 @@ CMemoryPoolManager::Cleanup()
 void
 CMemoryPoolManager::Shutdown()
 {
+	GPOS_ASSERT(nullptr != m_memory_pool_mgr);
 	// cleanup remaining memory pools
 	Cleanup();
 
 	// save off pointers for explicit deletion
-	CMemoryPool *internal = m_internal_memory_pool;
+	CMemoryPool *internal = m_memory_pool_mgr->m_internal_memory_pool;
 
 	::delete CMemoryPoolManager::m_memory_pool_mgr;
-	CMemoryPoolManager::m_memory_pool_mgr = nullptr;
+	m_memory_pool_mgr = nullptr;
 
 #ifdef GPOS_DEBUG
 	internal->AssertEmpty(oswcerr);

--- a/src/backend/gporca/libgpos/src/task/CTask.cpp
+++ b/src/backend/gporca/libgpos/src/task/CTask.cpp
@@ -75,7 +75,7 @@ CTask::~CTask()
 	GPOS_DELETE(m_task_ctxt);
 	GPOS_DELETE(m_err_ctxt);
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -62,10 +62,9 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 void
 CWorkerPoolManager::Init()
 {
-	GPOS_ASSERT(nullptr == WorkerPoolManager());
+	GPOS_ASSERT(nullptr == m_worker_pool_manager);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create worker pool
 	m_worker_pool_manager = GPOS_NEW(mp) CWorkerPoolManager(mp);
@@ -83,8 +82,7 @@ CWorkerPoolManager::Init()
 void
 CWorkerPoolManager::Shutdown()
 {
-	CWorkerPoolManager *worker_pool_manager =
-		CWorkerPoolManager::m_worker_pool_manager;
+	CWorkerPoolManager *worker_pool_manager = m_worker_pool_manager;
 
 	GPOS_ASSERT(nullptr != worker_pool_manager &&
 				"Worker pool has not been initialized");
@@ -98,11 +96,11 @@ CWorkerPoolManager::Shutdown()
 	CMemoryPool *mp = worker_pool_manager->m_mp;
 
 	// destroy worker pool
-	CWorkerPoolManager::m_worker_pool_manager = nullptr;
+	m_worker_pool_manager = nullptr;
 	GPOS_DELETE(worker_pool_manager);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -121,10 +121,10 @@ void
 gpdxl_init()
 {
 	// create memory pool for Xerces global allocations
-	pmpXerces = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	pmpXerces = CMemoryPoolManager::CreateMemoryPool();
 
 	// create memory pool for DXL global allocations
-	pmpDXL = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	pmpDXL = CMemoryPoolManager::CreateMemoryPool();
 
 	// add standard exception messages
 	EresExceptionInit(pmpDXL);
@@ -147,13 +147,13 @@ gpdxl_terminate()
 
 	if (nullptr != pmpDXL)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpDXL);
+		CMemoryPoolManager::Destroy(pmpDXL);
 		pmpDXL = nullptr;
 	}
 
 	if (nullptr != pmpXerces)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpXerces);
+		CMemoryPoolManager::Destroy(pmpXerces);
 		pmpXerces = nullptr;
 	}
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -188,7 +188,7 @@ CTestUtils::DestroyMDProvider()
 	CRefCount::SafeRelease(m_pmdpf);
 
 	// release local memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 


### PR DESCRIPTION
Refactoring. Declare methods as static if they work with static member variables only

- I made the CMemoryPoolManager::Cleanup method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::CreateMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::Destroy method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::GetGlobalMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::Shutdown method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMessageRepository::Shutdown method static, which was previously called on the static object m_repository.

I added assertions to make sure the pointers being dereferenced are not null.