### PR TITLE
Fix regression with QD relstats update on doing VACUUM/CLUSTER

### DIFF
--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -214,7 +214,16 @@ typedef struct VPgClassStats
 	BlockNumber rel_pages;
 	double		rel_tuples;
 	BlockNumber relallvisible;
+	int32		segid;
 } VPgClassStats;
+
+/* Hash entry for VPgClassStats */
+typedef struct VPgClassStatsEntry
+{
+	Oid	relid;
+	VPgClassStats	*relstats; /* array of relstats entries indexed by segid of size nseg */
+	int	count;	/* expect to equal to the number of dispatched segments */
+} VPgClassStatsEntry;
 
 typedef struct VPgClassStatsCombo
 {


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/commit/05b333dfdc03d0477fafe132b10c0cfa2a19d5ae Introduced a check to only update pg_class statistics on the QD when all QEs' data was collected to avoid partial updates.

https://github.com/greenplum-db/gpdb/commit/249581df95ef4c5bbfca2d27e3e64681f35d8ff2 Reused infrastructure for updating relstats that both VACUUM and CLUSTER use to update QD pg_class stats.

We usually expect to receive one stats entry per relid from each QE. However, if indexes are present, we might receive multiple stats entries for the same relid and QE pair (for parent relations only) when performing operations that reindex relations as a side effect, such as VACUUM, CLUSTER etc. This is because index_update_relstats is called for the parent relation from the reindex code.

For instance, if we are running a VACUUM on a parent relation bearing two indexes, we can expect 3 relstats entries per QE for the parent relation (one for the VACUUM and one for each reindex operation).

Since relstats updates are sent out in sequence via vac_send_relstats_to_qd(), we can expect that the last such relstats message for a parent relation contains the most updated relstats for that relation. So, here we only consider the
latest message in the stream for each relation and QE pair (by replacing older ones encountered).

Finally for each relation, we aggregate the relstats by summing up all the latest relstats messages from the QEs.

Authored-by: Brent Doil <bdoil@vmware.com>