### PR TITLE
Improve gp_toolkit.gp_check_orphaned_files for more reliable results

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -73,3 +73,4 @@ installcheck:
 	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
 	$(MAKE) -C gp_sparse_vector installcheck
 	$(MAKE) -C gp_exttable_fdw installcheck
+	$(MAKE) -C gp_toolkit installcheck

--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -8,6 +8,7 @@ OBJS = resgroup-dummy.o
 endif
 
 REGRESS = resource_manager_restore_to_none gp_toolkit resource_manager_switch_to_queue gp_toolkit_resqueue gp_toolkit_ao_funcs
+EXTRA_REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = gp_toolkit
-DATA = gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql
+DATA = gp_toolkit--1.1--1.2.sql gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql
 MODULE_big = gp_toolkit
 ifeq ($(PORTNAME),linux)
 OBJS = resgroup.o

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit.out
@@ -414,7 +414,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
-select * from gp_toolkit.gp_param_settings_seg_value_diffs;
+-- primary_conninfo can be different due to failovers in isolation2 tests
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
  psdname | psdvalue | psdcount 
 ---------+----------+----------
 (0 rows)

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
@@ -1,4 +1,5 @@
 -- Tests for the functions and views in gp_toolkit
+-- gp_resource_manager=none need to be set for this test to run as expected.
 -- Create an empty database to test in, because some of the gp_toolkit views
 -- are really slow, when there are a lot of objects in the database.
 create database toolkit_testdb;
@@ -417,7 +418,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
-select * from gp_toolkit.gp_param_settings_seg_value_diffs;
+-- primary_conninfo can be different due to failovers in isolation2 tests
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
  psdname | psdvalue | psdcount 
 ---------+----------+----------
 (0 rows)
@@ -666,9 +668,3 @@ reset session authorization;
 drop database toolkit_testdb;
 drop role toolkit_user1;
 drop role toolkit_admin;
--- Enable resource queue for the next test gp_toolkit_resqueue.
--- Have to do it here because the required server restart would kill existing test connections. But kill completed ones is OK.
-\! echo $?
-0
-\! echo $?
-0

--- a/gpcontrib/gp_toolkit/expected/resource_manager_restore_to_none.out
+++ b/gpcontrib/gp_toolkit/expected/resource_manager_restore_to_none.out
@@ -1,0 +1,36 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v none
+20230110:23:11:33:399571 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v none'
+-- end_ignore
+\! echo $?
+0
+-- start_ignore
+\! gpstop -rai
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16142.g1f3e5a0825 build dev'
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:11:34:400128 gpstop:ubuntu:gpadmin-[INFO]:-Stopping coordinator standby host ubuntu mode=immediate
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown standby process on ubuntu
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+-- end_ignore
+\! echo $?
+0

