### PR TITLE
[6X backport] Orca memory pool refactoring

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -114,7 +114,7 @@ public:
 	static void Init();
 
 	// destroy global factory instance
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CXformFactory
 

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -67,8 +67,7 @@ CColumnFactory::~CColumnFactory()
 	m_sht.Cleanup();
 
 	// destroy mem pool
-	CMemoryPoolManager *pmpm = CMemoryPoolManager::GetMemoryPoolMgr();
-	pmpm->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -40,7 +40,7 @@ static CMemoryPool *mp = NULL;
 void
 gpopt_init()
 {
-	mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	mp = CMemoryPoolManager::CreateMemoryPool();
 
 	gpopt::EresExceptionInit(mp);
 
@@ -61,9 +61,9 @@ gpopt_terminate()
 #ifdef GPOS_DEBUG
 	CMDCache::Shutdown();
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
@@ -53,7 +53,7 @@ CSchedulerContext::~CSchedulerContext()
 	// release local memory pool
 	if (FInit())
 	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(PmpLocal());
+		CMemoryPoolManager::Destroy(PmpLocal());
 	}
 }
 
@@ -77,7 +77,7 @@ CSchedulerContext::Init(CMemoryPool *pmpGlobal, CJobFactory *pjf,
 
 	GPOS_ASSERT(!FInit() && "Scheduling context is already initialized");
 
-	m_pmpLocal = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_pmpLocal = CMemoryPoolManager::CreateMemoryPool();
 
 	m_pmpGlobal = pmpGlobal;
 	m_pjf = pjf;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -356,11 +356,10 @@ CXformFactory::IsXformIdUsed(CXform::EXformId exfid)
 void
 CXformFactory::Init()
 {
-	GPOS_ASSERT(NULL == Pxff() && "Xform factory was already initialized");
+	GPOS_ASSERT(NULL == m_pxff && "Xform factory was already initialized");
 
 	// create xform factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create xform factory instance
 	m_pxff = GPOS_NEW(mp) CXformFactory(mp);
@@ -381,18 +380,18 @@ CXformFactory::Init()
 void
 CXformFactory::Shutdown()
 {
-	CXformFactory *pxff = CXformFactory::Pxff();
+	CXformFactory *pxff = m_pxff;
 
 	GPOS_ASSERT(NULL != pxff && "Xform factory has not been initialized");
 
 	CMemoryPool *mp = pxff->m_mp;
 
 	// destroy xform factory
-	CXformFactory::m_pxff = NULL;
+	m_pxff = NULL;
 	GPOS_DELETE(pxff);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -39,8 +39,7 @@ struct DbgPrintMixin
 	void
 	DbgPrint() const
 	{
-		CMemoryPool *mp =
-			CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool();
+		CMemoryPool *mp = CMemoryPoolManager::GetGlobalMemoryPool();
 		CAutoTrace at(mp);
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}

--- a/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
@@ -177,7 +177,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// destroy simulator
-	void Shutdown();
+	static void Shutdown();
 #endif	// GPOS_DEBUG
 
 	// accessor for global instance

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -69,7 +69,7 @@ public:
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();
 
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CMessageRepository
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
@@ -365,7 +365,7 @@ private:
 		// destroy the object before deleting memory pool. This cover the case where object & cacheentry use same memory pool
 		CMemoryPool *mp = entry->Pmp();
 		GPOS_DELETE(entry);
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 
 	// evict entries by making one pass through the hash table buckets

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
@@ -69,7 +69,7 @@ public:
 		// check if a memory pool was created but insertion failed
 		if (NULL != m_mp && !m_inserted)
 		{
-			CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+			CMemoryPoolManager::Destroy(m_mp);
 		}
 
 		// release entry if one was created
@@ -150,7 +150,7 @@ public:
 		GPOS_ASSERT(NULL == m_mp);
 
 		// construct a memory pool for cache entry
-		m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+		m_mp = CMemoryPoolManager::CreateMemoryPool();
 
 		return m_mp;
 	}

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -68,7 +68,7 @@ public:
 	static void Init();
 
 	// destroy global instance
-	void Shutdown();
+	static void Shutdown();
 
 	// global accessor
 	inline static CCacheFactory *
@@ -84,10 +84,10 @@ public:
 				typename CCache<T, K>::HashFuncPtr hash_func,
 				typename CCache<T, K>::EqualFuncPtr equal_func)
 	{
-		GPOS_ASSERT(NULL != GetFactory() &&
+		GPOS_ASSERT(NULL != m_factory &&
 					"Cache factory has not been initialized");
 
-		CMemoryPool *mp = GetFactory()->Pmp();
+		CMemoryPool *mp = m_factory->Pmp();
 		CCache<T, K> *cache = GPOS_NEW(mp)
 			CCache<T, K>(mp, unique, cache_quota, CCACHE_GCLOCK_INIT_COUNTER,
 						 hash_func, equal_func);

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -69,7 +69,7 @@ private:
 	CMemoryPoolManager(const CMemoryPoolManager &);
 
 	// clean-up memory pools
-	void Cleanup();
+	static void Cleanup();
 
 	// destroy a memory pool at shutdown
 	static void DestroyMemoryPoolAtShutdown(CMemoryPool *mp);
@@ -120,10 +120,10 @@ protected:
 
 public:
 	// create new memory pool
-	CMemoryPool *CreateMemoryPool();
+	static CMemoryPool *CreateMemoryPool();
 
 	// release memory pool
-	void Destroy(CMemoryPool *);
+	static void Destroy(CMemoryPool *);
 
 #ifdef GPOS_DEBUG
 	// print internal contents of allocated memory pools
@@ -134,13 +134,14 @@ public:
 #endif	// GPOS_DEBUG
 
 	// delete memory pools and release manager
-	void Shutdown();
+	static void Shutdown();
 
 	// accessor of memory pool used in global new allocations
-	CMemoryPool *
+	static CMemoryPool *
 	GetGlobalMemoryPool()
 	{
-		return m_global_memory_pool;
+		GPOS_ASSERT(NULL != m_memory_pool_mgr);
+		return m_memory_pool_mgr->m_global_memory_pool;
 	}
 
 	virtual ~CMemoryPoolManager()

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -264,12 +264,12 @@ gpos_terminate()
 #endif
 #ifdef GPOS_DEBUG
 #ifdef GPOS_FPSIMULATOR
-	CFSimulator::FSim()->Shutdown();
+	CFSimulator::Shutdown();
 #endif	// GPOS_FPSIMULATOR
-	CMessageRepository::GetMessageRepository()->Shutdown();
-	CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-	CCacheFactory::GetFactory()->Shutdown();
-	CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+	CMessageRepository::Shutdown();
+	CWorkerPoolManager::Shutdown();
+	CCacheFactory::Shutdown();
+	CMemoryPoolManager::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
+++ b/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
@@ -60,8 +60,7 @@ CDebugCounter::Init()
 {
 	GPOS_RTL_ASSERT(NULL == m_instance);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 }
@@ -75,7 +74,7 @@ CDebugCounter::Shutdown()
 
 		GPOS_DELETE(m_instance);
 		m_instance = NULL;
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 }
 

--- a/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
+++ b/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
@@ -133,8 +133,7 @@ CFSimulator::NewStack(ULONG major, ULONG minor)
 void
 CFSimulator::Init()
 {
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	m_fsim = GPOS_NEW(mp) CFSimulator(mp, GPOS_FSIM_RESOLUTION);
 }
@@ -152,11 +151,12 @@ CFSimulator::Init()
 void
 CFSimulator::Shutdown()
 {
-	CMemoryPool *mp = m_mp;
-	GPOS_DELETE(CFSimulator::m_fsim);
-	CFSimulator::m_fsim = NULL;
+	GPOS_ASSERT(NULL != m_fsim);
+	CMemoryPool *mp = m_fsim->m_mp;
+	GPOS_DELETE(m_fsim);
+	m_fsim = NULL;
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -107,8 +107,7 @@ CMessageRepository::Init()
 {
 	GPOS_ASSERT(NULL == m_repository);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	m_repository = GPOS_NEW(mp) CMessageRepository(mp);
 	m_repository->InitDirectory(mp);
@@ -145,8 +144,9 @@ CMessageRepository::GetMessageRepository()
 void
 CMessageRepository::Shutdown()
 {
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
-	CMessageRepository::m_repository = NULL;
+	GPOS_ASSERT(NULL != m_repository);
+	CMemoryPoolManager::Destroy(m_repository->m_mp);
+	m_repository = NULL;
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
@@ -42,7 +42,7 @@ using namespace gpos;
 CAutoMemoryPool::CAutoMemoryPool(ELeakCheck leak_check_type)
 	: m_leak_check_type(leak_check_type)
 {
-	m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_mp = CMemoryPoolManager::CreateMemoryPool();
 }
 
 
@@ -105,7 +105,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 		}
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 	}
 	GPOS_CATCH_EX(ex)
 	{
@@ -113,7 +113,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 			GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiAssert));
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 
 		GPOS_RETHROW(ex);
 	}
@@ -122,7 +122,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 #else  // GPOS_DEBUG
 
 	// hand in pool and return
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 
 #endif	// GPOS_DEBUG
 }

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -60,12 +60,10 @@ CCacheFactory::Pmp() const
 void
 CCacheFactory::Init()
 {
-	GPOS_ASSERT(NULL == GetFactory() &&
-				"Cache factory was already initialized");
+	GPOS_ASSERT(NULL == m_factory && "Cache factory was already initialized");
 
 	// create cache factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create cache factory instance
 	m_factory = GPOS_NEW(mp) CCacheFactory(mp);
@@ -83,17 +81,17 @@ CCacheFactory::Init()
 void
 CCacheFactory::Shutdown()
 {
-	CCacheFactory *factory = CCacheFactory::GetFactory();
+	CCacheFactory *factory = m_factory;
 
 	GPOS_ASSERT(NULL != factory && "Cache factory has not been initialized");
 
 	CMemoryPool *mp = factory->m_mp;
 
 	// destroy cache factory
-	CCacheFactory::m_factory = NULL;
+	m_factory = NULL;
 	GPOS_DELETE(factory);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 // EOF

--- a/src/backend/gporca/libgpos/src/task/CTask.cpp
+++ b/src/backend/gporca/libgpos/src/task/CTask.cpp
@@ -75,7 +75,7 @@ CTask::~CTask()
 	GPOS_DELETE(m_task_ctxt);
 	GPOS_DELETE(m_err_ctxt);
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -62,10 +62,9 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 void
 CWorkerPoolManager::Init()
 {
-	GPOS_ASSERT(NULL == WorkerPoolManager());
+	GPOS_ASSERT(NULL == m_worker_pool_manager);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	// create worker pool
 	m_worker_pool_manager = GPOS_NEW(mp) CWorkerPoolManager(mp);
@@ -83,8 +82,7 @@ CWorkerPoolManager::Init()
 void
 CWorkerPoolManager::Shutdown()
 {
-	CWorkerPoolManager *worker_pool_manager =
-		CWorkerPoolManager::m_worker_pool_manager;
+	CWorkerPoolManager *worker_pool_manager = m_worker_pool_manager;
 
 	GPOS_ASSERT(NULL != worker_pool_manager &&
 				"Worker pool has not been initialized");
@@ -98,11 +96,11 @@ CWorkerPoolManager::Shutdown()
 	CMemoryPool *mp = worker_pool_manager->m_mp;
 
 	// destroy worker pool
-	CWorkerPoolManager::m_worker_pool_manager = NULL;
+	m_worker_pool_manager = NULL;
 	GPOS_DELETE(worker_pool_manager);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -120,10 +120,10 @@ void
 gpdxl_init()
 {
 	// create memory pool for Xerces global allocations
-	pmpXerces = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	pmpXerces = CMemoryPoolManager::CreateMemoryPool();
 
 	// create memory pool for DXL global allocations
-	pmpDXL = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	pmpDXL = CMemoryPoolManager::CreateMemoryPool();
 
 	// add standard exception messages
 	EresExceptionInit(pmpDXL);
@@ -146,13 +146,13 @@ gpdxl_terminate()
 
 	if (NULL != pmpDXL)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpDXL);
+		CMemoryPoolManager::Destroy(pmpDXL);
 		pmpDXL = NULL;
 	}
 
 	if (NULL != pmpXerces)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpXerces);
+		CMemoryPoolManager::Destroy(pmpXerces);
 		pmpXerces = NULL;
 	}
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -243,7 +243,7 @@ ConfigureTests()
 
 #ifdef GPOS_DEBUG
 	// reset xforms factory to exercise xforms ctors and dtors
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 	CXformFactory::Init();
 #endif	// GPOS_DEBUG
 }

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -163,7 +163,7 @@ CTestUtils::DestroyMDProvider()
 	CRefCount::SafeRelease(m_pmdpf);
 
 	// release local memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 


### PR DESCRIPTION
Declare methods as static if they work with static member variables only

- I made the CMemoryPoolManager::Cleanup method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::CreateMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::Destroy method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::GetGlobalMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMemoryPoolManager::Shutdown method static, which was previously called only on the static object m_memory_pool_mgr.

- I made the CMessageRepository::Shutdown method static, which was previously called on the static object m_repository.

I added assertions to make sure the pointers being dereferenced are not null.

This is backport of 60c1cf578d21c41500bb1cf4c76c2126230df8ea with additions:

- I made the CCacheFactory::Shutdown method static because it only uses static variables.

- I made the CFSimulator::Shutdown method static, which was previously called only on the static object m_fsim.

- I made the CWorkerPoolManager::Shutdown method static because it uses only static variables.

- I made the CXformFactory::Shutdown method static because it uses only static variables.