### PR TITLE
Hash subplans in Orca plans when possible

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -42,6 +42,7 @@ extern "C" {
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/plancat.h"
+#include "optimizer/subselect.h"
 #include "parser/parse_agg.h"
 #include "partitioning/partdesc.h"
 #include "storage/lmgr.h"
@@ -2718,4 +2719,16 @@ gpdb::GPDBRelationRetrievePartitionKey(Relation rel)
 	}
 	GP_WRAP_END;
 }
+
+bool
+gpdb::TestexprIsHashable(Node *testexpr, List *param_ids)
+{
+	GP_WRAP_START;
+	{
+		return testexpr_is_hashable(testexpr, param_ids);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -869,6 +869,15 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	// translate other subplan params
 	TranslateSubplanParams(subplan, &subplan_translate_ctxt, outer_refs,
 						   colid_var);
+	// Similar to the logic in planner's build_subplan(), we can
+	// set useHashTable to true if the expr is hashable and there are no outer
+	// refs, which can significantly improve execution time
+	if (slink == ANY_SUBLINK && subplan->parParam == NIL &&
+		gpdb::TestexprIsHashable(subplan->testexpr, subplan->paramIds))
+	{
+		subplan->useHashTable = true;
+	}
+
 
 	return (Expr *) subplan;
 }

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -91,7 +91,6 @@ static Node *convert_testexpr_mutator(Node *node,
 									  convert_testexpr_context *context);
 static bool subplan_is_hashable(PlannerInfo *root, Plan *plan);
 static bool subpath_is_hashable(PlannerInfo *root, Path *path);
-static bool testexpr_is_hashable(Node *testexpr, List *param_ids);
 static bool test_opexpr_is_hashable(OpExpr *testexpr, List *param_ids);
 static bool hash_ok_operator(OpExpr *expr);
 #if 0
@@ -1000,7 +999,7 @@ subpath_is_hashable(PlannerInfo *root, Path *path)
  * To identify LHS vs RHS of the hash expression, we must be given the
  * list of output Param IDs of the SubLink's subquery.
  */
-static bool
+bool
 testexpr_is_hashable(Node *testexpr, List *param_ids)
 {
 	/*

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -674,6 +674,8 @@ PartitionDesc GPDBRelationRetrievePartitionDesc(Relation rel);
 
 PartitionKey GPDBRelationRetrievePartitionKey(Relation rel);
 
+bool TestexprIsHashable(Node *testexpr, List *param_ids);
+
 }  //namespace gpdb
 
 #define ForEach(cell, l) \

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -55,5 +55,7 @@ extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);
 extern bool QueryHasDistributedRelation(Query *q, bool recursive);
 extern bool contain_outer_selfref(Node *node);
+extern bool testexpr_is_hashable(Node *testexpr, List *param_ids);
+
 
 #endif							/* SUBSELECT_H */

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1754,5 +1754,56 @@ where xx='dd';
 ----+---
 (0 rows)
 
+-- Ensure we produce a hashed subplan when there are no outer references
+CREATE TABLE a1 AS (
+    SELECT * FROM generate_series(1, 5) AS a1)
+    WITH data distributed replicated;
+CREATE TABLE a2 AS (
+    SELECT * FROM generate_series(1, 10) AS a1)
+    WITH data distributed BY (a1);
+CREATE TABLE a3 AS (
+	SELECT a1, row_to_json(a2) AS rj FROM a2)
+	WITH data distributed BY (a1);
+-- explain "verbose" is needed to show that the subplan is hashed
+explain (verbose, costs off) select a1,case when a2 in (select a1::text from a1 where a1 is not null) then 'true' else 'false' end as checkcol
+from (
+      select a1,rj->>'a1'::text as a2
+      from a3
+      )t;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a3.a1, (CASE WHEN (hashed SubPlan 1) THEN 'true'::text ELSE 'false'::text END)
+   ->  Seq Scan on qp_subquery.a3
+         Output: a3.a1, CASE WHEN (hashed SubPlan 1) THEN 'true'::text ELSE 'false'::text END
+         SubPlan 1
+           ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                 Output: ((a1.a1)::text)
+                 ->  Seq Scan on qp_subquery.a1
+                       Output: (a1.a1)::text
+                       Filter: (a1.a1 IS NOT NULL)
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(12 rows)
+
+select a1,case when a2 in (select a1::text from a1 where a1 is not null) then 'true' else 'false' end as checkcol
+from (
+      select a1,rj->>'a1'::text as a2
+      from a3
+      )t;
+ a1 | checkcol 
+----+----------
+  1 | true
+  5 | true
+  6 | false
+  9 | false
+ 10 | false
+  2 | true
+  3 | true
+  4 | true
+  7 | false
+  8 | false
+(10 rows)
+
 set client_min_messages='warning';
 drop schema qp_subquery cascade;

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1730,7 +1730,7 @@ where xx='dd';
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
-         Filter: ((text((SubPlan 1))) = 'dd'::text)
+         Filter: ((text((hashed SubPlan 1))) = 'dd'::text)
          ->  Nested Loop
                Join Filter: true
                ->  Seq Scan on subquery_nonpush_through_1
@@ -1754,6 +1754,58 @@ where xx='dd';
  xx | b 
 ----+---
 (0 rows)
+
+-- Ensure we produce a hashed subplan when there are no outer references
+CREATE TABLE a1 AS (
+    SELECT * FROM generate_series(1, 5) AS a1)
+    WITH data distributed replicated;
+CREATE TABLE a2 AS (
+    SELECT * FROM generate_series(1, 10) AS a1)
+    WITH data distributed BY (a1);
+CREATE TABLE a3 AS (
+	SELECT a1, row_to_json(a2) AS rj FROM a2)
+	WITH data distributed BY (a1);
+-- explain "verbose" is needed to show that the subplan is hashed
+explain (verbose, costs off) select a1,case when a2 in (select a1::text from a1 where a1 is not null) then 'true' else 'false' end as checkcol
+from (
+      select a1,rj->>'a1'::text as a2
+      from a3
+      )t;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a3.a1, (CASE WHEN (hashed SubPlan 1) THEN 'true'::text ELSE 'false'::text END)
+   ->  Seq Scan on qp_subquery.a3
+         Output: a3.a1, CASE WHEN (hashed SubPlan 1) THEN 'true'::text ELSE 'false'::text END
+         SubPlan 1
+           ->  Result
+                 Output: ((a1.a1)::text)
+                 ->  Result
+                       Output: (a1.a1)::text, true
+                       ->  Seq Scan on qp_subquery.a1
+                             Output: a1.a1
+                             Filter: (NOT (a1.a1 IS NULL))
+ Optimizer: GPORCA
+(13 rows)
+
+select a1,case when a2 in (select a1::text from a1 where a1 is not null) then 'true' else 'false' end as checkcol
+from (
+      select a1,rj->>'a1'::text as a2
+      from a3
+      )t;
+ a1 | checkcol 
+----+----------
+  2 | true
+  3 | true
+  4 | true
+  7 | false
+  8 | false
+  1 | true
+  5 | true
+  6 | false
+  9 | false
+ 10 | false
+(10 rows)
 
 set client_min_messages='warning';
 drop schema qp_subquery cascade;


### PR DESCRIPTION
Previously, all subplans in Orca had the `useHashTable` parameter set to false. However, in certain cases, when the subplan testexpr is hashable and there aren't any outer refs, we can hash the subplan, which can significantly reduce execution time. This logic was taken from build_subplan in the planner code.

For example, consider the case:
```
explain analyze select a1,case when a2 in (select a1::text from a1 where a1 is not null) then 'true' else 'false' end as checkcol from (
      select a1,rj->>'a1'::text as a2
      from a3
      )t;
```
The execution time decreased by 75% by using a hashed subplan in this case. Orca now produces the plan:
```
                                        QUERY PLAN
-------------------------------------------------------------------------------------------
 Result  (cost=0.00..1427188.70 rows=500000 width=12)
   Output: a3.a1, CASE WHEN ((hashed SubPlan 1)) THEN 'true'::text ELSE 'false'::text END
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1427182.70 rows=1000 width=5)
         Output: a3.a1, ((hashed SubPlan 1))
         ->  Seq Scan on public.a3  (cost=0.00..435.31 rows=166667 width=17)
               Output: a3.a1, (hashed SubPlan 1)
               SubPlan 1
                 ->  Result  (cost=0.00..431.00 rows=5 width=9)
                       Output: ((a1.a1)::text)
                       ->  Result  (cost=0.00..431.00 rows=5 width=9)
                             Output: (a1.a1)::text, true
                             ->  Seq Scan on public.a1  (cost=0.00..431.00 rows=5 width=4)
                                   Output: a1.a1
                                   Filter: (NOT (a1.a1 IS NULL))
 Optimizer: GPORCA
(15 rows)
```
Note the "hashed" subplan, as the subplan does not depend on any outer references.

------------
Question: The planner logic also includes a check, subplan_is_hashable, which ensures the subplan's rows fit in work_mem. Should we include a similar check for Orca? I don't believe we do this check for regular hash joins/hash aggregates currently, so I've left it out for now.