### PR TITLE
Fix the use of PORTNAME in gp_toolkit makefile

### DIFF
--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = gp_toolkit
 DATA = gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql
 MODULE_big = gp_toolkit
-ifeq ($(PORTNAME),linux)
+ifeq ($(shell uname -s), Linux)
 OBJS = resgroup.o
 else
 OBJS = resgroup-dummy.o


### PR DESCRIPTION
PORTNAME is defined in Makefile.global, we can only use it after the
definition. But for extensions we also need to define the OBJS before
all the PGXS stuff.

This commit checks the operating system via `uname -s` instead, other
systems like Windows are not covered since Greenplum server is not
supported on them anyway.