--- a/gpcontrib/gp_toolkit/expected/resource_manager_switch_to_queue.out
+++ b/gpcontrib/gp_toolkit/expected/resource_manager_switch_to_queue.out
@@ -1,0 +1,32 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v queue
+20230109:22:58:10:221578 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v queue'
+-- end_ignore
+\! echo $?
+0
+-- start_ignore
+\! gpstop -rai
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16117.g367b82d8d9 build dev'
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-No standby coordinator host configured
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 3, 4] for shutdown
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 3
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 3 of 3 segment instances 
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+-- end_ignore
+\! echo $?
+0

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.1--1.2.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.1--1.2.sql
@@ -1,0 +1,86 @@
+/* gpcontrib/gp_toolkit/gp_toolkit--1.1--1.2.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_toolkit UPDATE TO '1.2'" to load this file. \quit
+
+-- Return the list of existing files in the database.
+-- Compared to the previous version, also show relative path of each file.
+CREATE OR REPLACE VIEW gp_toolkit.__get_exist_files AS
+WITH Tablespaces AS (
+-- 1. The default tablespace
+    SELECT 0 AS tablespace, 'base/' || d.oid::text AS dirname
+    FROM pg_database d
+    WHERE d.datname = current_database()
+    UNION
+-- 2. The global tablespace
+    SELECT 1664 AS tablespace, 'global/' AS dirname
+    UNION
+-- 3. The user-defined tablespaces
+    SELECT ts.oid AS tablespace,
+       'pg_tblspc/' || ts.oid::text || '/' || get_tablespace_version_directory_name() || '/' ||
+         (SELECT d.oid::text FROM pg_database d WHERE d.datname = current_database()) AS dirname
+    FROM pg_tablespace ts
+    WHERE ts.oid > 1664
+)
+SELECT tablespace, files.filename, dirname || '/' || files.filename AS filepath
+FROM Tablespaces, pg_ls_dir(dirname) AS files(filename);
+
+-- Check orphaned data files on default and user tablespaces.
+-- Compared to the previous version, also show relative path of each file.
+CREATE OR REPLACE VIEW gp_toolkit.__check_orphaned_files AS
+SELECT f1.tablespace, f1.filename, f1.filepath
+from gp_toolkit.__get_exist_files f1
+LEFT JOIN gp_toolkit.__get_expect_files f2
+ON f1.tablespace = f2.tablespace AND substring(f1.filename from '[0-9]+') = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+(\.)?(\_)?%';
+
+-- New function to check orphaned files
+CREATE OR REPLACE FUNCTION gp_toolkit.__gp_check_orphaned_files_func()
+RETURNS TABLE (
+    gp_segment_id int,
+    tablespace oid,
+    filename text,
+    filepath text
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        -- lock pg_class so that no one will be adding/altering relfilenodes
+        LOCK TABLE pg_class IN SHARE MODE NOWAIT;
+       
+        -- make sure no other active/idle transaction is running
+        IF EXISTS (
+            SELECT 1
+            FROM gp_stat_activity
+            WHERE
+            sess_id <> -1 AND backend_type IN ('client backend', 'unknown process type') -- exclude background worker types
+            AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        ) THEN
+            RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+        END IF;
+       
+        -- force checkpoint to make sure we do not include files that are normally pending delete
+        CHECKPOINT;
+       
+        RETURN QUERY 
+        SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
+        FROM gp_dist_random('gp_toolkit.__check_orphaned_files')
+        UNION ALL
+        SELECT -1 AS gp_segment_id, *
+        FROM gp_toolkit.__check_orphaned_files;
+    EXCEPTION
+        WHEN lock_not_available THEN
+            RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
+        WHEN OTHERS THEN
+            RAISE;
+    END;
+ 
+    RETURN;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION gp_toolkit.__gp_check_orphaned_files_func TO public;
+
+CREATE OR REPLACE VIEW gp_toolkit.gp_check_orphaned_files AS 
+SELECT * FROM gp_toolkit.__gp_check_orphaned_files_func();
+

--- a/gpcontrib/gp_toolkit/gp_toolkit.control
+++ b/gpcontrib/gp_toolkit/gp_toolkit.control
@@ -1,5 +1,5 @@
 # gp_toolkit extension
 
 comment = 'various GPDB administrative views/functions'
-default_version = '1.1'
+default_version = '1.2'
 relocatable = true

--- a/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
@@ -246,7 +246,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
-select * from gp_toolkit.gp_param_settings_seg_value_diffs;
+-- primary_conninfo can be different due to failovers in isolation2 tests
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
 
 
 -- gp_locks_on_relation

--- a/src/test/isolation2/expected/aoco_column_rewrite.out
+++ b/src/test/isolation2/expected/aoco_column_rewrite.out
@@ -110,13 +110,12 @@ SELECT * FROM gp_toolkit.__gp_aocsseg('alter_type_aoco') ORDER BY segment_id, co
 (4 rows)
 DROP TABLE alter_type_aoco;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
 -- check if all files are dropped correctly
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_type_aoco');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_type_aoco');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if column rewrite handles deleted rows in blockdirectory correctly for
@@ -685,13 +684,12 @@ SELECT * FROM part_alter_col;
 (1 row)
 DROP TABLE part_alter_col;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
 -- check if all files are dropped correctly
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'part_alter_col');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'part_alter_col');
+ count 
+-------
+ 0     
+(1 row)
 --------------------------------------------------------------------------------
 -- Test if column rewrite works when AT ALTER COLUMN TYPE for a column
 -- and then alter it back to the original type
@@ -794,13 +792,12 @@ SELECT * FROM alter_column_back;
 (2 rows)
 DROP TABLE alter_column_back;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
 -- check if all files are dropped correctly
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_back');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_back');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if ALTER COLUMN TYPE and SET ACCESS METHOD can be done in the same command
@@ -1055,6 +1052,8 @@ ALTER TABLE
 INSERT 0 10
 1: COMMIT;
 COMMIT
+-- gp_toolkit.gp_check_orphaned_files later requires that there's no concurrent sessions
+1q: ... <quitting>
 INSERT INTO alter_column_seg0 SELECT 1,i,i FROM generate_series(1,10)i;
 INSERT 0 10
 ALTER TABLE alter_column_seg0 ALTER COLUMN b TYPE text;
@@ -1076,12 +1075,11 @@ SELECT * FROM gp_toolkit.__gp_aocsseg('alter_column_seg0');
 (6 rows)
 DROP TABLE alter_column_seg0;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_seg0');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_seg0');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if ALTER COLUMN TYPE works correctly multiple segfiles are created
@@ -1102,6 +1100,8 @@ INSERT 0 10
 COMMIT
 2: COMMIT;
 COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
 ALTER TABLE alter_column_multiple_concurrency ALTER COLUMN b TYPE text;
 ALTER TABLE
 SELECT count(*) FROM alter_column_multiple_concurrency;
@@ -1119,12 +1119,11 @@ SELECT * FROM gp_toolkit.__gp_aocsseg('alter_column_multiple_concurrency');
 (4 rows)
 DROP TABLE alter_column_multiple_concurrency;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_multiple_concurrency');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_multiple_concurrency');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if ALTER COLUMN TYPE works correctly when a segfile is in AWAITING_DROP state
@@ -1144,6 +1143,8 @@ INSERT 0 10
 COMMIT
 2: COMMIT;
 COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
 DELETE FROM alter_column_awaiting_drop WHERE b > 10;
 DELETE 10
 VACUUM alter_column_awaiting_drop;
@@ -1177,12 +1178,17 @@ SELECT * FROM gp_toolkit.__gp_aocsseg('alter_column_awaiting_drop');
 (6 rows)
 DROP TABLE alter_column_awaiting_drop;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_awaiting_drop');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+-- VACUUM seems to incur some left-over session, wait a little while for that to go away to placate gp_check_orphaned_files
+SELECT pg_sleep(3);
+ pg_sleep 
+----------
+          
+(1 row)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_awaiting_drop');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if ALTER COLUMN TYPE works correctly for 0 inserted rows
@@ -1201,6 +1207,8 @@ INSERT 0 10
 ROLLBACK
 2: ABORT;
 ROLLBACK
+1q: ... <quitting>
+2q: ... <quitting>
 ALTER TABLE alter_column_zero_tupcount ALTER COLUMN b TYPE text;
 ALTER TABLE
 SELECT count(*) FROM alter_column_zero_tupcount;
@@ -1218,12 +1226,11 @@ SELECT * FROM gp_toolkit.__gp_aocsseg('alter_column_zero_tupcount');
 (4 rows)
 DROP TABLE alter_column_zero_tupcount;
 DROP TABLE
-CHECKPOINT;
-CHECKPOINT
-SELECT * FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_zero_tupcount');
- gp_segment_id | tablespace | filename 
----------------+------------+----------
-(0 rows)
+SELECT count(*) FROM gp_toolkit.gp_check_orphaned_files WHERE split_part(filename,'.',1) = (SELECT oid::text FROM pg_class WHERE relname = 'alter_column_zero_tupcount');
+ count 
+-------
+ 0     
+(1 row)
 
 --------------------------------------------------------------------------------
 -- Test if ALTER COLUMN TYPE works correctly for generated columns.
@@ -1301,6 +1308,8 @@ ALTER TABLE
 COMMIT
 2<:  <... completed>
 INSERT 0 10
+1q: ... <quitting>
+2q: ... <quitting>
 -- should see 30 rows
 SELECT count(*) FROM aoco_concurrent_inserts;
  count 

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -100,3 +100,21 @@ CREATE VIEW
 DROP VIEW
 drop view misc_v;
 DROP VIEW
+
+--
+-- gp_toolkit.gp_check_orphaned_files should not be running with concurrent transaction (even idle)
+--
+-- use a different database to do the test, otherwise we might be reporting tons
+-- of orphaned files produced by the many intential PANICs/restarts in the isolation2 tests.
+create database check_orphaned_db;
+CREATE DATABASE
+1:@db_name check_orphaned_db: begin;
+BEGIN
+2:@db_name check_orphaned_db: select * from gp_toolkit.gp_check_orphaned_files;
+ERROR:  There is a client session running on one or more segment. Aborting...
+CONTEXT:  PL/pgSQL function gp_toolkit.__gp_check_orphaned_files_func() line 15 at RAISE
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop database check_orphaned_db;
+DROP DATABASE

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -53,3 +53,16 @@ create or replace view misc_v as select 1;
 0U: select count(*) > 0 from gp_dist_random('misc_v2');
 0U: drop view misc_v2;
 drop view misc_v;
+
+--
+-- gp_toolkit.gp_check_orphaned_files should not be running with concurrent transaction (even idle)
+--
+-- use a different database to do the test, otherwise we might be reporting tons 
+-- of orphaned files produced by the many intential PANICs/restarts in the isolation2 tests.
+create database check_orphaned_db;
+1:@db_name check_orphaned_db: begin;
+2:@db_name check_orphaned_db: select * from gp_toolkit.gp_check_orphaned_files;
+1q:
+2q:
+
+drop database check_orphaned_db;

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -9,8 +9,30 @@
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
 
--- start from a clean state
-checkpoint;
+-- helper function to repeatedly run gp_toolkit.gp_check_orphaned_files for up to 10 minutes,
+-- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+DECLARE
+    retry_counter INT := 0;
+BEGIN
+    WHILE retry_counter < 120 LOOP
+        BEGIN
+            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_toolkit.gp_check_orphaned_files q;
+            RETURN; -- If successful
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
+                -- When an exception occurs, wait for 5 seconds and then retry
+                PERFORM pg_sleep(5);
+                retry_counter := retry_counter + 1;
+        END;
+    END LOOP;
+
+    -- all retries failed
+    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+END;
+$$ LANGUAGE plpgsql;
 
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
@@ -28,6 +50,19 @@ select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
+
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+
+-- check orphaned files, note that this forces a checkpoint internally.
+set client_min_messages = ERROR;
+select gp_segment_id, filename from run_orphaned_files_view();
+reset client_min_messages;
+
+-- remove the orphaned files so not affect subsequent tests
+\! rm 987654
+\! rm 987654.3
 
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under
@@ -47,10 +82,6 @@ insert into checkmissing_co select i,i,i from generate_series(1,100)i;
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
-
 -- create some normal tables
 CREATE TABLE checknormal_heap(a int, b int, c int);
 CREATE TABLE checknormal_ao(a int, b int, c int) using ao_row;
@@ -65,7 +96,6 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_tool
 SET client_min_messages = ERROR;
 
 -- check extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files_ext;
 
 RESET client_min_messages;

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -7,8 +7,30 @@
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
--- start from a clean state
-checkpoint;
+-- helper function to repeatedly run gp_toolkit.gp_check_orphaned_files for up to 10 minutes,
+-- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+DECLARE
+    retry_counter INT := 0;
+BEGIN
+    WHILE retry_counter < 120 LOOP
+        BEGIN
+            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_toolkit.gp_check_orphaned_files q;
+            RETURN; -- If successful
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
+                -- When an exception occurs, wait for 5 seconds and then retry
+                PERFORM pg_sleep(5);
+                retry_counter := retry_counter + 1;
+        END;
+    END LOOP;
+
+    -- all retries failed
+    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+END;
+$$ LANGUAGE plpgsql;
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;
@@ -23,6 +45,22 @@ select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+-- check orphaned files, note that this forces a checkpoint internally.
+set client_min_messages = ERROR;
+select gp_segment_id, filename from run_orphaned_files_view();
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654
+             1 | 987654.3
+(2 rows)
+
+reset client_min_messages;
+-- remove the orphaned files so not affect subsequent tests
+\! rm 987654
+\! rm 987654.3
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under
 -- the test tablespace). Also just delete one and only one file that
@@ -38,9 +76,6 @@ insert into checkmissing_co select i,i,i from generate_series(1,100)i;
 -- delete exact two '.1' files.
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
 -- create some normal tables
 CREATE TABLE checknormal_heap(a int, b int, c int);
 CREATE TABLE checknormal_ao(a int, b int, c int) using ao_row;
@@ -57,13 +92,6 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_tool
 
 SET client_min_messages = ERROR;
 -- check extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
- gp_segment_id | filename 
----------------+----------
-             1 | 987654
-             1 | 987654.3
-(2 rows)
-
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files_ext;
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------


### PR DESCRIPTION
This commit mainly improves the gp_check_orphaned_files view in the sense that, since ultimately its user is likely going to remove the reported orphaned files, we would not like that to cause any potential issues due to causes like:

* Main relation files that are associated with dropped tables are kept until the next CHECKPOINT in order to prevent potential issue with crash recovery (see comments for mdunlink()). So removing them would have issue.
* Relation files that are created during an ongoing transactions could be recognized as orphaned: another session will see an old pg_class.relfilenode so it would think the new relfilenode is orphaned. So if one removes that, we might have data loss.

So accordingly, the improvements are:
* We should force a CHECKPOINT prior to collecting the orphaned file list.
* We should exclude other activities that might change pg_class.relfilenode while running the view. This is done by locking pg_class in SHARE mode (which blocks writes but allows read) with "nowait" flag (which allows the lock attempt to immediately return so we are not blocked forever). We should also check pg_stat_activity to make sure that there is no idle transaction (because the idle transaction might've already modified pg_class and released the lock). In the new view we do that by simply making sure there's no concurrent client sessions. This might be a bit too restricted but it's better to be as safe as we can in sensitive area like this.

These steps will need to be written in a function. So rewrite the gp_check_orphaned_files view to be SELECT'ing from a new UDF.

Also improve the view results by adding relative path of each file being reported for convenience about further action of the files.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/orphaned-view-improve

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
