### PR TITLE
[6X Backport] Fix Differential recovery tablespace issue (#16195)

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -173,6 +173,20 @@ def kill_sequence(pid):
     logandkill(pid, signal.SIGABRT)
 
 
+def get_remote_link_path(path, host):
+    """
+      Function to get symlink target path for a given path on given host.
+      :param  path: path for which symlink has to be found
+      :param  host: host on which the given path is available
+      :return: returns symlink target path
+    """
+
+    cmdStr = """python -c 'import os; print(os.readlink("%s"))'""" % path
+    cmd = Command('get remote link path', cmdStr=cmdStr, ctxt=REMOTE,
+                       remoteHost=host)
+    cmd.run(validateAfter=True)
+    return cmd.get_stdout()
+
 # ---------------Platform Framework--------------------
 
 """ The following platform framework is used to handle any differences between

--- a/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
@@ -46,7 +46,7 @@ def get_tablespace_locations(all_hosts, mirror_data_directory):
     return tablespace_locations
 
 
-def get_segment_tablespace_locations(primary_hostname, primary_port):
+def get_segment_tablespace_oid_locations(primary_hostname, primary_port):
     """
         to get user defined tablespace locations for a specific primary segment. This function is called by
         gprecoverseg --differential to get the tablespace locations by connecting to primary while mirror is down.
@@ -54,9 +54,9 @@ def get_segment_tablespace_locations(primary_hostname, primary_port):
         as parameter and it is called before mirrors are moved to new location by gpmovemirrors.
         :param primary_hostname: string type primary hostname
         :param primary_port: int type primary segment port
-        :return: list of tablespace locations
+        :return: list of tablespace oids and locations
         """
-    sql = "SELECT distinct(tblspc_loc) FROM ( SELECT oid FROM pg_tablespace WHERE spcname NOT IN " \
+    sql = "SELECT distinct(oid),tblspc_loc FROM ( SELECT oid FROM pg_tablespace WHERE spcname NOT IN " \
           "('pg_default', 'pg_global')) AS q,LATERAL gp_tablespace_location(q.oid);"
     try:
         query = RemoteQueryCommand("Get segment tablespace locations", sql, primary_hostname, primary_port)

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from mock import Mock, patch, call
-from gppylib.operations.segment_tablespace_locations import get_tablespace_locations, get_segment_tablespace_locations
+from gppylib.operations.segment_tablespace_locations import get_tablespace_locations, get_segment_tablespace_oid_locations
 from test.unit.gp_unittest import GpTestCase
 
 class GetTablespaceDirTestCase(GpTestCase):
@@ -39,9 +39,9 @@ class GetTablespaceDirTestCase(GpTestCase):
         self.assertEqual(expected, get_tablespace_locations(False, mirror_data_directory))
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.run', side_effect=Exception())
-    def test_get_segment_tablespace_locations_exception(self, mock1):
+    def test_get_segment_tablespace_oid_locations_exception(self, mock1):
         with self.assertRaises(Exception) as ex:
-            get_segment_tablespace_locations('sdw1', 40000)
+            get_segment_tablespace_oid_locations('sdw1', 40000)
         self.assertEqual(0, self.mock_logger.debug.call_count)
         self.assertTrue('Failed to get segment tablespace locations for segment with host sdw1 and port 40000'
                         in str(ex.exception))
@@ -49,8 +49,8 @@ class GetTablespaceDirTestCase(GpTestCase):
     @patch('gppylib.db.catalog.RemoteQueryCommand.__init__', return_value=None)
     @patch('gppylib.db.catalog.RemoteQueryCommand.run')
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results')
-    def test_get_segment_tablespace_locations_success(self, mock1, mock2, mock3):
-        get_segment_tablespace_locations('sdw1', 40000)
+    def test_get_segment_tablespace_oid_locations_success(self, mock1, mock2, mock3):
+        get_segment_tablespace_oid_locations('sdw1', 40000)
         self.assertEqual(1, self.mock_logger.debug.call_count)
         self.assertEqual([call('Successfully got tablespace locations for segment with host sdw1, port 40000')],
                          self.mock_logger.debug.call_args_list)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -478,8 +478,12 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mytblspace1'], ['/data/mytblspace2']])
-    def test_sync_tablespaces_outside_data_dir(self, mock):
+           return_value=[['1111','/data/mytblspace1'], ['2222','/data/mytblspace2']])
+    @patch('gpsegrecovery.get_remote_link_path',
+           return_value='/data/mytblspace1/2')
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_outside_data_dir(self, mock1,mock2,mock3,mock4):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(2, self.mock_rsync_init.call_count)
         self.assertEqual(2, self.mock_rsync_run.call_count)
@@ -488,8 +492,10 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mirror0']])
-    def test_sync_tablespaces_within_data_dir(self, mock):
+           return_value=[['1234','/data/primary0']])
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_within_data_dir(self, mock, mock2,mock3):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(0, self.mock_rsync_init.call_count)
         self.assertEqual(0, self.mock_rsync_run.call_count)
@@ -497,8 +503,12 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                          self.mock_logger.debug.call_args_list)
 
     @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
-           return_value=[['/data/mirror0'], ['/data/mytblspace1']])
-    def test_sync_tablespaces_mix_data_dir(self, mock):
+           return_value=[['1111','/data/primary0'], ['2222','/data/mytblspace1']])
+    @patch('gpsegrecovery.get_remote_link_path',
+           return_value='/data/mytblspace1/2')
+    @patch('os.listdir')
+    @patch('os.symlink')
+    def test_sync_tablespaces_mix_data_dir(self, mock1, mock2, mock3,mock4):
         self.diff_recovery_cmd.sync_tablespaces()
         self.assertEqual(1, self.mock_rsync_init.call_count)
         self.assertEqual(1, self.mock_rsync_run.call_count)

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -11,9 +11,11 @@ from gppylib.commands.base import Command, LOCAL
 from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
 from gppylib.commands.gp import ModifyConfSetting
+from gppylib.db import dbconn
 from gppylib.db.catalog import RemoteQueryCommand
 from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
-from gppylib.operations.segment_tablespace_locations import get_segment_tablespace_locations
+from gppylib.operations.segment_tablespace_locations import get_segment_tablespace_oid_locations
+from gppylib.commands.unix import get_remote_link_path
 
 
 class FullRecovery(Command):
@@ -175,17 +177,25 @@ class DifferentialRecovery(Command):
             "pg_internal.init",
             "internal.auto.conf",
             "pg_dynshmem",
+            # tablespace_map file is generated on call of pg_start_backup on primary, this file contains the target link
+            # of the tablespace like 17264 /tmp/testtblspc/6.if we do not add this in exclude list the file will get
+            # copied to the mirror.and after recovery, if we start the segment, because of the presence of the tablespace_map
+            # file in mirror data_directory, it honors the file and recreates the symlinks as available in the tabespace_map file.
+            # but the problem here is as the tablespace_map file has the content from the primary segment
+            # it will create a wrong symlink for table space.
+            "tablespace_map",
             "pg_notify/*",
             "pg_replslot/*",
             "pg_serial/*",
             "pg_stat_tmp/*",
             "pg_snapshots/*",
             "pg_subtrans/*",
+            "pg_tblspc/*",  # excluding as the tablespace is handled in sync_tablespaces()
             "backups/*",
             "/db_dumps",  # as we exclude during pg_basebackup
             "gpperfmon/data", # as we exclude during pg_basebackup
             "gpperfmon/logs",  # as we exclude during pg_basebackup
-            "/promote",  # Need to check why do we exclude it during pg_basebackup
+            "/promote",  # as we exclude during pg_basebackup
         ]
         """
             Rsync options used:
@@ -269,24 +279,46 @@ class DifferentialRecovery(Command):
             "Syncing tablespaces of dbid {} which are outside of data_dir".format(
                 self.recovery_info.target_segment_dbid))
 
