### PR TITLE
docs - queries on hnsw indexes fall back to planner

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/pgvector/pgvector.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/pgvector/pgvector.html.md
@@ -305,7 +305,7 @@ CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 1000
 
 `pgvector` for Greenplum Database has the following limitations:
 
-- The Greenplum Query Optimizer (GPORCA) does not support vector indexes.
+- The Greenplum Query Optimizer (GPORCA) does not support `ivfflat` and `hnsw` vector indexes. Queries on tables that utilize these index types fall back to the Postgres-based Planner.
 - Append-optimized tables cannot use vector indexes.
 - The size of (a vector) index can be larger than the table size.
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/16384.  gporca doesn't support hnsw pgvector index types.
