### PR TITLE
ao/co: Update cost model for Index Only Scans

### DIFF
--- a/src/test/isolation2/input/uao/index_only_scan.source
+++ b/src/test/isolation2/input/uao/index_only_scan.source
@@ -14,9 +14,9 @@ INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(1, 3)i
 1: SET enable_seqscan TO off;
 1: SET optimizer TO off;
 1: BEGIN ISOLATION LEVEL REPEATABLE READ;
-1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@;
+1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@ ORDER BY i;
 -- We should see the rows from Set 1.
-1: SELECT i FROM uao_index_only_scan_@amname@;
+1: SELECT i FROM uao_index_only_scan_@amname@ ORDER BY i;
 
 -- Set 2: Insert and then delete some rows
 INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(4, 6)i;

--- a/src/test/isolation2/output/uao/index_only_scan.source
+++ b/src/test/isolation2/output/uao/index_only_scan.source
@@ -22,7 +22,7 @@ SET
 SET
 1: BEGIN ISOLATION LEVEL REPEATABLE READ;
 BEGIN
-1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@;
+1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@ ORDER BY i;
  QUERY PLAN                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.17..2265.67 rows=86100 width=4)                                                   
@@ -30,7 +30,7 @@ BEGIN
  Optimizer: Postgres query optimizer                                                                                                 
 (3 rows)
 -- We should see the rows from Set 1.
-1: SELECT i FROM uao_index_only_scan_@amname@;
+1: SELECT i FROM uao_index_only_scan_@amname@ ORDER BY i;
  i 
 ---
  1 

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -28,10 +28,13 @@ SET
 2: explain (costs off) select i from test_ao where i = 101;
  QUERY PLAN                                   
 ----------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)           
-   ->  Index Only Scan using test_ao_idx on test_ao 
-         Index Cond: (i = 101)                      
-(4 rows)
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 101)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 101)          
+ Optimizer: Postgres-based planner            
+(6 rows)
 2: select i from test_ao where i = 101;
  i   
 -----
@@ -66,10 +69,13 @@ CREATE INDEX
 2: explain (costs off) select i from test_ao where i = 100;
  QUERY PLAN                                   
 ----------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)           
-   ->  Index Only Scan using test_ao_idx on test_ao 
-         Index Cond: (i = 100)                      
-(4 rows)
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 100)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 100)          
+ Optimizer: Postgres-based planner            
+(6 rows)
 2: select i from test_ao where i = 100;
  i   
 -----

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -1346,6 +1346,7 @@ select count(*) from bfv_index_only_aocs where a < 1000;
 -- scan in enabled for AO tables in ORCA. To prevent retain
 -- the bitmap scan alternative, turn off index only scan.
 set optimizer_enable_indexonlyscan=off;
+set enable_indexonlyscan=off;
 -- Test AO table
 -- Index scan is disabled in AO table, so bitmap scan is the
 -- most performant
