### PR TITLE
replace 'utf8' with '\w+' to match different encoding

### DIFF
--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -1752,7 +1752,7 @@ my %tests = (
 		\n\QOPTIONS (\E
 		\n\s+\Qcommand 'echo foo',\E
 		\n\s+\Qdelimiter '\E\s+\Q',\E
-		\n\s+\Qencoding 'UTF8',\E
+		\n\s+\Qencoding '\E\w+\Q',\E
 		\n\s+\Qescape E'\\',\E
 		\n\s+\Qexecute_on 'ALL_SEGMENTS',\E
 		\n\s+\Qformat 'text',\E


### PR DESCRIPTION
External table's encoding keeps same with database server encoding when without specify data encoding, so change encoding 'utf8' with '\w+' to match different enncodings.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
