### PR TITLE
Fix flaky test gp_tablespace_with_faults

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -242,12 +242,15 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 --           it is no longer in memory, and we did not succeed in writing the
 --           prepared transaction, therefore we cannot safely clean
 --           the tablespace directory.
+--           Note that we need to panic even before writing WAL for creating the
+--           tablespace so mirror doesn't create the same and results in 2 orphaned
+--           directories instead of 1.
 --
 \set content_id_under_test 0
 \set expected_number_of_tablespaces 1
 \set error_type panic
 \set tablespace_location /tmp/my_tablespace_for_testing
-\set fault_to_set before_xlog_xact_prepare
+\set fault_to_set before_xlog_create_tablespace
 
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -356,12 +356,15 @@ select cleanup(:content_id_under_test, :'tablespace_location');
 --           it is no longer in memory, and we did not succeed in writing the
 --           prepared transaction, therefore we cannot safely clean
 --           the tablespace directory.
+--           Note that we need to panic even before writing WAL for creating the
+--           tablespace so mirror doesn't create the same and results in 2 orphaned
+--           directories instead of 1.
 --
 \set content_id_under_test 0
 \set expected_number_of_tablespaces 1
 \set error_type panic
 \set tablespace_location /tmp/my_tablespace_for_testing
-\set fault_to_set before_xlog_xact_prepare
+\set fault_to_set before_xlog_create_tablespace
 select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespace_location');
  setup 
 -------
@@ -369,7 +372,7 @@ select setup(:content_id_under_test, :'fault_to_set', :'error_type', :'tablespac
 (1 row)
 
 CREATE TABLESPACE my_tablespace_for_testing LOCATION :'tablespace_location';
-ERROR:  fault triggered, fault name:'before_xlog_xact_prepare' fault type:'panic'  (seg0 127.0.0.1:7002 pid=26919)
+ERROR:  fault triggered, fault name:'before_xlog_create_tablespace' fault type:'panic'  (seg0 127.0.0.1:7002 pid=26919)
 select wait_for_primaries_to_restart();
  wait_for_primaries_to_restart 
 -------------------------------


### PR DESCRIPTION
The test was flaky with a diff like:

```
@@ -397,9 +397,9 @@
 (8 rows)

 select list_tablespace_dbid_dirs(:expected_number_of_tablespaces, :'tablespace_location');
-                                 list_tablespace_dbid_dirs
+                                                 list_tablespace_dbid_dirs
 ------------
- {Success,"expected 1 tablespaces","found 1 tablespaces",/tmp/my_tablespace_for_testing/2}
+ {Failed,"expected 1 tablespaces","found 2 tablespaces",/tmp/my_tablespace_for_testing/2,/tmp/my_tablespace_for_testing/5}
 (1 row)
```

The reason is that there's a chance the mirror has already replayed the WAL to create tablespace, so we can have two orphaned tablespace directories instead of one. Now make it panic even before we write the WAL to create tablespace to make it not flaky.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
