### PR TITLE
Fix flaky test alter_distribution_policy

### DIFF
--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1662,8 +1662,8 @@ DROP TABLE t_reorganize_false;
 set optimizer = false;
 -- check the distribution difference between 't1' and 't2' after executing 'query_string'
 -- return true if data distribution changed, otherwise false.
--- Note: in extremely rare cases, even after 't2' being randomly-distributed from 't1', they could still have the 
--- exact same distribution. So let the tables have a reasonably large number of rows to reduce that possibility.
+-- Make sure that the data distribution of 't1' and 't2' should be significantly different for
+-- this function to detect it (e.g., 't1' has all data on one segment and 't2' is randomly-distributed, etc.)
 CREATE OR REPLACE FUNCTION check_redistributed(query_string text, t1 text, t2 text) 
 RETURNS BOOLEAN AS 
 $$
@@ -1700,6 +1700,7 @@ $$
 LANGUAGE plpgsql;
 -- CO table builds temp table first instead of doing CTAS during REORGANIZE=true
 create table t_reorganize(a int, b int) using ao_column distributed by (a);
+-- insert all data into one segment
 insert into t_reorganize select 0,i from generate_series(1,1000)i;
 select gp_segment_id, count(*) from t_reorganize group by gp_segment_id;
  gp_segment_id | count 
@@ -1707,22 +1708,27 @@ select gp_segment_id, count(*) from t_reorganize group by gp_segment_id;
              1 |  1000
 (1 row)
 
--- firstly, no redistribute
+-- firstly, no force redistribution
 set gp_force_random_redistribution = off;
+-- case 1. reorganize from hash to random should redistribute regardless of the GUC
 select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
  check_redistributed 
 ------------
  t
 (1 row)
 
--- reorganize from randomly to randomly should still redistribute
+-- make only one segment have data
+delete from t_reorganize where gp_segment_id != 0;
+-- case 2. reorganize from randomly to randomly should still redistribute
 select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
  check_redistributed 
 ------------
  t
 (1 row)
 
--- but insert into table won't redistribute
+-- change dist policy back for the rest of tests
+alter table t_reorganize set with (reorganize=true) distributed by (a);
+-- case 3. insert into a randomly-distributed table won't redistribute
 create table t_random (like t_reorganize) distributed randomly;
 select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
  check_redistributed 
@@ -1730,14 +1736,19 @@ select check_redistributed('insert into t_random select * from t_reorganize', 't
  f
 (1 row)
 
--- but insert into a different distribution policy would still redistribute
-create table t_distbya (like t_reorganize) distributed by (a);
-select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+-- case 4. but insert into a different distribution policy would still redistribute
+create table t_distbyb (like t_reorganize) distributed by (b);
+select check_redistributed('insert into t_distbyb select * from t_reorganize', 't_reorganize', 't_distbyb');
  check_redistributed 
 ------------
  t
 (1 row)
 
+drop table t_reorganize;
+drop table t_random;
+drop table t_distbyb;
+create table t_reorganize(a int, b int) using ao_column distributed by (a);
+insert into t_reorganize select 0,i from generate_series(1,1000)i;
 -- now force distribute should redistribute in all cases
 set gp_force_random_redistribution = on;
 select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
@@ -1746,6 +1757,7 @@ select check_redistributed('alter table t_reorganize set with (reorganize=true) 
  t
 (1 row)
 
+delete from t_reorganize where gp_segment_id != 0;
 select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
  check_redistributed 
 ------------
@@ -1753,16 +1765,15 @@ select check_redistributed('alter table t_reorganize set with (reorganize=true) 
 (1 row)
 
 create table t_random (like t_reorganize) distributed randomly;
-ERROR:  relation "t_random" already exists
 select check_redistributed('insert into t_random select * from t_reorganize', 't_reorganize', 't_random');
  check_redistributed 
 ------------
  t
 (1 row)
 
-create table t_distbya (like t_reorganize) distributed by (a);
-ERROR:  relation "t_distbya" already exists
-select check_redistributed('insert into t_distbya select * from t_reorganize', 't_reorganize', 't_distbya');
+alter table t_reorganize set with (reorganize=true) distributed by (a);
+create table t_distbyb (like t_reorganize) distributed by (b);
+select check_redistributed('insert into t_distbyb select * from t_reorganize', 't_reorganize', 't_distbyb');
  check_redistributed 
 ------------
  t


### PR DESCRIPTION
The test was flaky with a diff like:
```
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/alter_distribution_policy.out	2023-09-19 15:30:40.631966743 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/alter_distribution_policy.out	2023-09-19 15:30:40.699971949 +0000
@@ -1725,7 +1725,7 @@
 select check_redistributed('alter table t_reorganize set with (reorganize=true) distributed randomly', 't_reorganize', 't_reorganize');
  check_redistributed
 ------------
- t
+ f
 (1 row)
```

The reason is that table redistribution from random-to-random can happen to not change the number of rows on each segments. This was kinda expected during the PR preparation (https://github.com/greenplum-db/gpdb/pull/15795) but the chance that it happens is still higher than I would've hoped. Now always make sure we redistribute data from one-single segment to multiple segments or a different segment, which should have well enough margin to make it *almost* impossible to flake.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
