### PR TITLE
Fix flaky basebackup tap test that relied on pg_current_wal_lsn

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -179,9 +179,19 @@ ok(-f "$tempdir/tarbackup/base.tar", 'backup tar was created');
 rmtree("$tempdir/tarbackup");
 
 ########################## Test that the headers are zeroed out in both the primary and mirror WAL files
-my $compare_tempdir = "$tempdir/checksum_test";
+my $node_wal_compare_primary = get_new_node('wal_compare_primary');
+# We need to enable archiving for this test because we depend on the backup history
+# file created by pg_basebackup to retrieve the "STOP WAL LOCATION". This file only
+# gets persisted if archiving is turned on.
+$node_wal_compare_primary->init(
+	has_archiving    => 1,
+	allows_streaming => 1);
+$node_wal_compare_primary->start;
 
-# Ensure that when pg_basebackup is run that the last WAL segment file
+my $node_wal_compare_primary_datadir = $node_wal_compare_primary->data_dir;
+my $node_wal_compare_standby_datadir = "$tempdir/wal_compare_standby";
+
+# Ensure that when pg_basebackup is run, the last WAL segment file
 # containing the BACKUP_END and wal SWITCH records match on both
 # the primary and mirror segment. We want to ensure that all pages after
 # the wal SWITCH record are all zeroed out. Previously, the primary
@@ -191,31 +201,43 @@ my $compare_tempdir = "$tempdir/checksum_test";
 # and would lead to checksum mismatches for external tools that checked
 # for that.
 
