### PR TITLE
ao/co IndexOnlyScan: Use the last cached minipage

### DIFF
--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -298,7 +298,8 @@ So to perform the visibility check, we rely on the block directory to see if the
 is covered by a block directory entry. If no, the tid is not visible to the index only
 scan. If yes, we check if the tid is deleted in the visimap and if it isn't we declare
 that the tid is visible to the index only scan. This mechanism is very similar to unique
-index checks, except that we use a regular MVCC snapshot (and not SNAPSHOT_DIRTY).
+index checks, except that we use a regular MVCC snapshot (and not SNAPSHOT_DIRTY), and
+the fact that we can rely on the last cached minipage.
 
 A note about upgrades:
 given the commit of removing aoblkdir hole filling mechanism was introduced from GP7,


### PR DESCRIPTION
We can use the last cached minipage in the AppendOnlyBlockDirectory
structure during successive index only checks.

Today, index only scans on AO/CO tables have enormous per-tuple overhead
borne from the cost of starting, executing and tearing down short-lived
block directory sysscans.

This patch can result in a dramatic reduction in the number of these
shortlived sysscans, by referring to the last cached minipage. The best
case would be for highly correlated data where the next lookup would be
satisfied from the last cached minipage, with very high probability.

Example (TPC-H AO table of on-disk size 26GB, scale=30):

explain analyze select count(*) from lineitem where l_shipdate >= date '1994-01-01'
    and l_shipdate < date '1994-01-01' + interval '1' year;

and we have a clustered b-tree index on l_shipdate

Without patch: statement_timeout of 5min.
With patch: the query takes 3s to execute.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/optimize_blkdir_ios?group=all