### PR TITLE
fix REFRESH MATERIALIZED VIEW on AO table with index

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -181,7 +181,6 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	bool		createAoBlockDirectory;
 	ObjectAddress address;
 	RefreshClause *refreshClause;
-	List 		  *indexes;
 
 	/* MATERIALIZED_VIEW_FIXME: Refresh MatView is not MPP-fied. */
 
@@ -331,8 +330,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	}
 
 	/* If an AO temp table has index, we need to create it. */
-	indexes = RelationGetIndexList(matviewRel);
-	createAoBlockDirectory = (indexes != NIL);
+	createAoBlockDirectory = matviewRel->rd_rel->relhasindex;
 
 	/*
 	 * Create the transient table that will receive the regenerated data. Lock
@@ -555,7 +553,6 @@ transientrel_init(QueryDesc *queryDesc)
 	LOCKMODE	lockmode;
 	bool		createAoBlockDirectory;
 	RefreshClause *refreshClause;
-	List 		  *indexes;
 
 	refreshClause = queryDesc->plannedstmt->refreshClause;
 	/* Determine strength of lock needed. */
@@ -589,8 +586,7 @@ transientrel_init(QueryDesc *queryDesc)
 	}
 
 	/* If an AO temp table has index, we need to create it. */
-	indexes = RelationGetIndexList(matviewRel);
-	createAoBlockDirectory = (indexes != NIL);
+	createAoBlockDirectory = matviewRel->rd_rel->relhasindex;
 
 	/*
 	 * Create the transient table that will receive the regenerated data. Lock

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -675,3 +675,34 @@ ERROR:  materialized view "mat_view_twn" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 DROP MATERIALIZED VIEW mat_view_twn;
 DROP TABLE mvtest_twn;
+-- test REFRESH MATERIALIZED VIEW on AO table with index
+-- more details could be found at https://github.com/greenplum-db/gpdb/issues/16447
+CREATE TABLE base_table (idn character varying(10) NOT NULL);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'idn' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO base_table select i from generate_series(1, 5000) i;
+CREATE MATERIALIZED VIEW base_view WITH (APPENDONLY=true) AS SELECT tt1.idn AS idn_ban FROM base_table tt1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'idn_ban' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX test_id1 on base_view using btree(idn_ban);
+REFRESH MATERIALIZED VIEW base_view ;
+SELECT * FROM base_view where idn_ban = '10';
+ idn_ban 
+---------
+ 10
+(1 row)
+
+-- should use index scan rather than seq scan
+EXPLAIN SELECT * FROM base_view where idn_ban = '10';
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.19..8.28 rows=5 width=38)
+   ->  Bitmap Heap Scan on base_view  (cost=4.19..8.21 rows=2 width=38)
+         Recheck Cond: ((idn_ban)::text = '10'::text)
+         ->  Bitmap Index Scan on test_id1  (cost=0.00..4.19 rows=2 width=0)
+               Index Cond: ((idn_ban)::text = '10'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+DROP MATERIALIZED VIEW base_view;
+DROP TABLE base_table;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -685,3 +685,35 @@ ERROR:  materialized view "mat_view_twn" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
 DROP MATERIALIZED VIEW mat_view_twn;
 DROP TABLE mvtest_twn;
+-- test REFRESH MATERIALIZED VIEW on AO table with index
+-- more details could be found at https://github.com/greenplum-db/gpdb/issues/16447
+CREATE TABLE base_table (idn character varying(10) NOT NULL);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'idn' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO base_table select i from generate_series(1, 5000) i;
+CREATE MATERIALIZED VIEW base_view WITH (APPENDONLY=true) AS SELECT tt1.idn AS idn_ban FROM base_table tt1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+CREATE INDEX test_id1 on base_view using btree(idn_ban);
+REFRESH MATERIALIZED VIEW base_view ;
+SELECT * FROM base_view where idn_ban = '10';
+NOTICE:  One or more columns in the following table(s) do not have statistics: base_view
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+ idn_ban 
+---------
+ 10
+(1 row)
+
+-- should use index scan rather than seq scan
+EXPLAIN SELECT * FROM base_view where idn_ban = '10';
+NOTICE:  One or more columns in the following table(s) do not have statistics: base_view
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.09 rows=2000 width=8)
+   ->  Index Only Scan using test_id1 on base_view  (cost=0.00..17.02 rows=667 width=8)
+         Index Cond: (idn_ban = '10'::text)
+ Optimizer: GPORCA
+(4 rows)
+
+DROP MATERIALIZED VIEW base_view;
+DROP TABLE base_table;


### PR DESCRIPTION
This PR is trying to fix the issue #16447, the RCA for 7X could be found at [RCA for 7X](https://github.com/greenplum-db/gpdb/issues/16447#issuecomment-1725276402)

-----

The resolution is quite simple and direct: if an AO materialized view has indexes, create the block directory
for it.