### PR TITLE
Add a new GUC optimizer_dpe_histogram_scale_factor

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -172,6 +172,11 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 GPOS_WSZ_LIT(
 		 "Enable stats derivation of partitioned tables with dynamic partition elimination.")},
 
+	{EopttraceDPEHistogramScaleFactor, &optimizer_dpe_histogram_scale_factor,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT(
+		 "Enable calculating scale factor based on histogram for dynamic sequential scan.")},
+
 	{EopttraceEnumeratePlans, &optimizer_enumerate_plans,
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT("Enable plan enumeration.")},

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -250,6 +250,10 @@ enum EOptTraceFlag
 
 	// Use experimental cost model
 	EopttraceExperimentalCostModel = 104009,
+
+	// Calculating scale factor based on histogram for dynamic sequential scan
+	EopttraceDPEHistogramScaleFactor = 104010,
+
 	///////////////////////////////////////////////////////
 	/////////// constant expression evaluator flags ///////
 	///////////////////////////////////////////////////////

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1113,6 +1113,16 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 	IStatistics *left_semi_join_stats = base_table_stats->CalcLSJoinStats(
 		mp, part_selector_stats, join_preds_stats);
 
+	if (GPOS_FTRACE(EopttraceDPEHistogramScaleFactor) &&
+		left_semi_join_stats->Rows() == base_table_stats->Rows())
+	{
+		left_semi_join_stats->Release();
+		CJoinStatsProcessor::SetComputeScaleFactorFromHistogramBuckets(true);
+		left_semi_join_stats = base_table_stats->CalcLSJoinStats(
+			mp, part_selector_stats, join_preds_stats);
+		CJoinStatsProcessor::SetComputeScaleFactorFromHistogramBuckets(false);
+	}
+
 	if (nullptr != unsupported_pred_stats)
 	{
 		// apply the unsupported join filters as a filter on top of the join results.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -353,6 +353,7 @@ double		optimizer_damping_factor_join;
 double		optimizer_damping_factor_groupby;
 bool		optimizer_dpe_stats;
 bool		optimizer_enable_derive_stats_all_groups;
+bool		optimizer_dpe_histogram_scale_factor;
 
 /* Costing related GUCs used by the Optimizer */
 int			optimizer_segments;
@@ -2024,6 +2025,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_dpe_stats,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_dpe_histogram_scale_factor", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enable calculating scale factor based on histogram for dynamic sequential scan."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_dpe_histogram_scale_factor,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -530,6 +530,7 @@ extern double optimizer_damping_factor_join;
 extern double optimizer_damping_factor_groupby;
 extern bool optimizer_dpe_stats;
 extern bool optimizer_enable_derive_stats_all_groups;
+extern bool optimizer_dpe_histogram_scale_factor;
 
 /* Costing or tuning related GUCs used by the Optimizer */
 extern int optimizer_segments;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -339,6 +339,7 @@
 		"optimizer_damping_factor_groupby",
 		"optimizer_damping_factor_join",
 		"optimizer_discard_redistribute_hashjoin",
+		"optimizer_dpe_histogram_scale_factor",
 		"optimizer_dpe_stats",
 		"optimizer_enable_assert_maxonerow",
 		"optimizer_enable_associativity",


### PR DESCRIPTION
Background:
Observed that in 7X that the execution of TPCDS query 154 was taking around ~9 seconds while in 6X the execution time was around ~1 seconds. This test was done with number of segments as 64. On observing the plans for 6X and 7X, found that for a particular partitioned table store_sales the dynamic partition selector was not present in the plan in 7X. Due to the absence of the partition selector, all the partitions of store_sales were scanned which made the execution time of the query higher on 7X.

RCA:
On observing the memo of query 154 in 7X found that the plan containing the partition selector is generated but its not getting selected because of higher cost than the bad plan (the plan without PS) which is costed lower. On comparing the memo with 6X, found that the good plan ie with partition selector is costed similar in 6X and 7X while the bad plan ie without partition selector was costed more in 6X compared to 7X. In 6X to do static partition pruning a partition selector is generated on top of Dynamic Sequential Scan which was adding an extra cost to the bad plan. But in 7X we do the static partition pruning at preprocessing stage due to which a partition selector for static pruning is not generated on top of Dynamic Sequential Scan. Due to the absence of static partition selector in 7X, on increasing the number of segments the bad plan is costed lower than the good plan.

Fix:
This issue can be fixed either by adding an extra physical operator for static partition pruning in 7X similar to 6X to account for the extra cost but it will not be a good fix since the static pruning is done at preprocessing stage.  The approach taken in this PR is to fix the cardinality estimation of Dynamic Sequential Scan with a partition selector. Observed both in 6X and 7X for query 154 that even after having a partition selector the estimated rows for Dynamic Sequential scan in the plan is equal to total number of rows in the store_sales table. There was no reduction in cardinality. The cardinality is calculated as (Number of rows in table A * Number of rows in table B)/ scale_factor. This scale factor is currently calculated using the formula max(NDV(A),NDV(B)). But the above formula for cardinality estimation works good when the data distribution is uniform. There is one more method used within ORCA to calculate the scale_factor by using the resultant histogram generated by joining histograms. So the fix is to use the scale factor based on NDV's for cardinality estimation as it works fine in most of the cases. But if the scale factor using NDV's is not able to reduce the cardinality due to non uniform distribution of data then calculate the scale factor using histograms for cardinality estimation.  Also introduced a GUC
optimizer_dpe_histogram_scale_factor to calculate the scale factor using histograms while calulating the cardinality of a dynamic sequential scan when the data distribution is non uniform. Default value of the GUC is set to true.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
