### PR TITLE
Fix minirepro behave tests.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -69,6 +69,11 @@ def before_feature(context, feature):
         dbconn.execSQL(context.conn, 'insert into t1 values(1, 2)')
         dbconn.execSQL(context.conn, 'insert into t2 values(1, 3)')
         dbconn.execSQL(context.conn, 'insert into t3 values(1, 4)')
+        # minirepro tests requires statistical data about the contents of the database
+        # we should execute 'ANALYZE' to fill the pg_statistic catalog table.
+        dbconn.execSQL(context.conn, 'analyze t1')
+        dbconn.execSQL(context.conn, 'analyze t2')
+        dbconn.execSQL(context.conn, 'analyze t3')
         context.conn.commit()
 
 def after_feature(context, feature):

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -69,7 +69,7 @@ def before_feature(context, feature):
         dbconn.execSQL(context.conn, 'insert into t1 values(1, 2)')
         dbconn.execSQL(context.conn, 'insert into t2 values(1, 3)')
         dbconn.execSQL(context.conn, 'insert into t3 values(1, 4)')
-        # minirepro tests requires statistical data about the contents of the database
+        # minirepro tests require statistical data about the contents of the database
         # we should execute 'ANALYZE' to fill the pg_statistic catalog table.
         dbconn.execSQL(context.conn, 'analyze t1')
         dbconn.execSQL(context.conn, 'analyze t2')

--- a/gpMgmt/test/behave/mgmt_utils/minirepro.feature
+++ b/gpMgmt/test/behave/mgmt_utils/minirepro.feature
@@ -13,11 +13,11 @@ Feature: Dump minimum database objects that is related to the query
       When the user runs "minirepro"
       Then minirepro should print "error: No database specified" error message
       When the user runs "minirepro minireprodb -q"
-      Then minirepro should print "error: -q option requires an argument" error message
+      Then minirepro should print "error: -q option requires 1 argument" error message
       When the user runs "minirepro minireprodb -q ~/in.sql"
       Then minirepro should print "error: No output file specified" error message
       When the user runs "minirepro minireprodb -q ~/in.sql -f"
-      Then minirepro should print "error: -f option requires an argument" error message
+      Then minirepro should print "error: -f option requires 1 argument" error message
 
     @minirepro_UI
     Scenario: Query file does not exist
@@ -28,7 +28,9 @@ Feature: Dump minimum database objects that is related to the query
     @minirepro_UI
     Scenario: Database does not exist
       Given database "nonedb000" does not exist
-      When the user runs "minirepro nonedb000 -q ~/test/in.sql -f ~/out.sql"
+      # Make sure that minirepro doesn't complains about the missing of in.sql.
+      Given the file "/tmp/in.sql" exists and contains "select 1;"
+      When the user runs "minirepro nonedb000 -q /tmp/in.sql -f ~/out.sql"
       Then minirepro error should contain database "nonedb000" does not exist
 
     @minirepro_core
@@ -43,8 +45,8 @@ Feature: Dump minimum database objects that is related to the query
       Given the file "/tmp/in.sql" exists and contains "select * from t1; delete from t2;"
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t1"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t2"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t1"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't1'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
@@ -62,9 +64,9 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t1" before "CREATE TABLE t3"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3" before "CREATE VIEW v1"
-      And the output file "/tmp/out.sql" should not contain "CREATE TABLE t2"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t1" before "CREATE TABLE public.t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3" before "CREATE VIEW public.v1"
+      And the output file "/tmp/out.sql" should not contain "CREATE TABLE public.t2"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't1'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t1, Attribute: a"
@@ -80,12 +82,12 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t1" before "CREATE TABLE t3"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3" before "CREATE VIEW v1"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t2" before "CREATE TABLE t3"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3" before "CREATE VIEW v2"
-      And the output file "/tmp/out.sql" should contain "CREATE VIEW v1" before "CREATE VIEW v3"
-      And the output file "/tmp/out.sql" should contain "CREATE VIEW v2" before "CREATE VIEW v3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t1" before "CREATE TABLE public.t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3" before "CREATE VIEW public.v1"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2" before "CREATE TABLE public.t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3" before "CREATE VIEW public.v2"
+      And the output file "/tmp/out.sql" should contain "CREATE VIEW public.v1" before "CREATE VIEW public.v3"
+      And the output file "/tmp/out.sql" should contain "CREATE VIEW public.v2" before "CREATE VIEW public.v3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't1'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
@@ -104,7 +106,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t1"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t1"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't1'"
       And the output file "/tmp/out.sql" should contain "Table: t1, Attribute: a"
       And the output file "/tmp/out.sql" should contain "Table: t1, Attribute: b"
@@ -117,7 +119,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t2"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should contain "Table: t2, Attribute: c"
       And the output file "/tmp/out.sql" should contain "Table: t2, Attribute: d"
