### PR TITLE
[7x]: Added support for gpstate tracking of differential recovery

### DIFF
--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
@@ -66,27 +66,22 @@ class UnixCommandTestCase(GpTestCase):
         self.subject.logger.error.assert_called_once_with('Failed to kill process 789 for segment /data/primary/gpseg0: Kill Error')
 
 
-    @patch('gppylib.commands.unix.findCmdInPath', return_value='/usr/bin/rsync')
-    @patch('gppylib.commands.unix.check_cmd_version', return_value='rsync version 3.2.7')
+
+    @patch('gppylib.commands.unix.get_rsync_version', return_value='rsync version 3.2.7')
     @patch('gppylib.commands.unix.parse_version', side_effect=['3.2.7', '3.1.0'])
-    def test_compare_rsync_version(self, mock_parse_version, mock_check_cmd_version, mock_findCmdInPath):
+    def test_compare_rsync_version(self, mock_parse_version, mock_get_cmd_version):
 
-        self.subject.compare_rsync_version()
+        result = self.subject.validate_rsync_version("3.2.7")
+        self.assertTrue(result)
 
-        mock_findCmdInPath.assert_called_once_with('rsync')
-        mock_check_cmd_version.assert_called_once_with('/usr/bin/rsync')
-        mock_parse_version.assert_has_calls([call('3.2.7'), call('3.1.0')])
 
-    @patch('gppylib.commands.unix.findCmdInPath', return_value='/usr/bin/rsync')
-    @patch('gppylib.commands.unix.check_cmd_version', return_value='rsync version 2.6.9')
+    @patch('gppylib.commands.unix.get_rsync_version', return_value='rsync version 2.6.9')
     @patch('gppylib.commands.unix.parse_version', side_effect=['2.6.9', '3.1.0'])
-    def test_compare_rsync_version_exception(self, mock_parse_version, mock_check_cmd_version, mock_findCmdInPath):
-        with self.assertRaises(Exception) as e:
-            self.subject.compare_rsync_version()
+    def test_validate_rsync_version_false(self, mock_parse_version, mock_get_cmd_version):
 
-        self.assertEqual(str(e.exception),
-                         "Rsync current version 2.6.9 does not meet the required version 3.1.0 or above for utilizing"
-                         "differential recovery. Kindly update rsync to 3.1.0 or above version")
+        result =self.subject.validate_rsync_version("2.6.9")
+        self.assertFalse(result)
+
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -13,6 +13,8 @@ import socket
 import signal
 import uuid
 import pipes
+import re
+from pkg_resources import parse_version
 
 from gppylib.gplog import get_default_logger
 from gppylib.commands.base import *
@@ -538,8 +540,10 @@ class Rsync(Command):
         if whole_file:
             cmd_tokens.append('--whole-file')
 
+        # Shows the progress of the whole transfer,
+        # Note : It is only supported with rsync 3.1.0 or above
         if progress:
-            cmd_tokens.append('--progress')
+            cmd_tokens.append('--info=progress2,name0')
 
         # To show file transfer stats
         if stats:
@@ -572,14 +576,16 @@ class Rsync(Command):
 
         cmd_tokens.extend(exclude_str)
 
+        # Combines output streams, uses 'sed' to find lines with 'kB/s' or 'MB/s' and appends ':%s' as suffix to the end
+        # of each line and redirects it to progress_file
         if progress_file:
-            cmd_tokens.append('> %s 2>&1' % pipes.quote(progress_file))
+            cmd_tokens.append('2>&1 | tr "\\r" "\\n" |sed -E "/[kM]B\/s/ s/$/ :%s/" > %s' % (name, pipes.quote(progress_file)))
 
         cmdStr = ' '.join(cmd_tokens)
-
+        cmd_str = "set -o pipefail;" + cmdStr
         self.command_tokens = cmd_tokens
 
