### PR TITLE
Fix race condition in CTE reader-writer communication

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -550,8 +550,6 @@ ExecEndShareInputScan(ShareInputScanState *node)
 	ShareInputScan *sisc = (ShareInputScan *) node->ss.ps.plan;
 	shareinput_local_state *local_state = node->local_state;
 
-	SIMPLE_FAULT_INJECTOR("get_shareinput_reference_done");
-
 	/* clean up tuple table */
 	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
 
@@ -888,6 +886,8 @@ release_shareinput_reference(shareinput_Xslice_reference *ref, bool reader_squel
 		elog((Debug_shareinput_xslice ? LOG : DEBUG1), "SISC (shareid=%d, slice=%d): removed xslice state",
 			 state->tag.share_id, currentSliceId);
 	}
+	else if (state->refcount == 0)
+		SIMPLE_FAULT_INJECTOR("get_shareinput_reference_done");
 
 	dlist_delete(&ref->node);
 

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -497,7 +497,19 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 
 	/* Get a lease on the shared state */
 	if (node->cross_slice)
+	{
+#ifdef FAULT_INJECTOR
+		if (node->producer_slice_id == currentSliceId)
+		{
+			FaultInjector_InjectFaultIfSet("get_shareinput_reference_delay_writer",
+										   DDLNotSpecified,
+										   "",  // databaseName
+										   ""); // tableName
+		}
+#endif
 		sisstate->ref = get_shareinput_reference(node->share_id);
+		SIMPLE_FAULT_INJECTOR("get_shareinput_reference_done");
+	}
 	else
 		sisstate->ref = NULL;
 

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -666,7 +666,6 @@ ExecSquelchShareInputScan(ShareInputScanState *node)
 
 			if (local_state->ndone == local_state->nsharers)
 			{
-				shareinput_reader_waitready(node->ref);
 				shareinput_reader_notifydone(node->ref, sisc->nconsumers);
 				local_state->closed = true;
 			}

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -666,6 +666,7 @@ ExecSquelchShareInputScan(ShareInputScanState *node)
 
 			if (local_state->ndone == local_state->nsharers)
 			{
+				shareinput_reader_waitready(node->ref);
 				shareinput_reader_notifydone(node->ref, sisc->nconsumers);
 				local_state->closed = true;
 			}

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -508,7 +508,6 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 		}
 #endif
 		sisstate->ref = get_shareinput_reference(node->share_id);
-		SIMPLE_FAULT_INJECTOR("get_shareinput_reference_done");
 	}
 	else
 		sisstate->ref = NULL;
@@ -550,6 +549,8 @@ ExecEndShareInputScan(ShareInputScanState *node)
 	EState	   *estate = node->ss.ps.state;
 	ShareInputScan *sisc = (ShareInputScan *) node->ss.ps.plan;
 	shareinput_local_state *local_state = node->local_state;
+
+	SIMPLE_FAULT_INJECTOR("get_shareinput_reference_done");
 
 	/* clean up tuple table */
 	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -112,6 +112,7 @@ bool        gp_guc_need_restore = false;
 
 char	   *Debug_dtm_action_sql_command_tag;
 
+bool		Debug_shareinput_xslice = false;
 bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
 bool		Debug_disable_distributed_snapshot = false;
@@ -1456,6 +1457,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&Debug_dtm_action_primary,
 		DEBUG_DTM_ACTION_PRIMARY_DEFAULT, NULL, NULL, NULL
