### PR TITLE
Fix plpgsql/sql nested queries logging

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -1278,8 +1278,6 @@ PG_TRY();
 		gp_enable_gpperfmon = false;
 	}
 
-	gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-
 	/*
 	 * Execute each command in the function one after another until we either
 	 * run out of commands or get a result row from a lazily-evaluated SELECT.

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2278,6 +2278,19 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 
 			dest = CreateDestReceiver(canSetTag ? DestSPI : DestNone);
 
+			bool orig_gp_enable_gpperfmon = gp_enable_gpperfmon;
+			
+PG_TRY();
+{
+			/*
+			* Temporarily disable gpperfmon since we don't send information for internal queries in
+			* most cases, except when the debugging level is set to DEBUG4 or DEBUG5.
+			*/
+			if (log_min_messages > DEBUG4)
+			{
+				gp_enable_gpperfmon = false;
+			}
+
 			if (IsA(stmt, PlannedStmt) &&
 				((PlannedStmt *) stmt)->utilityStmt == NULL)
 			{
@@ -2299,9 +2312,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 				if (query_info_collect_hook)
 					(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, qdesc);
 			
-				if (gp_enable_gpperfmon 
-						&& Gp_role == GP_ROLE_DISPATCH 
-						&& log_min_messages < DEBUG4)
+				if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 				{
 					/* For log level of DEBUG4, gpmon is sent information about SPI internal queries as well */
 					Assert(plansource->query_string);
@@ -2376,6 +2387,15 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 													  NULL, 10);
 				}
 			}
+
+			gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
+}
+PG_CATCH();
+{
+			gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
+			PG_RE_THROW();
+}
+PG_END_TRY();
 
 			/*
 			 * The last canSetTag query sets the status values returned to the
@@ -2606,28 +2626,16 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 		ResetUsage();
 #endif
 
-	bool orig_gp_enable_gpperfmon = gp_enable_gpperfmon;
-
 	/* Select execution options */
 	if (fire_triggers)
 		eflags = 0;				/* default run-to-completion flags */
 	else
 		eflags = EXEC_FLAG_SKIP_TRIGGERS;
 
-	PG_TRY();
 	{
 		Oid			relationOid = InvalidOid; 	/* relation that is modified */
 		AutoStatsCmdType cmdType = AUTOSTATS_CMDTYPE_SENTINEL; 	/* command type */
 		bool		checkTuples;
-
-		/*
-		 * Temporarily disable gpperfmon since we don't send information for internal queries in
-		 * most cases, except when the debugging level is set to DEBUG4 or DEBUG5.
-		 */
-		if (log_min_messages > DEBUG4)
-		{
-			gp_enable_gpperfmon = false;
-		}
 
 		ExecutorStart(queryDesc, 0);
 
@@ -2679,18 +2687,10 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, int64 tcount)
 #endif /* FAULT_INJECTOR */
 		}
 
-		gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)
 			auto_stats(cmdType, relationOid, queryDesc->es_processed, true /* inFunction */);
 	}
-	PG_CATCH();
-	{
-		gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
 
 	_SPI_current->processed = queryDesc->es_processed;	/* Mpp: Dispatched
 														 * queries fill in this


### PR DESCRIPTION
gpdb changes gp_enable_gpperfmon guc value depending on log level to control which statements to log during query execution. We don't want to log nested statements of plpgsql function if log level is other than DEBUG5, but gpperfmon logs some despite of log level. This happened because only executor queries were properly covered to have correct gp_enable_gpperfmon value, when utility queries were executed with wrong value of this guc.

This patch covers utility queries as well, setting gp_enable_gpperfmon to correct value for them. Though gpperfmon doesn't log utility queries, gp_enable_gpperfmon can be set for nested executor queries (e.g. CTAS).

Also, gp_enable_gpperfmon was immediately reset in fmgr_sql to its original value which lead incorrect logging of child queries. This patch removes extra assignment.

There's an example of such behavior when gp_enable_gpperfmon was set incorrectly and unwanted record was added
```
gpperfmon=# select ctime, ccnt, tsubmit, query_text, status from queries_history order by 1 desc;
        ctime        | ccnt |       tsubmit       |      query_text       | status
---------------------+------+---------------------+-----------------------+--------
 2023-07-05 09:47:15 |   19 | 1970-01-01 00:00:00 |                       | done
```