-        Command.__init__(self, name, cmdStr, ctxt, remoteHost)
+        Command.__init__(self, name, cmd_str, ctxt, remoteHost)
 
     # Overriding validate() of Command class to handle few specific return codes of rsync which can be ignored
     def validate(self, expected_rc=0):
@@ -754,3 +760,31 @@ elif curr_platform == OPENBSD:
     SYSTEM = OpenBSDPlatform()
 else:
     raise Exception("Platform %s is not supported.  Supported platforms are: %s", SYSTEM, str(platform_list))
+
+
+
+def compare_rsync_version():
+    """
+    Compares the version of the 'rsync' command found in the system's PATH with a required version.
+    If the current version is lower than the required version, it raises an exception
+    """
+    cmd_path = findCmdInPath('rsync')
+    rsync_version_info = check_cmd_version(cmd_path)
+    pattern = r"version (\d+\.\d+\.\d+)"
+    match = re.search(pattern, rsync_version_info)
+    current_rsync_version = match.group(1)
+    required_rsync_version = '3.1.0'
+    if parse_version(current_rsync_version) < parse_version(required_rsync_version):
+        raise Exception("Rsync current version {0} does not meet the required version {1} or above for utilizing"
+                        "differential recovery. Kindly update rsync to {1} or above version"
+                        .format(current_rsync_version, required_rsync_version))
+
+
+def check_cmd_version(cmd_path):
+    """ Checks the version of a specified command """
+    cmd = Command("check version", cmdStr="{0} --version".format(cmd_path))
+    cmd.run(validateAfter=True)
+    version = cmd.get_stdout()
+
+    return version
+

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -68,7 +68,7 @@ def get_recovery_progress_pattern(recovery_type='incremental'):
         progress of rsync looks like: "1,036,923,510  99%   39.90MB/s    0:00:24"
     """
     if recovery_type == 'differential':
-        return r" +\d+%\ +\d+.\d+(kB|mB)\/s"
+        return r" +\d+%\ +\d+.\d+(kB|MB)\/s"
     return r"\d+\/\d+ (kB|mB) \(\d+\%\)"
 
 
@@ -437,7 +437,6 @@ class GpMirrorListToBuild:
                 if inplace:
                     output.append("\x1B[K")
                 output.append("\n")
-
                 if re.search(diff_pattern, results) or re.search(rewind_bb_pattern, results):
                     complete_progress_output.extend("%s:%d:%s\n" % (recovery_type, cmd.dbid, results))
 
@@ -469,18 +468,35 @@ class GpMirrorListToBuild:
                 os.remove(combined_progress_filepath)
 
 
-    def _get_progress_cmd(self, progressFile, targetSegmentDbId, targetHostname):
+    def _get_progress_cmd(self, progressFile, targetSegmentDbId, targetHostname, isDifferentialRecovery):
         """
         # There is race between when the recovery process creates the progressFile
         # when this progress cmd is run. Thus, the progress command touches
         # the file to ensure its presence before tailing.
         """
         if self.__progressMode != GpMirrorListToBuild.Progress.NONE:
-            return GpMirrorListToBuild.ProgressCommand("tail the last line of the file",
-                                                       "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' |"
-                                                       " tail -1".format(pipes.quote(progressFile)),
-                                                       targetSegmentDbId, progressFile, ctxt=base.REMOTE,
-                                                       remoteHost=targetHostname)
+            cmd_desc = "tail the last line of the file"
+            if isDifferentialRecovery:
+                # For differential recovery, use sed to filter lines with specific patterns to avoid race condition.
+                cmd_str = (
+                    "set -o pipefail; touch -a {0}; tail -3 {0} | sed -n -e '/:Syncing.*dbid/p; /error:/p; /total/p' | tr '\\r' '\\n' | tail -1"
+                    .format(pipes.quote(progressFile))
+                )
+            else:
+                # For full and incremental recovery, simply tail the last line.
+                cmd_str = (
+                    "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1"
+                    .format(pipes.quote(progressFile))
+                )
+
+            progress_command = GpMirrorListToBuild.ProgressCommand(
+                cmd_desc, cmd_str,
+                targetSegmentDbId, progressFile, ctxt=base.REMOTE,
+                remoteHost=targetHostname
+            )
+
+            return progress_command
+
         return None
 
     def _get_remove_cmd(self, remove_file, target_host):
@@ -543,7 +559,7 @@ class GpMirrorListToBuild:
         era = read_era(gpEnv.getCoordinatorDataDir(), logger=self.__logger)
         for hostName, recovery_info_list in recovery_info_by_host.items():
             for ri in recovery_info_list:
-                progressCmd = self._get_progress_cmd(ri.progress_file, ri.target_segment_dbid, hostName)
+                progressCmd = self._get_progress_cmd(ri.progress_file, ri.target_segment_dbid, hostName, ri.is_differential_recovery)
                 if progressCmd:
                     progress_cmds.append(progressCmd)
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -20,7 +20,7 @@ from gppylib.gparray import Segment, GpArray
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild, GpStopSegmentDirectoryDirective, get_recovery_progress_pattern
 from gppylib.system import configurationInterface
-from test.unit.gp_unittest import Contains, GpTestCase
+from gppylib.test.unit.gp_unittest import Contains, GpTestCase
 
 from gppylib.recoveryinfo import RecoveryInfo, RecoveryResult
 
@@ -476,7 +476,7 @@ class BuildMirrorsTestCase(GpTestCase):
         build_mirrors_obj._clean_up_failed_segments()
 
         self.mock_get_segments_by_hostname.assert_called_once_with([failed1, failed3])
-        self.mock_logger.info.called_once_with('"Cleaning files from 3 segment(s)')
+        self.mock_logger.info.called_once_with('Cleaning files from 3 segment(s)')
 
     def test_clean_up_failed_segments_no_segs_to_cleanup(self):
         failed2 = self._create_primary(dbid='3', status='d')

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -262,6 +262,17 @@ class GpRecoverSegmentProgram:
                 raise ProgramArgumentValidationException("-F option is not supported with -r option")
             if self.__options.newRecoverHosts is not None:
                 raise ProgramArgumentValidationException("-F option is not supported with -p option")
+
+        # Checking rsync version before performing a differential recovery operation.
+        # the --info=progress2 option, which provides whole file transfer progress, requires rsync 3.1.0 or above
+        min_rsync_ver = "3.1.0"
+        if self.__options.differentialResynchronization and not unix.validate_rsync_version(min_rsync_ver):
+            raise ProgramArgumentValidationException("To perform a differential recovery, a minimum rsync version "
+                                                         "of {0} is required. Please ensure that rsync is updated to "
+                                                         "version {0} or higher.".format(min_rsync_ver))
+
+
+
         return
 
     def run(self):

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -6,7 +6,7 @@ from contextlib import closing
 
 from gppylib.recoveryinfo import RecoveryErrorType
 from gppylib.commands.pg import PgBaseBackup, PgRewind, PgReplicationSlot
-from gppylib.commands.unix import Rsync,compare_rsync_version
+from gppylib.commands.unix import Rsync
 from recovery_base import RecoveryBase, set_recovery_cmd_results
 from gppylib.commands.base import Command, LOCAL
 from gppylib.commands.gp import SegmentStart
@@ -105,8 +105,6 @@ class DifferentialRecovery(Command):
         self.logger.info("Running differential recovery with progress output temporarily in {}".format(
             self.recovery_info.progress_file))
         self.error_type = RecoveryErrorType.DIFFERENTIAL_ERROR
-
-        compare_rsync_version()
 
         """ Drop replication slot 'internal_wal_replication_slot' """
         if self.replication_slot.slot_exists() and not self.replication_slot.drop_slot():

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -759,6 +759,7 @@ Feature: gprecoverseg tests
     And user immediately stops all mirror processes for content 0,1,2
     And the user waits until mirror on content 0,1,2 is down
     And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
     When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
@@ -827,6 +828,7 @@ Feature: gprecoverseg tests
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
     When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
     Then verify if the gprecoverseg.lock directory is present in coordinator_data_directory

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -112,6 +112,52 @@ Feature: gprecoverseg tests
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the cluster is rebalanced
 
+
+    @concourse_cluster
+    Scenario: gpstate track of differential recovery for single host
+      Given the database is running
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And user immediately stops all mirror processes for content 0
+      And the user waits until mirror on content 0 is down
+      And user can start transactions
+      And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+      And sql "DROP TABLE IF EXISTS test_recoverseg_1; CREATE TABLE test_recoverseg_1 AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+      When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+      Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies that all dbids progress with pg_data are present
+      When the user runs "gpstate -e"
+      Then gpstate should print "Segments in recovery" to stdout
+      And gpstate output contains "differential" entries for mirrors of content 0
+          And gpstate output looks like
+              | Segment | Port   | Recovery type  | Stage                                      | Completed bytes \(kB\) | Percentage completed |
+              | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 6                  | ([\d,]+)[ \t]          | \d+%                 |
+      And the user waits until saved async process is completed
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And sql "DROP TABLE IF EXISTS test_recoverseg;" is executed in "postgres" db
+      And sql "DROP TABLE IF EXISTS test_recoverseg_1;" is executed in "postgres" db
+      And the cluster is rebalanced
+
+
+    @concourse_cluster
+    Scenario: check Tablespace Recovery Progress with gpstate
+       Given the database is running
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And user immediately stops all mirror processes for content 0
+      And user can start transactions
+      And a tablespace is created with data
+      And insert additional data into the tablespace
+      When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+      Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies that all dbids progress with tablespace are present
+      When the user runs "gpstate -e"
+      Then gpstate should print "Segments in recovery" to stdout
+      And gpstate output contains "differential" entries for mirrors of content 0
+          And gpstate output looks like
+              | Segment | Port   | Recovery type  | Stage                                      | Completed bytes \(kB\) | Percentage completed |
+              | \S+     | [0-9]+ | differential   | Syncing tablespace of dbid 6 for oid \d+   | ([\d,]+)[ \t]          | \d+%                 |
+      And the user waits until saved async process is completed
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And the cluster is rebalanced
+
+
     Scenario Outline: full recovery limits number of parallel processes correctly
         Given the database is running
         And 2 gprecoverseg directory under '/tmp/recoverseg' with mode '0700' is created
@@ -2378,3 +2424,4 @@ Feature: gprecoverseg tests
         And user can start transactions
        Then the row count of table test_recoverseg in "postgres" should be 2000
        And the cluster is recovered in full and rebalanced
+

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -646,6 +646,24 @@ Feature: gpstate tests
             | Mirrors not configured on this array
         And "COORDINATOR_DATA_DIRECTORY" environment variable should be restored
 
+    Scenario: gpstate -e shows information about segments with ongoing differential recovery
+        Given a standard local demo cluster is running
+        Given all files in gpAdminLogs directory are deleted
+        And a sample recovery_progress.file is created with ongoing differential recoveries in gpAdminLogs
+        And we run a sample background script to generate a pid on "coordinator" segment
+        And a sample gprecoverseg.lock directory is created using the background pid in coordinator_data_directory
+        When the user runs "gpstate -e"
+        Then gpstate should print "Segments in recovery" to stdout
+        And gpstate output contains "differential,differential" entries for mirrors of content 0,1
+        And gpstate output looks like
+            | Segment | Port   | Recovery type  | Stage                              | Completed bytes \(kB\) | Percentage completed |
+            | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 5          | 16,454,866             | 4%                   |
+            | \S+     | [0-9]+ | differential   | Syncing pg_control file of dbid 6  | 8,192                  | 100%                 |
+        And all files in gpAdminLogs directory are deleted
+        And the background pid is killed on "coordinator" segment
+        And the gprecoverseg lock directory is removed
+
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -656,9 +656,9 @@ Feature: gpstate tests
         Then gpstate should print "Segments in recovery" to stdout
         And gpstate output contains "differential,differential" entries for mirrors of content 0,1
         And gpstate output looks like
-            | Segment | Port   | Recovery type  | Stage                              | Completed bytes \(kB\) | Percentage completed |
-            | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 5          | 16,454,866             | 4%                   |
-            | \S+     | [0-9]+ | differential   | Syncing pg_control file of dbid 6  | 8,192                  | 100%                 |
+            | Segment | Port   | Recovery type  | Stage                                       | Completed bytes \(kB\) | Percentage completed |
+            | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 5                   | 16,454,866             | 4%                   |
+            | \S+     | [0-9]+ | differential   | Syncing tablespace of dbid 6 for oid 20516  | 8,192                  | 100%                 |
         And all files in gpAdminLogs directory are deleted
         And the background pid is killed on "coordinator" segment
         And the gprecoverseg lock directory is removed

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -140,5 +140,5 @@ def impl(context):
         fp.write(
             "differential:5:     16,454,866   4%   16.52MB/s    0:00:00 (xfr#216, ir-chk=9669/9907) :Syncing pg_data "
             "of dbid 5\n")
-        fp.write("differential:6:          8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control "
-                 "file of dbid 6")
+        fp.write("differential:6:          8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing tablespace of "
+                 "dbid 6 for oid 20516")

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -70,7 +70,11 @@ def impl(context, recovery_types, contents):
     for index, seg_to_display in enumerate(segments_to_display):
         hostname = seg_to_display.getSegmentHostName()
         port = seg_to_display.getSegmentPort()
-        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
+        if recovery_types[index] == "differential":
+            expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+(.+?)[ \t]+([\d,]+)[ \t]+[0-9]+\%".format(hostname, port,
+                                                                                             recovery_types[index])
+        else:
+           expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
                                                                                          recovery_types[index])
         check_stdout_msg(context, expected_msg)
 
@@ -129,3 +133,12 @@ def check_stdout_msg_in_order(context, msg):
 
     context.stdout_position = match.end()
 
+
+@given('a sample recovery_progress.file is created with ongoing differential recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write(
+            "differential:5:     16,454,866   4%   16.52MB/s    0:00:00 (xfr#216, ir-chk=9669/9907) :Syncing pg_data "
+            "of dbid 5\n")
+        fp.write("differential:6:          8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control "
+                 "file of dbid 6")

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -462,7 +462,7 @@ def impl(context, logdir):
             with open(recovery_progress_file, 'r') as fp:
                 context.recovery_lines = fp.readlines()
             for line in context.recovery_lines:
-                recovery_type, dbid, progress = line.strip().split(':', 2)
+                recovery_type, dbid, progress = line.strip().split(':')[:3]
                 progress_pattern = re.compile(get_recovery_progress_pattern(recovery_type))
                 # TODO: assert progress line in the actual hosts bb/rewind progress file
                 if re.search(progress_pattern, progress) and dbid.isdigit() and recovery_type in ['full', 'differential', 'incremental']:

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4224,4 +4224,42 @@ def impl(context, output_config_file):
     if set(expected_seg_rows) != set(actual_seg_rows):
         raise Exception("created config file {} does not contain all of the expected rows".format(output_config_file))
 
+@then('the user waits until recovery_progress.file is created in {logdir} and verifies that all dbids progress with {stage} are present')
+def impl(context, logdir, stage):
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    failed_segments = filter(lambda seg: seg.getSegmentStatus() == 'd', all_segments)
+    stage_patterns = []
+    for seg in failed_segments:
+        dbid = seg.getSegmentDbId()
+        if stage == "tablespace":
+            pat = "Syncing tablespace of dbid {} for oid".format(dbid)
+        else:
+            pat = "differential:{}" .format(dbid)
+        stage_patterns.append(pat)
+    if len(stage_patterns) == 0:
+        raise Exception('Failed to get the details of down segment')
+    attempt = 0
+    num_retries = 9000
+    log_dir = _get_gpAdminLogs_directory() if logdir == 'gpAdminLogs' else logdir
+    recovery_progress_file = '{}/recovery_progress.file'.format(log_dir)
+    while attempt < num_retries:
+        attempt += 1
+        if os.path.exists(recovery_progress_file):
+            if verify_elements_in_file(recovery_progress_file, stage_patterns):
+                return
+        time.sleep(0.1)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))
+
+
+def verify_elements_in_file(filename, elements):
+    with open(filename, 'r') as file:
+        content = file.read()
+
+        for element in elements:
+            if element not in content:
+                return False
+
+        return True
+
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -126,6 +126,14 @@ class Tablespace:
                                 sorted(self.initial_data), sorted(data)))
 
 
+    def insert_more_data(self):
+        with closing(dbconn.connect(dbconn.DbURL(dbname=self.dbname), unsetSearchPath=False)) as conn:
+            dbconn.execSQL(conn, "CREATE TABLE tbl_1 (i int) DISTRIBUTED RANDOMLY")
+            dbconn.execSQL(conn, "INSERT INTO tbl_1 VALUES (GENERATE_SERIES(0, 100000000))")
+            dbconn.execSQL(conn, "CREATE TABLE tbl_2 (i int) DISTRIBUTED RANDOMLY")
+            dbconn.execSQL(conn, "INSERT INTO tbl_2 VALUES (GENERATE_SERIES(0, 100000000))")
+
+
 def _checkpoint_and_wait_for_replication_replay(conn):
     """
     Taken from src/test/walrep/sql/missing_xlog.sql