+	},
+
+	{
+		{"debug_shareinput_xslice", PGC_SUSET, LOGGING_WHAT,
+		 gettext_noop("Prints cross-slice share input scan information to server log."),
+		 NULL,
+		 GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_shareinput_xslice,
+		false,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -329,6 +329,7 @@ extern bool allow_segment_DML;
 extern bool gp_ignore_error_table;
 
 extern bool	Debug_dtm_action_primary;
+extern bool Debug_shareinput_xslice;
 
 extern bool gp_log_optimization_time;
 extern bool log_parser_stats;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -26,6 +26,7 @@
 		"debug_appendonly_print_verify_write_block",
 		"debug_appendonly_print_visimap",
 		"debug_appendonly_use_no_toast",
+		"Debug_shareinput_xslice",
 		"default_table_access_method",
 		"default_tablespace",
 		"dml_ignore_target_partition_check",

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -452,21 +452,21 @@ select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_se
 -- ability to redirect the LOGs as sterr into stdout. Hence directly using bash.
 \! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
 -- Wait for both SISC READERs to be initialized and squelched
-select gp_wait_until_triggered_fault('get_shareinput_reference_done', 2, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+select gp_wait_until_triggered_fault('get_shareinput_reference_done', 1, dbid) from gp_segment_configuration where content = 2 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
-select gp_inject_fault_infinite('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
- gp_inject_fault_infinite 
---------------------------
+select gp_inject_fault('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
-select gp_inject_fault_infinite('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
- gp_inject_fault_infinite 
---------------------------
+select gp_inject_fault('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -356,3 +356,166 @@ JOIN ttt ON cte.oid = ttt.tc2;
 ERROR:  relation "cte" does not exist
 LINE 7: FROM gp_dist_random('cte')
                             ^
+--
+-- Test bug fix for reader-writer communication in Share Input Scan (SISC)
+-- https://github.com/greenplum-db/gpdb/issues/16429
+--
+-- Helper function
+CREATE OR REPLACE FUNCTION wait_until_query_output_to_file(file_path text) RETURNS VOID AS $$
+DECLARE
+	content TEXT;
+	line TEXT;
+	match TEXT;
+BEGIN
+	LOOP
+		content := pg_read_file(file_path);
+		FOR line IN (SELECT unnest(string_to_array(content, E'\n'))) LOOP
+			match := substring(line FROM '\(([0-9]+) row[s]?\)');
+			IF match IS NOT NULL THEN
+				RETURN;
+			END IF;
+		END LOOP;
+		PERFORM pg_sleep(0.1);  -- Sleep for a short period before checking again
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+-- Setup tables
+CREATE TABLE sisc_t1(a int, b int) DISTRIBUTED BY (a);
+INSERT INTO sisc_t1 VALUES (1, 1), (2, 2), (5, 5);
+ANALYZE sisc_t1;
+CREATE TABLE sisc_t2(c int, d int) DISTRIBUTED BY (c);
+-- Ensure that sisc_t2 has 0 tuple on seg2
+INSERT INTO sisc_t2 VALUES (1, 1), (2, 2);
+ANALYZE sisc_t2;
+-- ORCA plan contains one SISC writer on slice1 and two readers on slice2 and slice4.
+-- The Hash Join on slice4 has its hash side being empty on seg2, so the SISC
+-- reader on the probe side will be squelched. Same applies to the Hash Join
+-- on slice2 for seg2.
+-- Similary, planner plan contains one SISC wirter on slice4 and one reader on slice2.
+-- The Hash Join on slice2 has its hash side being empty on seg2, so the SISC
+-- reader on the probe side will be squelched.
+SET optimizer_enable_motion_broadcast TO off;
+EXPLAIN (COSTS OFF)
+WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1)
+SELECT y.a, z.a
+FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y,
+     (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z
+WHERE y.b = z.b - 1;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (share0_ref2.b = (share0_ref1.b - 1))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: share0_ref2.b
+               ->  Hash Join
+                     Hash Cond: (share0_ref2.a = sisc_t2.d)
+                     ->  Shared Scan (share slice:id 2:0)
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: sisc_t2.d
+                                 ->  Seq Scan on sisc_t2
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     Hash Key: (share0_ref1.b - 1)
+                     ->  Hash Join
+                           Hash Cond: (share0_ref1.a = sisc_t2_1.d)
+                           ->  Shared Scan (share slice:id 4:0)
+                                 ->  Seq Scan on sisc_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                       Hash Key: sisc_t2_1.d
+                                       ->  Seq Scan on sisc_t2 sisc_t2_1
+ Optimizer: Postgres-based planner
+(24 rows)
+
+-- On seg2, introduce a delay in SISC WRITER (slice1) so that the xslice shared state
+-- which is stored in shared memory is initialized by the SISC READER (slice2 or slice4)
+select gp_inject_fault('get_shareinput_reference_delay_writer', 'suspend', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Run the above CTE query again with additional debug logging.
+-- Use debug_shareinput_xslice to verify that the SISC READER on seg2 is indeed
+-- initialized and squelched before the SISC WRITER starts its execution.
+--
+-- XXX: since this is a blocking query, we need to run it in a separate shell.
+-- isolation2 test seems to be a more intuitive option, however, it lacks the
+-- ability to redirect the LOGs as sterr into stdout. Hence directly using bash.
+\! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
+-- Wait for both SISC READERs to be initialized and squelched
+select gp_wait_until_triggered_fault('get_shareinput_reference_done', 2, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+select gp_inject_fault_infinite('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+select gp_inject_fault_infinite('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Wait for the query to finish
+select wait_until_query_output_to_file('/tmp/bfv_cte.out');
+ wait_until_query_output_to_file 
+---------------------------------
+ 
+(1 row)
+
+-- start_matchsubs
+-- m/SISC READER \(shareid=0, slice=2\)/
+-- s/SISC READER \(shareid=0, slice=2\)/SISC READER (shareid=0, slice={2|4})/g
+-- m/SISC READER \(shareid=0, slice=4\)/
+-- s/SISC READER \(shareid=0, slice=4\)/SISC READER (shareid=0, slice={2|4})/g
+-- m/slice=2\): initialized xslice state/
+-- s/slice=2\): initialized xslice state/slice={2|4}): initialized xslice state/g
+-- m/slice=4\): initialized xslice state/
+-- s/slice=4\): initialized xslice state/slice={2|4}): initialized xslice state/g
+-- end_matchsubs
+-- Filter out irrelevant LOG messages from segments other than seg2.
+\! cat /tmp/bfv_cte.out | grep -P '^(?!LOG)|^(LOG.*seg2)' | grep -vP 'LOG.*fault|decreased xslice state refcount'
+LOG:  SISC (shareid=0, slice=2): initialized xslice state  (seg2 slice2 127.0.1.1:7004 pid=1049102)
+LOG:  SISC READER (shareid=0, slice=2): wrote notify_done  (seg2 slice2 127.0.1.1:7004 pid=1049102)
+LOG:  SISC WRITER (shareid=0, slice=4): initializing because squelched  (seg2 slice4 127.0.1.1:7004 pid=1049114)
+LOG:  SISC WRITER (shareid=0, slice=4): No tuplestore yet, creating tuplestore  (seg2 slice4 127.0.1.1:7004 pid=1049114)
+LOG:  SISC WRITER (shareid=0, slice=4): wrote notify_ready  (seg2 slice4 127.0.1.1:7004 pid=1049114)
+LOG:  SISC WRITER (shareid=0, slice=4): got DONE message from 1 readers  (seg2 slice4 127.0.1.1:7004 pid=1049114)
+LOG:  SISC (shareid=0, slice=4): removed xslice state  (seg2 slice4 127.0.1.1:7004 pid=1049114)
+ a | a 
+---+---
+ 1 | 2
+(1 row)
+
+-- cleanup
+select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+RESET optimizer_enable_motion_broadcast;
+DROP TABLE sisc_t1;
+DROP TABLE sisc_t2;
+\! rm /tmp/bfv_cte.out

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -2,28 +2,31 @@
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
 DROP TABLE IF EXISTS test_group_window;
-
+NOTICE:  table "test_group_window" does not exist, skipping
 CREATE TABLE test_group_window(c1 int, c2 int);
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WITH tt AS (SELECT * FROM test_group_window)
 SELECT tt.c1, COUNT() over () as fraction
 FROM tt
 GROUP BY tt.c1
 ORDER BY tt.c1;
+ c1 | fraction 
+----+----------
+(0 rows)
 
 DROP TABLE test_group_window;
-
 --
 -- Set up
 --
 CREATE TABLE bfv_cte_foo AS SELECT i as a, i+1 as b from generate_series(1,10)i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE bfv_cte_bar AS SELECT i as c, i+1 as d from generate_series(1,10)i;
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 --
 -- Test with CTE inlining disabled
 --
 set optimizer_cte_inlining = off;
-
 --
 -- With clause select test 1
 --
@@ -38,11 +41,15 @@ WITH t AS
     (
        SELECT * FROM bfv_cte_bar WHERE c < 10
     ) f
-
   ON e.a = f.d )
 SELECT t.a,t.d, count(*) over () AS window
 FROM t
 GROUP BY t.a,t.d ORDER BY t.a,t.d LIMIT 2;
+ a | d | window 
+---+---+--------
+ 1 |   |      9
+ 2 | 2 |      9
+(2 rows)
 
 --
 -- With clause select test 2
@@ -52,6 +59,14 @@ WITH t(a,b,d) AS
   SELECT bfv_cte_foo.a,bfv_cte_foo.b,bfv_cte_bar.d FROM bfv_cte_foo,bfv_cte_bar WHERE bfv_cte_foo.a = bfv_cte_bar.d
 )
 SELECT t.b,avg(t.a), rank() OVER (PARTITION BY t.a ORDER BY t.a) FROM bfv_cte_foo,t GROUP BY bfv_cte_foo.a,bfv_cte_foo.b,t.b,t.a ORDER BY 1,2,3 LIMIT 5;
+ b |        avg         | rank 
+---+--------------------+------
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+(5 rows)
 
 --
 -- With clause select test 3
@@ -68,6 +83,19 @@ t WHERE cup.e < 10
 GROUP BY cup.c,cup.d, cup.e ,t.d, t.b
 ORDER BY 1,2,3,4
 LIMIT 10;
+ c | d |         e          | sum 
+---+---+--------------------+-----
+ 1 | 2 | 3.0000000000000000 | 140
+ 1 | 2 | 3.0000000000000000 | 210
+ 1 | 2 | 3.0000000000000000 | 280
+ 1 | 2 | 3.0000000000000000 | 350
+ 1 | 2 | 3.0000000000000000 | 420
+ 1 | 2 | 3.0000000000000000 | 490
+ 1 | 2 | 3.0000000000000000 | 560
+ 1 | 2 | 3.0000000000000000 | 630
+ 1 | 2 | 3.0000000000000000 | 700
+ 1 | 2 | 4.0000000000000000 | 140
+(10 rows)
 
 --
 -- With clause select test 4
@@ -82,6 +110,19 @@ SELECT cup.*, SUM(t.d) FROM
   ) AS cup,
 t GROUP BY cup.c,cup.d, cup.e,t.a
 HAVING AVG(t.d) < 10 ORDER BY 1,2,3,4 LIMIT 10;
+ c | d | e | sum 
+---+---+---+-----
+ 2 | 3 | 9 |   2
+ 2 | 3 | 9 |   3
+ 2 | 3 | 9 |   4
+ 2 | 3 | 9 |   5
+ 2 | 3 | 9 |   6
+ 2 | 3 | 9 |   7
+ 2 | 3 | 9 |   8
+ 2 | 3 | 9 |   9
+ 3 | 4 | 9 |   2
+ 3 | 4 | 9 |   3
+(10 rows)
 
 --
 -- With clause select test 5
@@ -101,13 +142,25 @@ t WHERE cup.e < 10
 GROUP BY cup.d, cup.e, t.d, t.b
 ORDER BY 1,2,3
 LIMIT 10;
+ e | d | sum 
+---+---+-----
+ 1 | 2 | 162
+ 1 | 2 | 243
+ 1 | 2 | 324
+ 1 | 2 | 405
+ 1 | 2 | 486
+ 1 | 2 | 567
+ 1 | 2 | 648
+ 1 | 2 | 729
+ 1 | 2 | 810
+ 1 | 3 | 162
+(10 rows)
 
 --
 -- Test with CTE inlining enabled
 --
 set optimizer_cte_inlining = on;
 set optimizer_cte_inlining_bound = 1000;
-
 --
 -- With clause select test 1
 --
@@ -122,11 +175,15 @@ WITH t AS
     (
        SELECT * FROM bfv_cte_bar WHERE c < 10
     ) f
-
   ON e.a = f.d )
 SELECT t.a,t.d, count(*) over () AS window
 FROM t
 GROUP BY t.a,t.d ORDER BY t.a,t.d LIMIT 2;
