### PR TITLE
Fix gpdb build logic needed for 7X workload pipeline

### DIFF
--- a/concourse/scripts/build_gpdb.py
+++ b/concourse/scripts/build_gpdb.py
@@ -23,6 +23,14 @@ def create_gpadmin_user():
     if status:
         return status
 
+def extract_explain_test_suite():
+    tarfiles = glob.glob('explain_test_suite/*.tar.gz')
+    if len(tarfiles) != 1:
+        print("Expected to find 1 tar file.")
+        return 1
+    status = subprocess.call(["tar", "xvf", tarfiles[0]])
+    return status
+
 def tar_explain_output():
     status = subprocess.call(["tar", "czvf", "output/explain_ouput.tar.gz", "out/"])
     return status
@@ -48,8 +56,12 @@ def main():
     status = gpBuild.install_dependency("bin_gpdb", INSTALL_DIR)
     fail_on_error(status)
 
-    status = create_gpadmin_user()
-    fail_on_error(status)
+    if not options.dbexists:
+        status = create_gpadmin_user()
+        fail_on_error(status)
+    else:
+        status = extract_explain_test_suite()
+        fail_on_error(status)
     status = gpBuild.run_explain_test_suite(options.dbexists)
     fail_on_error(status)
     status = tar_explain_output()

--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -77,12 +77,12 @@ class GpBuild:
                 fail_on_error(status)
 
         # set gucs if any were specified
-        self._run_cmd("source gpdb_src/gpAux/gpdemo/gpdemo-env.sh && cat gporca-commits-to-test/optional_gucs.txt >> $COORDINATOR_DATA_DIRECTORY/postgresql.conf", None)
+        status = self._run_cmd("source gpdb_src/gpAux/gpdemo/gpdemo-env.sh && cat gporca-commits-to-test/optional_gucs.txt >> $COORDINATOR_DATA_DIRECTORY/postgresql.conf", None)
         fail_on_error(status)
         # use 32 segments for explain tests (this number is fairly arbitrary, it might be better to make this dependent on the workload?)
-        self._run_cmd("source gpdb_src/gpAux/gpdemo/gpdemo-env.sh && echo 'optimizer_segments=32\ngp_segments_for_planner=32' >> $COORDINATOR_DATA_DIRECTORY/postgresql.conf", None)
+        status = self._run_cmd("source gpdb_src/gpAux/gpdemo/gpdemo-env.sh && echo 'optimizer_segments=32\ngp_segments_for_planner=32' >> $COORDINATOR_DATA_DIRECTORY/postgresql.conf", None)
         fail_on_error(status)
-        self._run_gpdb_command("gpstop -ar")
+        status = self._run_gpdb_command("gpstop -ar")
         fail_on_error(status)
 
         # Now run the queries !!


### PR DESCRIPTION
1. Fix UnboundLocalError in GpBuild.py. Local variable 'status' was referenced before assignment.
2. Reinstate the test suite extraction logic from 6X. This logic is needed when the database already exists, which is the case of the workload pipeline. The workload stats is extensive. To avoid loading the stats each time the pipeline is executed, we preload the Docker image with the stats. When testing a specific branch version, we swap the gpdb binary with the desired version and reboot the cluster.