### PR TITLE
Docs resgroups new

### DIFF
--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -18,6 +18,7 @@ The following table compares the main concepts of resource management and how ea
 |Limit Bypass|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
 |External Components|Manage PL/Container CPU and memory resources|None|
 
+> **Note** Disk I/O limits are only available when you use Linux Control Groups v2. See [Configuring and Using Resource Groups](workload_mgmt_resgroups.html#topic71717999) for more information.
 
 ### <a id="attributes"></a>Changes to Resource Groups Attributes
 

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -2,9 +2,7 @@
 title: About Changes to Resource Groups in Greenplum 7
 ---
 
-VMware Greenplum 7 introduces substantial changes to resource group-based resource management. 
-
-This topic describes the Greenplum 7 resource group and compares with resource groups 6.
+VMware Greenplum 7 introduces substantial changes to resource group-based resource management. This topic describes the Greenplum 7 resource group and compares with resource groups 6.
 
 |Metric|Resource Groups in Greenplum 6|Resource Groups in Greenplum 7|
 |------|---------------|---------------|
@@ -24,9 +22,14 @@ The possible settings for the `gp_resource_manager` server configuration paramet
 - `group-v2` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v2 version of Linux cgroup functionality.
 - `queue` - Configures Greenplum Database to use resource queues.
 
-Greenplum Database now includes a new server configuration parameter -- `gp_resgroup_memory_query_fixed_mem` -- which allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
-- The `gp_resgroup_status_per_segment` system view has been removed from Greenplum Database.
+The new server configuration parameter `gp_resgroup_memory_query_fixed_mem` allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
+
+
+Changes to system views:
+
+- The `gp_resgroup_status_per_segment` system view has been removed.
 - The `cpu_usage` and `memory_usage` fields have been moved from the `gp_resgroup_status` system view to the `gp_resgroup_status_per_host` system view.
+- The `gp_resgroup_iostats_per_host` system view has been added.
 
 You may configure three new resource group attributes using the `CREATE RESOURCE GROUP` and `ALTER RESOURCE GROUP` SQL commands:
 - `CPU_MAX_PERCENT`, which configures the maximum amount of CPU resources the resource group can use.

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -31,7 +31,7 @@ The following resource group attributes have been removed:
 - `CPU_RATE_LIMIT`
 - `MEMORY_AUDITOR`
 - `MEMORY_SPILL_RATIO`
-- `MEMORY_SHARED_QUOTA
+- `MEMORY_SHARED_QUOTA`
 
 ### <a id="gucs"></a>Changes to Server Configuration Parameters
 

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -9,8 +9,8 @@ The following table compares the main concepts of resource management and how ea
 |Metric|Resource Groups in Greenplum 6|Resource Groups in Greenplum 7|
 |------|---------------|---------------|
 |Concurrency|Managed at the transaction level|Managed at the transaction level|
-|CPU|Specify percentage of CPU resources or the number of CPU cores; uses Linux Control Groups|Specify percentage of CPU resources or the number of CPU cores; uses Linux Control Groups|
-|Memory|Managed at the transaction level, with enhanced allocation and tracking; users cannot over-subscribe|Managed at the transaction level, with enhanced allocation and tracking; users can over-subscribe|
+|CPU|Specify percentage of CPU resources or the number of CPU cores; uses Linux Control Groups|Specify percentage of CPU resources or the number of CPU cores, as well as set upper limits per resource group; uses Linux Control Groups|
+|Memory|Managed at the transaction level, with enhanced allocation and tracking; users cannot over-subscribe|Managed at the transaction level, with enhanced allocation and tracking; users can over-subscribe; simpler and more convenient configuration|
 |Disk I/O|None|Limit the maximum read/write disk I/O throughput, and maximum read/write I/O operations per second|
 |Users|Limits are applied to `SUPERUSER` and non-admin users alike<br>There are two default resource groups: `admin_group` and `default_group`|Limits are applied to `SUPERUSER`, non-admin users, and system processes of non-user classes<br>There are three default resource groups: `admin_group`, `default_group`, and `system_group`|
 |Queueing|Queue when no slot is available or not enough available memory|Queue when no slot is available|
@@ -27,6 +27,8 @@ You may configure four new resource group attributes using the `CREATE RESOURCE 
 - `CPU_WEIGHT`, which configures the scheduling priority of the resource group.
 - `MIN_COST`, which configures the minimum amount a query's query plan cost for the query to remain in the resource group.
 - `IO_LIMIT`, which configures device I/O usage at the resource group level to manage the maximum throughput of read/write operations, and the maximum read/write operations per second. 
+
+In addition, the limit `MEMORY_LIMIT` is now an integer (in MB), instead of a percentage.
 
 The following resource group attributes have been removed:
 - `CPU_RATE_LIMIT`

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -37,17 +37,17 @@ The following resource group attributes have been removed:
 
 Greenplum 7 resource group management introduces the following changes to server configuration parameters:
 
-- The possible settings for the `gp_resource_manager` server configuration parameter have changed. They now include the following:
+- The possible settings for the [gp_resource_manager](../ref_guide/config_params/guc-list.html#gp_resource_manager) server configuration parameter have changed. They now include the following:
     - `none` - Configures Greenplum Database to not use any resource manager. This is the default.
     - `group` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v1 version of Linux cgroup functionality.
     - `group-v2` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v2 version of Linux cgroup functionality.
     - `queue` - Configures Greenplum Database to use resource queues.
 
-- The new server configuration parameter `gp_resgroup_memory_query_fixed_mem` allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
+- The new server configuration parameter [gp_resgroup_memory_query_fixed_mem](../ref_guide/config_params/guc-list.html#gp_resgroup_memory_query_fixed_mem) allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
 
-- The new server configuration parameter `gp_resource_group_move_timeout`
+- The new server configuration parameter [gp_resource_group_move_timeout](../ref_guide/config_params/guc-list.html#gp_resource_group_move_timeout) cancels the `pg_resgroup_move_query()` function, which moves a running query from one resouce group to another, if it waits longer than the specified number of miliseconds.
 
-- The new server configuration parameter `gp_resource_group_bypass_direct_dispatch` bypasses the resource group's limits for a direct dispatch query so it can run immediately. A direct dispatch query is a special type of query that only requires a single segment to participate in the execution.
+- The new server configuration parameter [gp_resource_group_bypass_direct_dispatch](../ref_guide/config_params/guc-list.html#gp_resource_group_bypass_direct_dispatch) bypasses the resource group's limits for a direct dispatch query so it can run immediately. A direct dispatch query is a special type of query that only requires a single segment to participate in the execution.
 
 - The server configuration parameter `gp_resource_group_cpu_ceiling_enforcement` has been removed.
 

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -16,6 +16,12 @@ VMware Greenplum 7 introduces substantial changes to resource group-based resour
 |Limit Bypass|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
 |External Components|Manage PL/Container CPU and memory resources|None|
 
+
+CPU management
+Memory management
+
+Changes to server configuration parameters:
+
 The possible settings for the `gp_resource_manager` server configuration parameter have changed. They now include the following:
 - `none` - Configures Greenplum Database to not use any resource manager. This is the default.
 - `group` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v1 version of Linux cgroup functionality.
@@ -24,6 +30,7 @@ The possible settings for the `gp_resource_manager` server configuration paramet
 
 The new server configuration parameter `gp_resgroup_memory_query_fixed_mem` allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
 
+The new server configuration parameter `gp_resource_group_bypass_direct_dispatch` bypasses the resource group's limits for a direct dispatch query so it can run immediately.
 
 Changes to system views:
 
@@ -31,22 +38,20 @@ Changes to system views:
 - The `cpu_usage` and `memory_usage` fields have been moved from the `gp_resgroup_status` system view to the `gp_resgroup_status_per_host` system view.
 - The `gp_resgroup_iostats_per_host` system view has been added.
 
-You may configure three new resource group attributes using the `CREATE RESOURCE GROUP` and `ALTER RESOURCE GROUP` SQL commands:
+
+Changes to resource group attributes and limits:
+
+You may configure four new resource group attributes using the `CREATE RESOURCE GROUP` and `ALTER RESOURCE GROUP` SQL commands:
 - `CPU_MAX_PERCENT`, which configures the maximum amount of CPU resources the resource group can use.
 - `CPU_WEIGHT`, which configures the scheduling priority of the resource group.
 - `MIN_COST`, which configures the minimum amount a query's query plan cost for the query to remain in the resource group.
+- `IO_LIMIT`, which configures device I/O usage at the resource group level to manage the maximum throughput of read/write operations, and the maximum read/write operations per second.
 
 The following resource group attributes have been removed:
 - `CPU_RATE_LIMIT`
 - `MEMORY_AUDITOR`
 - `MEMORY_SPILL_RATIO`
 - `MEMORY_SHARED_QUOTA`
-
-You may now configure device I/O usage at the resource group level via the new `IO_LIMIT` resource group attribute. Specifically, you can control for processes in a resource group:
-- the maximum bandwidth of read/write operations from the disk per second
-- the maximum number of IO read/write operations from the disk per second
-
-You may control this for particular tablespaces or across all tablespaces.
 
 Refer to [Using Resource Groups](/oss/admin_guide/workload_mgmt_resgroups.html) for more information about resource groups.
 

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -1,0 +1,51 @@
+---
+title: About Changes to Resource Groups in Greenplum 7
+---
+
+VMware Greenplum 7 introduces substantial changes to resource group-based resource management. 
+
+This topic describes the Greenplum 7 resource group and compares with resource groups 6.
+
+|Metric|Resource Groups in Greenplum 6|Resource Groups in Greenplum 7|
+|------|---------------|---------------|
+|Concurrency|Managed at the transaction level|Managed at the transaction level|
+|CPU|Specify percentage of CPU resources or the number of CPU cores; uses Linux Control Groups|Specify percentage of CPU resources or the number of CPU cores; uses Linux Control Groups|
+|Memory|Managed at the transaction level, with enhanced allocation and tracking; users cannot over-subscribe|Managed at the transaction level, with enhanced allocation and tracking; users can over-subscribe|
+|Disk I/O|None|Limit the maximum read/write disk I/O throughput, and maximum read/write I/O operations per second|
+|Users|Limits are applied to `SUPERUSER` and non-admin users alike<br>There are two default resource groups: `admin_group` and `default_group`|Limits are applied to `SUPERUSER`, non-admin users, and system processes of non-user classes<br>There are three default resource groups: `admin_group`, `default_group`, and `system_group`|
+|Queueing|Queue when no slot is available or not enough available memory|Queue when no slot is available|
+|Query Failure|Query may fail after reaching transaction fixed memory limit when no shared resource group memory exists and the transaction requests more memory|Query may fail if the allocated memory for the query surpasses the available system memory and spill limits|
+|Limit Bypass|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
+|External Components|Manage PL/Container CPU and memory resources|None|
+
+The possible settings for the `gp_resource_manager` server configuration parameter have changed. They now include the following:
+- `none` - Configures Greenplum Database to not use any resource manager. This is the default.
+- `group` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v1 version of Linux cgroup functionality.
+- `group-v2` - Configures Greenplum Database to use resource groups and base resource group behavior on the cgroup v2 version of Linux cgroup functionality.
+- `queue` - Configures Greenplum Database to use resource queues.
+
+Greenplum Database now includes a new server configuration parameter -- `gp_resgroup_memory_query_fixed_mem` -- which allows you to override at a session level the fixed amount of memory reserved for all queries in a resource group.
+- The `gp_resgroup_status_per_segment` system view has been removed from Greenplum Database.
+- The `cpu_usage` and `memory_usage` fields have been moved from the `gp_resgroup_status` system view to the `gp_resgroup_status_per_host` system view.
+
+You may configure three new resource group attributes using the `CREATE RESOURCE GROUP` and `ALTER RESOURCE GROUP` SQL commands:
+- `CPU_MAX_PERCENT`, which configures the maximum amount of CPU resources the resource group can use.
+- `CPU_WEIGHT`, which configures the scheduling priority of the resource group.
+- `MIN_COST`, which configures the minimum amount a query's query plan cost for the query to remain in the resource group.
+
+The following resource group attributes have been removed:
+- `CPU_RATE_LIMIT`
+- `MEMORY_AUDITOR`
+- `MEMORY_SPILL_RATIO`
+- `MEMORY_SHARED_QUOTA`
+
+You may now configure device I/O usage at the resource group level via the new `IO_LIMIT` resource group attribute. Specifically, you can control for processes in a resource group:
+- the maximum bandwidth of read/write operations from the disk per second
+- the maximum number of IO read/write operations from the disk per second
+
+You may control this for particular tablespaces or across all tablespaces.
+
+Refer to [Using Resource Groups](/oss/admin_guide/workload_mgmt_resgroups.html) for more information about resource groups.
+
+
+


### PR DESCRIPTION
This PR creates a new page "About Changes to Resource Groups in Greenplum 7" which compares resource groups implementation between GPDB 6 and 7.

I still need to confirm more details on guc `gp_resource_group_move_timeout`. Feel free to suggest any changes.

staging site: https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-rg-changes/greenplum-database/admin_guide-about-resgroups-changes.html