+ a | d | window 
+---+---+--------
+ 1 |   |      9
+ 2 | 2 |      9
+(2 rows)
 
 --
 -- With clause select test 2
@@ -136,6 +193,14 @@ WITH t(a,b,d) AS
   SELECT bfv_cte_foo.a,bfv_cte_foo.b,bfv_cte_bar.d FROM bfv_cte_foo,bfv_cte_bar WHERE bfv_cte_foo.a = bfv_cte_bar.d
 )
 SELECT t.b,avg(t.a), rank() OVER (PARTITION BY t.a ORDER BY t.a) FROM bfv_cte_foo,t GROUP BY bfv_cte_foo.a,bfv_cte_foo.b,t.b,t.a ORDER BY 1,2,3 LIMIT 5;
+ b |        avg         | rank 
+---+--------------------+------
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+ 3 | 2.0000000000000000 |    1
+(5 rows)
 
 --
 -- With clause select test 3
@@ -152,6 +217,19 @@ t WHERE cup.e < 10
 GROUP BY cup.c,cup.d, cup.e ,t.d, t.b
 ORDER BY 1,2,3,4
 LIMIT 10;
+ c | d |         e          | sum 
+---+---+--------------------+-----
+ 1 | 2 | 3.0000000000000000 | 140
+ 1 | 2 | 3.0000000000000000 | 210
+ 1 | 2 | 3.0000000000000000 | 280
+ 1 | 2 | 3.0000000000000000 | 350
+ 1 | 2 | 3.0000000000000000 | 420
+ 1 | 2 | 3.0000000000000000 | 490
+ 1 | 2 | 3.0000000000000000 | 560
+ 1 | 2 | 3.0000000000000000 | 630
+ 1 | 2 | 3.0000000000000000 | 700
+ 1 | 2 | 4.0000000000000000 | 140
+(10 rows)
 
 --
 -- With clause select test 4