@@ -240,3 +248,9 @@ def impl(context):
     for tablespace in list(context.tablespaces.values()):
         tablespace.cleanup()
     context.tablespaces = {}
+
+
+@given('insert additional data into the tablespace')
+def impl(context):
+    context.tablespaces["outerspace"].insert_more_data()
+


### PR DESCRIPTION
**Issue :** The "gpstate -e" command allows us to track full and incremental recovery progress. However, this functionality is not available for differential recovery.

**Approach :**  Show the progress stage-wise with rsync version 3.1.0 or above. We are synchronizing data for several components of the segment data directory, including pg_data, tablespace, pg_wal, and pg_control. Multiple rsync sessions will run sequentially for these components, and we want to track the progress of each stage. In rsync version 3.1.0 and above, the --info=progress2 option is available, which allows us to display cumulative progress information for a running rsync session. As each rsync session progresses, the cumulative progress information will be displayed on the terminal. The --info=progress2 option details the bytes transferred and the percentage completed for each session. Using --info=progress2 we can monitor the progress stage-wise of the rsync session. The displayed information includes the remote segment, port, recovery type, stage name, completed bytes, and percentage completed.

**Implementation:**  The approach now includes a validation check for rsync version 3.1.0 or above. If the current version is below this threshold, an exception will be raised. Added a suffix of the stage name to each line with a 'kB/s' or 'MB/s' pattern in it of rsync.*.dbid5.out file. While tailing data from rsync.*.dbid5.out and writing in recovery_progress file to avoid race conditions sed to filter lines with specific patterns. In gpsate utility parse the recovery_progress data and process differential recovery progress.

So the stage-wise progress  looks like this:
```
[INFO]:-   Segment                    Port   Recovery type   Stage                       Completed bytes (kB)   Percentage completed
[INFO]:-   pkumar144Q6L7.vmware.com   7005   differential    Syncing pg_data of dbid 5   298,338,995            32%
[INFO]:-   pkumar144Q6L7.vmware.com   7007   differential    Syncing pg_data of dbid 7   157,475,653            18%
```


Test: Added unit and behave test cases

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