@@ -130,7 +132,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: e"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"
@@ -143,7 +145,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should not contain "CREATE TABLE t0"
+      And the output file "/tmp/out.sql" should not contain "CREATE TABLE public.t0"
       And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
       And the file "/tmp/in.sql" should be executed in database "minidb_tmp" without error
 
@@ -153,8 +155,8 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should not contain "CREATE TABLE t0"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3"
+      And the output file "/tmp/out.sql" should not contain "CREATE TABLE public.t0"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: e"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"
@@ -167,7 +169,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t2"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should contain "Table: t2, Attribute: c"
       And the output file "/tmp/out.sql" should contain "Table: t2, Attribute: d"
@@ -180,7 +182,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t1"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t1"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't1'"
       And the output file "/tmp/out.sql" should contain "Table: t1, Attribute: a"
       And the output file "/tmp/out.sql" should contain "Table: t1, Attribute: b"
@@ -193,7 +195,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: e"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"
@@ -206,8 +208,8 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t2" before "CREATE TABLE t3"
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3" before "CREATE VIEW v2"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2" before "CREATE TABLE public.t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3" before "CREATE VIEW public.v2"
       And the output file "/tmp/out.sql" should not contain "CREATE TABLE t1"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
@@ -244,7 +246,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: e"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"
@@ -257,7 +259,7 @@ Feature: Dump minimum database objects that is related to the query
       And the file "/tmp/out.sql" does not exist
       When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
       Then the output file "/tmp/out.sql" should exist
-      And the output file "/tmp/out.sql" should contain "CREATE TABLE t3"
+      And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: e"
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"

--- a/gpMgmt/test/behave/mgmt_utils/minirepro.feature
+++ b/gpMgmt/test/behave/mgmt_utils/minirepro.feature
@@ -210,7 +210,7 @@ Feature: Dump minimum database objects that is related to the query
       Then the output file "/tmp/out.sql" should exist
       And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t2" before "CREATE TABLE public.t3"
       And the output file "/tmp/out.sql" should contain "CREATE TABLE public.t3" before "CREATE VIEW public.v2"
-      And the output file "/tmp/out.sql" should not contain "CREATE TABLE t1"
+      And the output file "/tmp/out.sql" should not contain "CREATE TABLE public.t1"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't2'"
       And the output file "/tmp/out.sql" should contain "WHERE relname = 't3'"
       And the output file "/tmp/out.sql" should contain "Table: t2, Attribute: c"

--- a/gpMgmt/test/behave/mgmt_utils/steps/minirepro_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/minirepro_mgmt_utils.py
@@ -1,5 +1,5 @@
-import os, mmap
-from test.behave_utils.utils import drop_database_if_exists, drop_table_if_exists
+import os, mmap, re
+from test.behave_utils.utils import *
 
 @given('database "{dbname}" does not exist')
 def impl(context, dbname):
@@ -18,7 +18,7 @@ def impl(context, file_name, sql_query):
     if not os.path.exists(file_dir):
         os.makedirs(file_dir)
     with open(file_name, 'w') as query_f:
-            query_f.writelines(sql_query)
+        query_f.writelines(sql_query)
 
 @given('the table "{rel_name}" does not exist in database "{db_name}"')
 def impl(context, rel_name, db_name):
@@ -41,8 +41,8 @@ def impl(context, output_file):
 def impl(context, output_file, str_before, str_after):
     with open(output_file, 'r') as output_f:
         s = mmap.mmap(output_f.fileno(), 0, access=mmap.ACCESS_READ)
-        pos_before = s.find(str_before)
-        pos_after = s.find(str_after)
+        pos_before = s.find(str_before.encode())
+        pos_after = s.find(str_after.encode())
         if pos_before == -1:
             raise Exception('%s not found.' % str_before)
         if pos_after == -1:
@@ -54,14 +54,14 @@ def impl(context, output_file, str_before, str_after):
 def impl(context, output_file, search_str):
     with open(output_file, 'r') as output_f:
         s = mmap.mmap(output_f.fileno(), 0, access=mmap.ACCESS_READ)
-        if s.find(search_str) == -1:
+        if s.find(search_str.encode()) == -1:
             raise Exception('%s not found.' % search_str)
 
 @then('the output file "{output_file}" should not contain "{search_str}"')
 def impl(context, output_file, search_str):
     with open(output_file, 'r') as output_f:
         s = mmap.mmap(output_f.fileno(), 0, access=mmap.ACCESS_READ)
-        if s.find(search_str) != -1:
+        if s.find(search_str.encode()) != -1:
             raise Exception('%s should not exist.' % search_str)
 
 @then('the output file "{output_file}" should be loaded to database "{db_name}" without error')


### PR DESCRIPTION
I'm not sure why minirepro behave tests are not run on our CI and those tests cannot pass. This patch fixes them.

We need to re-enable them on our CI.

Steps to run minirepro's tests locally:

```
cd gpMgmt
make behave flags='--tags=minirepro'
```

