### PR TITLE
Lazy load relcache partition data

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -4438,7 +4438,7 @@ StorePartitionBound(Relation rel, Relation parent, PartitionBoundSpec *bound)
 	 * relcache entry for that partition every time a partition is added or
 	 * removed.
 	 */
-	defaultPartOid = get_default_oid_from_partdesc(RelationGetPartitionDesc(parent));
+	defaultPartOid = get_default_oid_from_partdesc(RelationRetrievePartitionDesc(parent));
 	if (OidIsValid(defaultPartOid))
 		CacheInvalidateRelcacheByRelid(defaultPartOid);
 

--- a/src/backend/catalog/partition.c
+++ b/src/backend/catalog/partition.c
@@ -268,7 +268,7 @@ has_partition_attrs(Relation rel, Bitmapset *attnums, bool *used_in_expr)
 	if (attnums == NULL || rel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
 		return false;
 
-	key = RelationGetPartitionKey(rel);
+	key = RelationRetrievePartitionKey(rel);
 	partnatts = get_partition_natts(key);
 	partexprs = get_partition_exprs(key);
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3152,8 +3152,8 @@ CopyTo(CopyState cstate)
 				 */
 				if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 				{
-					for (int i = 0; i < rel->rd_partdesc->nparts; i++)
-						inhRelIds = lappend_oid(inhRelIds, rel->rd_partdesc->oids[i]);
+					for (int i = 0; i < RelationRetrievePartitionDesc(rel)->nparts; i++)
+						inhRelIds = lappend_oid(inhRelIds, RelationRetrievePartitionDesc(rel)->oids[i]);
 				}
 				else if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 				{

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1125,7 +1125,7 @@ DefineIndex(Oid relationId,
 	 */
 	if (partitioned && (stmt->unique || stmt->primary))
 	{
-		PartitionKey key = RelationGetPartitionKey(rel);
+		PartitionKey key = RelationRetrievePartitionKey(rel);
 		const char *constraint_type;
 		int			i;
 
@@ -1357,7 +1357,7 @@ DefineIndex(Oid relationId,
 	 */
 	if (partitioned && stmt->relation && !stmt->relation->inh)
 	{
-		PartitionDesc pd = RelationGetPartitionDesc(rel);
+		PartitionDesc pd = RelationRetrievePartitionDesc(rel);
 
 		if (pd->nparts != 0)
 			flags |= INDEX_CREATE_INVALID;
@@ -1435,7 +1435,7 @@ DefineIndex(Oid relationId,
 		 *
 		 * If we're called internally (no stmt->relation), recurse always.
 		 */
-		partdesc = RelationGetPartitionDesc(rel);
+		partdesc = RelationRetrievePartitionDesc(rel);
 		if ((!stmt->relation || stmt->relation->inh) && partdesc->nparts > 0)
 		{
 			int			nparts = partdesc->nparts;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1235,7 +1235,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		 * lock the partition so as to avoid a deadlock.
 		 */
 		defaultPartOid =
-			get_default_oid_from_partdesc(RelationGetPartitionDesc(parent));
+			get_default_oid_from_partdesc(RelationRetrievePartitionDesc(parent));
 		if (OidIsValid(defaultPartOid))
 			defaultRel = table_open(defaultPartOid, AccessExclusiveLock);
 
@@ -5210,7 +5210,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 						if (!recurse)
 						{
 							/* Don't allow ALTER TABLE ONLY on a partitioned table */
-							if (RelationGetPartitionKey(rel))
+							if (RelationRetrievePartitionKey(rel))
 							{
 								ereport(ERROR,
 										(errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -7995,7 +7995,7 @@ ATPrepDropNotNull(Relation rel, bool recurse, bool recursing)
 	 */
 	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 	{
-		PartitionDesc partdesc = RelationGetPartitionDesc(rel);
+		PartitionDesc partdesc = RelationRetrievePartitionDesc(rel);
 
 		Assert(partdesc != NULL);
 		if (partdesc->nparts > 0 && !recurse && !recursing)
@@ -10318,7 +10318,7 @@ addFkRecurseReferenced(List **wqueue, Constraint *fkconstraint, Relation rel,
 	 */
 	if (pkrel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 	{
-		PartitionDesc pd = RelationGetPartitionDesc(pkrel);
+		PartitionDesc pd = RelationRetrievePartitionDesc(pkrel);
 
 		for (int i = 0; i < pd->nparts; i++)
 		{
@@ -10453,7 +10453,7 @@ addFkRecurseReferencing(List **wqueue, Constraint *fkconstraint, Relation rel,
 	}
 	else if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 	{
-		PartitionDesc pd = RelationGetPartitionDesc(rel);
+		PartitionDesc pd = RelationRetrievePartitionDesc(rel);
 
 		/*
 		 * Recurse to take appropriate action on each partition; either we
@@ -20386,7 +20386,7 @@ QueuePartitionConstraintValidation(List **wqueue, Relation scanrel,
 	}
 	else if (scanrel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 	{
-		PartitionDesc partdesc = RelationGetPartitionDesc(scanrel);
+		PartitionDesc partdesc = RelationRetrievePartitionDesc(scanrel);
 		int			i;
 
 		for (i = 0; i < partdesc->nparts; i++)
@@ -20447,7 +20447,7 @@ ATExecAttachPartition(List **wqueue, Relation rel, PartitionCmd *cmd)
 	 * new partition will change its partition constraint.
 	 */
 	defaultPartOid =
-		get_default_oid_from_partdesc(RelationGetPartitionDesc(rel));
+		get_default_oid_from_partdesc(RelationRetrievePartitionDesc(rel));
 	if (OidIsValid(defaultPartOid))
 		LockRelationOid(defaultPartOid, AccessExclusiveLock);
 
@@ -21186,7 +21186,7 @@ ATExecDetachPartition(Relation rel, RangeVar *name)
 	 * will change its partition constraint.
 	 */
 	defaultPartOid =
-		get_default_oid_from_partdesc(RelationGetPartitionDesc(rel));
+		get_default_oid_from_partdesc(RelationRetrievePartitionDesc(rel));
 	if (OidIsValid(defaultPartOid))
 		LockRelationOid(defaultPartOid, AccessExclusiveLock);
 
@@ -21571,7 +21571,7 @@ ATExecAttachPartitionIdx(List **wqueue, Relation parentIdx, RangeVar *name)
 							   RelationGetRelationName(partIdx))));
 
 		/* Make sure it indexes a partition of the other index's table */
-		partDesc = RelationGetPartitionDesc(parentTbl);
+		partDesc = RelationRetrievePartitionDesc(parentTbl);
 		found = false;
 		for (i = 0; i < partDesc->nparts; i++)
 		{
@@ -21727,7 +21727,7 @@ validatePartitionedIndex(Relation partedIdx, Relation partedTbl)
 	 * If we found as many inherited indexes as the partitioned table has
 	 * partitions, we're good; update pg_index to set indisvalid.
 	 */
-	if (tuples == RelationGetPartitionDesc(partedTbl)->nparts)
+	if (tuples == RelationRetrievePartitionDesc(partedTbl)->nparts)
 	{
 		Relation	idxRel;
 		HeapTuple	newtup;

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1180,7 +1180,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	 */
 	if (partition_recurse)
 	{
-		PartitionDesc partdesc = RelationGetPartitionDesc(rel);
+		PartitionDesc partdesc = RelationRetrievePartitionDesc(rel);
 		List	   *idxs = NIL;
 		List	   *childTbls = NIL;
 		ListCell   *l;
@@ -1960,7 +1960,7 @@ EnableDisableTriggerNew(Relation rel, const char *tgname,
 			rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE &&
 			(TRIGGER_FOR_ROW(oldtrig->tgtype)))
 		{
-			PartitionDesc partdesc = RelationGetPartitionDesc(rel);
+			PartitionDesc partdesc = RelationRetrievePartitionDesc(rel);
 			int			i;
 
 			for (i = 0; i < partdesc->nparts; i++)

--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -1107,7 +1107,7 @@ ExecInitPartitionDispatchInfo(EState *estate,
 	pd = (PartitionDispatch) palloc(offsetof(PartitionDispatchData, indexes) +
 									partdesc->nparts * sizeof(int));
 	pd->reldesc = rel;
-	pd->key = RelationGetPartitionKey(rel);
+	pd->key = RelationRetrievePartitionKey(rel);
 	pd->keystate = NIL;
 	pd->partdesc = partdesc;
 	if (parent_pd != NULL)
@@ -1450,7 +1450,7 @@ ExecBuildSlotPartitionKeyDescription(Relation rel,
 									 int maxfieldlen)
 {
 	StringInfoData buf;
-	PartitionKey key = RelationGetPartitionKey(rel);
+	PartitionKey key = RelationRetrievePartitionKey(rel);
 	int			partnatts = get_partition_natts(key);
 	int			i;
 	Oid			relid = RelationGetRelid(rel);
@@ -1747,7 +1747,7 @@ ExecCreatePartitionPruneState(PlanState *planstate,
 			 * duration of this executor run.
 			 */
 			partrel = ExecGetRangeTableRelation(estate, pinfo->rtindex);
-			partkey = RelationGetPartitionKey(partrel);
+			partkey = RelationRetrievePartitionKey(partrel);
 			partdesc = PartitionDirectoryLookup(estate->es_partition_directory,
 												partrel);
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2699,4 +2699,23 @@ gpdb::GetIndexAmRoutineFromAmHandler(Oid am_handler)
 	GP_WRAP_END;
 }
 
+PartitionDesc
+gpdb::GPDBRelationRetrievePartitionDesc(Relation rel)
+{
+	GP_WRAP_START;
+	{
+		return RelationRetrievePartitionDesc(rel);
+	}
+	GP_WRAP_END;
+}
+
+PartitionKey
+gpdb::GPDBRelationRetrievePartitionKey(Relation rel)
+{
+	GP_WRAP_START;
+	{
+		return RelationRetrievePartitionKey(rel);
+	}
+	GP_WRAP_END;
+}
 // EOF

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -2568,7 +2568,7 @@ set_relation_partition_info(PlannerInfo *root, RelOptInfo *rel,
 static PartitionScheme
 find_partition_scheme(PlannerInfo *root, Relation relation)
 {
-	PartitionKey partkey = RelationGetPartitionKey(relation);
+	PartitionKey partkey = RelationRetrievePartitionKey(relation);
 	ListCell   *lc;
 	int			partnatts,
 				i;
@@ -2677,7 +2677,7 @@ static void
 set_baserel_partition_key_exprs(Relation relation,
 								RelOptInfo *rel)
 {
-	PartitionKey partkey = RelationGetPartitionKey(relation);
+	PartitionKey partkey = RelationRetrievePartitionKey(relation);
 	int			partnatts;
 	int			cnt;
 	List	  **partexprs;

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -355,8 +355,8 @@ list_qsort_arg(List *list, qsort_arg_comparator cmp, void *arg)
 static void
 deduceImplicitRangeBounds(ParseState *pstate, Relation parentrel, List *stmts, bool addpartition)
 {
-	PartitionKey key = RelationGetPartitionKey(parentrel);
-	PartitionDesc desc = RelationGetPartitionDesc(parentrel);
+	PartitionKey key = RelationRetrievePartitionKey(parentrel);
+	PartitionDesc desc = RelationRetrievePartitionDesc(parentrel);
 
 	list_qsort_arg(stmts, qsort_stmt_cmp, key);
 
@@ -817,7 +817,7 @@ generateRangePartitions(ParseState *pstate,
 				 parser_errposition(pstate, elem->location)));
 
 	boundspec = (GpPartitionRangeSpec *) elem->boundSpec;
-	partkey = RelationGetPartitionKey(parentrel);
+	partkey = RelationRetrievePartitionKey(parentrel);
 	/* Syntax doesn't allow expressions in partition key */
 	Assert(partkey->partattrs[0] != 0);
 
@@ -1385,7 +1385,7 @@ transformGpPartDefElemWithRangeSpec(ParseState *pstate, Relation parentrel, GpPa
 					parser_errposition(pstate, elem->location)));
 
 	boundspec = (GpPartitionRangeSpec *) elem->boundSpec;
-	partkey = RelationGetPartitionKey(parentrel);
+	partkey = RelationRetrievePartitionKey(parentrel);
 
 	/*
 	 * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We currently disabled support for multi-column
@@ -1613,7 +1613,7 @@ transformGpPartitionDefinition(Oid parentrelid, const char *queryString,
 	pstate->p_sourcetext = queryString;
 
 	parentrel = table_open(parentrelid, NoLock);
-	partkey = RelationGetPartitionKey(parentrel);
+	partkey = RelationRetrievePartitionKey(parentrel);
 	Assert(partkey != NULL);
 	if (list_length(partkey->partexprs) > 0)
 		ereport(ERROR,
@@ -1832,7 +1832,7 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 			new_parts = generateDefaultPartition(pstate, parentrel, elem, tmpSubPartSpec, &partcomp);
 		else
 		{
-			PartitionKey key = RelationGetPartitionKey(parentrel);
+			PartitionKey key = RelationRetrievePartitionKey(parentrel);
 			Assert(key != NULL);
 			switch (key->strategy)
 			{

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -5037,7 +5037,7 @@ transformPartitionCmd(CreateStmtContext *cxt, PartitionCmd *cmd)
 	{
 		case RELKIND_PARTITIONED_TABLE:
 			/* transform the partition bound, if any */
-			Assert(RelationGetPartitionKey(parentRel) != NULL);
+			Assert(RelationRetrievePartitionKey(parentRel) != NULL);
 			if (cmd->bound != NULL)
 				cxt->partbound = transformPartitionBound(cxt->pstate, parentRel,
 														 cmd->bound);
@@ -5077,7 +5077,7 @@ transformPartitionBound(ParseState *pstate, Relation parent,
 						PartitionBoundSpec *spec)
 {
 	PartitionBoundSpec *result_spec;
-	PartitionKey key = RelationGetPartitionKey(parent);
+	PartitionKey key = RelationRetrievePartitionKey(parent);
 	char		strategy = get_partition_strategy(key);
 	int			partnatts = get_partition_natts(key);
 	List	   *partexprs = get_partition_exprs(key);
@@ -5225,7 +5225,7 @@ transformPartitionRangeBounds(ParseState *pstate, List *blist,
 							  Relation parent)
 {
 	List	   *result = NIL;
-	PartitionKey key = RelationGetPartitionKey(parent);
+	PartitionKey key = RelationRetrievePartitionKey(parent);
 	List	   *partexprs = get_partition_exprs(key);
 	ListCell   *lc;
 	int			i,

--- a/src/backend/partitioning/partdesc.c
+++ b/src/backend/partitioning/partdesc.c
@@ -46,7 +46,34 @@ typedef struct PartitionDirectoryEntry
 	Relation	rel;
 	PartitionDesc pd;
 } PartitionDirectoryEntry;
+/*
+ * RelationRetrievePartitionDesc -- get partition descriptor, if relation is partitioned
+ *
+ * Note: we arrange for partition descriptors to not get freed until the
+ * relcache entry's refcount goes to zero (see hacks in RelationClose,
+ * RelationClearRelation, and RelationBuildPartitionDesc).  Therefore, even
+ * though we hand back a direct pointer into the relcache entry, it's safe
+ * for callers to continue to use that pointer as long as (a) they hold the
+ * relation open, and (b) they hold a relation lock strong enough to ensure
+ * that the data doesn't become stale.
+ *
+ * GPDB FIXME: This is a one-to-one replacement of the macro RelationGetPartitionDesc. That macro
+ * is kept to prevent ABI breakage during an ABI freeze, but when possible it should be removed,
+ * and this should be renamed to RelationGetPartitionDesc to keep alignment with upstream.
+ * RelationBuildPartitionDesc can also be redefined to static, as it should only ever be accessed
+ * through here.
+ */
+PartitionDesc
+RelationRetrievePartitionDesc(Relation rel)
+{
+	if (rel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
+		return NULL;
 
+	if (unlikely(rel->rd_partdesc == NULL))
+		RelationBuildPartitionDesc(rel);
+
+	return rel->rd_partdesc;
+}
 /*
  * RelationBuildPartitionDesc
  *		Form rel's partition descriptor, and store in relcache entry
@@ -56,6 +83,17 @@ typedef struct PartitionDirectoryEntry
  * addition or removal of a partition.  Hence, code holding a lock
  * that's sufficient to prevent that can assume that rd_partdesc
  * won't change underneath it.
+ *
+ * Partition descriptor is a complex structure; to avoid complicated logic to
+ * free individual elements whenever the relcache entry is flushed, we give it
+ * its own memory context, a child of CacheMemoryContext, which can easily be
+ * deleted on its own.  To avoid leaking memory in that context in case of an
+ * error partway through this function, the context is initially created as a
+ * child of CurTransactionContext and only re-parented to CacheMemoryContext
+ * at the end, when no further errors are possible.  Also, we don't make this
+ * context the current context except in very brief code sections, out of fear
+ * that some of our callees allocate memory on their own which would be leaked
+ * permanently.
  */
 void
 RelationBuildPartitionDesc(Relation rel)
@@ -65,10 +103,12 @@ RelationBuildPartitionDesc(Relation rel)
 	List	   *inhoids;
 	PartitionBoundSpec **boundspecs = NULL;
 	Oid		   *oids = NULL;
+	bool	   *is_leaf = NULL;
 	ListCell   *cell;
 	int			i,
 				nparts;
-	PartitionKey key = RelationGetPartitionKey(rel);
+	PartitionKey key = RelationRetrievePartitionKey(rel);
+	MemoryContext new_pdcxt;
 	MemoryContext oldcxt;
 	MemoryContext rbcontext;
 	int		   *mapping;
@@ -106,7 +146,8 @@ RelationBuildPartitionDesc(Relation rel)
 	/* Allocate arrays for OIDs and boundspecs. */
 	if (nparts > 0)
 	{
-		oids = palloc(nparts * sizeof(Oid));
+		oids = (Oid *) palloc(nparts * sizeof(Oid));
+		is_leaf = (bool *) palloc(nparts * sizeof(bool));
 		boundspecs = palloc(nparts * sizeof(PartitionBoundSpec *));
 	}
 
@@ -196,13 +237,17 @@ RelationBuildPartitionDesc(Relation rel)
 
 		/* Save results. */
 		oids[i] = inhrelid;
+		is_leaf[i] = (get_rel_relkind(inhrelid) != RELKIND_PARTITIONED_TABLE);
 		boundspecs[i] = boundspec;
 		++i;
 	}
 
-	/* Assert we aren't about to leak any old data structure */
-	Assert(rel->rd_pdcxt == NULL);
-	Assert(rel->rd_partdesc == NULL);
+	/*
+	 * Create PartitionBoundInfo and mapping, working in the caller's context.
+	 * This could fail, but we haven't done any damage if so.
+	 */
+	if (nparts > 0)
+		boundinfo = partition_bounds_create(boundspecs, nparts, key, &mapping);
 
 	/*
 	 * Now build the actual relcache partition descriptor.  Note that the
@@ -213,27 +258,23 @@ RelationBuildPartitionDesc(Relation rel)
 	 * rd_partdesc until the cached data structure is fully complete and
 	 * valid, so that no other code might try to use it.
 	 */
-	rel->rd_pdcxt = AllocSetContextCreate(CacheMemoryContext,
-										  "partition descriptor",
-										  ALLOCSET_SMALL_SIZES);
-	MemoryContextCopyAndSetIdentifier(rel->rd_pdcxt,
+	new_pdcxt = AllocSetContextCreate(CurTransactionContext,
+									  "partition descriptor",
+									  ALLOCSET_SMALL_SIZES);
+	MemoryContextCopyAndSetIdentifier(new_pdcxt,
 									  RelationGetRelationName(rel));
 
 	partdesc = (PartitionDescData *)
-		MemoryContextAllocZero(rel->rd_pdcxt, sizeof(PartitionDescData));
+		MemoryContextAllocZero(new_pdcxt, sizeof(PartitionDescData));
 	partdesc->nparts = nparts;
 	/* If there are no partitions, the rest of the partdesc can stay zero */
 	if (nparts > 0)
 	{
-		/* Create PartitionBoundInfo, using the temporary context. */
-		boundinfo = partition_bounds_create(boundspecs, nparts, key, &mapping);
-
 		/* Now copy all info into relcache's partdesc. */
-		MemoryContextSwitchTo(rel->rd_pdcxt);
+		MemoryContextSwitchTo(new_pdcxt);
 		partdesc->boundinfo = partition_bounds_copy(boundinfo, key);
 		partdesc->oids = (Oid *) palloc(nparts * sizeof(Oid));
 		partdesc->is_leaf = (bool *) palloc(nparts * sizeof(bool));
-		MemoryContextSwitchTo(oldcxt);
 
 		/*
 		 * Assign OIDs from the original array into mapped indexes of the
@@ -241,22 +282,36 @@ RelationBuildPartitionDesc(Relation rel)
 		 * catalog scan that retrieved them, whereas that in the latter is
 		 * defined by canonicalized representation of the partition bounds.
 		 *
-		 * Also record leaf-ness of each partition.  For this we use
-		 * get_rel_relkind() which may leak memory, so be sure to run it in
-		 * the temporary context.
+		 * Also save leaf-ness of each partition.
 		 */
-		MemoryContextSwitchTo(rbcontext);
 		for (i = 0; i < nparts; i++)
 		{
 			int			index = mapping[i];
 
 			partdesc->oids[index] = oids[i];
-			partdesc->is_leaf[index] =
-				(get_rel_relkind(oids[i]) != RELKIND_PARTITIONED_TABLE);
+			partdesc->is_leaf[index] = is_leaf[i];
 		}
+		MemoryContextSwitchTo(rbcontext);
 	}
 
+	/*
+	 * We have a fully valid partdesc ready to store into the relcache.
+	 * Reparent it so it has the right lifespan.
+	 */
+	MemoryContextSetParent(new_pdcxt, CacheMemoryContext);
+
+	/*
+	 * But first, a kluge: if there's an old rd_pdcxt, it contains an old
+	 * partition descriptor that may still be referenced somewhere.  Preserve
+	 * it, while not leaking it, by reattaching it as a child context of the
+	 * new rd_pdcxt.  Eventually it will get dropped by either RelationClose
+	 * or RelationClearRelation.
+	 */
+	if (rel->rd_pdcxt != NULL)
+		MemoryContextSetParent(rel->rd_pdcxt, new_pdcxt);
+	rel->rd_pdcxt = new_pdcxt;
 	rel->rd_partdesc = partdesc;
+
 	/* Return to caller's context, and blow away the temporary context. */
 	MemoryContextSwitchTo(oldcxt);
 	MemoryContextDelete(rbcontext);
@@ -314,7 +369,7 @@ PartitionDirectoryLookup(PartitionDirectory pdir, Relation rel)
 		 */
 		RelationIncrementReferenceCount(rel);
 		pde->rel = rel;
-		pde->pd = RelationGetPartitionDesc(rel);
+		pde->pd = RelationRetrievePartitionDesc(rel);
 		Assert(pde->pd != NULL);
 	}
 	return pde->pd;

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1238,20 +1238,11 @@ retry:
 	relation->rd_fkeylist = NIL;
 	relation->rd_fkeyvalid = false;
 
-	/* if a partitioned table, initialize key and partition descriptor info */
-	if (relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
-	{
-		RelationBuildPartitionKey(relation);
-		RelationBuildPartitionDesc(relation);
-	}
-	else
-	{
-		relation->rd_partkey = NULL;
-		relation->rd_partkeycxt = NULL;
-		relation->rd_partdesc = NULL;
-		relation->rd_pdcxt = NULL;
-	}
-	/* ... but partcheck is not loaded till asked for */
+	/* partitioning data is not loaded till asked for */
+	relation->rd_partkey = NULL;
+	relation->rd_partkeycxt = NULL;
+	relation->rd_partdesc = NULL;
+	relation->rd_pdcxt = NULL;
 	relation->rd_partcheck = NIL;
 	relation->rd_partcheckvalid = false;
 	relation->rd_partcheckcxt = NULL;
@@ -2275,6 +2266,16 @@ RelationClose(Relation relation)
 	/* Note: no locking manipulations needed */
 	RelationDecrementReferenceCount(relation);
 
+	/*
+	 * If the relation is no longer open in this session, we can clean up any
+	 * stale partition descriptors it has.  This is unlikely, so check to see
+	 * if there are child contexts before expending a call to mcxt.c.
+	 */
+	if (RelationHasReferenceCountZero(relation) &&
+		relation->rd_pdcxt != NULL &&
+		relation->rd_pdcxt->firstchild != NULL)
+		MemoryContextDeleteChildren(relation->rd_pdcxt);
+
 #ifdef RELCACHE_FORCE_RELEASE
 	if (RelationHasReferenceCountZero(relation) &&
 		relation->rd_createSubid == InvalidSubTransactionId &&
@@ -2727,7 +2728,6 @@ RelationClearRelation(Relation relation, bool rebuild)
 		bool		keep_gp_policy;
 		bool		keep_policies;
 		bool		keep_partkey;
-		bool		keep_partdesc;
 
 		/* Build temporary entry, but don't link it into hashtable */
 		newrel = RelationBuildDesc(save_relid, false);
@@ -2769,9 +2769,6 @@ RelationClearRelation(Relation relation, bool rebuild)
 		keep_policies = equalRSDesc(relation->rd_rsdesc, newrel->rd_rsdesc);
 		/* partkey is immutable once set up, so we can always keep it */
 		keep_partkey = (relation->rd_partkey != NULL);
-		keep_partdesc = equalPartitionDescs(relation->rd_partkey,
-											relation->rd_partdesc,
-											newrel->rd_partdesc);
 
 		/*
 		 * Perform swapping of the relcache entry contents.  Within this
@@ -2829,34 +2826,45 @@ RelationClearRelation(Relation relation, bool rebuild)
 		SWAPFIELD(Oid, rd_toastoid);
 		/* pgstat_info must be preserved */
 		SWAPFIELD(struct PgStat_TableStatus *, pgstat_info);
-		/* preserve old partitioning info if no logical change */
+		/* preserve old partitioning key if we have one */
 		if (keep_partkey)
 		{
 			SWAPFIELD(PartitionKey, rd_partkey);
 			SWAPFIELD(MemoryContext, rd_partkeycxt);
 		}
-		if (keep_partdesc)
-		{
-			SWAPFIELD(PartitionDesc, rd_partdesc);
-			SWAPFIELD(MemoryContext, rd_pdcxt);
-		}
-		else if (rebuild && newrel->rd_pdcxt != NULL)
+		if (newrel->rd_pdcxt != NULL)
 		{
 			/*
 			 * We are rebuilding a partitioned relation with a non-zero
-			 * reference count, so keep the old partition descriptor around,
-			 * in case there's a PartitionDirectory with a pointer to it.
-			 * Attach it to the new rd_pdcxt so that it gets cleaned up
-			 * eventually.  In the case where the reference count is 0, this
-			 * code is not reached, which should be OK because in that case
-			 * there should be no PartitionDirectory with a pointer to the old
-			 * entry.
+			 * reference count, so we must keep the old partition descriptor
+			 * around, in case there's a PartitionDirectory with a pointer to
+			 * it.  This means we can't free the old rd_pdcxt yet.  (This is
+			 * necessary because RelationGetPartitionDesc hands out direct
+			 * pointers to the relcache's data structure, unlike our usual
+			 * practice which is to hand out copies.  We'd have the same
+			 * problem with rd_partkey, except that we always preserve that
+			 * once created.)
+			 *
+			 * To ensure that it's not leaked completely, re-attach it to the
+			 * new reldesc, or make it a child of the new reldesc's rd_pdcxt
+			 * in the unlikely event that there is one already.  (Compare hack
+			 * in RelationBuildPartitionDesc.)  RelationClose will clean up
+			 * any such contexts once the reference count reaches zero.
+			 *
+			 * In the case where the reference count is zero, this code is not
+			 * reached, which should be OK because in that case there should
+			 * be no PartitionDirectory with a pointer to the old entry.
 			 *
 			 * Note that newrel and relation have already been swapped, so the
 			 * "old" partition descriptor is actually the one hanging off of
 			 * newrel.
 			 */
-			MemoryContextSetParent(newrel->rd_pdcxt, relation->rd_pdcxt);
+			relation->rd_partdesc = NULL;	/* ensure rd_partdesc is invalid */
+			if (relation->rd_pdcxt != NULL) /* probably never happens */
+				MemoryContextSetParent(newrel->rd_pdcxt, relation->rd_pdcxt);
+			else
+				relation->rd_pdcxt = newrel->rd_pdcxt;
+			/* drop newrel's pointers so we don't destroy it below */
 			newrel->rd_partdesc = NULL;
 			newrel->rd_pdcxt = NULL;
 		}
@@ -4239,39 +4247,7 @@ RelationCacheInitializePhase3(void)
 			restart = true;
 		}
 
-		/*
-		 * Reload the partition key and descriptor for a partitioned table.
-		 */
-		if (relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE &&
-			relation->rd_partkey == NULL)
-		{
-			RelationBuildPartitionKey(relation);
-			Assert(relation->rd_partkey != NULL);
-
-			restart = true;
-		}
-
-		if (relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE &&
-			relation->rd_partdesc == NULL)
-		{
-			RelationBuildPartitionDesc(relation);
-			Assert(relation->rd_partdesc != NULL);
-
-			restart = true;
-		}
-
-		if (relation->rd_tableam == NULL &&
-			(relation->rd_rel->relkind == RELKIND_RELATION ||
-			 relation->rd_rel->relkind == RELKIND_SEQUENCE ||
-			 relation->rd_rel->relkind == RELKIND_TOASTVALUE ||
-			 relation->rd_rel->relkind == RELKIND_MATVIEW))
-		{
-			RelationInitTableAccessMethod(relation);
-			Assert(relation->rd_tableam != NULL);
-
-			restart = true;
-		}
-
+		/* Reload tableam data if needed */
 		if (relation->rd_tableam == NULL &&
 			(relation->rd_rel->relkind == RELKIND_AOSEGMENTS ||
 			 relation->rd_rel->relkind == RELKIND_AOBLOCKDIR ||

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -670,6 +670,10 @@ char *GetRelAmName(Oid reloid);
 
 IndexAmRoutine *GetIndexAmRoutineFromAmHandler(Oid am_handler);
 
+PartitionDesc GPDBRelationRetrievePartitionDesc(Relation rel);
+
+PartitionKey GPDBRelationRetrievePartitionKey(Relation rel);
+
 }  //namespace gpdb
 
 #define ForEach(cell, l) \

--- a/src/include/partitioning/partdesc.h
+++ b/src/include/partitioning/partdesc.h
@@ -29,6 +29,7 @@ typedef struct PartitionDescData
 	PartitionBoundInfo boundinfo;	/* collection of partition bounds */
 } PartitionDescData;
 
+extern PartitionDesc RelationRetrievePartitionDesc(Relation rel);
 extern void RelationBuildPartitionDesc(Relation rel);
 
 extern PartitionDirectory CreatePartitionDirectory(MemoryContext mcxt);

--- a/src/include/utils/partcache.h
+++ b/src/include/utils/partcache.h
@@ -46,6 +46,7 @@ typedef struct PartitionKeyData
 	Oid		   *parttypcoll;
 }			PartitionKeyData;
 
+extern PartitionKey RelationRetrievePartitionKey(Relation rel);
 extern void RelationBuildPartitionKey(Relation relation);
 extern List *RelationGetPartitionQual(Relation rel);
 extern Expr *get_partition_qual_relid(Oid relid);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -107,10 +107,15 @@ typedef struct RelationData
 	List	   *rd_fkeylist;	/* list of ForeignKeyCacheInfo (see below) */
 	bool		rd_fkeyvalid;	/* true if list has been computed */
 
-	struct PartitionKeyData *rd_partkey;	/* partition key, or NULL */
+	/* data managed by RelationRetrievePartitionKey: */
+	PartitionKey rd_partkey;	/* partition key, or NULL */
 	MemoryContext rd_partkeycxt;	/* private context for rd_partkey, if any */
-	struct PartitionDescData *rd_partdesc;	/* partitions, or NULL */
+
+	/* data managed by RelationRetrievePartitionDesc: */
+	PartitionDesc rd_partdesc;	/* partition descriptor, or NULL */
 	MemoryContext rd_pdcxt;		/* private context for rd_partdesc, if any */
+
+	/* data managed by RelationGetPartitionQual: */
 	List	   *rd_partcheck;	/* partition CHECK quals */
 	bool		rd_partcheckvalid;	/* true if list has been computed */
 	MemoryContext rd_partcheckcxt;	/* private cxt for rd_partcheck, if any */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -704,12 +704,20 @@ typedef struct ViewOptions
 /*
  * RelationGetPartitionKey
  *		Returns the PartitionKey of a relation
+ *
+ * GPDB: This should not be used anymore. It is superceded by
+ * RelationRetrievePartionKey, and is kept around only to prevent ABI 
+ * breakage. See comments on that function for more details.
  */
 #define RelationGetPartitionKey(relation) ((relation)->rd_partkey)
 
 /*
  * RelationGetPartitionDesc
  *		Returns partition descriptor for a relation.
+ *
+ * GPDB: This should not be used anymore. It is superceded by
+ * RelationRetrievePartionDesc, and is kept around only to prevent ABI 
+ * breakage. See comments on that function for more details.
  */
 #define RelationGetPartitionDesc(relation) ((relation)->rd_partdesc)
 

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -512,6 +512,24 @@ Partition of: partitioned2 FOR VALUES FROM ('-1', 'aaaaa') TO (100, 'ccccc')
 Partition constraint: (((a + 1) IS NOT NULL) AND (substr(b, 1, 5) IS NOT NULL) AND (((a + 1) > '-1'::integer) OR (((a + 1) = '-1'::integer) AND (substr(b, 1, 5) >= 'aaaaa'::text))) AND (((a + 1) < 100) OR (((a + 1) = 100) AND (substr(b, 1, 5) < 'ccccc'::text))))
 
 DROP TABLE partitioned, partitioned2;
+-- check reference to partitioned table's rowtype in partition descriptor
+create table partitioned (a int, b int)
+  partition by list ((row(a, b)::partitioned));
+create table partitioned1
+  partition of partitioned for values in ('(1,2)'::partitioned);
+create table partitioned2
+  partition of partitioned for values in ('(2,4)'::partitioned);
+explain (costs off)
+select * from partitioned where row(a,b)::partitioned = '(1,2)'::partitioned;
+                        QUERY PLAN                         
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on partitioned1
+         Filter: (ROW(a, b)::partitioned = '(1,2)'::partitioned)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+drop table partitioned;
 -- check that dependencies of partition columns are handled correctly
 create domain intdom1 as int;
 create table partitioned (

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -459,6 +459,17 @@ CREATE TABLE part2_1 PARTITION OF partitioned2 FOR VALUES FROM (-1, 'aaaaa') TO 
 
 DROP TABLE partitioned, partitioned2;
 
+-- check reference to partitioned table's rowtype in partition descriptor
+create table partitioned (a int, b int)
+  partition by list ((row(a, b)::partitioned));
+create table partitioned1
+  partition of partitioned for values in ('(1,2)'::partitioned);
+create table partitioned2
+  partition of partitioned for values in ('(2,4)'::partitioned);
+explain (costs off)
+select * from partitioned where row(a,b)::partitioned = '(1,2)'::partitioned;
+drop table partitioned;
+
 -- check that dependencies of partition columns are handled correctly
 create domain intdom1 as int;
 


### PR DESCRIPTION
This commit is heavily taken from an upstream commit: 5b9312378e2f8fb35ef4584aea351c3319a10422

That commit could not be backported directly due to the current ABI freeze for GPDB7.  In addition, there were multiple GPDB-only changes needed to route all rd_partdesc and rd_partkey accesses through the new RelationRetrievePartition* functions to ensure that there are no null pointer accesses for those fields.

This commit fixes a regression in partition behavior that can be observed if the dependencies of a partitioned table are altered during a single connection.  GPDB6 and previous, with classic partitioning syntax, handled this correctly, but modern syntax requires late loading of the partition description to match it.

Note that we disable optimizer during partition bound generation. Orca was falling back anyway since query parameters are unsupported, and generating an exception here reset the error context to an unsupported state.

Coauthored-by: Chris Hajas <chajas@vmware.com>