### PR TITLE
[6X backport]Fix utilities do not honor -d flag when MASTER_DATA_DIRECTORY is not set (#16433)

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1177,12 +1177,27 @@ def get_gphome():
         raise GpError('Environment Variable GPHOME not set')
     return gphome
 
+'''
+gprecoverseg, gpstart, gpstate, gpstop, gpaddmirror have -d option to give the master data directory.
+but its value was not used throughout the utilities. to fix this the best possible way is
+to set and retrieve that set master dir when we call get_masterdatadir().
+'''
+option_master_datadir = None
+def set_masterdatadir(master_datadir=None):
+    global option_master_datadir
+    option_master_datadir = master_datadir
 
 ######
+# if -d <master_datadir> is provided with utility, it will be prioritiese over other options.
 def get_masterdatadir():
-    master_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
+    if option_master_datadir is not None:
+        master_datadir = option_master_datadir
+    else:
+        master_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
+
     if not master_datadir:
         raise GpError("Environment Variable MASTER_DATA_DIRECTORY not set!")
+
     return master_datadir
 
 ######

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -174,7 +174,7 @@ class SimpleMainLock:
             # If the process is already killed, remove the lock directory.
             if not unix.check_pid(self.pidfilepid):
                 shutil.rmtree(self.ppath)
-                
+
         # try and acquire the lock
         try:
             self.pidlockfile.acquire()
@@ -264,6 +264,18 @@ def simple_main(createOptionParserFn, createCommandFn, mainOptions=None):
 
 
 def simple_main_internal(createOptionParserFn, createCommandFn, mainOptions):
+
+    """
+    if -d <master_data_dir> option is provided in that case doing parsing after creating
+    lock file would not be a good idea therefore handling -d option before lock.
+    """
+    parser = createOptionParserFn()
+    (parserOptions, parserArgs) = parser.parse_args()
+
+    if parserOptions.ensure_value("masterDataDirectory", None) is not None:
+        parserOptions.master_data_directory = os.path.abspath(parserOptions.masterDataDirectory)
+        gp.set_masterdatadir(parserOptions.master_data_directory)
+
     """
     If caller specifies 'pidlockpath' in mainOptions then we manage the
     specified pid file within the MASTER_DATA_DIRECTORY before proceeding
@@ -282,13 +294,13 @@ def simple_main_internal(createOptionParserFn, createCommandFn, mainOptions):
 
     # at this point we have whatever lock we require
     try:
-        simple_main_locked(createOptionParserFn, createCommandFn, mainOptions)
+        simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions)
     finally:
         if sml is not None:
             sml.release()
 
 
-def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
+def simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions):
     """
     Not to be called externally -- use simple_main instead
     """
@@ -304,7 +316,6 @@ def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
     parser = None
 
     forceQuiet = mainOptions is not None and mainOptions.get("forceQuietOutput")
-    options = None
 
     if mainOptions is not None and mainOptions.get("programNameOverride"):
         global gProgramName
@@ -320,30 +331,24 @@ def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
         hostname = unix.getLocalHostname()
         username = unix.getUserName()
 
-        parser = createOptionParserFn()
-        (options, args) = parser.parse_args()
-
         if useHelperToolLogging:
             gplog.setup_helper_tool_logging(execname, hostname, username)
         else:
             gplog.setup_tool_logging(execname, hostname, username,
-                                     logdir=options.ensure_value("logfileDirectory", None), nonuser=nonuser)
+                                     logdir=parserOptions.ensure_value("logfileDirectory", None), nonuser=nonuser)
 
         if forceQuiet:
             gplog.quiet_stdout_logging()
         else:
-            if options.ensure_value("verbose", False):
+            if parserOptions.ensure_value("verbose", False):
                 gplog.enable_verbose_logging()
-            if options.ensure_value("quiet", False):
+            if parserOptions.ensure_value("quiet", False):
                 gplog.quiet_stdout_logging()
-
-        if options.ensure_value("masterDataDirectory", None) is not None:
-            options.master_data_directory = os.path.abspath(options.masterDataDirectory)
 
         if not suppressStartupLogMessage:
             logger.info("Starting %s with args: %s" % (gProgramName, ' '.join(sys.argv[1:])))
 
-        commandObject = createCommandFn(options, args)
+        commandObject = createCommandFn(parserOptions, parserArgs)
         exitCode = commandObject.run()
         exit_status = exitCode
 
@@ -365,10 +370,10 @@ def simple_main_locked(createOptionParserFn, createCommandFn, mainOptions):
                       e.cmd.results.stderr))
         exit_status = 2
     except Exception, e:
-        if options is None:
+        if parserOptions is None:
             logger.exception("%s failed.  exiting...", gProgramName)
         else:
-            if options.ensure_value("verbose", False):
+            if parserOptions.ensure_value("verbose", False):
                 logger.exception("%s failed.  exiting...", gProgramName)
             else:
                 logger.fatal("%s failed. (Reason='%s') exiting..." % (gProgramName, e))

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,7 +1,7 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
-    Scenario Outline: <scenario>recovery works with tablespaces
+    Scenario Outline: <scenario> recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
           And user stops all primary processes
@@ -296,7 +296,33 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
 
-  Scenario: gprecoverseg differential recovery displays rsync progress to the user
+    Scenario: gprecoverseg runs with given master data directory option
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all mirror processes
+          And user can start transactions
+          And "MASTER_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gprecoverseg" with master data directory and "-F -a"
+          And gprecoverseg should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+          And the segments are synchronized
+
+    Scenario: gprecoverseg priorities given master data directory over env option
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all mirror processes
+          And user can start transactions
+          And the environment variable "MASTER_DATA_DIRECTORY" is set to "/tmp/"
+         Then the user runs utility "gprecoverseg" with master data directory and "-F -a"
+          And gprecoverseg should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+          And the segments are synchronized
+
+    Scenario: gprecoverseg differential recovery displays rsync progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -1410,6 +1436,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
+
       Examples:
         | scenario     | args               |
         | differential | -a --differential  |

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -27,6 +27,32 @@ Feature: gpstart behave tests
           And gpstart should return a return code of 0
           And all the segments are running
 
+    @demo_cluster
+    Scenario: gpstart runs with given master data directory option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the user runs "gpstop -a"
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+          And "MASTER_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstart" with master data directory and "-a"
+          And gpstart should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+
+    @demo_cluster
+    Scenario: gpstart priorities given master data directory over env option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the user runs "gpstop -a"
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+          And the environment variable "MASTER_DATA_DIRECTORY" is set to "/tmp/"
+         Then the user runs utility "gpstart" with master data directory and "-a"
+          And gpstart should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And all the segments are running
+
     @concourse_cluster
     @demo_cluster
     Scenario: gpstart starts even if a segment host is unreachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -596,6 +596,55 @@ Feature: gpstate tests
         And the pg_log files on primary segments should not contain "connections to primary segments are not allowed"
         And the user drops log_timestamp table
 
+    Scenario: gpstate runs with given master data directory option
+        Given the cluster is generated with "3" primaries only
+         And "MASTER_DATA_DIRECTORY" environment variable is not set
+        Then the user runs utility "gpstate" with master data directory and "-a -b"
+         And gpstate should return a return code of 0
+         And gpstate output has rows with keys values
+            | Master instance                                   = Active                            |
+            | Master standby                                    = No master standby configured      |
+            | Total segment instance count from metadata        = 3                                 |
+            | Primary Segment Status                                                                |
+            | Total primary segments                            = 3                                 |
+            | Total primary segment valid \(at master\)         = 3                                 |
+            | Total primary segment failures \(at master\)      = 0                                 |
+            | Total number of postmaster.pid files missing      = 0                                 |
+            | Total number of postmaster.pid files found        = 3                                 |
+            | Total number of postmaster.pid PIDs missing       = 0                                 |
+            | Total number of postmaster.pid PIDs found         = 3                                 |
+            | Total number of /tmp lock files missing           = 0                                 |
+            | Total number of /tmp lock files found             = 3                                 |
+            | Total number postmaster processes missing         = 0                                 |
+            | Total number postmaster processes found           = 3                                 |
+            | Mirror Segment Status                                                                 |
+            | Mirrors not configured on this array
+         And "MASTER_DATA_DIRECTORY" environment variable should be restored
+
+    Scenario: gpstate priorities given master data directory over env option
+        Given the cluster is generated with "3" primaries only
+          And the environment variable "MASTER_DATA_DIRECTORY" is set to "/tmp/"
+        Then the user runs utility "gpstate" with master data directory and "-a -b"
+         And gpstate should return a return code of 0
+         And gpstate output has rows with keys values
+            | Master instance                                   = Active                            |
+            | Master standby                                    = No master standby configured      |
+            | Total segment instance count from metadata        = 3                                 |
+            | Primary Segment Status                                                                |
+            | Total primary segments                            = 3                                 |
+            | Total primary segment valid \(at master\)         = 3                                 |
+            | Total primary segment failures \(at master\)      = 0                                 |
+            | Total number of postmaster.pid files missing      = 0                                 |
+            | Total number of postmaster.pid files found        = 3                                 |
+            | Total number of postmaster.pid PIDs missing       = 0                                 |
+            | Total number of postmaster.pid PIDs found         = 3                                 |
+            | Total number of /tmp lock files missing           = 0                                 |
+            | Total number of /tmp lock files found             = 3                                 |
+            | Total number postmaster processes missing         = 0                                 |
+            | Total number postmaster processes found           = 3                                 |
+            | Mirror Segment Status                                                                 |
+            | Mirrors not configured on this array
+        And "MASTER_DATA_DIRECTORY" environment variable should be restored
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -10,6 +10,26 @@ Feature: gpstop behave tests
          Then gpstop should return a return code of 0
          And verify no postgres process is running on all hosts
 
+    @demo_cluster
+    Scenario: gpstop runs with given master data directory option
+        Given the database is running
+          And running postgres processes are saved in context
+          And "MASTER_DATA_DIRECTORY" environment variable is not set
+         Then the user runs utility "gpstop" with master data directory and "-a"
+          And gpstop should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And verify no postgres process is running on all hosts
+
+    @demo_cluster
+    Scenario: gpstop priorities given master data directory over env option
+        Given the database is running
+          And running postgres processes are saved in context
+          And the environment variable "MASTER_DATA_DIRECTORY" is set to "/tmp/"
+         Then the user runs utility "gpstop" with master data directory and "-a"
+          And gpstop should return a return code of 0
+          And "MASTER_DATA_DIRECTORY" environment variable should be restored
+          And verify no postgres process is running on all hosts
+
     @concourse_cluster
     @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user switches to fast mode

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -362,7 +362,7 @@ def impl(context, dbname):
     drop_database(context, dbname)
 
 
-@given('{env_var} environment variable is not set')
+@given('"{env_var}" environment variable is not set')
 def impl(context, env_var):
     if not hasattr(context, 'orig_env'):
         context.orig_env = dict()
@@ -1199,6 +1199,15 @@ def impl(context, options):
 def impl(context, options):
     context.execute_steps(u'''Then the user runs command "gpactivatestandby -a %s" from standby master''' % options)
     context.standby_was_activated = True
+
+
+@given('the user runs utility "{utility}" with master data directory and "{options}"')
+@when('the user runs utility "{utility}" with master data directory and "{options}"')
+@then('the user runs utility "{utility}" with master data directory and "{options}"')
+def impl(context, utility, options):
+    cmd = "{} -d {} {}".format(utility, master_data_dir, options)
+    context.execute_steps(u'''then the user runs command "%s"''' % cmd )
+
 
 @then('gpintsystem logs should {contain} lines about running backout script')
 def impl(context, contain):


### PR DESCRIPTION
cherry-pick  (#16433)

Issue: Following are the gpMgmt utilities that do not honor the -d flag, when MASTER_DATA_DIRECTORY is not set.
1. gpstart
2. gpstop
3. gpstate
4. gprecoverseg
5. gpaddmirror

RCA: to get the master data directory gp.getmaster_datadir() function is called from the above-listed utilities. the function does not have any provision to return the master data directory which is provided with the -d flag. currently, it looks for MASTER_DATA_DIRECTORY and MASTER_DATA_DIRECTORY env variable.

also in some of the utilities, we were creating lock files before parsing the provided options which looks like the design flow that was causing the utilities to crash when looking for the master data directory.

Fix: Added a global flag that holds the data directory provided with the -d option. so when we run the utility and do parsing it sets the flag with the provided datadirectory and the same will be returned when we call gp.gp.getmaster_datadir().

Test:
Added behave test cases to use the provided data directory if MASTER_DATA_DIRECTORY is not set.
Added behave test case to check if the provided master data directory is preferred over the already set master_data_dir env variable. it is tested by setting a wrong MASTER_DATA_DIRECTORY env variable and when we run the utility with the correct data directory using the -d option then the utility should execute successfully.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