@@ -166,6 +244,19 @@ SELECT cup.*, SUM(t.d) FROM
   ) AS cup,
 t GROUP BY cup.c,cup.d, cup.e,t.a
 HAVING AVG(t.d) < 10 ORDER BY 1,2,3,4 LIMIT 10;
+ c | d | e | sum 
+---+---+---+-----
+ 2 | 3 | 9 |   2
+ 2 | 3 | 9 |   3
+ 2 | 3 | 9 |   4
+ 2 | 3 | 9 |   5
+ 2 | 3 | 9 |   6
+ 2 | 3 | 9 |   7
+ 2 | 3 | 9 |   8
+ 2 | 3 | 9 |   9
+ 3 | 4 | 9 |   2
+ 3 | 4 | 9 |   3
+(10 rows)
 
 --
 -- With clause select test 5
@@ -185,12 +276,24 @@ t WHERE cup.e < 10
 GROUP BY cup.d, cup.e, t.d, t.b
 ORDER BY 1,2,3
 LIMIT 10;
+ e | d | sum 
+---+---+-----
+ 1 | 2 | 162
+ 1 | 2 | 243
+ 1 | 2 | 324
+ 1 | 2 | 405
+ 1 | 2 | 486
+ 1 | 2 | 567
+ 1 | 2 | 648
+ 1 | 2 | 729
+ 1 | 2 | 810
+ 1 | 3 | 162
+(10 rows)
 
 DROP TABLE IF EXISTS bfv_cte_foo;
 DROP TABLE IF EXISTS bfv_cte_bar;
 reset optimizer_cte_inlining;
 reset optimizer_cte_inlining_bound;
