### PR TITLE
[7x]: Analyzedb add materialized views to list of tables to be analyzed

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -51,14 +51,14 @@ NUM_REPORTS_TO_SAVE = 3
 GET_ALL_DATA_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and c.relkind='r'::char
+where c.relnamespace = n.oid and (c.relkind='r'::char or c.relkind = 'm'::char)
 and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 """
 
 GET_VALID_DATA_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename from pg_class c, pg_namespace n where
-c.relnamespace = n.oid and c.oid in (%s) and c.relkind='r'::char and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog') and c.oid not in (select ftrelid from pg_foreign_table)
+c.relnamespace = n.oid and c.oid in (%s) and (c.relkind='r'::char or c.relkind = 'm'::char) and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog') and c.oid not in (select ftrelid from pg_foreign_table)
 """
 
 GET_REQUESTED_AO_DATA_TABLE_INFO_SQL = """
@@ -85,7 +85,7 @@ GET_REQUESTED_LAST_OP_INFO_SQL = """
 GET_ALL_DATA_TABLES_IN_SCHEMA_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and c.relkind='r'::char
+where c.relnamespace = n.oid and (c.relkind='r'::char or c.relkind = 'm'::char)
  and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 and n.nspname = '%s'
@@ -111,7 +111,7 @@ and c.relkind = 'p' and c.relispartition
 GET_REQUESTED_NON_AO_TABLES_SQL = """
 select n.nspname as schemaname, c.relname as tablename
 from pg_class c, pg_namespace n
-where c.relnamespace = n.oid and c.relkind='r'::char
+where c.relnamespace = n.oid and (c.relkind='r'::char or c.relkind = 'm'::char)
 and (c.relnamespace >= 16384 or n.nspname = 'public' or n.nspname = 'pg_catalog')
 and c.oid not in (select ftrelid from pg_foreign_table)
 and c.oid not in (select relid from pg_appendonly)
@@ -553,7 +553,7 @@ class AnalyzeDb(Operation):
         At the same time, parse the requested columns and populate the col_dict.
         If a requested table is partitioned, expand all the leaf partitions.
         """
-        logger.info("Getting and verifying input tables...")
+        logger.info("Getting and verifying input tables and materialized views...")
         if self.single_table:
 
             # Check that the table name given on the command line is schema-qualified.

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1785,6 +1785,8 @@ Feature: Incrementally analyze the database
     Scenario: analyzedb finds materialized views
         Given  a materialized view "public.mv_test_view" exists on table "pg_class"
         And the user runs "analyzedb -a -d incr_analyze"
+        Then analyzedb should print "-public.mv_test_view" to stdout
         And the user runs "analyzedb -a -s public -d incr_analyze"
+        Then analyzedb should print "-public.mv_test_view" to stdout
         And the user runs "analyzedb -a -t public.mv_test_view -d incr_analyze"
         Then analyzedb should print "-public.mv_test_view" to stdout

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1781,3 +1781,18 @@ Feature: Incrementally analyze the database
         And the user executes "CREATE TEMP TABLE spiegelungssätze (c1 int) DISTRIBUTED BY (c1)" with named connection "default"
         When the user runs "analyzedb -a -d special_encoding_db"
         Then analyzedb should return a return code of 0
+
+    Scenario: analyzedb finds materialized views
+        Given  a materialized view "public.mv_test_view" exists on table "pg_class"
+        When the user runs "analyzedb -a -d incr_analyze"
+        Then analyzedb should print "-public.mv_test_view" to stdout
+
+    Scenario: analyzedb finds materialized views when schema is passed
+        Given  a materialized view "public.mv_test_view" exists on table "pg_class"
+        When the user runs "analyzedb -a -s public -d incr_analyze"
+        Then analyzedb should print "-public.mv_test_view" to stdout
+
+    Scenario: analyzedb finds materialized views when materialized view name is passed
+        Given  a materialized view "public.mv_test_view" exists on table "pg_class"
+        When the user runs "analyzedb -a -t public.mv_test_view -d incr_analyze"
+        Then analyzedb should print "-public.mv_test_view" to stdout

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1784,15 +1784,7 @@ Feature: Incrementally analyze the database
 
     Scenario: analyzedb finds materialized views
         Given  a materialized view "public.mv_test_view" exists on table "pg_class"
-        When the user runs "analyzedb -a -d incr_analyze"
-        Then analyzedb should print "-public.mv_test_view" to stdout
-
-    Scenario: analyzedb finds materialized views when schema is passed
-        Given  a materialized view "public.mv_test_view" exists on table "pg_class"
-        When the user runs "analyzedb -a -s public -d incr_analyze"
-        Then analyzedb should print "-public.mv_test_view" to stdout
-
-    Scenario: analyzedb finds materialized views when materialized view name is passed
-        Given  a materialized view "public.mv_test_view" exists on table "pg_class"
-        When the user runs "analyzedb -a -t public.mv_test_view -d incr_analyze"
+        And the user runs "analyzedb -a -d incr_analyze"
+        And the user runs "analyzedb -a -s public -d incr_analyze"
+        And the user runs "analyzedb -a -t public.mv_test_view -d incr_analyze"
         Then analyzedb should print "-public.mv_test_view" to stdout

--- a/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/analyzedb_mgmt_utils.py
@@ -37,7 +37,6 @@ DEFAULT PARTITION default_dates);
 """
 
 
-
 @given('there is a regular "{storage_type}" table "{tablename}" with column name list "{col_name_list}" and column type list "{col_type_list}" in schema "{schemaname}"')
 def impl(context, storage_type, tablename, col_name_list, col_type_list, schemaname):
     schemaname_no_quote = schemaname
@@ -96,6 +95,13 @@ def impl(context, view_name, table_name, schema_name):
 def impl(context, view_name, table_name):
     with closing(dbconn.connect(dbconn.DbURL(dbname=context.dbname))) as conn:
         create_view_on_table(context.conn, view_name, table_name)
+
+
+@given('a materialized view "{view_name}" exists on table "{table_name}"')
+def impl(context, view_name, table_name):
+    with closing(dbconn.connect(dbconn.DbURL(dbname=context.dbname))) as conn:
+        create_materialized_view_on_table_in_schema(context.conn, viewname=view_name,
+                                                     tablename=table_name)
 
 
 @given('"{qualified_table}" appears in the latest state files')
@@ -459,6 +465,14 @@ def create_view_on_table_in_schema(conn, schemaname, tablename, viewname):
 
 def create_view_on_table(conn, viewname, tablename):
     query = "CREATE OR REPLACE VIEW " + viewname + \
+            " AS SELECT * FROM " + tablename
+    dbconn.execSQL(conn, query)
+    conn.commit()
+
+
+def create_materialized_view_on_table_in_schema(conn, tablename, viewname):
+    query = "DROP MATERIALIZED VIEW IF EXISTS " + viewname + ";" \
+            "CREATE MATERIALIZED VIEW " + viewname + \
             " AS SELECT * FROM " + tablename
     dbconn.execSQL(conn, query)
     conn.commit()


### PR DESCRIPTION
Problem:
analyzedb does not include materialized views when preparing the list of tables to be analyzed.
Some refreshed materialized views have poor performance until analyzed.

Solution:
Updated the SQL statements in analyzedb that collect the list of tables to also include relkind='m' from pg_class.
This will add materialized views to the list of hash tables to be analyzed for each run.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
