### PR TITLE
Docs llvm

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -40,10 +40,7 @@ The internal workflow of JIT can be divided into three different stages:
     
     This stage takes place in the Greenplum Database coordinator. The planner generates the plan tree of a query and its estimated cost. By default, Greenplum Database uses GPORCA to generate a query plan. Otherwise it uses Postgres-based planner as a fallback method.
 
-> **Note** In order to use JIT, you must first install the LLVM libraries in your system:
-> ```
-> yum install llvm-libs
-> ```
+> **Note** In order to use JIT, you must first install the LLVM libraries in your system by running the command `yum install llvm-libs`.
 
     The planner decides to trigger JIT compilation if:
 

--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -34,13 +34,14 @@ LLVM has support for optimizing generated code. Some of the optimizations are ch
 
 JIT compilation is beneficial primarily for long-running CPU-bound queries. Frequently these are analytical queries. For short queries the added overhead of performing JIT compilation will often be higher than the time it can save.
 
+> **Note** In order to use JIT, you must first install the LLVM libraries in your system by running the command `yum install llvm-libs`.
+
 The internal workflow of JIT can be divided into three different stages:
 
 1. Planner Stage
     
     This stage takes place in the Greenplum Database coordinator. The planner generates the plan tree of a query and its estimated cost. By default, Greenplum Database uses GPORCA to generate a query plan. Otherwise it uses Postgres-based planner as a fallback method.
 
-> **Note** In order to use JIT, you must first install the LLVM libraries in your system by running the command `yum install llvm-libs`.
     The planner decides to trigger JIT compilation if:
 
     - The server configuration parameter [jit](../../../ref_guide/config_params/guc-list.html#jit) is `true`.

--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -40,6 +40,11 @@ The internal workflow of JIT can be divided into three different stages:
     
     This stage takes place in the Greenplum Database coordinator. The planner generates the plan tree of a query and its estimated cost. By default, Greenplum Database uses GPORCA to generate a query plan. Otherwise it uses Postgres-based planner as a fallback method.
 
+> **Note** In order to use JIT, you must first install the LLVM libraries in your system:
+> ```
+> yum install llvm-libs
+> ```
+
     The planner decides to trigger JIT compilation if:
 
     - The server configuration parameter [jit](../../../ref_guide/config_params/guc-list.html#jit) is `true`.

--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -41,7 +41,6 @@ The internal workflow of JIT can be divided into three different stages:
     This stage takes place in the Greenplum Database coordinator. The planner generates the plan tree of a query and its estimated cost. By default, Greenplum Database uses GPORCA to generate a query plan. Otherwise it uses Postgres-based planner as a fallback method.
 
 > **Note** In order to use JIT, you must first install the LLVM libraries in your system by running the command `yum install llvm-libs`.
-
     The planner decides to trigger JIT compilation if:
 
     - The server configuration parameter [jit](../../../ref_guide/config_params/guc-list.html#jit) is `true`.


### PR DESCRIPTION
This PR adds a note to the Just in Time compilation page to install llvm libraries before using JIT. 