### PR TITLE
Fix bug: copy to a replicated table from an empty file (7X)

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -643,7 +643,12 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 					PQfreemem(buffer);
 			}
 
-			/* in SREH mode, check if this seg rejected (how many) rows */
+			/* 
+			 * in SREH mode, check if this seg rejected (how many) rows
+			 * 
+			 * To ensure the correctness of COPY FROM an empty file,
+			 * we have to check res->numRejected == 0, please refer to issue-16250
+			 */
 			if (res->numRejected >= 0)
 			{
 				segment_rows_rejected = res->numRejected;
@@ -667,6 +672,9 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 			/*
 			 * When COPY FROM, need to calculate the number of this
 			 * segment's completed rows
+			 * 
+			 * To ensure the correctness of COPY FROM an empty file,
+			 * we have to check res->numCompleted == 0, please refer to issue-16250
 			 */
 			if (res->numCompleted >= 0)
 			{

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -434,9 +434,9 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 											 * QEs */
 	int64		total_rows_rejected = 0;	/* total num rows rejected by all
 											 * QEs */
-	int64		first_segment_rows_completed = -1;	/* total num rows completed by first QE,
+	int64		first_segment_rows_completed = 0;	/* total num rows completed by first QE,
 											 		 * mainly for replicated table */
-	int64		first_segment_rows_rejected = -1;	/* total num rows rejected by first QE,
+	int64		first_segment_rows_rejected = 0;	/* total num rows rejected by first QE,
 													 * mainly for replicated table */
 	ErrorData *first_error = NULL;
 	int			seg;
@@ -643,13 +643,8 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 					PQfreemem(buffer);
 			}
 
-			/* 
-			 * in SREH mode, check if this seg rejected (how many) rows
-			 * 
-			 * To ensure the correctness of COPY FROM an empty file,
-			 * we have to check res->numRejected == 0, please refer to issue-16250
-			 */
-			if (res->numRejected >= 0)
+			/* in SREH mode, check if this seg rejected (how many) rows */
+			if (res->numRejected > 0)
 			{
 				segment_rows_rejected = res->numRejected;
 				/* 
@@ -658,7 +653,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 				 */
 				if (c->is_replicated)
 				{
-					if (first_segment_rows_rejected == -1) 
+					if (first_segment_rows_rejected == 0) 
 						first_segment_rows_rejected = res->numRejected;
 					else
 					{
@@ -672,11 +667,8 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 			/*
 			 * When COPY FROM, need to calculate the number of this
 			 * segment's completed rows
-			 * 
-			 * To ensure the correctness of COPY FROM an empty file,
-			 * we have to check res->numCompleted == 0, please refer to issue-16250
 			 */
-			if (res->numCompleted >= 0)
+			if (res->numCompleted > 0)
 			{
 				segment_rows_completed = res->numCompleted;
 				/* 
@@ -685,7 +677,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 				 */
 				if (c->is_replicated)
 				{
-					if (first_segment_rows_completed == -1) 
+					if (first_segment_rows_completed == 0) 
 						first_segment_rows_completed = res->numCompleted;
 					else
 					{

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -644,7 +644,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 			}
 
 			/* in SREH mode, check if this seg rejected (how many) rows */
-			if (res->numRejected > 0)
+			if (res->numRejected >= 0)
 			{
 				segment_rows_rejected = res->numRejected;
 				/* 
@@ -668,7 +668,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 			 * When COPY FROM, need to calculate the number of this
 			 * segment's completed rows
 			 */
-			if (res->numCompleted > 0)
+			if (res->numCompleted >= 0)
 			{
 				segment_rows_completed = res->numCompleted;
 				/* 

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1376,3 +1376,16 @@ COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH 
 -- Test that gpdb emits an error message saying the data distribution is malformed.
 \! cp /tmp/issue_14353_multi_dist_1.csv /tmp/issue_14353_multi_dist_0.csv
 COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+
+-- special case about distributed replicated table
+\set QUIET off
+-- please refer to https://github.com/greenplum-db/gpdb/issues/16250
+CREATE TABLE replicated_issue_16250(c1 int, c2 text) distributed replicated;
+COPY replicated_issue_16250 FROM '@abs_srcdir@/data/empty.data';
+DROP TABLE replicated_issue_16250;
+
+-- please refer to https://github.com/greenplum-db/gpdb/issues/14126
+CREATE TABLE replicated_issue_14126(c1 int, c2 text) distributed replicated;
+COPY replicated_issue_14126 FROM '@abs_srcdir@/data/copy.data' DELIMITER ',';
+DROP TABLE replicated_issue_14126;
+\set QUIET on

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1377,14 +1377,12 @@ COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH 
 \! cp /tmp/issue_14353_multi_dist_1.csv /tmp/issue_14353_multi_dist_0.csv
 COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
 
--- special case about distributed replicated table
+-- special case about distributed replicated table, please refer to issue-14126 and issue-16250
 \set QUIET off
--- please refer to https://github.com/greenplum-db/gpdb/issues/16250
 CREATE TABLE replicated_issue_16250(c1 int, c2 text) distributed replicated;
 COPY replicated_issue_16250 FROM '@abs_srcdir@/data/empty.data';
 DROP TABLE replicated_issue_16250;
 
--- please refer to https://github.com/greenplum-db/gpdb/issues/14126
 CREATE TABLE replicated_issue_14126(c1 int, c2 text) distributed replicated;
 COPY replicated_issue_14126 FROM '@abs_srcdir@/data/copy.data' DELIMITER ',';
 DROP TABLE replicated_issue_14126;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1700,16 +1700,14 @@ COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH 
 COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
 ERROR:  value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:7002 pid=21933)
 CONTEXT:  COPY issue_14353_multi_dist, line 11: "1,1,a"
--- special case about distributed replicated table
+-- special case about distributed replicated table, please refer to issue-14126 and issue-16250
 \set QUIET off
--- please refer to https://github.com/greenplum-db/gpdb/issues/16250
 CREATE TABLE replicated_issue_16250(c1 int, c2 text) distributed replicated;
 CREATE TABLE
 COPY replicated_issue_16250 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/empty.data';
 COPY 0
 DROP TABLE replicated_issue_16250;
 DROP TABLE
--- please refer to https://github.com/greenplum-db/gpdb/issues/14126
 CREATE TABLE replicated_issue_14126(c1 int, c2 text) distributed replicated;
 CREATE TABLE
 COPY replicated_issue_14126 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/copy.data' DELIMITER ',';

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1704,13 +1704,13 @@ CONTEXT:  COPY issue_14353_multi_dist, line 11: "1,1,a"
 \set QUIET off
 CREATE TABLE replicated_issue_16250(c1 int, c2 text) distributed replicated;
 CREATE TABLE
-COPY replicated_issue_16250 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/empty.data';
+COPY replicated_issue_16250 FROM '@abs_srcdir@/data/empty.data';
 COPY 0
 DROP TABLE replicated_issue_16250;
 DROP TABLE
 CREATE TABLE replicated_issue_14126(c1 int, c2 text) distributed replicated;
 CREATE TABLE
-COPY replicated_issue_14126 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/copy.data' DELIMITER ',';
+COPY replicated_issue_14126 FROM '@abs_srcdir@/data/copy.data' DELIMITER ',';
 COPY 1
 DROP TABLE replicated_issue_14126;
 DROP TABLE

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1700,3 +1700,20 @@ COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH 
 COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
 ERROR:  value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:7002 pid=21933)
 CONTEXT:  COPY issue_14353_multi_dist, line 11: "1,1,a"
+-- special case about distributed replicated table
+\set QUIET off
+-- please refer to https://github.com/greenplum-db/gpdb/issues/16250
+CREATE TABLE replicated_issue_16250(c1 int, c2 text) distributed replicated;
+CREATE TABLE
+COPY replicated_issue_16250 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/empty.data';
+COPY 0
+DROP TABLE replicated_issue_16250;
+DROP TABLE
+-- please refer to https://github.com/greenplum-db/gpdb/issues/14126
+CREATE TABLE replicated_issue_14126(c1 int, c2 text) distributed replicated;
+CREATE TABLE
+COPY replicated_issue_14126 FROM '/home/gpadmin/workspace/gpdb/src/test/regress/data/copy.data' DELIMITER ',';
+COPY 1
+DROP TABLE replicated_issue_14126;
+DROP TABLE
+\set QUIET on


### PR DESCRIPTION
Long log:

This pr can fix bug reported in https://github.com/greenplum-db/gpdb/issues/16250
The bug is introduced by https://github.com/greenplum-db/gpdb/pull/14989, which forgets to check the corner test case.
Solution: 	
set the default value of `first_segment_rows_completed` and `first_segment_rows_rejected` as 0

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
