### PR TITLE
Docs: pg_stat_activity's rsgname column now displays <bypass> if the query is bypassing rg limits

### DIFF
--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -480,6 +480,10 @@ SELECT query, waiting, rsgname, rsgqueueduration
 FROM pg_stat_activity;
 ```
 
+If a query is configured to bypass the resource group limits, or unassigned from its resource group, the column `rsgname` displays `<bypass>` appended to the resource group name. See [Bypass and Unassign from Resource Groups](#bypass) for more details.
+
+
+
 ### <a id="topic27"></a>Cancelling a Running or Queued Transaction in a Resource Group 
 
 There may be cases when you want to cancel a running or queued transaction in a resource group. For example, you may want to remove a query that is waiting in the resource group queue but has not yet been run. Or, you may want to stop a running query that is taking too long to run, or one that is sitting idle in a transaction and taking up resource group transaction slots that are needed by other users.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -1278,6 +1278,7 @@ The maximum length of the query text string stored in the column `query` can be 
 
 > **Note**
 > When resource groups are enabled. Only query dispatcher (QD) processes will have a `rsgid` and `rsgname`. Other server processes such as a query executer (QE) process or session connection processes will have a `rsgid` value of `0` and a `rsgname` value of `unknown`. QE processes are managed by the same resource group as the dispatching QD process.
+> If the query is configured to bypass the resource group limits, or unassigned from its resource group, the column `rsgname` displays `<bypass>` appended to the resource group name. See [Bypass and Unassign from Resource Groups](../../admin_guide/workload_mgmt_resgroups.html#bypass) for more details.
 
 ## <a id="pg_stat_all_indexes"></a>pg_stat_all_indexes
 


### PR DESCRIPTION
This PR documents the changes made in https://github.com/greenplum-db/gpdb/pull/16411
The column rsgname now displays <bypass> appended to the resource group name if the query is bypassing resource group limits or unassigned from it.