### PR TITLE
Remove unused PartIndexId DXL token from Orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3949,31 +3949,6 @@ CTranslatorDXLToPlStmt::TranslateDXLAppend(
 	GPOS_ASSERT(EdxlappendIndexFirstChild < arity);
 	append->appendplans = NIL;
 
-	// translate table descriptor into a range table entry
-	CDXLPhysicalAppend *phy_append_dxlop =
-		CDXLPhysicalAppend::Cast(append_dxlnode->GetOperator());
-
-	// If this append was create from a DynamicTableScan node in ORCA, it will
-	// contain the table descriptor of the root partitioned table. Add that to
-	// the range table in the PlStmt.
-	if (phy_append_dxlop->GetScanId() != gpos::ulong_max)
-	{
-		GPOS_ASSERT(nullptr != phy_append_dxlop->GetDXLTableDesc());
-
-		// translation context for column mappings in the base relation
-		CDXLTranslateContextBaseTable base_table_context(m_mp);
-
-		(void) ProcessDXLTblDescr(phy_append_dxlop->GetDXLTableDesc(),
-								  &base_table_context);
-
-		OID oid_type =
-			CMDIdGPDB::CastMdid(m_md_accessor->PtMDType<IMDTypeInt4>()->MDId())
-				->Oid();
-		append->join_prune_paramids =
-			TranslateJoinPruneParamids(phy_append_dxlop->GetSelectorIds(),
-									   oid_type, m_dxl_to_plstmt_context);
-	}
-
 	// translate children
 	CDXLTranslateContext child_context(m_mp, false,
 									   output_context->GetColIdToParamIdMap());

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetBooleanNotPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetBooleanNotPlan.xml
@@ -63,7 +63,7 @@
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetBooleanPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetBooleanPlan.xml
@@ -61,7 +61,7 @@
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetCountStarPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetCountStarPlan.xml
@@ -55,7 +55,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="280643"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="1"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetHashJoinOtherKeyPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetHashJoinOtherKeyPlan.xml
@@ -85,7 +85,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="17243"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetHashJoinPartKeyPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetHashJoinPartKeyPlan.xml
@@ -47,7 +47,7 @@
             <dxl:Ident ColId="9" ColName="s.c" TypeMdid="0.23.1.0"/>
           </dxl:Comparison>
         </dxl:HashCondList>
-        <dxl:DynamicTableScan PartIndexId="0">
+        <dxl:DynamicTableScan>
           <dxl:Properties>
             <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetMultiJoinPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetMultiJoinPlan.xml
@@ -112,7 +112,7 @@
                   </dxl:Not>
                 </dxl:Filter>
                 <dxl:OneTimeFilter/>
-                <dxl:DynamicTableScan PartIndexId="0">
+                <dxl:DynamicTableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="8"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetNLJoinOtherKeyPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetNLJoinOtherKeyPlan.xml
@@ -84,7 +84,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="25064"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetNLJoinPartKeyPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetNLJoinPartKeyPlan.xml
@@ -84,7 +84,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="25064"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetPlan.xml
@@ -53,7 +53,7 @@
             <dxl:ConstValue TypeMdid="0.26.1.0" Value="280643"/>
           </dxl:TableValuedFunction>
         </dxl:Result>
-        <dxl:DynamicTableScan PartIndexId="0">
+        <dxl:DynamicTableScan>
           <dxl:Properties>
             <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetPointPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetPointPlan.xml
@@ -64,7 +64,7 @@
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetRangeSelectPlan1.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetRangeSelectPlan1.xml
@@ -101,7 +101,7 @@
               </dxl:TableValuedFunction>
             </dxl:Result>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetRangeSelectPlan2.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetRangeSelectPlan2.xml
@@ -101,7 +101,7 @@
               </dxl:TableValuedFunction>
             </dxl:Result>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/DynamicGetUnionAllOuterJoinPlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/DynamicGetUnionAllOuterJoinPlan.xml
@@ -104,7 +104,7 @@
                 <dxl:ConstValue TypeMdid="0.26.1.0" Value="25064"/>
               </dxl:TableValuedFunction>
             </dxl:Result>
-            <dxl:DynamicTableScan PartIndexId="0">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
               </dxl:Properties>
@@ -295,7 +295,7 @@
                   <dxl:ConstValue TypeMdid="0.26.1.0" Value="25064"/>
                 </dxl:TableValuedFunction>
               </dxl:Result>
-              <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:DynamicTableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/expressiontests/VolatileWithPartTablePlan.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/VolatileWithPartTablePlan.xml
@@ -74,7 +74,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="74764"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="0" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-3.mdp
@@ -421,7 +421,7 @@
                   <dxl:Ident ColId="10" ColName="column2" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:JoinFilter>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-4.mdp
@@ -488,7 +488,7 @@
                     <dxl:Ident ColId="10" ColName="column2" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:JoinFilter>
-                <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
@@ -554,7 +554,7 @@
                     <dxl:Ident ColId="21" ColName="column2" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:JoinFilter>
-                <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddRedistributeBeforeInsert-5.mdp
@@ -332,7 +332,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -754,7 +754,7 @@ select * from x, y where x.i > y.j and y.k = 10;
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:BroadcastMotion>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="391.295690" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
@@ -1933,7 +1933,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+            <dxl:DynamicBitmapTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
@@ -1128,7 +1128,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+            <dxl:DynamicBitmapTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="10454.797600" Rows="1.000000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -1927,7 +1927,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+            <dxl:DynamicBitmapTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -748,7 +748,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicBitmapTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.061218" Rows="1.766098" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
@@ -791,7 +791,7 @@ explain select * from t where b=3;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicBitmapTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="387.962211" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -742,7 +742,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+            <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="6.000706" Rows="1.000000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -429,7 +429,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000136" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
@@ -1717,7 +1717,7 @@
                   </dxl:OpExpr>
                 </dxl:HashExpr>
               </dxl:HashExprList>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.007883" Rows="1000.000000" Width="13"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedNLJ-PartSelector-Subplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedNLJ-PartSelector-Subplan.mdp
@@ -405,7 +405,7 @@ EXPLAIN SELECT pk from partitioned_table WHERE a > (select d from other_table wh
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1293.000962" Rows="3.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -1022,7 +1022,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -1014,7 +1014,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2474,7 +2474,7 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.077000" Rows="10000.000000" Width="12"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DTS-Hetrogeneous-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DTS-Hetrogeneous-Partitioned.mdp
@@ -322,7 +322,7 @@ explain select * from t;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -934,7 +934,7 @@ where a=1 and b>0;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000403" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -777,7 +777,7 @@ see sql/DynamicBitmapIndexScan.sql
               </dxl:TableScan>
             </dxl:NestedLoopJoin>
           </dxl:RedistributeMotion>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="397.966888" Rows="1.000000" Width="1"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -706,7 +706,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="391.295555" Rows="1.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -2429,7 +2429,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000841" Rows="1.774224" Width="88"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -812,7 +812,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.004742" Rows="19.607843" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -487,7 +487,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000159" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
@@ -770,7 +770,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000136" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -924,7 +924,7 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000181" Rows="1.000000" Width="27"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -461,7 +461,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -487,7 +487,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000487" Rows="3.200000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -487,7 +487,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000487" Rows="3.200000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -930,7 +930,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -930,7 +930,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
@@ -660,7 +660,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -698,7 +698,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="2" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="387.966633" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -346,7 +346,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -790,7 +790,7 @@
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="41"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -487,7 +487,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -384,7 +384,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -367,7 +367,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000167" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -626,7 +626,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicBitmapTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="391.295544" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -714,7 +714,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000304" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
@@ -13840,7 +13840,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="475.508350" Rows="716144.000000" Width="196"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -15689,7 +15689,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                         <dxl:Ident ColId="55" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
                       </dxl:Comparison>
                     </dxl:HashCondList>
-                    <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+                    <dxl:DynamicTableScan SelectorIds="0">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="561.720656" Rows="2880896.000000" Width="22"/>
                       </dxl:Properties>
@@ -15771,7 +15771,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
-                        <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+                        <dxl:DynamicTableScan SelectorIds="">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="436.227274" Rows="6437.375227" Width="12"/>
                           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
@@ -401,7 +401,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000193" Rows="1.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
@@ -352,7 +352,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000208" Rows="1.000000" Width="4"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
@@ -367,7 +367,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=44)
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000164" Rows="1.000000" Width="44"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
@@ -4160,7 +4160,7 @@
                     <dxl:Ident ColId="27" ColName="date" TypeMdid="0.1114.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
-                <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:DynamicTableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="100962.368230" Rows="17210680.000000" Width="79"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
@@ -861,7 +861,7 @@ select * from x, y where (x.i > y.j);
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="20"/>
               </dxl:Properties>
@@ -901,7 +901,7 @@ select * from x, y where (x.i > y.j);
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:BroadcastMotion>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="2" SelectorIds="">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000111" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
@@ -906,7 +906,7 @@ WHERE tt.event_ts >= tq.ets AND
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000112" Rows="1.000000" Width="24"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -969,7 +969,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:BroadcastMotion>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000485" Rows="1.000000" Width="33"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
@@ -716,7 +716,7 @@ select count(*) from x10, y10 where (x10.i > y10.j AND x10.j <= y10.i);
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilterExpr>
             </dxl:PartitionSelector>
-            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
+            <dxl:DynamicIndexScan IndexScanDirection="Forward">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="60.009658" Rows="1.000000" Width="82"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
@@ -478,7 +478,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+        <dxl:DynamicBitmapTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.060689" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -514,7 +514,7 @@
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -545,7 +545,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="2" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="397.966656" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
@@ -771,7 +771,7 @@
               </dxl:Cast>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000733" Rows="111.111111" Width="6"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -833,7 +833,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelQuery3WayHashJoinPartTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelQuery3WayHashJoinPartTbl.mdp
@@ -1401,7 +1401,7 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.139333" Rows="20000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -2923,7 +2923,7 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:DynamicTableScan PartIndexId="3" SelectorIds="11">
+            <dxl:DynamicTableScan SelectorIds="11">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.003571" Rows="156.000000" Width="8"/>
               </dxl:Properties>
@@ -2990,7 +2990,7 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000001" Width="8"/>
                   </dxl:Properties>
@@ -3043,7 +3043,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.013988" Rows="610.993500" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -507,7 +507,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:DynamicBitmapTableScan PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicBitmapTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="488.566558" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -479,7 +479,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="0" PrintablePartIndexId="1" SelectorIds="">
+          <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="60.003041" Rows="0.100000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/LargeMultiColumnInList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LargeMultiColumnInList.mdp
@@ -1898,7 +1898,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.004031" Rows="7.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastEq.mdp
@@ -423,7 +423,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastLT.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastLT.mdp
@@ -423,7 +423,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
@@ -294,7 +294,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevelPartLossyCastNEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevelPartLossyCastNEq.mdp
@@ -333,7 +333,7 @@ default subpartition other2
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000143" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
@@ -577,7 +577,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.032819" Rows="799.200000" Width="8"/>
               </dxl:Properties>
@@ -613,7 +613,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:BroadcastMotion>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.031350" Rows="3000.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -4451,7 +4451,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilterExpr>
             </dxl:PartitionSelector>
-            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
+            <dxl:DynamicIndexScan IndexScanDirection="Forward">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="10.434215" Rows="9908.370184" Width="107"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NoPartConstraint-WhenNoDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPartConstraint-WhenNoDefaultPartsAndIndices.mdp
@@ -427,7 +427,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000293" Rows="10.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/NoPartPropagationPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPartPropagationPlan.mdp
@@ -992,7 +992,7 @@
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="39.843750" Rows="10200.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-1.mdp
@@ -562,7 +562,7 @@ select * from P where a = ANY ('{1,2,3}'::integer[]);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-ConstArray-2.mdp
@@ -561,7 +561,7 @@ select * from P where a > ALL ('{1,2,3}'::integer[]);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-IN.mdp
@@ -582,7 +582,7 @@ Select * from P where P.a IN (1,2);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Part-Selection-NOT-IN.mdp
@@ -561,7 +561,7 @@ Select * from P where P.a NOT IN (1,2);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
@@ -3384,7 +3384,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicBitmapTableScan PartIndexId="1">
+          <dxl:DynamicBitmapTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="430.960341" Rows="1201.003300" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
@@ -2339,7 +2339,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicBitmapTableScan PartIndexId="1">
+          <dxl:DynamicBitmapTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="397.982520" Rows="10.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
@@ -639,7 +639,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.035213" Rows="1201.003300" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -2195,7 +2195,7 @@
               <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+          <dxl:DynamicTableScan SelectorIds="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.770000" Rows="100000.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -2694,7 +2694,7 @@
               <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+          <dxl:DynamicTableScan SelectorIds="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="814.633627" Rows="2000523.000000" Width="8"/>
             </dxl:Properties>
@@ -2754,7 +2754,7 @@
                 <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:PartFilterExpr>
-            <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="847.578426" Rows="1479264.726597" Width="12"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
@@ -320,7 +320,7 @@ select * from pt where gender in ( 'F', 'FM');
               </dxl:Or>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayIn.mdp
@@ -353,7 +353,7 @@ WHERE b in (1,2);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AsymmetricRangePredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AsymmetricRangePredicate.mdp
@@ -345,7 +345,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-CSQ-PartKey.mdp
@@ -623,7 +623,7 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
-                        <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+                        <dxl:DynamicTableScan SelectorIds="">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
@@ -689,7 +689,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="32"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
@@ -685,7 +685,7 @@ explain select * from foo where b = 25 or b = 35;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate2.mdp
@@ -691,7 +691,7 @@ explain select * from foo where (b = 25 and a > 10) or b<15;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate3.mdp
@@ -697,7 +697,7 @@ explain select * from foo where (b = 25 and a > 10) or (b<15 and a>5);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
@@ -703,7 +703,7 @@ explain select * from foo where ((b = 25 or b=35) and a > 10) or (b<15 and a>5);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexPredicate5.mdp
@@ -676,7 +676,7 @@ explain select * from foo where (b > 25 and b<35 and a > 10) or (b<15 and a>5);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -420,7 +420,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-NoDefaultPart.mdp
@@ -358,7 +358,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
@@ -435,7 +435,7 @@ select (select h.i from t2) from h where h.j = 1;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1324039.424481" Rows="1000.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE.mdp
@@ -610,7 +610,7 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="20"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DTS.mdp
@@ -417,7 +417,7 @@
               <dxl:ConstValue TypeMdid="0.26.1.0" Value="18534"/>
             </dxl:TableValuedFunction>
           </dxl:Result>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DTSEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DTSEq.mdp
@@ -458,7 +458,7 @@
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
             </dxl:Result>
-            <dxl:DynamicTableScan PartIndexId="0">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DTSLessThan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DTSLessThan.mdp
@@ -507,7 +507,7 @@
                 </dxl:TableValuedFunction>
               </dxl:Result>
             </dxl:Result>
-            <dxl:DynamicTableScan PartIndexId="0">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DateTime.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DateTime.mdp
@@ -654,7 +654,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="157"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelection.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelection.mdp
@@ -424,7 +424,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
@@ -822,7 +822,7 @@
               <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Disjunction.mdp
@@ -400,7 +400,7 @@ WHERE b = 1 or b = 2;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="24"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-EqPredicateWithCastRange.mdp
@@ -401,7 +401,7 @@ explain select * from R where b::int8=5::int8;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ1.mdp
@@ -458,7 +458,7 @@
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
             </dxl:Result>
-            <dxl:DynamicTableScan PartIndexId="0">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ2.mdp
@@ -578,7 +578,7 @@
               <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="0">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
@@ -474,7 +474,7 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
               </dxl:Properties>
@@ -509,7 +509,7 @@
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
           </dxl:RedistributeMotion>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
@@ -671,7 +671,7 @@
               <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+          <dxl:DynamicTableScan SelectorIds="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -716,7 +716,7 @@
                 <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:PartFilterExpr>
-            <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
@@ -602,7 +602,7 @@ select * from s,t where s.b=t.a and t.b=35;
               <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+          <dxl:DynamicTableScan SelectorIds="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="16"/>
             </dxl:Properties>
@@ -668,7 +668,7 @@ select * from s,t where s.b=t.a and t.b=35;
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="16"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
@@ -431,7 +431,7 @@ EXPLAIN SELECT * FROM listfoo WHERE b IS DISTINCT FROM 2;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFNull.mdp
@@ -407,7 +407,7 @@ EXPLAIN SELECT * FROM listfoo WHERE b IS DISTINCT FROM NULL;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IsNotNullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IsNotNullPredicate.mdp
@@ -326,7 +326,7 @@ explain select * from foo where b is not null;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
@@ -524,7 +524,7 @@ explain select * from dd_part_singlecol where a is null and b is null;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1750,7 +1750,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
                   </dxl:IsDistinctFrom>
                 </dxl:Not>
               </dxl:HashCondList>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+              <dxl:DynamicTableScan SelectorIds="0">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                 </dxl:Properties>
@@ -1784,7 +1784,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:DynamicTableScan>
-              <dxl:DynamicTableScan PartIndexId="2" SelectorIds="1">
+              <dxl:DynamicTableScan SelectorIds="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1750,7 +1750,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+              <dxl:DynamicTableScan SelectorIds="0">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                 </dxl:Properties>
@@ -1802,7 +1802,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:DynamicTableScan PartIndexId="2" SelectorIds="1">
+              <dxl:DynamicTableScan SelectorIds="1">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1718,7 +1718,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+            <dxl:DynamicTableScan SelectorIds="0">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
               </dxl:Properties>
@@ -1752,7 +1752,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
-            <dxl:DynamicTableScan PartIndexId="2" SelectorIds="1">
+            <dxl:DynamicTableScan SelectorIds="1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1154,7 +1154,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+            <dxl:DynamicTableScan SelectorIds="0">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
@@ -440,7 +440,7 @@ select * from t2 left outer join t1 on t1.b = t2.d where t1.b is null;
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterNLJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterNLJoin-DPE-IsNull.mdp
@@ -452,7 +452,7 @@ select * from t2 left outer join t1 on t1.b = t2.d where t1.b is null;
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
@@ -449,7 +449,7 @@ select * from foo where b is not null;
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -485,7 +485,7 @@ select * from foo where b is not null;
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -521,7 +521,7 @@ select * from foo where b is not null;
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicTableScan PartIndexId="3" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
             </dxl:Properties>
@@ -560,7 +560,7 @@ select * from foo where b is not null;
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicTableScan PartIndexId="4" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -5000,7 +5000,7 @@
                   <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+              <dxl:DynamicTableScan SelectorIds="0">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="213404.135560" Rows="3367164198.571393" Width="200"/>
                 </dxl:Properties>
@@ -5419,7 +5419,7 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:DynamicTableScan PartIndexId="3" SelectorIds="">
+                <dxl:DynamicTableScan SelectorIds="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.067902" Rows="419.245726" Width="107"/>
                   </dxl:Properties>
@@ -5582,7 +5582,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="579.521120" Rows="11740800.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
@@ -5593,7 +5593,7 @@
                       <dxl:Ident ColId="24" ColName="id" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:DynamicTableScan PartIndexId="0">
+                  <dxl:DynamicTableScan>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="3.404481" Rows="66.628895" Width="19"/>
                     </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -484,7 +484,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NLJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NLJ.mdp
@@ -622,7 +622,7 @@
                 <dxl:ConstValue TypeMdid="0.26.1.0" ConstNull="false" ConstByValue="true" Value="18534"/>
               </dxl:TableValuedFunction>
             </dxl:Result>
-            <dxl:DynamicTableScan PartIndexId="0">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="1000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NonConstSelect.mdp
@@ -621,7 +621,7 @@
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCast.mdp
@@ -401,7 +401,7 @@ explain select * from R where b::int8=5::int8;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastList.mdp
@@ -348,7 +348,7 @@ explain select * from L where b::numeric < 3::numeric;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastMultiLevelList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-PredicateWithCastMultiLevelList.mdp
@@ -324,7 +324,7 @@ EXPLAIN SELECT * FROM pt_complex WHERE  k::numeric = 2::numeric AND j::numeric =
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
@@ -5247,7 +5247,7 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
               </dxl:Cast>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1212816.873037" Rows="766993024.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
@@ -303,7 +303,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Range.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Range.mdp
@@ -371,7 +371,7 @@
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost1.mdp
@@ -1345,7 +1345,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost2.mdp
@@ -1349,7 +1349,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost3.mdp
@@ -1355,7 +1355,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="1546.493903" Rows="120031.800448" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost4.mdp
@@ -1360,7 +1360,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost5.mdp
@@ -1354,7 +1354,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="1422.155163" Rows="100001.500000" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost1.mdp
@@ -1694,7 +1694,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="616.198758" Rows="1.000000" Width="10011"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost2.mdp
@@ -1702,7 +1702,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="801.476281" Rows="3.071793" Width="10011"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost3.mdp
@@ -1745,7 +1745,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost4.mdp
@@ -1096,7 +1096,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="616.206207" Rows="1.000000" Width="10012"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost5.mdp
@@ -1716,7 +1716,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQAll.mdp
@@ -839,7 +839,7 @@
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
-                            <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+                            <dxl:DynamicTableScan SelectorIds="">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
@@ -894,7 +894,7 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
@@ -664,7 +664,7 @@
               <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
@@ -697,7 +697,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
@@ -658,7 +658,7 @@
               <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
             </dxl:Properties>
@@ -691,7 +691,7 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -790,7 +790,7 @@ explain select * from t1 where a = 1 and b in (select b from t2);
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.003902" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-VolatileFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-VolatileFunc.mdp
@@ -439,7 +439,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+        <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
@@ -452,7 +452,7 @@
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                   </dxl:PartFilterExpr>
                 </dxl:PartitionSelector>
-                <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:DynamicTableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="16"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
@@ -442,7 +442,7 @@
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartFilterExpr>
               </dxl:PartitionSelector>
-              <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:DynamicTableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="24"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
@@ -512,7 +512,7 @@
                       </dxl:Comparison>
                     </dxl:PartFilterExpr>
                   </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
+                  <dxl:DynamicTableScan>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="24"/>
                     </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -513,7 +513,7 @@
                     </dxl:And>
                   </dxl:PartFilterExpr>
                 </dxl:PartitionSelector>
-                <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:DynamicTableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="24"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
@@ -436,7 +436,7 @@
                     </dxl:Comparison>
                   </dxl:PartFilterExpr>
                 </dxl:PartitionSelector>
-                <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:DynamicTableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
                   </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -942,7 +942,7 @@
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="432.045094" Rows="100009.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -5320,7 +5320,7 @@
               </dxl:Comparison>
             </dxl:Or>
           </dxl:JoinFilter>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+          <dxl:DynamicTableScan SelectorIds="">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="433.846277" Rows="60175.000000" Width="14"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqInPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqInPartitionRange.mdp
@@ -773,7 +773,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastEqOnEndPartitionRange.mdp
@@ -771,7 +771,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqInPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqInPartitionRange.mdp
@@ -745,7 +745,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTEqOnEndPartitionRange.mdp
@@ -744,7 +744,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTInPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTInPartitionRange.mdp
@@ -732,7 +732,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTOnEndPartitionRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RangePartLossyCastLTOnEndPartitionRange.mdp
@@ -732,7 +732,7 @@
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="16"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -893,7 +893,7 @@
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1" SelectorIds="0">
+          <dxl:DynamicTableScan SelectorIds="0">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
@@ -1236,7 +1236,7 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.006967" Rows="1000.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
@@ -841,7 +841,7 @@ And instead have a plan like
                   <dxl:Ident ColId="19" ColName="d" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+              <dxl:DynamicTableScan SelectorIds="">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000223" Rows="32.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -4472,7 +4472,7 @@
                       <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
-                  <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+                  <dxl:DynamicTableScan SelectorIds="">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="71396.512218" Rows="1536050048.000000" Width="138"/>
                     </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -22052,7 +22052,7 @@ select  i_item_id
                             <dxl:Ident ColId="40" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
                           </dxl:Comparison>
                         </dxl:HashCondList>
-                        <dxl:DynamicTableScan PartIndexId="1">
+                        <dxl:DynamicTableScan>
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="432.807725" Rows="1059928.350347" Width="12"/>
                           </dxl:Properties>
@@ -22177,7 +22177,7 @@ select  i_item_id
                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                   </dxl:PartFilterExpr>
                                 </dxl:PartitionSelector>
-                                <dxl:DynamicTableScan PartIndexId="2">
+                                <dxl:DynamicTableScan>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.099780" Rows="57.241643" Width="8"/>
                                   </dxl:Properties>
@@ -22337,7 +22337,7 @@ select  i_item_id
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                             </dxl:PartFilterExpr>
                           </dxl:PartitionSelector>
-                          <dxl:DynamicTableScan PartIndexId="3">
+                          <dxl:DynamicTableScan>
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="19945.218662" Rows="14745100288.000000" Width="4"/>
                             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4435,7 +4435,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                           </dxl:And>
                         </dxl:PartFilterExpr>
                       </dxl:PartitionSelector>
-                      <dxl:DynamicTableScan PartIndexId="1">
+                      <dxl:DynamicTableScan>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="789102.230675" Rows="246206051.943378" Width="27"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
@@ -372,7 +372,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="18"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
@@ -397,7 +397,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01';
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
@@ -372,7 +372,7 @@ explain select * from TestPartitionFilterCasting where p3 = 1.0;
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="18"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
@@ -391,7 +391,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
@@ -483,7 +483,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
@@ -445,7 +445,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="18"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
@@ -360,7 +360,7 @@ select * from PT where j < 5 and k = 4;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
@@ -352,7 +352,7 @@ explain select * from PT where j < 5 and k = 4;
               </dxl:And>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="24"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
@@ -275,7 +275,7 @@ select * from PT where k < 4;
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-NoDefault.mdp
@@ -270,7 +270,7 @@ select * from PT where k < 4;
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
@@ -303,7 +303,7 @@ select * from PT where j = 5;
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
@@ -301,7 +301,7 @@ select * from PT where j = 5;
               </dxl:Comparison>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-FullScan.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-FullScan.mdp
@@ -294,7 +294,7 @@ select * from pt;
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilterExpr>
           </dxl:PartitionSelector>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="20"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
@@ -383,7 +383,7 @@ select * from pt, t where pt.j = t.t1 and pt.k = t.t2;
               <dxl:Ident ColId="7" ColName="t2" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000215" Rows="30.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
@@ -397,7 +397,7 @@ select * from pt, t where pt.k = t.t1;
               <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000215" Rows="30.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
@@ -397,7 +397,7 @@ select * from pt, t where pt.j = t.t1;
               <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:DynamicTableScan PartIndexId="1">
+          <dxl:DynamicTableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000215" Rows="30.000000" Width="12"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
@@ -1504,7 +1504,7 @@ select * from pt, foo, bar where pt.k=foo.a and pt.j = bar.a;
                 <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:DynamicTableScan PartIndexId="1">
+            <dxl:DynamicTableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000644" Rows="90.000000" Width="12"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/tpch/q1-partitioned.mdp
+++ b/src/backend/gporca/data/dxl/tpch/q1-partitioned.mdp
@@ -889,7 +889,7 @@
                       </dxl:TableValuedFunction>
                     </dxl:Result>
                   </dxl:Result>
-                  <dxl:DynamicTableScan PartIndexId="0">
+                  <dxl:DynamicTableScan>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.179688" Rows="1.000000" Width="56"/>
                     </dxl:Properties>

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalAppend.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalAppend.h
@@ -49,28 +49,11 @@ private:
 	// TODO:  - Apr 12, 2011; find a better name (and comments) for this variable
 	BOOL m_is_zapped = false;
 
-	// scan id from the CPhysicalDynamicTableScan (a.k.a part_index_id)
-	// when m_scan_id != gpos::ulong_max
-	ULONG m_scan_id = gpos::ulong_max;
-
-	// table descr of the root partitioned table (when translated from a CPhysicalDynamicTableScan)
-	CDXLTableDescr *m_dxl_table_descr = nullptr;
-
-	ULongPtrArray *m_selector_ids = nullptr;
-
 public:
 	CDXLPhysicalAppend(const CDXLPhysicalAppend &) = delete;
 
 	// ctor/dtor
 	CDXLPhysicalAppend(CMemoryPool *mp, BOOL fIsTarget, BOOL fIsZapped);
-
-	// ctor for partitioned table scan
-	CDXLPhysicalAppend(CMemoryPool *mp, BOOL fIsTarget, BOOL fIsZapped,
-					   ULONG scan_id, CDXLTableDescr *dxl_table_desc,
-					   ULongPtrArray *selector_ids);
-
-	// dtor
-	~CDXLPhysicalAppend() override;
 
 	// accessors
 	Edxlopid GetDXLOperator() const override;
@@ -78,30 +61,6 @@ public:
 
 	BOOL IsUsedInUpdDel() const;
 	BOOL IsZapped() const;
-
-	CDXLTableDescr *
-	GetDXLTableDesc() const
-	{
-		return m_dxl_table_descr;
-	}
-
-	void
-	SetDXLTableDesc(CDXLTableDescr *dxl_table_desc)
-	{
-		m_dxl_table_descr = dxl_table_desc;
-	}
-
-	ULONG
-	GetScanId() const
-	{
-		return m_scan_id;
-	}
-
-	const ULongPtrArray *
-	GetSelectorIds() const
-	{
-		return m_selector_ids;
-	}
 
 	// serialize operator in DXL format
 	void SerializeToDXL(CXMLSerializer *xml_serializer,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -122,8 +122,6 @@ enum Edxltoken
 
 	EdxltokenDuplicateSensitive,
 
-	EdxltokenPartIndexId,
-	EdxltokenPartIndexIdPrintable,
 	EdxltokenSegmentIdCol,
 
 	EdxltokenScalar,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -397,21 +397,7 @@ CDXLOperatorFactory::MakeDXLAppend(CDXLMemoryManager *dxl_memory_manager,
 												   EdxltokenAppendIsZapped,
 												   EdxltokenPhysicalAppend);
 
-	ULONG scan_id = ExtractConvertAttrValueToUlong(
-		dxl_memory_manager, attrs, EdxltokenPartIndexId,
-		EdxltokenPhysicalAppend, true /* is_optional */,
-		gpos::ulong_max /* default_value */);
-
-	ULongPtrArray *selector_ids = nullptr;
-	if (scan_id != gpos::ulong_max)
-	{
-		selector_ids = ExtractConvertValuesToArray(dxl_memory_manager, attrs,
-												   EdxltokenSelectorIds,
-												   EdxltokenPhysicalAppend);
-	}
-
-	return GPOS_NEW(mp) CDXLPhysicalAppend(mp, is_target, is_zapped, scan_id,
-										   nullptr, selector_ids);
+	return GPOS_NEW(mp) CDXLPhysicalAppend(mp, is_target, is_zapped);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalAppend.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalAppend.cpp
@@ -34,25 +34,6 @@ CDXLPhysicalAppend::CDXLPhysicalAppend(CMemoryPool *mp, BOOL fIsTarget,
 {
 }
 
-CDXLPhysicalAppend::CDXLPhysicalAppend(CMemoryPool *mp, BOOL fIsTarget,
-									   BOOL fIsZapped, ULONG scan_id,
-									   CDXLTableDescr *dxl_table_desc,
-									   ULongPtrArray *selector_ids)
-	: CDXLPhysical(mp),
-	  m_used_in_upd_del(fIsTarget),
-	  m_is_zapped(fIsZapped),
-	  m_scan_id(scan_id),
-	  m_dxl_table_descr(dxl_table_desc),
-	  m_selector_ids(selector_ids)
-{
-}
-
-CDXLPhysicalAppend::~CDXLPhysicalAppend()
-{
-	CRefCount::SafeRelease(m_dxl_table_descr);
-	CRefCount::SafeRelease(m_selector_ids);
-}
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CDXLPhysicalAppend::GetDXLOperator
@@ -132,27 +113,8 @@ CDXLPhysicalAppend::SerializeToDXL(CXMLSerializer *xml_serializer,
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenAppendIsZapped), m_is_zapped);
 
-	if (m_scan_id != gpos::ulong_max)
-	{
-		xml_serializer->AddAttribute(
-			CDXLTokens::GetDXLTokenStr(EdxltokenPartIndexId), m_scan_id);
-
-		CWStringDynamic *serialized_selector_ids =
-			CDXLUtils::Serialize(m_mp, m_selector_ids);
-		xml_serializer->AddAttribute(
-			CDXLTokens::GetDXLTokenStr(EdxltokenSelectorIds),
-			serialized_selector_ids);
-		GPOS_DELETE(serialized_selector_ids);
-	}
 	// serialize properties
 	dxlnode->SerializePropertiesToDXL(xml_serializer);
-
-	if (m_dxl_table_descr != nullptr)
-	{
-		GPOS_ASSERT(m_scan_id != gpos::ulong_max);
-		m_dxl_table_descr->SerializeToDXL(xml_serializer);
-	}
-
 
 	// serialize children
 	dxlnode->SerializeChildrenToDXL(xml_serializer);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerAppend.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerAppend.cpp
@@ -75,16 +75,6 @@ CParseHandlerAppend::SetupInitialHandlers(const Attributes &attrs)
 			m_parse_handler_mgr, this);
 	m_parse_handler_mgr->ActivateParseHandler(proj_list_parse_handler);
 
-	CParseHandlerBase *table_descr_parse_handler = nullptr;
-	if (m_dxl_op->GetScanId() != gpos::ulong_max)
-	{
-		// parse handler for table descriptor
-		table_descr_parse_handler = CParseHandlerFactory::GetParseHandler(
-			m_mp, CDXLTokens::XmlstrToken(EdxltokenTableDescr),
-			m_parse_handler_mgr, this);
-		m_parse_handler_mgr->ActivateParseHandler(table_descr_parse_handler);
-	}
-
 	//parse handler for the properties of the operator
 	CParseHandlerBase *prop_parse_handler =
 		CParseHandlerFactory::GetParseHandler(
@@ -93,11 +83,6 @@ CParseHandlerAppend::SetupInitialHandlers(const Attributes &attrs)
 	m_parse_handler_mgr->ActivateParseHandler(prop_parse_handler);
 
 	this->Append(prop_parse_handler);
-	if (m_dxl_op->GetScanId() != gpos::ulong_max)
-	{
-		GPOS_ASSERT(nullptr != table_descr_parse_handler);
-		this->Append(table_descr_parse_handler);
-	}
 	this->Append(proj_list_parse_handler);
 	this->Append(filter_parse_handler);
 }
@@ -175,15 +160,6 @@ CParseHandlerAppend::EndElement(const XMLCh *const,	 // element_uri,
 	// construct node from the created child nodes
 	CParseHandlerProperties *prop_parse_handler =
 		dynamic_cast<CParseHandlerProperties *>((*this)[child_index++]);
-	if (m_dxl_op->GetScanId() != gpos::ulong_max)
-	{
-		CParseHandlerTableDescr *table_descr_parse_handler =
-			dynamic_cast<CParseHandlerTableDescr *>((*this)[child_index++]);
-		CDXLTableDescr *table_descr =
-			table_descr_parse_handler->GetDXLTableDescr();
-		table_descr->AddRef();
-		m_dxl_op->SetDXLTableDesc(table_descr);
-	}
 	CParseHandlerProjList *proj_list_parse_handler =
 		dynamic_cast<CParseHandlerProjList *>((*this)[child_index++]);
 	CParseHandlerFilter *filter_parse_handler =

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -166,8 +166,6 @@ CDXLTokens::Init(CMemoryPool *mp)
 
 		{EdxltokenDuplicateSensitive, GPOS_WSZ_LIT("DuplicateSensitive")},
 
-		{EdxltokenPartIndexId, GPOS_WSZ_LIT("PartIndexId")},
-		{EdxltokenPartIndexIdPrintable, GPOS_WSZ_LIT("PrintablePartIndexId")},
 		{EdxltokenSegmentIdCol, GPOS_WSZ_LIT("SegmentIdCol")},
 
 		{EdxltokenScalar, GPOS_WSZ_LIT("Scalar")},


### PR DESCRIPTION
This was initially added as part of the GP7 support for partitioned tables in Orca, but is no longer needed after we instead used Dynamic Scans instead of append nodes.
