### PR TITLE
Revert "fix pg_stat_activity display and Improve output warning"

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4542,23 +4542,6 @@ pgstat_get_crashed_backend_activity(int pid, char *buffer, int buflen)
 	return NULL;
 }
 
-bool
-pgstat_get_backend_query_isbypassed(int pid)
-{
-	int			tot_backends = pgstat_fetch_stat_numbackends();
-	int                     beid;
-
-	for (beid = 1; beid <= tot_backends; beid++)
-	{
-		PgBackendStatus *beentry = pgstat_fetch_stat_beentry(beid);
-
-		if (beentry && beentry->st_procpid == pid)
-			return beentry->st_bypass_rsg;
-	}
-
-	return false;
-}
-
 const char *
 pgstat_get_backend_desc(BackendType backendType)
 {

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3179,7 +3179,6 @@ pgstat_bestart(void)
 	lbeentry.st_progress_command = PROGRESS_COMMAND_INVALID;
 	lbeentry.st_progress_command_target = InvalidOid;
 	lbeentry.st_rsgid = InvalidOid;
-	lbeentry.st_bypass_rsg = false;
 
 	/*
 	 * we don't zero st_progress_param here to save cycles; nobody should
@@ -3526,7 +3525,6 @@ pgstat_report_resgroup(Oid groupid)
 	beentry->st_changecount++;
 
 	beentry->st_rsgid = groupid;
-	beentry->st_bypass_rsg = groupid == InvalidOid ? false : ResGroupIsBypassed();
 	beentry->st_changecount++;
 	Assert((beentry->st_changecount & 1) == 0);
 }

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -919,17 +919,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 				values[30] = ObjectIdGetDatum(beentry->st_rsgid);
 
 				if (groupName != NULL)
-				{
-					if(beentry->st_bypass_rsg)
-					{
-						StringInfoData buf;
-						initStringInfo(&buf);
-						appendStringInfo(&buf, "%s<bypass>", groupName);
-						values[31] = CStringGetTextDatum(buf.data);
-					}
-					else
-						values[31] = CStringGetTextDatum(groupName);
-				}
+					values[31] = CStringGetTextDatum(groupName);
 				else
 					nulls[31] = true;
 			}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3884,9 +3884,3 @@ can_bypass_direct_dispatch_plan(PlannedStmt *stmt)
 	else
 		return false;
 }
-
-bool
-ResGroupIsBypassed(void)
-{
-	return bypassedGroup != NULL;
-}

--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -15,7 +15,6 @@
 #include "funcapi.h"
 #include "libpq-fe.h"
 #include "miscadmin.h"
-#include "pgstat.h"
 #include "catalog/pg_resgroup.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
@@ -495,14 +494,10 @@ pg_resgroup_move_query(PG_FUNCTION_ARGS)
 							(errmsg("cannot find process: %d", pid))));
 
 		currentGroupId = ResGroupGetGroupIdBySessionId(sessionId);
-		if (currentGroupId == InvalidOid && pgstat_get_backend_query_isbypassed(pid))
+		if (currentGroupId == InvalidOid)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
-							(errmsg("cannot move a bypassed or unassigned query"))));
-		else if (currentGroupId == InvalidOid)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-							(errmsg("process %d is in IDLE state, cannot move a queued or pending query in idle state", pid))));
+							(errmsg("process %d is in IDLE state", pid))));
 		if (currentGroupId == groupId)
 			PG_RETURN_BOOL(true);
 

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -1480,7 +1480,6 @@ extern void pgstat_report_activity(BackendState state, const char *cmd_str);
 extern void pgstat_report_tempfile(size_t filesize);
 extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);
-extern bool pgstat_get_backend_query_isbypassed(int pid);
 extern const char *pgstat_get_wait_event(uint32 wait_event_info);
 extern const char *pgstat_get_wait_event_type(uint32 wait_event_info);
 extern const char *pgstat_get_backend_current_activity(int pid, bool checkUser);

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -1272,8 +1272,6 @@ typedef struct PgBackendStatus
 	ProgressCommandType st_progress_command;
 	Oid			st_progress_command_target;
 	int64		st_progress_param[PGSTAT_NUM_PROGRESS_PARAM];
-
-	bool                    st_bypass_rsg;
 } PgBackendStatus;
 
 /*

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -175,7 +175,6 @@ extern void UnassignResGroup(void);
 extern void SwitchResGroupOnSegment(const char *buf, int len);
 
 extern bool ResGroupIsAssigned(void);
-extern bool ResGroupIsBypassed(void);
 
 /* Retrieve statistic information of type from resource group */
 extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);

--- a/src/test/isolation2/expected/resgroup/resgroup_move_query.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_move_query.out
@@ -51,7 +51,7 @@ SET
 1: SET gp_vmem_idle_resource_timeout = 0;
 SET
 SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%gp_vmem_idle_resource_timeout%' AND state = 'idle';
-ERROR:  process 3402671 is in IDLE state, cannot move a queued or pending query in idle state
+ERROR:  process 1665030 is in IDLE state
 SELECT is_session_in_group(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%gp_vmem_idle_resource_timeout%' AND state = 'idle';
  is_session_in_group 
 ---------------------
@@ -67,7 +67,7 @@ BEGIN
 SET
 2&: BEGIN;  <waiting ...>
 SELECT pg_resgroup_move_query(pid, 'default_group') FROM pg_stat_activity WHERE wait_event_type='ResourceGroup';
-ERROR:  process 3402849 is in IDLE state, cannot move a queued or pending query in idle state
+ERROR:  process 1665105 is in IDLE state
 SELECT is_session_in_group(pid, 'default_group') FROM pg_stat_activity WHERE wait_event_type='ResourceGroup';
  is_session_in_group 
 ---------------------

--- a/src/test/isolation2/expected/resgroup/resgroup_move_query.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_move_query.out
@@ -100,10 +100,10 @@ SET
  t                      
 (1 row)
 3: SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active' and query like 'SELECT%';
- rsgname             | query                                                                                        
----------------------+----------------------------------------------------------------------------------------------
- rg_move_query       | SELECT pg_sleep(10);                                                                         
- admin_group<bypass> | SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active' and query like 'SELECT%'; 
+ rsgname       | query                                                                                        
+---------------+----------------------------------------------------------------------------------------------
+ rg_move_query | SELECT pg_sleep(10);                                                                         
+ admin_group   | SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active' and query like 'SELECT%'; 
 (2 rows)
 2<:  <... completed>
  pg_sleep 


### PR DESCRIPTION
The first commit add a field ‘st_bypass_rsg’ of exported struct PgBackendStatus, even if it append at the end, this struct is included as middle element of other struct LocalPgBackendStatus which is also export, and the other commit also used the field ‘st_bypass_rsg’, revert both of them.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
