### PR TITLE
io limit: fix double free

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -433,6 +433,12 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 	/* Load current resource group capabilities */
 	GetResGroupCapabilities(pg_resgroupcapability_rel, groupid, &oldCaps);
+	/* If io_limit not been altered, reset io_limit field to NIL */
+	if (limitType != RESGROUP_LIMIT_TYPE_IO_LIMIT && oldCaps.io_limit != NIL)
+	{
+		cgroupOpsRoutine->freeio(oldCaps.io_limit);
+		oldCaps.io_limit = NIL;
+	}
 	caps = oldCaps;
 
 	switch (limitType)
@@ -474,6 +480,8 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	}
 
 	validateCapabilities(pg_resgroupcapability_rel, groupid, &caps, false);
+	AssertImply(limitType != RESGROUP_LIMIT_TYPE_IO_LIMIT, caps.io_limit == NIL);
+	AssertImply(limitType == RESGROUP_LIMIT_TYPE_IO_LIMIT, caps.io_limit != NIL);
 
 	/* cpuset & cpu_max_percent can not coexist.
 	 * if cpuset is active, then cpu_max_percent must set to CPU_RATE_LIMIT_DISABLED,
@@ -1113,11 +1121,7 @@ alterResgroupCallback(XactEvent event, void *arg)
 	if (callbackCtx->caps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
 
-	/*
-	 * In alterResgroupCallback, the callbackCtx->caps equals callbackCtx->oldCaps initially.
-	 * If the io_limit has not been altered, the io_limit of caps and old Caps will be identical finally.*/
-	if (callbackCtx->caps.io_limit != callbackCtx->oldCaps.io_limit &&
-		callbackCtx->oldCaps.io_limit != NIL)
+	if (callbackCtx->oldCaps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);
 
 	pfree(callbackCtx);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1113,7 +1113,8 @@ alterResgroupCallback(XactEvent event, void *arg)
 	if (callbackCtx->caps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
 
-	if (callbackCtx->oldCaps.io_limit != NIL)
+	if (callbackCtx->caps.io_limit != callbackCtx->oldCaps.io_limit &&
+		callbackCtx->oldCaps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);
 
 	pfree(callbackCtx);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1113,7 +1113,7 @@ alterResgroupCallback(XactEvent event, void *arg)
 	if (callbackCtx->caps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
 
-	if (callbackCtx->caps.io_limit != NIL)
+	if (callbackCtx->oldCaps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);
 
 	pfree(callbackCtx);

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1113,6 +1113,9 @@ alterResgroupCallback(XactEvent event, void *arg)
 	if (callbackCtx->caps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);
 
+	/*
+	 * In alterResgroupCallback, the callbackCtx->caps equals callbackCtx->oldCaps initially.
+	 * If the io_limit has not been altered, the io_limit of caps and old Caps will be identical finally.*/
 	if (callbackCtx->caps.io_limit != callbackCtx->oldCaps.io_limit &&
 		callbackCtx->oldCaps.io_limit != NIL)
 		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);

--- a/src/test/isolation2/input/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_io_limit.source
@@ -78,7 +78,7 @@ SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
 -- m/^ rg_test_group\d+ \|/
 -- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
 -- end_matchsubs
-SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1';
+SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1' limit 1;
 
 -- clean
 DROP RESOURCE GROUP rg_test_group1;

--- a/src/test/isolation2/input/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_io_limit.source
@@ -74,11 +74,7 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
 -- end_ignore
 
--- start_matchsubs
--- m/^ rg_test_group\d+ \|/
--- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
--- end_matchsubs
-SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1' limit 1;
+SELECT count(*) > 0 as r from gp_toolkit.gp_resgroup_iostats_per_host;
 
 -- clean
 DROP RESOURCE GROUP rg_test_group1;

--- a/src/test/isolation2/input/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_io_limit.source
@@ -56,6 +56,8 @@ ALTER RESOURCE GROUP rg_test_group5 SET io_limit 'rg_io_limit_ts_1:rbps=1000,wbp
 
 SELECT check_cgroup_io_max('rg_test_group5', 'rg_io_limit_ts_1', 'rbps=1048576000 wbps=1048576000 riops=max wiops=max');
 
+ALTER RESOURCE GROUP rg_test_group5 SET concurrency 1;
+
 SELECT check_clear_io_max('rg_test_group5');
 
 -- fault injector
@@ -67,10 +69,16 @@ SELECT groupid, groupname, cpuset FROM gp_toolkit.gp_resgroup_config WHERE group
 
 SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 
--- start_ignore
 -- view
+-- start_ignore
 SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
 -- end_ignore
+
+-- start_matchsubs
+-- m/^ rg_test_group\d+ \|/
+-- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
+-- end_matchsubs
+SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1';
 
 -- clean
 DROP RESOURCE GROUP rg_test_group1;

--- a/src/test/isolation2/output/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_io_limit.source
@@ -107,6 +107,9 @@ SELECT check_cgroup_io_max('rg_test_group5', 'rg_io_limit_ts_1', 'rbps=104857600
  t                   
 (1 row)
 
+ALTER RESOURCE GROUP rg_test_group5 SET concurrency 1;
+ALTER RESOURCE GROUP
+
 SELECT check_clear_io_max('rg_test_group5');
  check_clear_io_max 
 --------------------
@@ -134,8 +137,8 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  Success:        
 (1 row)
 
--- start_ignore
 -- view
+-- start_ignore
 SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
  rsgname        | hostname | tablespace       | rbps | wbps | riops | wiops 
 ----------------+----------+------------------+------+------+-------+-------
@@ -146,6 +149,16 @@ SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
  rg_test_group5 | mtspc    | rg_io_limit_ts_1 | 0    | 0    | 0     | 0     
 (5 rows)
 -- end_ignore
+
+-- start_matchsubs
+-- m/^ rg_test_group\d+ \|/
+-- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
+-- end_matchsubs
+SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1';
+ rsgname        | hostname | tablespace | rbps | wbps | riops | wiops 
+----------------+----------+------------+------+------+-------+-------
+ rg_test_group1 | mdw    | pg_default | 0    | 0    | 0     | 0     
+(1 row)
 
 -- clean
 DROP RESOURCE GROUP rg_test_group1;

--- a/src/test/isolation2/output/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_io_limit.source
@@ -154,7 +154,7 @@ SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
 -- m/^ rg_test_group\d+ \|/
 -- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
 -- end_matchsubs
-SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1';
+SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1' limit 1;
  rsgname        | hostname | tablespace | rbps | wbps | riops | wiops 
 ----------------+----------+------------+------+------+-------+-------
  rg_test_group1 | mdw    | pg_default | 0    | 0    | 0     | 0     

--- a/src/test/isolation2/output/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_io_limit.source
@@ -150,14 +150,10 @@ SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
 (5 rows)
 -- end_ignore
 
--- start_matchsubs
--- m/^ rg_test_group\d+ \|/
--- s/(\| \S+ *){2}(\| \d+ *){4}/| gpadmin | $2 | 0 | 0 | 0 | 0 /
--- end_matchsubs
-SELECT * from gp_toolkit.gp_resgroup_iostats_per_host where rsgname = 'rg_test_group1' limit 1;
- rsgname        | hostname | tablespace | rbps | wbps | riops | wiops 
-----------------+----------+------------+------+------+-------+-------
- rg_test_group1 | mdw    | pg_default | 0    | 0    | 0     | 0     
+SELECT count(*) > 0 as r from gp_toolkit.gp_resgroup_iostats_per_host;
+ r    
+------
+ t    
 (1 row)
 
 -- clean


### PR DESCRIPTION
There is a such example:
```
CREATE RESOURCE GROUP test WITH (CPU_MAX_PERCENT=20, MEMORY_LIMIT=25, io_limit = 'pg_default:rbps=1024,wbps=1024');
```
and then
```
ALTER RESOURCE GROUP test SET concurrency 10;
```
GPDB will throw some errors now.

That's because following reasons:
In `AlterResourceGroup`:
```
	GetResGroupCapabilities(pg_resgroupcapability_rel, groupid, &oldCaps);
	caps = oldCaps;
```
now, `caps.io_limit = oldCaps.io_limit`.
And then, in `alterResgroupCallback`:
```
	if (callbackCtx->caps.io_limit != NIL)
		cgroupOpsRoutine->freeio(callbackCtx->caps.io_limit);

	if (callbackCtx->oldCaps.io_limit != NIL)
		cgroupOpsRoutine->freeio(callbackCtx->oldCaps.io_limit);
```
io_limit has been double freed.