-#Insert data and then run pg_basebackup
-$node->safe_psql('postgres',  'CREATE TABLE zero_header_test as SELECT generate_series(1,1000);');
-$node->command_ok([ 'pg_basebackup', '-D', $compare_tempdir, '--target-gp-dbid', '123' , '-X', 'stream'],
+## Insert data and then run pg_basebackup
+$node_wal_compare_primary->safe_psql('postgres',  'CREATE TABLE zero_header_test as SELECT generate_series(1,1000);');
+$node_wal_compare_primary->command_ok([ 'pg_basebackup', '-D', $node_wal_compare_standby_datadir, '--target-gp-dbid', '123' , '-X', 'stream'],
 	'pg_basebackup wal file comparison test');
-ok( -f "$compare_tempdir/PG_VERSION", 'pg_basebackup ran successfully');
+ok( -f "$node_wal_compare_standby_datadir/PG_VERSION", 'pg_basebackup ran successfully');
 
-my $current_wal_file = $node->safe_psql('postgres', "SELECT pg_walfile_name(pg_current_wal_lsn());");
-my $primary_wal_file_path = "$pgdata/pg_wal/$current_wal_file";
-my $mirror_wal_file_path = "$compare_tempdir/pg_wal/$current_wal_file";
+# We can't rely on `pg_current_wal_lsn()` to get the last WAL filename that was
+# copied over to the standby. This is because it's possible for newer WAL files
+# to get created after pg_basebackup is run. More specifically, insertion of
+# "Standby" records can create new WAL files quickly enough for
+# `pg_current_wal_lsn()` to not return the WAL file where pg_basebackup had stopped.
+# So instead, we rely on the backup history file created by pg_basebackup to get
+# this information. We can safely assume that there's only one backup history
+# file in the primary's wal dir
+my $backup_history_file = "$node_wal_compare_primary_datadir/pg_wal/*.backup";
+my $stop_wal_file_cmd = 'sed -n "s/STOP WAL LOCATION.*(file //p" ' . $backup_history_file . ' | sed "s/)//g"';
+my $stop_wal_file = `$stop_wal_file_cmd`;
+chomp($stop_wal_file);
 
-## Test that primary and mirror WAL file is the same
+my $primary_wal_file_path = "$node_wal_compare_primary_datadir/pg_wal/$stop_wal_file";
+my $mirror_wal_file_path = "$node_wal_compare_standby_datadir/pg_wal/$stop_wal_file";
+
+# Test that primary and mirror WAL file is the same
 ok(compare($primary_wal_file_path, $mirror_wal_file_path) eq 0, "wal file comparison");
 
-## Test that all the bytes after the last written record in the WAL file are zeroed out
-my $total_bytes_cmd = 'pg_controldata ' . $compare_tempdir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
+# Test that all the bytes after the last written record in the WAL file are zeroed out
+my $total_bytes_cmd = 'pg_controldata ' . $node_wal_compare_standby_datadir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
 my $total_allocated_bytes = `$total_bytes_cmd`;
 
 my $current_lsn_cmd = 'pg_waldump -f ' . $primary_wal_file_path . ' | grep "SWITCH" | awk \'{print $10}\' | sed "s/,//"';
 my $current_lsn = `$current_lsn_cmd`;
 chomp($current_lsn);
-my $current_byte_offset = $node->safe_psql('postgres', "SELECT file_offset FROM pg_walfile_name_offset('$current_lsn');");
+my $current_byte_offset = $node_wal_compare_primary->safe_psql('postgres', "SELECT file_offset FROM pg_walfile_name_offset('$current_lsn');");
 
-#Get offset of last written record
+# Get offset of last written record
 open my $fh, '<:raw', $primary_wal_file_path;
-#Since pg_walfile_name_offset does not account for the wal switch record, we need to add it ourselves
+# Since pg_walfile_name_offset does not account for the wal switch record, we need to add it ourselves
 my $wal_switch_record_len = 32;
 seek $fh, $current_byte_offset + $wal_switch_record_len, 0;
 my $bytes_read = "";
@@ -223,6 +245,8 @@ my $len_bytes_to_validate = $total_allocated_bytes - $current_byte_offset;
 read($fh, $bytes_read, $len_bytes_to_validate);
 close $fh;
 ok($bytes_read =~ /\A\x00*+\z/, 'make sure wal segment is zeroed');
+
+############################## End header test #####################################
 
 $node->command_fails(
 	[ 'pg_basebackup', '-D', "$tempdir/backup_foo", '--target-gp-dbid', '123', '-Fp', "-T=/foo" ],

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -230,7 +230,7 @@ ok(compare($primary_wal_file_path, $mirror_wal_file_path) eq 0, "wal file compar
 my $total_bytes_cmd = 'pg_controldata ' . $node_wal_compare_standby_datadir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
 my $total_allocated_bytes = `$total_bytes_cmd`;
 
-my $current_lsn_cmd = 'pg_waldump -f ' . $primary_wal_file_path . ' | grep "SWITCH" | awk \'{print $10}\' | sed "s/,//"';
+my $current_lsn_cmd = 'pg_waldump ' . $primary_wal_file_path . ' | grep "SWITCH" | awk \'{print $10}\' | sed "s/,//"';
 my $current_lsn = `$current_lsn_cmd`;
 chomp($current_lsn);
 my $current_byte_offset = $node_wal_compare_primary->safe_psql('postgres', "SELECT file_offset FROM pg_walfile_name_offset('$current_lsn');");


### PR DESCRIPTION
**CONTEXT**:
A previous commit
https://github.com/greenplum-db/gpdb/commit/bef7e82d270f422c975e57e5f83fa517fe83e1e8 had added a basebackup tap test to ensure that the primary WAL file containing the wal switch record (created by pg_basebackup) exactly matched the WAL file on the standby.

**PROBLEM**:
In order to get the name of the WAL file to compare, we used to rely on `pg_current_wal_lsn()` to return the "last WAL file" copied over by pg_basebackup to the standby server. This wasn't always reliable because because it's possible for newer WAL files to get created after pg_basebackup is run.
More specifically on 7X, insertion of "Standby" records can create new WAL files quickly enough for `pg_current_wal_lsn()` to not return the WAL file where pg_basebackup had stopped.
Because of this, the pg_basebackup test was flaky and would error out and get stuck

**FIX**:
Instead of relying on `pg_current_wal_lsn()`, we can rely on the backup history file created by pg_basebackup which contains information about the "STOP WAL LOCATION". This will always give us accurate information about the last wal file that was shipped by pg_basebackup to the standby server.
In order for pg_basebackup to retain this backup history file, we need to enable archiving because otherwise, the file gets deleted.

Sample backup history file

cat 000000010000000000000014.00000028.backup
```
START WAL LOCATION: 0/50000028 (file 000000010000000000000014)
STOP WAL LOCATION: 0/50000110 (file 000000010000000000000014)
CHECKPOINT LOCATION: 0/50000060
BACKUP METHOD: streamed
BACKUP FROM: primary
START TIME: 2023-09-13 12:36:01 PDT
LABEL: pg_basebackup base backup
START TIMELINE: 1
STOP TIME: 2023-09-13 12:36:02 PDT
```

**RCA WITH EXAMPLE**:

Contents of primary’s pg_wal dir before running pg_basebackup
```
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000001
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000002
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000003
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000004
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000005
```

Contents of primary’s pg_wal dir after running pg_basebackup
```
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000001
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000002
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000003
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000004
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000005
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000006
-rw------- 1 gpadmin gpadmin 67108864 Sep 13 01:33 000000010000000000000007
```

Workflow:
* pg_basebackup is run by the test. Internally, pg_basebackup runs pg_stop_backup

* This pg_stop_backup function calls gp_switch_wal which gets inserted into the 000000010000000000000006 wal file

* The mirror receives the  000000010000000000000006 wal file

* In the test, we run pg_walfile_name(pg_current_wal_lsn()) to get the current wal filename which in most cases, returns
000000010000000000000006 . We then make sure that this 000000010000000000000006 wal file on the primary matches the 000000010000000000000006 wal file on the mirror.

* The problem happens when pg_walfile_name(pg_current_wal_lsn()) returns 000000010000000000000007  instead of 000000010000000000000006

* That happens because intermittently, a new wal file 000000010000000000000007 gets created on the primary which obviously doesn’t exist on the mirror because this file gets created immediately after pg_basebackup is run (Adding a sleep of 10s after pg_basebackup makes the test fail more often)

* The main problem is that this new wal file gets created too quickly after running pg_basebackup because of which we end up comparing 000000010000000000000007 on the primary with 000000010000000000000006 on the mirror

* The very first record in this new wal file 000000010000000000000007 is a "Standby" record. The insertion of this "Standby" record creates the WAL file
```
rmgr: Standby     len (rec/tot):     50/    50, tx:          0, lsn:
0/20000028, prev 0/1C000110, desc: RUNNING_XACTS nextXid 1082
latestCompletedXid 1081 oldestRunningXid 1082
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