-        # get the tablespace locations
-        tablespaces = get_segment_tablespace_locations(self.recovery_info.source_hostname,
+        # get the oid and tablespace locations
+        tablespaces = get_segment_tablespace_oid_locations(self.recovery_info.source_hostname,
                                                        self.recovery_info.source_port)
 
-        for tablespace_location in tablespaces:
-            if tablespace_location[0].startswith(self.recovery_info.target_datadir):
-                continue
-            # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
-            # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
-            # will copy the last directory and the content of the directory.
-            cmd = Rsync(name="Sync tablespace",
-                        srcFile=os.path.join(tablespace_location[0], ""),
-                        dstFile=tablespace_location[0],
-                        srcHost=self.recovery_info.source_hostname,
-                        progress=True,
-                        checksum=True,
-                        progress_file=self.recovery_info.progress_file)
-            cmd.run(validateAfter=True)
+        # clear all tablespace symlink for target.
+        for file in os.listdir(os.path.join(self.recovery_info.target_datadir,"pg_tblspc")):
+            file_path = os.path.join(self.recovery_info.target_datadir,"pg_tblspc",file)
+            try:
+                if os.path.isfile(file_path) or os.path.islink(file_path):
+                    os.unlink(file_path)
+            except Exception as e:
+                raise Exception("Failed to remove link {} for dbid {} : {}".
+                                format(file_path,self.recovery_info.target_segment_dbid, str(e)))
+
+        for oid, tablespace_location in tablespaces:
+            # tablespace_location is the link path who's symlink is created at $DATADIR/pg_tblspc/{oid}
+            # tablespace_location is the base path in which datafiles are stored in respective dbid directory.
+            targetOidPath = os.path.join(self.recovery_info.target_datadir, "pg_tblspc", str(oid))
+            targetPath = os.path.join(tablespace_location, str(self.recovery_info.target_segment_dbid))
+
+            #if tablespace is not inside the datadir do rsync for copy, if it is inside datadirectory
+            #files would have been copied while doing rsync for data dir.
+            if not tablespace_location.startswith(self.recovery_info.source_datadir):
+                srcOidPath = os.path.join(self.recovery_info.source_datadir, "pg_tblspc", str(oid))
+                srcPath = get_remote_link_path(srcOidPath,self.recovery_info.source_hostname)
+
+                # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
+                # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
+                # will copy the last directory and the content of the directory.
+                cmd = Rsync(name="Sync tablespace",
+                            srcFile=os.path.join(srcPath, ""),
+                            dstFile=targetPath,
+                            srcHost=self.recovery_info.source_hostname,
+                            progress=True,
+                            checksum=True,
+                            progress_file=self.recovery_info.progress_file)
+                cmd.run(validateAfter=True)
+
+            # create tablespace symlink for target data directory.
+            os.symlink(targetPath, targetOidPath)
 
 
 def start_segment(recovery_info, logger, era):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -3,14 +3,15 @@ Feature: gprecoverseg tests
 
     Scenario Outline: <scenario>recovery works with tablespaces
         Given the database is running
-          And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
+          And a tablespace is created with data
          When the user runs "gprecoverseg <args>"
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
+          And the tablespace has valid symlink
           And the database segments are in execute mode
 
         Given another tablespace is created with data
@@ -19,6 +20,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
+          And the tablespace has valid symlink
           And the other tablespace is valid
           And the database segments are in execute mode
       Examples:
@@ -647,13 +649,14 @@ Feature: gprecoverseg tests
   @concourse_cluster
   Scenario Outline: <scenario> incremental recovery works with tablespaces on a multi-host environment
     Given the database is running
-    And a tablespace is created with data
     And user stops all primary processes
     And user can start transactions
+    And a tablespace is created with data
     When the user runs "gprecoverseg <args>"
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the database segments are in execute mode
 
     Given another tablespace is created with data
@@ -662,6 +665,7 @@ Feature: gprecoverseg tests
     And the segments are synchronized
     And verify replication slot internal_wal_replication_slot is available on all the segments
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the other tablespace is valid
     And the database segments are in execute mode
     Examples:
@@ -709,6 +713,7 @@ Feature: gprecoverseg tests
 
         # verify the data
     And the tablespace is valid
+    And the tablespace has valid symlink
     And the row count from table "public.before_host_is_down" in "gptest" is verified against the saved data
     And the row count from table "public.after_host_is_down" in "gptest" is verified against the saved data
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -1,6 +1,6 @@
 import pipes
 import tempfile
-import time
+import os
 
 from behave import given, then
 from pygresql import pg
@@ -9,6 +9,8 @@ from gppylib.db import dbconn
 from gppylib.gparray import GpArray
 from test.behave_utils.utils import run_cmd,wait_for_database_dropped
 from gppylib.commands.base import Command, REMOTE
+from gppylib.commands.unix import get_remote_link_path
+from contextlib import closing
 
 class Tablespace:
     def __init__(self, name):
@@ -71,6 +73,32 @@ class Tablespace:
         if sorted(data) != sorted(self.initial_data):
             raise Exception("Tablespace data is not identically distributed. Expected:\n%r\n but found:\n%r" % (
                 sorted(self.initial_data), sorted(data)))
+
+    def verify_symlink(self, hostname=None, port=0):
+        url = dbconn.DbURL(hostname=hostname, port=port, dbname=self.dbname)
+        gparray = GpArray.initFromCatalog(url)
+        all_segments = gparray.getDbList()
+
+        # fetching oid of available user created tablespaces
+        with closing(dbconn.connect(url, unsetSearchPath=False)) as conn:
+            tblspc_oids = dbconn.execSQL(conn, "SELECT oid FROM pg_tablespace WHERE spcname NOT IN ('pg_default', 'pg_global')").fetchall()
+
+        if not tblspc_oids:
+            return None  # no table space is present
+
+        # keeping a list to check if any of the symlink has duplicate entry
+        tblspc = []
+        for seg in all_segments:
+            for tblspc_oid in tblspc_oids:
+                symlink_path = os.path.join(seg.getSegmentTableSpaceDirectory(), str(tblspc_oid[0]))
+                target_path = get_remote_link_path(symlink_path, seg.getSegmentHostName())
+                segDbId = seg.getSegmentDbId()
+                #checking for duplicate and wrong symlink target
+                if target_path in tblspc or os.path.basename(target_path) != str(segDbId):
+                    raise Exception("tablespac has invalid/duplicate symlink for oid {0} in segment dbid {1}".\
+                        format(str(tblspc_oid[0]),str(segDbId)))
+
+                tblspc.append(target_path)
 
     def verify_for_gpexpand(self, hostname=None, port=0):
         """
@@ -191,6 +219,9 @@ def _create_tablespace_with_data(context, name):
 def impl(context):
     context.tablespaces["outerspace"].verify()
 
+@then('the tablespace has valid symlink')
+def impl(context):
+    context.tablespaces["outerspace"].verify_symlink()
 
 @then('the tablespace is valid on the standby master')
 def impl(context):


### PR DESCRIPTION
cherry-pick: https://github.com/greenplum-db/gpdb/pull/16195
Issue:
1. Post differential recovery more tablespace directory is created on the target segment.

[gpadmin@cdw ~]$ gpssh -f segment_host_list -v
[WARN] Reference default values as $COORDINATOR_DATA_DIRECTORY/gpssh.conf could not be found Using delaybeforesend 0.05 and prompt_validation_timeout 1.0 [Reset ...]
[INFO] login sdw2
[INFO] login sdw1
=> ls /tmp/mytblespace/
ls /tmp/mytblespace/
[sdw2] 4 5 6 7
[sdw1] 2 3 8 9
=> exit

[gpadmin@cdw ~]$ gpssh -f segment_host_list -v
[WARN] Reference default values as $COORDINATOR_DATA_DIRECTORY/gpssh.conf could not be found Using delaybeforesend 0.05 and prompt_validation_timeout 1.0 [Reset ...]
[INFO] login sdw1
[INFO] login sdw2
=> ls /tmp/mytblespace/
ls /tmp/mytblespace/
[sdw1] 2 3 4 5 6 7 8 9
[sdw2] 4 5 6 7
=> exit

Steps to reproduce ( tested on demo cluster):

1. make sure that the cluster is up and running in a balance state.
2. create a tablespace to a location outside of the data directory, add some tables just to have some data.
3. check the content of tablespace location(/tmp/mytblespace/) for all host.
4. pick any of the segments and make primary down and wait until mirror gets promoted.
5. run differential recovery.
6. post recover check the content of tablespace location(/tmp/mytblespace/) for all host. you will find that source tablespace data also getting populated in the target data dir.

RCA: In differential recovery when we perform the step of sync_tablespaces() there is a bug because of that we are copying all the directories under the tablespace location. which was not intended as the get_segment_tablespace returning only base tablespace location, not the segment-specific target link location.

Fix: Updated algorithm to copy tablespaces data directory and updating the symlink. following are the steps
1. First get the tablespace location using get_segment_tablespace_oid_locations()
2. clean all the symlink files available in $DATADIR/pg_tblspc/ for target data directory.
3. loopthrough all oid,location for the segment and do rsync from source to target tablespace dir.
4. create a symlink for target tablespace directory under $DATADIR/pg_tblspc.

2. Post differential recovery tablespace symlink is pointing to the wrong target path(source). for dbid 3: 17270 -> /tmp/testtblspc/3 (primary)
for dbid 6: 17270 -> /tmp/testtblspc/3 (mirror)

Steps to reproduce:
1. make sure that the cluster is up and running in a balanced state.
2. create a tablespace to a location outside of the data directory, add some tables just to have some data.
3. pick any one segment pair and check the symlink for primary and mirror at location $PG_DATA/pg_tblspc/{oid}. you will find that both are pointing to different locations, such as tablespace_location/{dbid}.
4. now make primary down and wait until mirror gets promoted.
5. run differential recovery.
6. post recovery check tablespace symlink for the current primary and mirror, you will find that mirror is pointing to the source tablespace location (tablespace_location/{primary_dbid}) or in other words both are pointing to same location.

RCA: From the code when we are doing sync_pgdata we are copying all data from $PG_DATA/pg_tblspc/ to the target data directory, which is an overwriting symlink in the target data directory. Fix: recreated the symlink in sync_tablespaces() step. Some observation: when we create checkpoint before recovery via pg_start_backup() it creates tablespace_map file along with backup_label that also holds the entries for tablespace symlink. on segment_start it reads symlink from the tablespace_map file and creates the same. As we wanted the fix to be consistent with gp_expand and gpupgrade instead of updating tablespaace_map file we have updated the symlinkthat is the reason in this fix, we have excluded tablespace_map file from the file list.  we have also excluded pg_tblspc dir in sync_pg_data(), this will help us to run rsync for pg_data and tablespace in parallel.

Unit Test:
Updated the unit test impacted by the changes.

Behave test:
extended the current tablespace verification step to verify tablespace to check for the symlink duplication and wrong entry. also updated tablespace to make it little more complex scenario.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