@@ -1357,22 +1358,26 @@ insert into ao_tbl select 'abc' from generate_series(1,20) i;
 analyze ao_tbl;
 -- identical plans
 explain select * from ao_tbl where path_hash = 'ABC'; 
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.14..4.17 rows=1 width=4)
-   ->  Index Only Scan using ao_idx on ao_tbl  (cost=0.14..4.16 rows=1 width=4)
-         Index Cond: (path_hash = 'ABC'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.14..8.17 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=4.14..8.15 rows=1 width=4)
+         Recheck Cond: ((path_hash)::text = 'ABC'::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..4.14 rows=1 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 explain select * from ao_tbl where 'ABC' = path_hash;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.14..4.17 rows=1 width=4)
-   ->  Index Only Scan using ao_idx on ao_tbl  (cost=0.14..4.16 rows=1 width=4)
-         Index Cond: (path_hash = 'ABC'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.14..8.17 rows=1 width=4)
+   ->  Bitmap Heap Scan on ao_tbl  (cost=4.14..8.15 rows=1 width=4)
+         Recheck Cond: ('ABC'::text = (path_hash)::text)
+         ->  Bitmap Index Scan on ao_idx  (cost=0.00..4.14 rows=1 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 -- Test AO partition table
 -- Dynamic index scan is disabled in AO table, so dynamic bitmap
@@ -1387,22 +1392,26 @@ insert into part_tbl select 'abc' from generate_series(1,20) i;
 analyze part_tbl;
 -- identical plans
 explain select * from part_tbl where path_hash = 'ABC'; 
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.14..4.17 rows=1 width=4)
-   ->  Index Only Scan using part_tbl_1_prt_other_path_hash_idx on part_tbl_1_prt_other  (cost=0.14..4.16 rows=1 width=4)
-         Index Cond: (path_hash = 'ABC'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.14..8.17 rows=1 width=4)
+   ->  Bitmap Heap Scan on part_tbl_1_prt_other  (cost=4.14..8.15 rows=1 width=4)
+         Recheck Cond: ((path_hash)::text = 'ABC'::text)
+         ->  Bitmap Index Scan on part_tbl_1_prt_other_path_hash_idx  (cost=0.00..4.14 rows=1 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 explain select * from part_tbl where 'ABC' = path_hash; 
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.14..4.17 rows=1 width=4)
-   ->  Index Only Scan using part_tbl_1_prt_other_path_hash_idx on part_tbl_1_prt_other  (cost=0.14..4.16 rows=1 width=4)
-         Index Cond: (path_hash = 'ABC'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.14..8.17 rows=1 width=4)
+   ->  Bitmap Heap Scan on part_tbl_1_prt_other  (cost=4.14..8.15 rows=1 width=4)
+         Recheck Cond: ('ABC'::text = (path_hash)::text)
+         ->  Bitmap Index Scan on part_tbl_1_prt_other_path_hash_idx  (cost=0.00..4.14 rows=1 width=0)
+               Index Cond: ((path_hash)::text = 'ABC'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 -- Test table indexed on two columns
 -- Two indices allow ORCA to generate the bitmap scan alternative

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -1304,6 +1304,7 @@ select count(*) from bfv_index_only_aocs where a < 1000;
 -- scan in enabled for AO tables in ORCA. To prevent retain
 -- the bitmap scan alternative, turn off index only scan.
 set optimizer_enable_indexonlyscan=off;
+set enable_indexonlyscan=off;
 -- Test AO table
 -- Index scan is disabled in AO table, so bitmap scan is the
 -- most performant

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -1860,8 +1860,9 @@ CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appen
 CREATE INDEX ao_index_eda on test_ao_table using btree(e desc nulls last, d,a desc);
 INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
 -- Expected to choose IndexOnlyScan Forward
-explain(costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
-                              QUERY PLAN
+set enable_sort to off; -- help planner generate IndexOnlyScan
+explain (costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
+                              QUERY PLAN                               
 -----------------------------------------------------------------------
  Limit
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -1899,6 +1900,7 @@ select e,d,a from test_ao_table order by e nulls first, d desc, a limit 3;
  0 | sample_text 2 | 2
 (3 rows)
 
+reset enable_sort;
 -- Expected to choose SeqScan with a Sort as IndexOnlyScan doesn't support, since it selects all columns
 explain(costs off) select * from test_ao_table order by e desc nulls last, d, a desc limit 3;
                          QUERY PLAN

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -1861,8 +1861,9 @@ CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appen
 CREATE INDEX ao_index_eda on test_ao_table using btree(e desc nulls last, d,a desc);
 INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
 -- Expected to choose IndexOnlyScan Forward
-explain(costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
-                           QUERY PLAN
+set enable_sort to off; -- help planner generate IndexOnlyScan
+explain (costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
+                           QUERY PLAN                            
 -----------------------------------------------------------------
  Limit
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -1898,6 +1899,7 @@ select e,d,a from test_ao_table order by e nulls first, d desc, a limit 3;
  0 | sample_text 2 | 2
 (3 rows)
 
+reset enable_sort;
 -- Expected to choose SeqScan with a Sort as IndexOnlyScan doesn't support, since it selects all columns
 explain(costs off) select * from test_ao_table order by e desc nulls last, d, a desc limit 3;
                       QUERY PLAN

--- a/src/test/regress/input/uao_dml/ao_covering_index.source
+++ b/src/test/regress/input/uao_dml/ao_covering_index.source
@@ -91,15 +91,14 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtyp
 --
 -- Alter (add/drop) columns to check that the correct data is read from the
 -- physical scan.
-CREATE TABLE test_add_drop_columns_@amname@(a int, aa int, b int, bb int, c int, d int) USING @amname@;
+CREATE TABLE test_add_drop_columns_@amname@(a bigint, aa bigint, b bigint, bb bigint, c bigint, d bigint) USING @amname@;
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN aa;
-INSERT INTO test_add_drop_columns_@amname@ SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+INSERT INTO test_add_drop_columns_@amname@ SELECT i, 2 * i, 3 * i, 4 * i, 5 * i FROM generate_series(1, 100000)i;
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN bb;
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e bigint;
 CREATE INDEX i_test_add_drop_columns_@amname@ ON test_add_drop_columns_@amname@(a, b) INCLUDE (c);
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f bigint;
 VACUUM ANALYZE test_add_drop_columns_@amname@;
-
 -- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_add_drop_columns_@amname@ WHERE a<42 AND b>42;
@@ -230,10 +229,11 @@ SELECT a, b, c FROM test_cover_index_on_pt_@amname@ WHERE b<10;
 CREATE TABLE leaf_part_@amname@(a int, b int, c int) USING @amname@ DISTRIBUTED BY (a);
 -- without explicit index declared on leaf_part_@amname@
 ALTER TABLE test_cover_index_on_pt_@amname@ EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part_@amname@;
-INSERT INTO test_cover_index_on_pt_@amname@ VALUES (2, 2, 2);
+INSERT INTO test_cover_index_on_pt_@amname@ SELECT i, 2, 2 FROM generate_series(1, 10000) i;
 VACUUM ANALYZE test_cover_index_on_pt_@amname@;
 
 -- KEYS: [a]    INCLUDED: [b]
+
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
 
@@ -250,9 +250,9 @@ SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
 --
 -- Check that different index types can be used with cover indexes.
 -- Note: brin, hash, and spgist do not suport included columns.
-CREATE TABLE test_index_types_@amname@(a box, b int, c int) USING @amname@ DISTRIBUTED BY (b);
-INSERT INTO test_index_types_@amname@ VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
-INSERT INTO test_index_types_@amname@ VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE TABLE test_index_types_@amname@(a box, b bigint, c bigint) USING @amname@ DISTRIBUTED BY (b);
+INSERT INTO test_index_types_@amname@ SELECT '(2.0,2.0,0.0,0.0)', 2, 2 FROM generate_series(1, 20000);
+INSERT INTO test_index_types_@amname@ SELECT '(1.0,1.0,3.0,3.0)', 3, 3 FROM generate_series(1, 20000);
 CREATE INDEX i_test_index_types_@amname@ ON test_index_types_@amname@ USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types_@amname@;
 
@@ -260,7 +260,6 @@ VACUUM ANALYZE test_index_types_@amname@;
 -- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types_@amname@ WHERE a<@ box '(0,0,3,3)';
-
 -- 8) Test partial indexes
 --
 -- Check that partial cover indexes may be used

--- a/src/test/regress/output/uao_dml/ao_covering_index.source
+++ b/src/test/regress/output/uao_dml/ao_covering_index.source
@@ -154,15 +154,15 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtyp
 --
 -- Alter (add/drop) columns to check that the correct data is read from the
 -- physical scan.
-CREATE TABLE test_add_drop_columns_@amname@(a int, aa int, b int, bb int, c int, d int) USING @amname@;
+CREATE TABLE test_add_drop_columns_@amname@(a bigint, aa bigint, b bigint, bb bigint, c bigint, d bigint) USING @amname@;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN aa;
-INSERT INTO test_add_drop_columns_@amname@ SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+INSERT INTO test_add_drop_columns_@amname@ SELECT i, 2 * i, 3 * i, 4 * i, 5 * i FROM generate_series(1, 100000)i;
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN bb;
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e bigint;
 CREATE INDEX i_test_add_drop_columns_@amname@ ON test_add_drop_columns_@amname@(a, b) INCLUDE (c);
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f bigint;
 VACUUM ANALYZE test_add_drop_columns_@amname@;
 -- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
@@ -314,11 +314,12 @@ SELECT b FROM test_select_best_cover_@amname@ WHERE a>42 AND b>42;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Index Only Scan using i_test_select_best_cover_ab_@amname@ on test_select_best_cover_@amname@ (actual rows=25 loops=1)
-         Index Cond: ((a > 42) AND (b > 42))
+   ->  Index Only Scan using i_test_select_best_cover_a_bc_@amname@ on test_select_best_cover_@amname@ (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
          Heap Fetches: 0
- Optimizer: Postgres query optimizer
-(5 rows)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 -- KEYS: [a]    INCLUDED: []
 -- KEYS: [a]    INCLUDED: [b]
@@ -445,22 +446,22 @@ SELECT a, b, c FROM test_cover_index_on_pt_@amname@ WHERE b<10;
 CREATE TABLE leaf_part_@amname@(a int, b int, c int) USING @amname@ DISTRIBUTED BY (a);
 -- without explicit index declared on leaf_part_@amname@
 ALTER TABLE test_cover_index_on_pt_@amname@ EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part_@amname@;
-INSERT INTO test_cover_index_on_pt_@amname@ VALUES (2, 2, 2);
+INSERT INTO test_cover_index_on_pt_@amname@ SELECT i, 2, 2 FROM generate_series(1, 10000) i;
 VACUUM ANALYZE test_cover_index_on_pt_@amname@;
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
-   ->  Append (actual rows=3 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=12 loops=1)
+   ->  Append (actual rows=7 loops=1)
          ->  Index Only Scan using test_cover_index_on_pt_@amname@_1_prt_1_a_b_idx on test_cover_index_on_pt_@amname@_1_prt_1 (actual rows=1 loops=1)
                Index Cond: (a < 10)
                Heap Fetches: 0
          ->  Index Only Scan using test_cover_index_on_pt_@amname@_1_prt_2_a_b_idx on test_cover_index_on_pt_@amname@_1_prt_2 (actual rows=1 loops=1)
                Index Cond: (a < 10)
                Heap Fetches: 0
-         ->  Index Only Scan using leaf_part_@amname@_a_b_idx on test_cover_index_on_pt_@amname@_1_prt_3 (actual rows=1 loops=1)
+         ->  Index Only Scan using leaf_part_@amname@_a_b_idx on test_cover_index_on_pt_@amname@_1_prt_3 (actual rows=5 loops=1)
                Index Cond: (a < 10)
                Heap Fetches: 0
          ->  Index Only Scan using test_cover_index_on_pt_@amname@_1_prt_4_a_b_idx on test_cover_index_on_pt_@amname@_1_prt_4 (actual rows=1 loops=1)
@@ -478,39 +479,40 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
-   ->  Append (actual rows=3 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=12 loops=1)
+   ->  Append (actual rows=7 loops=1)
          ->  Seq Scan on test_cover_index_on_pt_@amname@_1_prt_1 (actual rows=1 loops=1)
                Filter: (a < 10)
                Rows Removed by Filter: 1
          ->  Seq Scan on test_cover_index_on_pt_@amname@_1_prt_2 (actual rows=1 loops=1)
                Filter: (a < 10)
                Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_@amname@_1_prt_3 (actual rows=1 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_@amname@_1_prt_3 (actual rows=5 loops=1)
                Filter: (a < 10)
+               Rows Removed by Filter: 3363
          ->  Seq Scan on test_cover_index_on_pt_@amname@_1_prt_4 (actual rows=1 loops=1)
                Filter: (a < 10)
                Rows Removed by Filter: 1
- Optimizer: Postgres query optimizer
-(14 rows)
+ Optimizer: Postgres-based planner
+(15 rows)
 
 -- Test various index types
 --
 -- Check that different index types can be used with cover indexes.
 -- Note: brin, hash, and spgist do not suport included columns.
-CREATE TABLE test_index_types_@amname@(a box, b int, c int) USING @amname@ DISTRIBUTED BY (b);
-INSERT INTO test_index_types_@amname@ VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
-INSERT INTO test_index_types_@amname@ VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE TABLE test_index_types_@amname@(a box, b bigint, c bigint) USING @amname@ DISTRIBUTED BY (b);
+INSERT INTO test_index_types_@amname@ SELECT '(2.0,2.0,0.0,0.0)', 2, 2 FROM generate_series(1, 20000);
+INSERT INTO test_index_types_@amname@ SELECT '(1.0,1.0,3.0,3.0)', 3, 3 FROM generate_series(1, 20000);
 CREATE INDEX i_test_index_types_@amname@ ON test_index_types_@amname@ USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types_@amname@;
 -- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types_@amname@ WHERE a<@ box '(0,0,3,3)';
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-   ->  Index Only Scan using i_test_index_types_@amname@ on test_index_types_@amname@ (actual rows=2 loops=1)
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=40000 loops=1)
+   ->  Index Only Scan using i_test_index_types_@amname@ on test_index_types_@amname@ (actual rows=40000 loops=1)
          Index Cond: (a <@ '(3,3),(0,0)'::box)
          Heap Fetches: 0
  Optimizer: Postgres query optimizer

--- a/src/test/regress/output/uao_dml/ao_covering_index_optimizer.source
+++ b/src/test/regress/output/uao_dml/ao_covering_index_optimizer.source
@@ -153,15 +153,15 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtyp
 --
 -- Alter (add/drop) columns to check that the correct data is read from the
 -- physical scan.
-CREATE TABLE test_add_drop_columns_@amname@(a int, aa int, b int, bb int, c int, d int) USING @amname@;
+CREATE TABLE test_add_drop_columns_@amname@(a bigint, aa bigint, b bigint, bb bigint, c bigint, d bigint) USING @amname@;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN aa;
-INSERT INTO test_add_drop_columns_@amname@ SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+INSERT INTO test_add_drop_columns_@amname@ SELECT i, 2 * i, 3 * i, 4 * i, 5 * i FROM generate_series(1, 100000)i;
 ALTER TABLE test_add_drop_columns_@amname@ DROP COLUMN bb;
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN e bigint;
 CREATE INDEX i_test_add_drop_columns_@amname@ ON test_add_drop_columns_@amname@(a, b) INCLUDE (c);
-ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f int;
+ALTER TABLE test_add_drop_columns_@amname@ ADD COLUMN f bigint;
 VACUUM ANALYZE test_add_drop_columns_@amname@;
 -- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
@@ -194,11 +194,13 @@ SELECT a, b, c, d, e FROM test_add_drop_columns_@amname@ WHERE a<42 AND b>42 AND
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_add_drop_columns_@amname@ (actual rows=8 loops=1)
-         Filter: ((a < 42) AND (b > 42) AND (c > 42) AND (e IS NULL))
-         Rows Removed by Filter: 30
- Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+   ->  Bitmap Heap Scan on test_add_drop_columns_@amname@ (actual rows=8 loops=1)
+         Recheck Cond: ((a < 42) AND (b > 42))
+         Filter: ((e IS NULL) AND (c > 42))
+         ->  Bitmap Index Scan on i_test_add_drop_columns_@amname@ (actual rows=8 loops=1)
+               Index Cond: ((a < 42) AND (b > 42))
+ Optimizer: GPORCA
+(7 rows)
 
 -- Test various table types (e.g. AO/AOCO/replicated)
 --
@@ -414,15 +416,15 @@ SELECT a, b, c FROM test_cover_index_on_pt_@amname@ WHERE b<10;
 CREATE TABLE leaf_part_@amname@(a int, b int, c int) USING @amname@ DISTRIBUTED BY (a);
 -- without explicit index declared on leaf_part_@amname@
 ALTER TABLE test_cover_index_on_pt_@amname@ EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part_@amname@;
-INSERT INTO test_cover_index_on_pt_@amname@ VALUES (2, 2, 2);
+INSERT INTO test_cover_index_on_pt_@amname@ SELECT i, 2, 2 FROM generate_series(1, 10000) i;
 VACUUM ANALYZE test_cover_index_on_pt_@amname@;
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
-   ->  Dynamic Index Only Scan on i_test_cover_index_scan_on_partition_table_@amname@ on test_cover_index_on_pt_@amname@ (actual rows=3 loops=1)
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=12 loops=1)
+   ->  Dynamic Index Only Scan on i_test_cover_index_scan_on_partition_table_@amname@ on test_cover_index_on_pt_@amname@ (actual rows=7 loops=1)
          Index Cond: (a < 10)
          Heap Fetches: 0
          Number of partitions to scan: 4 (out of 4)
@@ -437,10 +439,10 @@ VACUUM ANALYZE test_cover_index_on_pt_@amname@;
 -- ORCA_FEATURE_NOT_SUPPORTED: partial dynamic index scan
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
-   ->  Dynamic Seq Scan on test_cover_index_on_pt_@amname@ (actual rows=3 loops=1)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=12 loops=1)
+   ->  Dynamic Seq Scan on test_cover_index_on_pt_@amname@ (actual rows=7 loops=1)
          Number of partitions to scan: 4 (out of 4)
          Filter: (a < 10)
          Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
@@ -451,24 +453,22 @@ SELECT a, b FROM test_cover_index_on_pt_@amname@ WHERE a<10;
 --
 -- Check that different index types can be used with cover indexes.
 -- Note: brin, hash, and spgist do not suport included columns.
-CREATE TABLE test_index_types_@amname@(a box, b int, c int) USING @amname@ DISTRIBUTED BY (b);
-INSERT INTO test_index_types_@amname@ VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
-INSERT INTO test_index_types_@amname@ VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE TABLE test_index_types_@amname@(a box, b bigint, c bigint) USING @amname@ DISTRIBUTED BY (b);
+INSERT INTO test_index_types_@amname@ SELECT '(2.0,2.0,0.0,0.0)', 2, 2 FROM generate_series(1, 20000);
+INSERT INTO test_index_types_@amname@ SELECT '(1.0,1.0,3.0,3.0)', 3, 3 FROM generate_series(1, 20000);
 CREATE INDEX i_test_index_types_@amname@ ON test_index_types_@amname@ USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types_@amname@;
 -- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types_@amname@ WHERE a<@ box '(0,0,3,3)';
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-   ->  Bitmap Heap Scan on test_index_types_@amname@ (actual rows=2 loops=1)
-         Recheck Cond: (a <@ '(3,3),(0,0)'::box)
-         ->  Bitmap Index Scan on i_test_index_types_@amname@ (actual rows=2 loops=1)
-               Index Cond: (a <@ '(3,3),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=40000 loops=1)
+   ->  Seq Scan on test_index_types_@amname@ (actual rows=40000 loops=1)
+         Filter: (a <@ '(3,3),(0,0)'::box)
+ Optimizer: GPORCA
+(4 rows)
 
 -- 8) Test partial indexes
 --

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -580,6 +580,7 @@ select count(*) from bfv_index_only_aocs where a < 1000;
 -- scan in enabled for AO tables in ORCA. To prevent retain
 -- the bitmap scan alternative, turn off index only scan.
 set optimizer_enable_indexonlyscan=off;
+set enable_indexonlyscan=off;
 -- Test AO table
 -- Index scan is disabled in AO table, so bitmap scan is the
 -- most performant

--- a/src/test/regress/sql/qp_indexscan.sql
+++ b/src/test/regress/sql/qp_indexscan.sql
@@ -352,11 +352,14 @@ CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appen
 CREATE INDEX ao_index_eda on test_ao_table using btree(e desc nulls last, d,a desc);
 INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
 -- Expected to choose IndexOnlyScan Forward
-explain(costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
+set enable_sort to off; -- help planner generate IndexOnlyScan
+explain (costs off) select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
 select e,d,a from test_ao_table order by e desc nulls last, d, a desc limit 3;
 -- Expected to choose IndexOnlyScan Backward
 explain(costs off) select e,d,a from test_ao_table order by e nulls first, d desc, a limit 3;
 select e,d,a from test_ao_table order by e nulls first, d desc, a limit 3;
+reset enable_sort;
+
 -- Expected to choose SeqScan with a Sort as IndexOnlyScan doesn't support, since it selects all columns
 explain(costs off) select * from test_ao_table order by e desc nulls last, d, a desc limit 3;
 select * from test_ao_table order by e desc nulls last, d, a desc limit 3;


### PR DESCRIPTION
This resolves to an extent #15914.

In this commit, we take into account the heavy cost of performing
repeated sysscans (begin -> getnext -> end) for each index tuple in
Index Only Scans on AO/CO block directory and visimap tables.

This massive overhead is not felt when the index is highly correlated.
We take that into account as well and interpolate our costs accordingly.

Since the block directory and visimap relstats aren't available on the
QD, we estimate the block directory relstats from the parent rel's
relstats and consider the visimap to be empty. This is an area that can
be definitely improved upon.

Testing reveals that with this patch, we are no longer wrongfully
choosing an Index Only Scan on un-correlated indexes created on lineitem
for TPC-H Q4, Q17, Q18, Q20, Q21, which was causing statement timeouts.

Further this patch is able to pick the Index Only Scan on correlated
indexes on lineitem in TPC-H.

A known limitation of this patch is that we still might end up choosing
an IndexOnlyScan for very narrow (1-col) tables, in spite of penalizing
the un-correlated case. This is also an area for improvement.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_ioscan_costing
