### PR TITLE
Disable autovacuum for flaky test gp_check_files

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -284,6 +284,9 @@ test: instr_in_shmem_verify
 # check autostats
 test: autostats
 test: dpe
+# run this near the end of the schedule for more chance to catch abnormalities
+# Have to run it w/o autovacuum to make sure it won't cause gp_check_orphaned_files to fail in any way.
+test: gp_check_files
 test: enable_autovacuum
 
 test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics
@@ -354,9 +357,6 @@ test: enum_dist_part_ban
 
 # test compresstype fallback from quicklz when gp_quicklz_fallback=true
 test: quicklz_fallback
-
-# run this at the end of the schedule for more chance to catch abnormalities
-test: gp_check_files
 
 # run pg_hba raleted testing
 test: hba_conf


### PR DESCRIPTION
After #16469 we are still having the issue which however seems to be associated with a few platforms. Now doing the original fix which is to disable autovacuum for the test to make sure it won't get in the way of gp_check_orphaned_files in any way. Meanwhile will look at the platform-specific issue separately.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/flake-gpcheckfiles

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
