### PR TITLE
[7X]Fix utilities does not honor -d flag when COORDINATOR_DATA_DIRECTORY is not set.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1191,18 +1191,19 @@ def get_gphome():
     return gphome
 
 '''
-gprecoverseg, gpstart, gpstate, gpstop, gpaddmirror  has option to give -d <datadirctory>
-but that is not getting followed throught the utility. to avoid that best possible way is 
+gprecoverseg, gpstart, gpstate, gpstop, gpaddmirror have -d option to give the coordinator data directory.
+but its value was not used throughout the utilities. to fix this the best possible way is
 to set and retrieve that set coordinator dir when we call get_coordinatordatadir().
 '''
 option_coordinator_datadir = None
-def set_coordinatordatadir( coordinator_datadir=None):
+def set_coordinatordatadir(coordinator_datadir=None):
     global option_coordinator_datadir
     option_coordinator_datadir = coordinator_datadir
 
 ######
 # Support both COORDINATOR_DATA_DIRECTORY and MASTER_DATA_DIRECTORY for backwards compatibility.
 # If both are set, the former is used and the latter is ignored.
+# if -d <coordinator_datadir> is provided with utility, it will be prioritiese over other options.
 def get_coordinatordatadir():
     if option_coordinator_datadir is not None:
         coordinator_datadir = option_coordinator_datadir

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1190,16 +1190,30 @@ def get_gphome():
         raise GpError('Environment Variable GPHOME not set')
     return gphome
 
+'''
+gprecoverseg, gpstart, gpstate, gpstop, gpaddmirror  has option to give -d <datadirctory>
+but that is not getting followed throught the utility. to avoid that best possible way is 
+to set and retrieve that set coordinator dir when we call get_coordinatordatadir().
+'''
+option_coordinator_datadir = None
+def set_coordinatordatadir( coordinator_datadir=None):
+    global option_coordinator_datadir
+    option_coordinator_datadir = coordinator_datadir
 
 ######
 # Support both COORDINATOR_DATA_DIRECTORY and MASTER_DATA_DIRECTORY for backwards compatibility.
 # If both are set, the former is used and the latter is ignored.
 def get_coordinatordatadir():
-    coordinator_datadir = os.environ.get('COORDINATOR_DATA_DIRECTORY')
-    if not coordinator_datadir:
-        coordinator_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
+    if option_coordinator_datadir is not None:
+        coordinator_datadir = option_coordinator_datadir
+    else:
+        coordinator_datadir = os.environ.get('COORDINATOR_DATA_DIRECTORY')
+        if not coordinator_datadir:
+            coordinator_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
+
     if not coordinator_datadir:
         raise GpError("Environment Variable COORDINATOR_DATA_DIRECTORY not set!")
+
     return coordinator_datadir
 
 ######

