### PR TITLE
[7x] Use utility mode when connecting to DB with dbconn.Connect()

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -352,7 +352,7 @@ class GpStop:
         """
         try:
             self.dburl = dbconn.DbURL(port=self.port, dbname='template1')
-            with closing(dbconn.connect(self.dburl)) as conn:
+            with closing(dbconn.connect(self.dburl, utility=True)) as conn:
                 pass  # Nothing to do here, as we are only testing the database connection
         except Exception as exc:
             if "the database system is shutting down" in str(exc):

--- a/gpMgmt/doc/gpstop_help
+++ b/gpMgmt/doc/gpstop_help
@@ -118,8 +118,12 @@ OPTIONS
 
 -M smart
  
- Smart shut down. If there are active connections, this command 
- fails with a warning. This is the default shutdown mode.
+ Smart shut down. This is the default shutdown mode. gpstop waits for
+ active user connections to disconnect and then proceeds with the
+ shutdown. If any user connections remain open after the timeout period
+ (or if you interrupt by pressing CTRL-C) gpstop lists the open user
+ connections and prompts whether to continue waiting for connections to
+ finish, or to perform a fast or immediate shutdown.
 
 
 -q


### PR DESCRIPTION
In 6x, The gpdb_pitr job encountered an indefinite delay while attempting to establish a connection with the database. This issue was investigated and resolved by specifying the 'utility=True' parameter when invoking the 'dbconn.Connect()'
function (https://github.com/greenplum-db/gpdb/pull/16413). Incorporating those changes to 7x to keep both versions in sync.

Other changes include moving the doc update in #16239 to 7x.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
