### PR TITLE
docs - gporca supports indexonlyscan on gist for some ops

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -52,7 +52,6 @@ These features are unsupported when GPORCA is enabled \(the default\):
 
     - Index scan on AO tables
     - Partial dynamic index scan
-    - Index-only scan on GIST indexes
     - Partial indexes
     - Forward and backward dynamic index and dynamic index-only scans on partitioned tables
     - Indexed expressions (an index defined as an expression based on one or more columns of the table)

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2392,7 +2392,7 @@ When GPORCA is enabled \(the default\) and this configuration parameter is `true
 
 ## <a id="optimizer_enable_indexonlyscan"></a>optimizer\_enable\_indexonlyscan 
 
-When GPORCA is enabled \(the default\) and this parameter is `true` \(the default\), GPORCA can generate index-only scan plan types for B-tree indexes. GPORCA accesses the index values only, not the data blocks of the relation. This provides a query execution performance improvement, particularly when the table has been vacuumed, has wide columns, and GPORCA does not need to fetch any data blocks \(for example, they are visible\).
+When GPORCA is enabled \(the default\) and this parameter is `true` \(the default\), GPORCA can generate index-only scan plan types for B-tree indexes and any index type that contains all of the used columns inside the index. (GiST indexes support index-only scans for some operator classes but not others.) GPORCA accesses the index values only, not the data blocks of the relation. This provides a query execution performance improvement, particularly when the table has been vacuumed, has wide columns, and GPORCA does not need to fetch any data blocks \(for example, they are visible\).
 
 When deactivated \(`false`\), GPORCA does not generate index-only scan plan types.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2392,7 +2392,7 @@ When GPORCA is enabled \(the default\) and this configuration parameter is `true
 
 ## <a id="optimizer_enable_indexonlyscan"></a>optimizer\_enable\_indexonlyscan 
 
-When GPORCA is enabled \(the default\) and this parameter is `true` \(the default\), GPORCA can generate index-only scan plan types for B-tree indexes and any index type that contains all of the used columns inside the index. (GiST indexes support index-only scans for some operator classes but not others.) GPORCA accesses the index values only, not the data blocks of the relation. This provides a query execution performance improvement, particularly when the table has been vacuumed, has wide columns, and GPORCA does not need to fetch any data blocks \(for example, they are visible\).
+When GPORCA is enabled \(the default\) and this parameter is `true` \(the default\), GPORCA can generate index-only scan plan types for B-tree indexes and any index type that contains all of the columns used by the query inside the index. (GiST indexes support index-only scans for some operator classes but not others.) GPORCA accesses the index values only, not the data blocks of the relation. This provides a query execution performance improvement, particularly when the table has been vacuumed, has wide columns, and GPORCA does not need to fetch any data blocks \(for example, they are visible\).
 
 When deactivated \(`false`\), GPORCA does not generate index-only scan plan types.
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/16260.

remove an item from unsupported features, update the optimizer_enable_indexonlyscan guc description.  didn't seem to be other doc areas that discussed this.