-
 --
 -- Test for an old bug with rescanning window functions. This needs to use
 -- catalog tables, otherwise the plan will contain a Motion node that
@@ -202,6 +305,10 @@ SELECT cup.* FROM
 SELECT sum(t.b) OVER(PARTITION BY t.a ) AS e FROM (select 1 as a, 2 as b from pg_class limit 1)foo,t
 ) as cup
 GROUP BY cup.e;
+ e 
+---
+ 2
+(1 row)
 
 --
 -- Test for a bug in translating a CTE's locus to the outer query.
@@ -212,14 +319,11 @@ GROUP BY cup.e;
 -- rel.
 --
 create temp table bfv_cte_tab (t text, i int4, j int4) distributed randomly;
-
 insert into bfv_cte_tab values ('foo', 1, -1);
 insert into bfv_cte_tab values ('bar', 2, -2);
-
 with
   foo as (select t, sum(i) as n from bfv_cte_tab group by t),
   bar as (select t, sum(j) as n from bfv_cte_tab group by t)
-
 select const_a, const_b, sum(n)
  from
  (select 'foo_a' as const_a, 'foo_b' as const_b, n from foo
@@ -228,13 +332,19 @@ select const_a, const_b, sum(n)
  ) x
  group by const_a, const_b
 ;
