### PR TITLE
Fix the failure of src/backend/cdb/dispatcher/test/cdbdisp_query_test.c

### DIFF
--- a/src/backend/cdb/dispatcher/test/Makefile
+++ b/src/backend/cdb/dispatcher/test/Makefile
@@ -30,3 +30,5 @@ cdbdisp_query.t: \
 	$(MOCK_DIR)/backend/libpq/fe-misc_mock.o \
 	$(MOCK_DIR)/backend/cdb/cdbfts_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/gpexpand_mock.o
+
+include $(top_builddir)/src/backend/mock.mk


### PR DESCRIPTION
My previous https://github.com/greenplum-db/gpdb/commit/8ada6cbe4e3ca514981200acc53e0826dca03ac6 caused `cdbdisp_query_test.c` failed:
```
mocking /tmp/build/f8c7ee08/gpdb_src/src/backend/libpq/fe-misc.c
mocking /tmp/build/f8c7ee08/gpdb_src/src/backend/utils/misc/gpexpand.c
[          OK ] test__CdbDispatchPlan_may_be_interrupted
[=============] 1 tests ran
[ PASSED      ] 1 tests
make[3]: *** wait: No child processes.  Stop.
make[3]: *** Waiting for unfinished jobs....
make[3]: *** wait: No child processes.  Stop.
make[2]: *** [../../../src/backend/common.mk:49: unittest-check-dispatcher-recurse] Error 2
make[1]: *** [common.mk:49: unittest-check-cdb-recurse] Hangup
make[4]: *** [../../../../../src/Makefile.mock:25: cdbdisp_query-check] Hangup
make: *** [GNUmakefile:221: unittest-check] Hangup
```
This PR fixes it, have verified in my dev pipeline:
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-fix_ut_dispquery-rhel8/jobs/compile_gpdb_rocky8/builds/2

Thanks @Chibin 's help.
(no need to pick up to main branch)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