--- a/gpMgmt/bin/gppylib/system/environment.py
+++ b/gpMgmt/bin/gppylib/system/environment.py
@@ -29,7 +29,9 @@ class GpCoordinatorEnvironment:
         """
         if coordinatorDataDir is None:
             self.__coordinatorDataDir = gp.get_coordinatordatadir()
-        else: self.__coordinatorDataDir = coordinatorDataDir
+        else:
+            self.__coordinatorDataDir = coordinatorDataDir
+            gp.set_coordinatordatadir(coordinatorDataDir)
 
         logger.debug("Obtaining coordinator's port from coordinator data directory")
         pgconf_dict = pgconf.readfile(self.__coordinatorDataDir + "/postgresql.conf")

--- a/gpMgmt/bin/gppylib/system/environment.py
+++ b/gpMgmt/bin/gppylib/system/environment.py
@@ -31,7 +31,6 @@ class GpCoordinatorEnvironment:
             self.__coordinatorDataDir = gp.get_coordinatordatadir()
         else:
             self.__coordinatorDataDir = coordinatorDataDir
-            gp.set_coordinatordatadir(coordinatorDataDir)
 
         logger.debug("Obtaining coordinator's port from coordinator data directory")
         pgconf_dict = pgconf.readfile(self.__coordinatorDataDir + "/postgresql.conf")

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -291,6 +291,19 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
+    Scenario: gprecoverseg runs with given coordinator data directory option
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all mirror processes
+          And user can start transactions
+          And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gprecoverseg" with coordinator data directory and "-F -a"
+          And gprecoverseg should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+          And the segments are synchronized
+
     Scenario: gprecoverseg differential recovery displays rsync progress to the user
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -304,6 +304,19 @@ Feature: gprecoverseg tests
           And all the segments are running
           And the segments are synchronized
 
+    Scenario: gprecoverseg priorities given coordinator data directory over env option
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all mirror processes
+          And user can start transactions
+          And the environment variable "COORDINATOR_DATA_DIRECTORY" is set to "/tmp/"
+         Then the user runs utility "gprecoverseg" with coordinator data directory and "-F -a"
+          And gprecoverseg should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+          And the segments are synchronized
+
     Scenario: gprecoverseg differential recovery displays rsync progress to the user
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -29,6 +29,18 @@ Feature: gpstart behave tests
           And gpstart should return a return code of 0
           And all the segments are running
 
+    Scenario: gpstart runs with given coordinator data directory option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the user runs "gpstop -a"
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+          And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstart" with coordinator data directory and "-a"
+          And gpstart should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+
     @concourse_cluster
     @demo_cluster
     Scenario: gpstart starts even if a segment host is unreachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -29,6 +29,7 @@ Feature: gpstart behave tests
           And gpstart should return a return code of 0
           And all the segments are running
 
+    @demo_cluster
     Scenario: gpstart runs with given coordinator data directory option
         Given the database is running
           And running postgres processes are saved in context
@@ -36,6 +37,19 @@ Feature: gpstart behave tests
           And gpstop should return a return code of 0
           And verify no postgres process is running on all hosts
           And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstart" with coordinator data directory and "-a"
+          And gpstart should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+
+    @demo_cluster
+    Scenario: gpstart priorities given coordinator data directory over env option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the user runs "gpstop -a"
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+          And the environment variable "COORDINATOR_DATA_DIRECTORY" is set to "/tmp/"
          Then the user runs utility "gpstart" with coordinator data directory and "-a"
           And gpstart should return a return code of 0
           And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -619,6 +619,32 @@ Feature: gpstate tests
             | Total number postmaster processes found           = 3                                 |
             | Mirror Segment Status                                                                 |
             | Mirrors not configured on this array
+         And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+
+    Scenario: gpstate priorities given coordinator data directory over env option
+        Given the cluster is generated with "3" primaries only
+          And the environment variable "COORDINATOR_DATA_DIRECTORY" is set to "/tmp/"
+        Then the user runs utility "gpstate" with coordinator data directory and "-a -b"
+         And gpstate should return a return code of 0
+         And gpstate output has rows with keys values
+            | Coordinator instance                              = Active                            |
+            | Coordinator standby                               = No coordinator standby configured |
+            | Total segment instance count from metadata        = 3                                 |
+            | Primary Segment Status                                                                |
+            | Total primary segments                            = 3                                 |
+            | Total primary segment valid \(at coordinator\)    = 3                                 |
+            | Total primary segment failures \(at coordinator\) = 0                                 |
+            | Total number of postmaster.pid files missing      = 0                                 |
+            | Total number of postmaster.pid files found        = 3                                 |
+            | Total number of postmaster.pid PIDs missing       = 0                                 |
+            | Total number of postmaster.pid PIDs found         = 3                                 |
+            | Total number of /tmp lock files missing           = 0                                 |
+            | Total number of /tmp lock files found             = 3                                 |
+            | Total number postmaster processes missing         = 0                                 |
+            | Total number postmaster processes found           = 3                                 |
+            | Mirror Segment Status                                                                 |
+            | Mirrors not configured on this array
+        And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -596,6 +596,29 @@ Feature: gpstate tests
         And the pg_log files on primary segments should not contain "connections to primary segments are not allowed"
         And the user drops log_timestamp table
 
+    Scenario: gpstate runs with given coordinator data directory option
+        Given the cluster is generated with "3" primaries only
+         And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+        Then the user runs utility "gpstate" with coordinator data directory and "-a -b"
+         And gpstate should return a return code of 0
+         And gpstate output has rows with keys values
+            | Coordinator instance                              = Active                            |
+            | Coordinator standby                               = No coordinator standby configured |
+            | Total segment instance count from metadata        = 3                                 |
+            | Primary Segment Status                                                                |
+            | Total primary segments                            = 3                                 |
+            | Total primary segment valid \(at coordinator\)    = 3                                 |
+            | Total primary segment failures \(at coordinator\) = 0                                 |
+            | Total number of postmaster.pid files missing      = 0                                 |
+            | Total number of postmaster.pid files found        = 3                                 |
+            | Total number of postmaster.pid PIDs missing       = 0                                 |
+            | Total number of postmaster.pid PIDs found         = 3                                 |
+            | Total number of /tmp lock files missing           = 0                                 |
+            | Total number of /tmp lock files found             = 3                                 |
+            | Total number postmaster processes missing         = 0                                 |
+            | Total number postmaster processes found           = 3                                 |
+            | Mirror Segment Status                                                                 |
+            | Mirrors not configured on this array
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -10,12 +10,21 @@ Feature: gpstop behave tests
          Then gpstop should return a return code of 0
          And verify no postgres process is running on all hosts
 
-    @concourse_cluster
     @demo_cluster
     Scenario: gpstop runs with given coordinator data directory option
         Given the database is running
           And running postgres processes are saved in context
           And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstop" with coordinator data directory and "-a"
+          And gpstop should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And verify no postgres process is running on all hosts
+
+    @demo_cluster
+    Scenario: gpstop priorities given coordinator data directory over env option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the environment variable "COORDINATOR_DATA_DIRECTORY" is set to "/tmp/"
          Then the user runs utility "gpstop" with coordinator data directory and "-a"
           And gpstop should return a return code of 0
           And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -12,6 +12,17 @@ Feature: gpstop behave tests
 
     @concourse_cluster
     @demo_cluster
+    Scenario: gpstop runs with given coordinator data directory option
+        Given the database is running
+          And running postgres processes are saved in context
+          And "COORDINATOR_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstop" with coordinator data directory and "-a"
+          And gpstop should return a return code of 0
+          And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
+          And verify no postgres process is running on all hosts
+
+    @concourse_cluster
+    @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user switches to fast mode
         Given the database is running
           And the user asynchronously runs "psql postgres" and the process is saved

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1222,6 +1222,15 @@ def impl(context, options):
     context.execute_steps('''Then the user runs command "gpactivatestandby -a %s" from standby coordinator''' % options)
     context.standby_was_activated = True
 
+
+@given('the user runs utility "{utility}" with coordinator data directory and "{options}"')
+@when('the user runs utility "{utility}" with coordinator data directory and "{options}"')
+@then('the user runs utility "{utility}" with coordinator data directory and "{options}"')
+def impl(context, utility, options):
+    cmd = "{} -d {} {}".format(utility, coordinator_data_dir, options)
+    context.execute_steps('''then the user runs command "%s"''' % cmd )
+
+
 @then('gpintsystem logs should {contain} lines about running backout script')
 def impl(context, contain):
     string_to_find = 'Run command bash .*backout_gpinitsystem.* on coordinator to remove these changes$'


### PR DESCRIPTION

**Issue**: following are the gpMgmt utilities does not honor -d flag, when COORDINATOR_DATA_DIRECTORY is not set.
1. gpstart
2. gpstop
3. gpstatus
4. gprecoverseg
5. gpaddmirror

**RCA**: to get the coordinator data directory gp.getcoordinator_datadir() function is called from the above-listed utilties. The function do not have any provision to return the coordinator data directory which is provided with -d flag. currently, it looks for COORDINATOR_DATA_DIRECTORY and MASTER_DATA_DIRECTORY env variable.
    Also in some of the utilities, we were creating a lock file before parsing the provided options which looks like a design flow that was causing the utilities to crash when looking for the coordinator data directory.

**Fix**: added a global flag that holds the datadirectory provided with the -d option. so when we run the utility and do parsing of options, it set the flag with provided datadirectory and the same will be return when we call gp.gp.getcoordinator_datadir().

**Test**: Added behave test cases to support the code changes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