+ const_a | const_b | sum 
+---------+---------+-----
+ bar_a   | bar_b   |  -3
+ foo_a   | foo_b   |   3
+(2 rows)
 
 -- test cte can not be the param for gp_dist_random
 -- so in set_cte_pathlist we do not neet to check forceDistRandom
 create table ttt(tc1 int,tc2 int) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into ttt values(1,1);
 insert into ttt  values(2,2);
-
 WITH cte AS (
   SELECT oid, relname
   FROM pg_class
@@ -243,7 +353,9 @@ WITH cte AS (
 SELECT *
 FROM gp_dist_random('cte')
 JOIN ttt ON cte.oid = ttt.tc2;
-
+ERROR:  relation "cte" does not exist
+LINE 7: FROM gp_dist_random('cte')
+                            ^
 --
 -- Test bug fix for reader-writer communication in Share Input Scan (SISC)
 -- https://github.com/greenplum-db/gpdb/issues/16429
@@ -267,7 +379,6 @@ BEGIN
 	END LOOP;
 END;
 $$ LANGUAGE plpgsql;
-
 -- Setup tables
 CREATE TABLE sisc_t1(a int, b int) DISTRIBUTED BY (a);
 INSERT INTO sisc_t1 VALUES (1, 1), (2, 2), (5, 5);
@@ -276,7 +387,6 @@ CREATE TABLE sisc_t2(c int, d int) DISTRIBUTED BY (c);
 -- Ensure that sisc_t2 has 0 tuple on seg2
 INSERT INTO sisc_t2 VALUES (1, 1), (2, 2);
 ANALYZE sisc_t2;
-
 -- ORCA plan contains one SISC writer on slice1 and two readers on slice2 and slice4.
 -- The Hash Join on slice4 has its hash side being empty on seg2, so the SISC
 -- reader on the probe side will be squelched. Same applies to the Hash Join
@@ -291,11 +401,49 @@ SELECT y.a, z.a
 FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y,
      (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z
 WHERE y.b = z.b - 1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on sisc_t1
+         ->  Hash Join
+               Hash Cond: (share0_ref3.b = (share0_ref2.b - 1))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: share0_ref3.b
+                     ->  Hash Join
+                           Hash Cond: (share0_ref3.a = sisc_t2.d)
+                           ->  Shared Scan (share slice:id 2:0)
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: sisc_t2.d
+                                       ->  Seq Scan on sisc_t2
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: (share0_ref2.b - 1)
+                           ->  Hash Join
+                                 Hash Cond: (share0_ref2.a = sisc_t2_1.d)
+                                 ->  Shared Scan (share slice:id 4:0)
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                             Hash Key: sisc_t2_1.d
+                                             ->  Seq Scan on sisc_t2 sisc_t2_1
+ Optimizer: GPORCA
+(26 rows)
 
 -- On seg2, introduce a delay in SISC WRITER (slice1) so that the xslice shared state
 -- which is stored in shared memory is initialized by the SISC READER (slice2 or slice4)
 select gp_inject_fault('get_shareinput_reference_delay_writer', 'suspend', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
 
 -- Run the above CTE query again with additional debug logging.
 -- Use debug_shareinput_xslice to verify that the SISC READER on seg2 is indeed
@@ -305,14 +453,32 @@ select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_se
 -- isolation2 test seems to be a more intuitive option, however, it lacks the
 -- ability to redirect the LOGs as sterr into stdout. Hence directly using bash.
 \! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
-
 -- Wait for both SISC READERs to be initialized and squelched
 select gp_wait_until_triggered_fault('get_shareinput_reference_done', 2, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
 select gp_inject_fault_infinite('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
 select gp_inject_fault_infinite('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
 
 -- Wait for the query to finish
 select wait_until_query_output_to_file('/tmp/bfv_cte.out');
+ wait_until_query_output_to_file 
+---------------------------------
+ 
+(1 row)
+
 -- start_matchsubs
 -- m/SISC READER \(shareid=0, slice=2\)/
 -- s/SISC READER \(shareid=0, slice=2\)/SISC READER (shareid=0, slice={2|4})/g
@@ -325,9 +491,32 @@ select wait_until_query_output_to_file('/tmp/bfv_cte.out');
 -- end_matchsubs
 -- Filter out irrelevant LOG messages from segments other than seg2.
 \! cat /tmp/bfv_cte.out | grep -P '^(?!LOG)|^(LOG.*seg2)' | grep -vP 'LOG.*fault|decreased xslice state refcount'
+LOG:  SISC (shareid=0, slice=2): initialized xslice state  (seg2 slice2 127.0.1.1:7004 pid=1048240)
+LOG:  SISC READER (shareid=0, slice=2): wrote notify_done  (seg2 slice2 127.0.1.1:7004 pid=1048240)
+LOG:  SISC READER (shareid=0, slice=4): wrote notify_done  (seg2 slice4 127.0.1.1:7004 pid=1048252)
+LOG:  SISC WRITER (shareid=0, slice=1): No tuplestore yet, creating tuplestore  (seg2 slice1 127.0.1.1:7004 pid=1048234)
+LOG:  SISC WRITER (shareid=0, slice=1): wrote notify_ready  (seg2 slice1 127.0.1.1:7004 pid=1048234)
+LOG:  SISC WRITER (shareid=0, slice=1): got DONE message from 2 readers  (seg2 slice1 127.0.1.1:7004 pid=1048234)
+LOG:  SISC (shareid=0, slice=1): removed xslice state  (seg2 slice1 127.0.1.1:7004 pid=1048234)
+ a | a 
+---+---
+ 1 | 2
+(1 row)
 
 -- cleanup
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
 RESET optimizer_enable_motion_broadcast;
 DROP TABLE sisc_t1;
 DROP TABLE sisc_t2;

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -454,21 +454,21 @@ select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_se
 -- ability to redirect the LOGs as sterr into stdout. Hence directly using bash.
 \! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
 -- Wait for both SISC READERs to be initialized and squelched
-select gp_wait_until_triggered_fault('get_shareinput_reference_done', 2, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+select gp_wait_until_triggered_fault('get_shareinput_reference_done', 1, dbid) from gp_segment_configuration where content = 2 and role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
-select gp_inject_fault_infinite('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
- gp_inject_fault_infinite 
---------------------------
+select gp_inject_fault('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 
-select gp_inject_fault_infinite('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
- gp_inject_fault_infinite 
---------------------------
+select gp_inject_fault('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+ gp_inject_fault 
+-----------------
  Success:
 (1 row)
 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -196,7 +196,8 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # NOTE: The bfv_temp test assumes that there are no temporary tables in
 # other sessions. Therefore the other tests in this group mustn't create
 # temp tables
-test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
+test: bfv_cte
+test: bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
 
 test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew qp_select partition_prune_opfamily gp_tsrf qp_join_union_all qp_join_universal
 

--- a/src/test/regress/sql/bfv_cte.sql
+++ b/src/test/regress/sql/bfv_cte.sql
@@ -307,9 +307,9 @@ select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_se
 \! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
 
 -- Wait for both SISC READERs to be initialized and squelched
-select gp_wait_until_triggered_fault('get_shareinput_reference_done', 2, dbid) from gp_segment_configuration where content = 2 and role = 'p';
-select gp_inject_fault_infinite('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
-select gp_inject_fault_infinite('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+select gp_wait_until_triggered_fault('get_shareinput_reference_done', 1, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+select gp_inject_fault('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+select gp_inject_fault('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
 
 -- Wait for the query to finish
 select wait_until_query_output_to_file('/tmp/bfv_cte.out');


### PR DESCRIPTION
Previously, a race condition between Share Input Scan (SISC) reader and
writer could cause the writer to hang if the reader node was squelched
before the writer node was initialized.

Here's an example plan:
```
-- Setup tables
CREATE TABLE sisc_t1(a int, b int) DISTRIBUTED BY (a);
INSERT INTO sisc_t1 VALUES (1, 1), (2, 2), (5, 5);
ANALYZE sisc_t1;
CREATE TABLE sisc_t2(c int, d int) DISTRIBUTED BY (c);
-- Ensure that sisc_t2 has 0 tuple on seg2
INSERT INTO sisc_t2 VALUES (1, 1), (2, 2);
ANALYZE sisc_t2;

-- Query
EXPLAIN (COSTS OFF)
WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1)
SELECT y.a, z.a
FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y,
     (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z
WHERE y.b = z.b - 1;
```
                                            QUERY PLAN
    ------------------------------------------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)
       ->  Sequence
             ->  Shared Scan (share slice:id 1:0)
                   ->  Seq Scan on t1
             ->  Hash Join
                   Hash Cond: (share0_ref3.b = (share0_ref2.b - 53))
                   ->  Redistribute Motion 3:3  (slice2; segments: 3)
                         Hash Key: share0_ref3.b
                         ->  Hash Join
                               Hash Cond: (share0_ref3.a = t2.d)
                               ->  Shared Scan (share slice:id 2:0)
                               ->  Hash
                                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                           Hash Key: t2.d
                                           ->  Seq Scan on t2
                   ->  Hash
                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
                               Hash Key: (share0_ref2.b - 53)
                               ->  Hash Join
                                     Hash Cond: (share0_ref2.a = t2_1.d)
                                     ->  Shared Scan (share slice:id 4:0)
                                     ->  Hash
                                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
                                                 Hash Key: t2_1.d
                                                 ->  Seq Scan on t2 t2_1
     Optimizer: GPORCA
    (26 rows)


In this plan, both Share Input Scan reader nodes on slice2 and slice4
on seg2 are squelched due to no result from the inner sides of the
Hash Joins. The squelching could happen even before the Share Input
Scan writer node on slice1 is initialized.

For cross-slice shared scan, readers and writer communicate through
shareinput_Xslice_state (xslice state in short) in shared memory.
There is a hash table shareinput_Xslice_hash in shared memory that
contains one "xslice state" entry per shared scan. Currently, the
"xslice state" entry is created by the first participant that
initializes, which can be a producer or a consumer; It is removed by
the last participant that references it, which also can be a producer
or a consumer.

In most cases when all participants are executed, the producer would
be the last one who references the "xslice state".  However, in case
of reader initialized and squelched before the writer initializes, the
reader would remove the "xslice state" entry from the hash table even
before the writer references it. So by the time the writer initializes,
it will be ignorant of the already removed "xslice state" and
create a new one. In this case, the write wish to communicate with
the readers through the new "xslice state", while the readers are
already squelched. So the writer will hang.

Please review commit by commit.
- As working through the problem, I found it helpful to add a new GUC `debug_shareinput_xslice` for debuging issues in this area.
- Test would hang for both ORCA and planner plan w/o the fix
- Two fix options in seperate commits. I prefer the later because it is more efficient and needs less thought, but I'm open to other fix ideas and/or potential missed cases.

Fixes https://github.com/greenplum-db/gpdb/issues/16429
