### PR TITLE
Add support for min/max aggregates optimization

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1204,12 +1204,8 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 		{
 			left_arg = (Node *) lfirst(gpdb::ListHead(args_list));
 			right_arg = (Node *) lfirst(gpdb::ListTail(args_list));
-		}
-
-		// Type Coercion doesn't add much value for IS NULL and IS NOT NULL
-		// conditions, and is not supported
-		if (!is_null_test_type)
-		{
+			// Type Coercion doesn't add much value for IS NULL and IS NOT NULL
+			// conditions, and is not supported
 			BOOL is_relabel_type = false;
 			if (IsA(left_arg, RelabelType) &&
 				IsA(((RelabelType *) left_arg)->arg, Var))

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1124,7 +1124,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 	for (ULONG ul = 0; ul < arity; ul++)
 	{
 		CDXLNode *index_cond_dxlnode = (*index_cond_list_dxlnode)[ul];
-                CDXLNode *modified_null_test_cond_dxlnode = nullptr;
+		CDXLNode *modified_null_test_cond_dxlnode = nullptr;
 		// Translate index condition CDXLScalarBoolExpr of format 'NOT (col IS NULL)'
 		// to CDXLScalarNullTest 'col IS NOT NULL', because IndexScan only
 		// supports indexquals of types: OpExpr, RowCompareExpr,
@@ -1139,10 +1139,9 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 					EdxlopScalarNullTest)
 			{
 				CDXLNode *null_test_cond_dxlnode = (*index_cond_dxlnode)[0];
-                                modified_null_test_cond_dxlnode = GPOS_NEW(m_mp)
-					CDXLNode(m_mp,
-							 GPOS_NEW(m_mp) CDXLScalarNullTest(m_mp, false),
-							 (*null_test_cond_dxlnode)[0]);
+				modified_null_test_cond_dxlnode = GPOS_NEW(m_mp) CDXLNode(
+					m_mp, GPOS_NEW(m_mp) CDXLScalarNullTest(m_mp, false),
+					(*null_test_cond_dxlnode)[0]);
 				index_cond_dxlnode = modified_null_test_cond_dxlnode;
 			}
 		}
@@ -1283,10 +1282,10 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 				attno, index_cond_expr, original_index_cond_expr, strategy_num,
 				index_subtype_oid));
 		}
-                if (modified_null_test_cond_dxlnode != nullptr)
-                {
-                    modified_null_test_cond_dxlnode->Release();
-                }
+		if (modified_null_test_cond_dxlnode != nullptr)
+		{
+			modified_null_test_cond_dxlnode->Release();
+		}
 	}
 
 	// the index quals much be ordered by attribute number

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1124,7 +1124,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 	for (ULONG ul = 0; ul < arity; ul++)
 	{
 		CDXLNode *index_cond_dxlnode = (*index_cond_list_dxlnode)[ul];
-
+                CDXLNode *modified_null_test_cond_dxlnode = nullptr;
 		// Translate index condition CDXLScalarBoolExpr of format 'NOT (col IS NULL)'
 		// to CDXLScalarNullTest 'col IS NOT NULL', because IndexScan only
 		// supports indexquals of types: OpExpr, RowCompareExpr,
@@ -1139,7 +1139,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 					EdxlopScalarNullTest)
 			{
 				CDXLNode *null_test_cond_dxlnode = (*index_cond_dxlnode)[0];
-				CDXLNode *modified_null_test_cond_dxlnode = GPOS_NEW(m_mp)
+                                modified_null_test_cond_dxlnode = GPOS_NEW(m_mp)
 					CDXLNode(m_mp,
 							 GPOS_NEW(m_mp) CDXLScalarNullTest(m_mp, false),
 							 (*null_test_cond_dxlnode)[0]);
@@ -1283,6 +1283,10 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 				attno, index_cond_expr, original_index_cond_expr, strategy_num,
 				index_subtype_oid));
 		}
+                if (modified_null_test_cond_dxlnode != nullptr)
+                {
+                    modified_null_test_cond_dxlnode->Release();
+                }
 	}
 
 	// the index quals much be ordered by attribute number

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-IsNotNullPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-IsNotNullPred.mdp
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+
+            Objective of this test is to ensure IsNotNull predicates on btree indices use IndexScan
+
+            create table index_scan_null_test_preds(a int, b float, c text);
+            create index idx_b on index_scan_null_test_preds using btree(b);
+
+            Query: explain select * from index_scan_null_test_preds where b is not null;
+
+            Plan:
+                                                                          QUERY PLAN
+
+               Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=20)
+                  ->  Index Scan using idx_b on index_scan_null_test_preds  (cost=0.00..6.00 rows=1 width=20)
+                        Index Cond: (b IS NOT NULL)
+                Optimizer: GPORCA
+               (4 rows)
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Index Mdid="7.31038.1.0" Name="idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.31033.1.0" Name="index_scan_null_test_preds" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.31033.1.0" Name="index_scan_null_test_preds" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.31038.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.31033.1.0" Name="index_scan_null_test_preds"/>
+      <dxl:ColumnStatistics Mdid="1.31033.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.31033.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:IsNotNull>
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.701.1.0"/>
+        </dxl:IsNotNull>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.31033.1.0" TableName="index_scan_null_test_preds" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000203" Rows="1.000000" Width="20"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000116" Rows="1.000000" Width="20"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Not>
+              <dxl:IsNull>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+              </dxl:IsNull>
+            </dxl:Not>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.31038.1.0" IndexName="idx_b"/>
+          <dxl:TableDescriptor Mdid="6.31033.1.0" TableName="index_scan_null_test_preds" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-IsNullPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-IsNullPred.mdp
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+
+            Objective of this test is to ensure IsNull predicates on btree indices use IndexScan
+
+            create table index_scan_null_test_preds(a int, b float, c text);
+            create index idx_b on index_scan_null_test_preds using btree(b);
+
+            Query: explain select * from index_scan_null_test_preds where b is null;
+
+            Plan:
+                                                                          QUERY PLAN
+
+                Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=20)
+                   ->  Index Scan using idx_b on index_scan_null_test_preds  (cost=0.00..6.00 rows=1 width=20)
+                         Index Cond: (b IS NULL)
+                 Optimizer: GPORCA
+                (4 rows)
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Index Mdid="7.31038.1.0" Name="idx_b" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.31033.1.0" Name="index_scan_null_test_preds" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.31033.1.0" Name="index_scan_null_test_preds" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.31038.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.31033.1.0" Name="index_scan_null_test_preds"/>
+      <dxl:ColumnStatistics Mdid="1.31033.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.31033.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:IsNull>
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.701.1.0"/>
+        </dxl:IsNull>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.31033.1.0" TableName="index_scan_null_test_preds" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000203" Rows="1.000000" Width="20"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000116" Rows="1.000000" Width="20"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:IsNull>
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.701.1.0"/>
+            </dxl:IsNull>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.31038.1.0" IndexName="idx_b"/>
+          <dxl:TableDescriptor Mdid="6.31033.1.0" TableName="index_scan_null_test_preds" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
@@ -14,7 +14,7 @@
 
             Plan:
                                                                           QUERY PLAN
-               --------------------------------------------------------------------------------------------------------------------------------
+
                 Aggregate  (cost=0.00..7.83 rows=1 width=8)
                   ->  Limit  (cost=0.00..7.83 rows=1 width=9)
                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..7.83 rows=1 width=9)

--- a/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
@@ -1,0 +1,793 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+
+            Objective of this test is to ensure if max() aggregate on an btree index column is optimized
+            to use a plan with IndexScan and Limit.
+
+            create table optimize_min_max_aggregates(a int, b text, c float, d int);
+            create index index_bc on optimize_min_max_aggregates using btree(b,c);
+            insert into optimize_min_max_aggregates select i, concat('col_b', i), i/4.1, i*2 from generate_series(1,10000)i;
+            analyze optimize_min_max_aggregates;
+
+            Query: explain select max(b) from optimize_min_max_aggregates;
+
+            Plan:
+                                                                          QUERY PLAN
+               --------------------------------------------------------------------------------------------------------------------------------
+                Aggregate  (cost=0.00..7.83 rows=1 width=8)
+                  ->  Limit  (cost=0.00..7.83 rows=1 width=9)
+                        ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..7.83 rows=1 width=9)
+                              Merge Key: b
+                              ->  Limit  (cost=0.00..7.83 rows=1 width=9)
+                                    ->  Index Scan Backward using index_bc on optimize_min_max_aggregates  (cost=0.00..7.77 rows=3334 width=9)
+                                          Index Cond: (b IS NOT NULL)
+                Optimizer: GPORCA
+               (8 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.666.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.742.1.0"/>
+        <dxl:Commutator Mdid="0.664.1.0"/>
+        <dxl:InverseOp Mdid="0.665.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.56034.1.0.1" Name="b" Width="9.000000" NullFreq="0.000000" NdvRemain="10000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.56034.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationExtendedStatistics Mdid="10.56034.1.0" Name="optimize_min_max_aggregates"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2129.1.0" Name="max" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.56034.1.0" Name="optimize_min_max_aggregates" Rows="10000.000000" RelPages="20" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.56034.1.0" Name="optimize_min_max_aggregates" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="9"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.56039.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.56039.1.0" Name="index_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="max" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="max">
+            <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="25">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.56034.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="9"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="7.826857" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="max">
+            <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="25">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="7.826856" Rows="1.000000" Width="9"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="7.826847" Rows="1.000000" Width="9"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.666.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+            </dxl:SortingColumnList>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="7.826813" Rows="1.000000" Width="9"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:IndexScan IndexScanDirection="Backward">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="7.771010" Rows="10000.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:IndexCondList>
+                  <dxl:Not>
+                    <dxl:IsNull>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                    </dxl:IsNull>
+                  </dxl:Not>
+                </dxl:IndexCondList>
+                <dxl:Partitions/>
+                <dxl:IndexDescriptor Mdid="7.56039.1.0" IndexName="index_bc"/>
+                <dxl:TableDescriptor Mdid="6.56034.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="9"/>
+                    <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:IndexScan>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Max-Aggregate-uses-IndexScan-and-Limit.mdp
@@ -41,6 +41,12 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Index Mdid="7.17330.1.0" Name="index_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -195,8 +201,53 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.56034.1.0.1" Name="b" Width="9.000000" NullFreq="0.000000" NdvRemain="10000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.56034.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+      <dxl:RelationStatistics Mdid="2.17325.1.0" Name="optimize_min_max_aggregates" Rows="10000.000000" RelPages="20" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.17325.1.0" Name="optimize_min_max_aggregates" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="9"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.17330.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2129.1.0" Name="max" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.17325.1.0.1" Name="b" Width="9.000000" NullFreq="0.000000" NdvRemain="10000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.17325.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
@@ -598,58 +649,409 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:RelationExtendedStatistics Mdid="10.56034.1.0" Name="optimize_min_max_aggregates"/>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.2129.1.0" Name="max" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
-        <dxl:ResultType Mdid="0.25.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.25.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.56034.1.0" Name="optimize_min_max_aggregates" Rows="10000.000000" RelPages="20" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.56034.1.0" Name="optimize_min_max_aggregates" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="9"/>
-          <dxl:Column Name="c" Attno="3" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
-          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
-        </dxl:Columns>
-        <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="7.56039.1.0" IsPartial="false"/>
-        </dxl:IndexInfoList>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-      </dxl:Relation>
-      <dxl:Index Mdid="7.56039.1.0" Name="index_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1994.1.0"/>
-          <dxl:Opfamily Mdid="0.1970.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.17325.1.0.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="OB+D8zE4zz8=" DoubleValue="0.24390243902439024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjOEA=" DoubleValue="24.39024390243902474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjOEA=" DoubleValue="24.39024390243902474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjSEA=" DoubleValue="48.78048780487804947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjSEA=" DoubleValue="48.78048780487804947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KUkA=" DoubleValue="73.17073170731707421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KUkA=" DoubleValue="73.17073170731707421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjWEA=" DoubleValue="97.56097560975609895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjWEA=" DoubleValue="97.56097560975609895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="fQzOx+B8XkA=" DoubleValue="121.95121951219512368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="fQzOx+B8XkA=" DoubleValue="121.95121951219512368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KYkA=" DoubleValue="146.34146341463414842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KYkA=" DoubleValue="146.34146341463414842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="V6J2JWpXZUA=" DoubleValue="170.73170731707315895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="V6J2JWpXZUA=" DoubleValue="170.73170731707315895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjaEA=" DoubleValue="195.12195121951219789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjaEA=" DoubleValue="195.12195121951219789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="cD4G52Nwa0A=" DoubleValue="219.51219512195120842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="cD4G52Nwa0A=" DoubleValue="219.51219512195120842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="fQzOx+B8bkA=" DoubleValue="243.90243902439024737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="fQzOx+B8bkA=" DoubleValue="243.90243902439024737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="Re1K1K7EcEA=" DoubleValue="268.29268292682928632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="Re1K1K7EcEA=" DoubleValue="268.29268292682928632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KckA=" DoubleValue="292.68292682926829684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KckA=" DoubleValue="292.68292682926829684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="UbsStSvRc0A=" DoubleValue="317.07317073170730737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="UbsStSvRc0A=" DoubleValue="317.07317073170730737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="V6J2JWpXdUA=" DoubleValue="341.46341463414631789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="V6J2JWpXdUA=" DoubleValue="341.46341463414631789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="XonalajddkA=" DoubleValue="365.85365853658538526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="XonalajddkA=" DoubleValue="365.85365853658538526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjeEA=" DoubleValue="390.24390243902439579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjeEA=" DoubleValue="390.24390243902439579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="aleidiXqeUA=" DoubleValue="414.63414634146340632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="aleidiXqeUA=" DoubleValue="414.63414634146340632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="cD4G52Nwe0A=" DoubleValue="439.02439024390241684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="cD4G52Nwe0A=" DoubleValue="439.02439024390241684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="dyVqV6L2fEA=" DoubleValue="463.41463414634148421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="dyVqV6L2fEA=" DoubleValue="463.41463414634148421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="fQzOx+B8fkA=" DoubleValue="487.80487804878049474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="fQzOx+B8fkA=" DoubleValue="487.80487804878049474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="wvkYnI8BgEA=" DoubleValue="512.19512195121956211"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="wvkYnI8BgEA=" DoubleValue="512.19512195121956211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="Re1K1K7EgEA=" DoubleValue="536.58536585365857263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="Re1K1K7EgEA=" DoubleValue="536.58536585365857263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="yOB8DM6HgUA=" DoubleValue="560.97560975609758316"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="yOB8DM6HgUA=" DoubleValue="560.97560975609758316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KgkA=" DoubleValue="585.36585365853659368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KgkA=" DoubleValue="585.36585365853659368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="zsfgfAwOg0A=" DoubleValue="609.75609756097560421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="zsfgfAwOg0A=" DoubleValue="609.75609756097560421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="UbsStSvRg0A=" DoubleValue="634.14634146341461474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="UbsStSvRg0A=" DoubleValue="634.14634146341461474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="1K5E7UqUhEA=" DoubleValue="658.53658536585362526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="1K5E7UqUhEA=" DoubleValue="658.53658536585362526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="V6J2JWpXhUA=" DoubleValue="682.92682926829263579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="V6J2JWpXhUA=" DoubleValue="682.92682926829263579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="25WoXYkahkA=" DoubleValue="707.31707317073176000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="25WoXYkahkA=" DoubleValue="707.31707317073176000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="XonalajdhkA=" DoubleValue="731.70731707317077053"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="XonalajdhkA=" DoubleValue="731.70731707317077053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="4XwMzsegh0A=" DoubleValue="756.09756097560978105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="4XwMzsegh0A=" DoubleValue="756.09756097560978105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjiEA=" DoubleValue="780.48780487804879158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjiEA=" DoubleValue="780.48780487804879158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="52NwPgYniUA=" DoubleValue="804.87804878048780211"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="52NwPgYniUA=" DoubleValue="804.87804878048780211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="aleidiXqiUA=" DoubleValue="829.26829268292681263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="aleidiXqiUA=" DoubleValue="829.26829268292681263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="7UrUrkStikA=" DoubleValue="853.65853658536582316"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="7UrUrkStikA=" DoubleValue="853.65853658536582316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="cD4G52Nwi0A=" DoubleValue="878.04878048780483368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="cD4G52Nwi0A=" DoubleValue="878.04878048780483368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="9DE4H4MzjEA=" DoubleValue="902.43902439024395790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="9DE4H4MzjEA=" DoubleValue="902.43902439024395790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="dyVqV6L2jEA=" DoubleValue="926.82926829268296842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="dyVqV6L2jEA=" DoubleValue="926.82926829268296842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="+hicj8G5jUA=" DoubleValue="951.21951219512197895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="+hicj8G5jUA=" DoubleValue="951.21951219512197895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="fQzOx+B8jkA=" DoubleValue="975.60975609756098947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="fQzOx+B8jkA=" DoubleValue="975.60975609756098947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABAj0A=" DoubleValue="1000.00000000000000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABAj0A=" DoubleValue="1000.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="wvkYnI8BkEA=" DoubleValue="1024.39024390243912421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="wvkYnI8BkEA=" DoubleValue="1024.39024390243912421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="g/MxOB9jkEA=" DoubleValue="1048.78048780487802105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="g/MxOB9jkEA=" DoubleValue="1048.78048780487802105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="Re1K1K7EkEA=" DoubleValue="1073.17073170731714526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="Re1K1K7EkEA=" DoubleValue="1073.17073170731714526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="BudjcD4mkUA=" DoubleValue="1097.56097560975604210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="BudjcD4mkUA=" DoubleValue="1097.56097560975604210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="yOB8DM6HkUA=" DoubleValue="1121.95121951219516632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="yOB8DM6HkUA=" DoubleValue="1121.95121951219516632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="idqVqF3pkUA=" DoubleValue="1146.34146341463406316"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="idqVqF3pkUA=" DoubleValue="1146.34146341463406316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KkkA=" DoubleValue="1170.73170731707318737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KkkA=" DoubleValue="1170.73170731707318737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="DM7H4HyskkA=" DoubleValue="1195.12195121951208421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="DM7H4HyskkA=" DoubleValue="1195.12195121951208421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="zsfgfAwOk0A=" DoubleValue="1219.51219512195120842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="zsfgfAwOk0A=" DoubleValue="1219.51219512195120842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="kMH5GJxvk0A=" DoubleValue="1243.90243902439033263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="kMH5GJxvk0A=" DoubleValue="1243.90243902439033263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="UbsStSvRk0A=" DoubleValue="1268.29268292682922947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="UbsStSvRk0A=" DoubleValue="1268.29268292682922947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="E7UrUbsylEA=" DoubleValue="1292.68292682926835369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="E7UrUbsylEA=" DoubleValue="1292.68292682926835369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="1K5E7UqUlEA=" DoubleValue="1317.07317073170725052"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="1K5E7UqUlEA=" DoubleValue="1317.07317073170725052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="lqhdidr1lEA=" DoubleValue="1341.46341463414637474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="lqhdidr1lEA=" DoubleValue="1341.46341463414637474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="V6J2JWpXlUA=" DoubleValue="1365.85365853658527158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="V6J2JWpXlUA=" DoubleValue="1365.85365853658527158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="GZyPwfm4lUA=" DoubleValue="1390.24390243902439579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="GZyPwfm4lUA=" DoubleValue="1390.24390243902439579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="25WoXYkalkA=" DoubleValue="1414.63414634146352000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="25WoXYkalkA=" DoubleValue="1414.63414634146352000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="nI/B+Rh8lkA=" DoubleValue="1439.02439024390241684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="nI/B+Rh8lkA=" DoubleValue="1439.02439024390241684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="XonalajdlkA=" DoubleValue="1463.41463414634154105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="XonalajdlkA=" DoubleValue="1463.41463414634154105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="H4PzMTg/l0A=" DoubleValue="1487.80487804878043789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="H4PzMTg/l0A=" DoubleValue="1487.80487804878043789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="4XwMzsegl0A=" DoubleValue="1512.19512195121956211"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="4XwMzsegl0A=" DoubleValue="1512.19512195121956211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="onYlalcCmEA=" DoubleValue="1536.58536585365845895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="onYlalcCmEA=" DoubleValue="1536.58536585365845895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BudjmEA=" DoubleValue="1560.97560975609758316"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BudjmEA=" DoubleValue="1560.97560975609758316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="JWpXonbFmEA=" DoubleValue="1585.36585365853648000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="JWpXonbFmEA=" DoubleValue="1585.36585365853648000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="52NwPgYnmUA=" DoubleValue="1609.75609756097560421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="52NwPgYnmUA=" DoubleValue="1609.75609756097560421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="qV2J2pWImUA=" DoubleValue="1634.14634146341472842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="qV2J2pWImUA=" DoubleValue="1634.14634146341472842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="aleidiXqmUA=" DoubleValue="1658.53658536585362526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="aleidiXqmUA=" DoubleValue="1658.53658536585362526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="LFG7ErVLmkA=" DoubleValue="1682.92682926829274948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="LFG7ErVLmkA=" DoubleValue="1682.92682926829274948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="7UrUrkStmkA=" DoubleValue="1707.31707317073164631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="7UrUrkStmkA=" DoubleValue="1707.31707317073164631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="r0TtStQOm0A=" DoubleValue="1731.70731707317077053"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="r0TtStQOm0A=" DoubleValue="1731.70731707317077053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="cD4G52Nwm0A=" DoubleValue="1756.09756097560966737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="cD4G52Nwm0A=" DoubleValue="1756.09756097560966737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="Mjgfg/PRm0A=" DoubleValue="1780.48780487804879158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="Mjgfg/PRm0A=" DoubleValue="1780.48780487804879158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="9DE4H4MznEA=" DoubleValue="1804.87804878048791579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="9DE4H4MznEA=" DoubleValue="1804.87804878048791579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="tStRuxKVnEA=" DoubleValue="1829.26829268292681263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="tStRuxKVnEA=" DoubleValue="1829.26829268292681263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="dyVqV6L2nEA=" DoubleValue="1853.65853658536593684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="dyVqV6L2nEA=" DoubleValue="1853.65853658536593684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="OB+D8zFYnUA=" DoubleValue="1878.04878048780483368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="OB+D8zFYnUA=" DoubleValue="1878.04878048780483368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="+hicj8G5nUA=" DoubleValue="1902.43902439024395790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="+hicj8G5nUA=" DoubleValue="1902.43902439024395790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="uxK1K1EbnkA=" DoubleValue="1926.82926829268285474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="uxK1K1EbnkA=" DoubleValue="1926.82926829268285474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="fQzOx+B8nkA=" DoubleValue="1951.21951219512197895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="fQzOx+B8nkA=" DoubleValue="1951.21951219512197895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="PgbnY3DenkA=" DoubleValue="1975.60975609756087579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="PgbnY3DenkA=" DoubleValue="1975.60975609756087579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="AAAAAABAn0A=" DoubleValue="2000.00000000000000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="AAAAAABAn0A=" DoubleValue="2000.00000000000000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="wvkYnI+hn0A=" DoubleValue="2024.39024390243912421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="wvkYnI+hn0A=" DoubleValue="2024.39024390243912421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="wvkYnI8BoEA=" DoubleValue="2048.78048780487824843"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="wvkYnI8BoEA=" DoubleValue="2048.78048780487824843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="onYlalcyoEA=" DoubleValue="2073.17073170731691789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="onYlalcyoEA=" DoubleValue="2073.17073170731691789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="g/MxOB9joEA=" DoubleValue="2097.56097560975604210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="g/MxOB9joEA=" DoubleValue="2097.56097560975604210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="ZHA+BueToEA=" DoubleValue="2121.95121951219516632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="ZHA+BueToEA=" DoubleValue="2121.95121951219516632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="Re1K1K7EoEA=" DoubleValue="2146.34146341463429053"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="Re1K1K7EoEA=" DoubleValue="2146.34146341463429053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="JWpXonb1oEA=" DoubleValue="2170.73170731707296000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="JWpXonb1oEA=" DoubleValue="2170.73170731707296000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="BudjcD4moUA=" DoubleValue="2195.12195121951208421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="BudjcD4moUA=" DoubleValue="2195.12195121951208421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="52NwPgZXoUA=" DoubleValue="2219.51219512195120842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="52NwPgZXoUA=" DoubleValue="2219.51219512195120842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="yOB8DM6HoUA=" DoubleValue="2243.90243902439033263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="yOB8DM6HoUA=" DoubleValue="2243.90243902439033263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="qV2J2pW4oUA=" DoubleValue="2268.29268292682945685"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="qV2J2pW4oUA=" DoubleValue="2268.29268292682945685"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="idqVqF3poUA=" DoubleValue="2292.68292682926812631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="idqVqF3poUA=" DoubleValue="2292.68292682926812631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="aleidiUaokA=" DoubleValue="2317.07317073170725052"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="aleidiUaokA=" DoubleValue="2317.07317073170725052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="S9SuRO1KokA=" DoubleValue="2341.46341463414637474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="S9SuRO1KokA=" DoubleValue="2341.46341463414637474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="LFG7ErV7okA=" DoubleValue="2365.85365853658549895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="LFG7ErV7okA=" DoubleValue="2365.85365853658549895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="DM7H4HysokA=" DoubleValue="2390.24390243902416842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="DM7H4HysokA=" DoubleValue="2390.24390243902416842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.701.1.0" Value="7UrUrkTdokA=" DoubleValue="2414.63414634146329263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.701.1.0" Value="7UrUrkTdokA=" DoubleValue="2414.63414634146329263"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.701.1.0" Value="zsfgfAwOo0A=" DoubleValue="2439.02439024390241684"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationExtendedStatistics Mdid="10.17325.1.0" Name="optimize_min_max_aggregates"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -671,7 +1073,7 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.56034.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+          <dxl:TableDescriptor Mdid="6.17325.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="9"/>
@@ -757,8 +1159,8 @@
                   </dxl:Not>
                 </dxl:IndexCondList>
                 <dxl:Partitions/>
-                <dxl:IndexDescriptor Mdid="7.56039.1.0" IndexName="index_bc"/>
-                <dxl:TableDescriptor Mdid="6.56034.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+                <dxl:IndexDescriptor Mdid="7.17330.1.0" IndexName="index_bc"/>
+                <dxl:TableDescriptor Mdid="6.17325.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
                   <dxl:Columns>
                     <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                     <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="9"/>

--- a/src/backend/gporca/data/dxl/minidump/Min-Aggregate-uses-IndexScan-and-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Min-Aggregate-uses-IndexScan-and-Limit.mdp
@@ -1,0 +1,1199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+
+            Objective of this test is to ensure if min() aggregate on an btree index column is optimized
+            to use a plan with IndexScan and Limit.
+
+            create table optimize_min_max_aggregates(a int, b text, c float, d int);
+            create index index_d on optimize_min_max_aggregates using btree(d);
+            insert into optimize_min_max_aggregates select i, concat('col_b', i), i/4.1, i*2 from generate_series(1,10000)i;
+            analyze optimize_min_max_aggregates;
+
+            Query: explain select min(d) from optimize_min_max_aggregates;
+
+            Plan:
+                                                                    QUERY PLAN
+              ----------------------------------------------------------------------------------------------------------------------
+               Aggregate  (cost=0.00..7.25 rows=1 width=4)
+                 ->  Limit  (cost=0.00..7.25 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..7.25 rows=1 width=4)
+                             Merge Key: d
+                             ->  Limit  (cost=0.00..7.25 rows=1 width=4)
+                                   ->  Index Scan using index_d on optimize_min_max_aggregates  (cost=0.00..7.22 rows=3334 width=4)
+                                         Index Cond: (d IS NOT NULL)
+               Optimizer: GPORCA
+              (8 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.21124.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19800"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Index Mdid="7.21130.1.0" Name="index_d" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="" ReturnableColumns="3" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.21129.1.0" Name="index_bc" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="" ReturnableColumns="1,2" SortDirection="ASC,ASC" NullsDirection="LAST,LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.21124.1.0" Name="optimize_min_max_aggregates" Rows="10000.000000" RelPages="20" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.21124.1.0" Name="optimize_min_max_aggregates" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="9"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.701.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.21129.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.21130.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.21124.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1970.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2132.1.0" Name="min" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.23.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationExtendedStatistics Mdid="10.21124.1.0" Name="optimize_min_max_aggregates"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="min" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="min">
+            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.21124.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="9"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="7.245821" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="min">
+            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="7.245820" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="3" Alias="d">
+              <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="7.245816" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="3" Alias="d">
+                <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="3" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="7.245801" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="d">
+                  <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:IndexScan IndexScanDirection="Forward">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="7.221000" Rows="10000.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="3" Alias="d">
+                    <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:IndexCondList>
+                  <dxl:Not>
+                    <dxl:IsNull>
+                      <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:IsNull>
+                  </dxl:Not>
+                </dxl:IndexCondList>
+                <dxl:Partitions/>
+                <dxl:IndexDescriptor Mdid="7.21130.1.0" IndexName="index_d"/>
+                <dxl:TableDescriptor Mdid="6.21124.1.0" TableName="optimize_min_max_aggregates" LockMode="1" AclMode="2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:IndexScan>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Min-Aggregate-uses-IndexScan-and-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Min-Aggregate-uses-IndexScan-and-Limit.mdp
@@ -14,7 +14,7 @@
 
             Plan:
                                                                     QUERY PLAN
-              ----------------------------------------------------------------------------------------------------------------------
+
                Aggregate  (cost=0.00..7.25 rows=1 width=4)
                  ->  Limit  (cost=0.00..7.25 rows=1 width=4)
                        ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..7.25 rows=1 width=4)

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1012,6 +1012,8 @@ public:
 	static BOOL FScalarConstBoolNull(CExpression *pexpr);
 
 	static BOOL FScalarConstOrBinaryCoercible(CExpression *pexpr);
+
+	static BOOL FScalarIdentNullTest(CExpression *pexpr);
 };	// class CUtils
 
 // hash set from expressions

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -964,6 +964,13 @@ public:
 	static CExpression *PexprLimit(CMemoryPool *mp, CExpression *pexpr,
 								   ULONG ulOffSet, ULONG count);
 
+	// generate a limit expression on top of the given relational child with given offset, limit count and OrderSpec
+	static CExpression *BuildLimitExprWithOrderSpec(CMemoryPool *mp,
+													CExpression *pexpr,
+													COrderSpec *pos,
+													ULONG ulOffSet,
+													ULONG count);
+
 	// return true if given expression contains window aggregate function
 	static BOOL FHasAggWindowFunc(CExpression *pexpr);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectElement.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectElement.h
@@ -39,6 +39,10 @@ private:
 public:
 	CScalarProjectElement(const CScalarProjectElement &) = delete;
 
+	CScalarProjectElement(CMemoryPool *mp) : CScalar(mp)
+	{
+	}
+
 	// ctor
 	CScalarProjectElement(CMemoryPool *mp, CColRef *colref)
 		: CScalar(mp), m_pcr(colref)

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -229,6 +229,7 @@ public:
 		ExfPushJoinBelowRightUnionAll,
 		ExfLimit2IndexGet,
 		ExfDynamicIndexGet2DynamicIndexOnlyScan,
+		ExfMinMax2IndexGet,
 		ExfInvalid,
 		ExfSentinel = ExfInvalid
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
@@ -1,0 +1,77 @@
+//-------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CXformMinMax2IndexGet.h
+//
+//	@doc:
+//		Transform aggregates min, max to queries with IndexScan with
+//		Limit.
+//-------------------------------------------------------------------
+#ifndef GPOPT_CXformMinMax2IndexGet_H
+#define GPOPT_CXformMinMax2IndexGet_H
+
+#include "gpos/base.h"
+
+#include "gpopt/operators/CLogical.h"
+#include "gpopt/xforms/CXformExploration.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+//-------------------------------------------------------------------
+//	@class:
+//		CXformMinMax2IndexGet
+//
+//	@doc:
+//		Transform aggregates min, max to queries with IndexScan with
+//		Limit.
+//-------------------------------------------------------------------
+class CXformMinMax2IndexGet : public CXformExploration
+{
+private:
+	// helper function to validate if index is applicable and determine Index Scan
+	// direction, given index columns.
+	static EIndexScanDirection GetScanDirection(
+		const CColRef *agg_col, CColRefArray *pdrgpcrIndexColumns,
+		const IMDIndex *pmdindex, CScalarAggFunc *popScAggFunc,
+		const IMDType *agg_col_type);
+
+public:
+	CXformMinMax2IndexGet(const CXformMinMax2IndexGet &) = delete;
+
+	// ctor
+	CXformMinMax2IndexGet(CMemoryPool *mp);
+
+	// dtor
+	~CXformMinMax2IndexGet() override = default;
+
+	// ident accessors
+	EXformId
+	Exfid() const override
+	{
+		return ExfMinMax2IndexGet;
+	}
+
+	// return a string for xform name
+	const CHAR *
+	SzId() const override
+	{
+		return "CXformMinMax2IndexGet";
+	}
+
+	// compute xform promise for a given expression handle
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
+
+	// actual transform
+	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+				   CExpression *pexpr) const override;
+
+};	// class CXformMinMax2IndexGet
+
+}  // namespace gpopt
+
+
+#endif	//GPOPT_CXformMinMax2IndexGet_H

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
@@ -38,10 +38,16 @@ private:
 												CScalarAggFunc *popScAggFunc,
 												const IMDType *agg_col_type);
 
-	static IMdIdArray *IsMinMaxAggOnColumn(
-		CMemoryPool *mp, const IMDType *agg_func_type,
-		CExpression *pexprAggFunc, CColRefArray *output_col_array,
-		CMDAccessor *md_accessor, const IMDRelation *pmdrel, ULONG ulIndices);
+	static BOOL IsMinMaxAggOnColumn(const IMDType *agg_func_type,
+									CExpression *pexprAggFunc,
+									const CColRef **agg_colref);
+
+	static IMdIdArray *GetApplicableIndices(CMemoryPool *mp,
+											const CColRef *agg_colref,
+											CColRefArray *output_col_array,
+											CMDAccessor *md_accessor,
+											const IMDRelation *pmdrel,
+											ULONG ulIndices);
 
 public:
 	CXformMinMax2IndexGet(const CXformMinMax2IndexGet &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMinMax2IndexGet.h
@@ -34,10 +34,14 @@ class CXformMinMax2IndexGet : public CXformExploration
 private:
 	// helper function to validate if index is applicable and determine Index Scan
 	// direction, given index columns.
-	static EIndexScanDirection GetScanDirection(
-		const CColRef *agg_col, CColRefArray *pdrgpcrIndexColumns,
-		const IMDIndex *pmdindex, CScalarAggFunc *popScAggFunc,
-		const IMDType *agg_col_type);
+	static EIndexScanDirection GetScanDirection(const IMDIndex *pmdindex,
+												CScalarAggFunc *popScAggFunc,
+												const IMDType *agg_col_type);
+
+	static IMdIdArray *IsMinMaxAggOnColumn(
+		CMemoryPool *mp, const IMDType *agg_func_type,
+		CExpression *pexprAggFunc, CColRefArray *output_col_array,
+		CMDAccessor *md_accessor, const IMDRelation *pmdrel, ULONG ulIndices);
 
 public:
 	CXformMinMax2IndexGet(const CXformMinMax2IndexGet &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -571,10 +571,12 @@ public:
 							CTableDescriptor *ptabdesc,
 							CColRefArray *pdrgpcrOutput);
 
-	static COrderSpec *ComputeOrderSpecForIndexKey(
-		CMemoryPool *mp, const IMDIndex *pmdindex,
-		EIndexScanDirection scan_direction, const CColRef *colref,
-		ULONG key_position);
+	static void ComputeOrderSpecForIndexKey(CMemoryPool *mp,
+											COrderSpec **order_spec,
+											const IMDIndex *pmdindex,
+											EIndexScanDirection scan_direction,
+											const CColRef *colref,
+											ULONG key_position);
 
 };	// class CXformUtils
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -571,10 +571,11 @@ public:
 							CTableDescriptor *ptabdesc,
 							CColRefArray *pdrgpcrOutput);
 
-	static void PosForIndexKey(const IMDIndex *pmdindex,
-							   EIndexScanDirection scan_direction,
-							   const CColRef *colref, COrderSpec *pos,
-							   ULONG key_position);
+	static void ComputeOrderSpecForIndexKey(const IMDIndex *pmdindex,
+											EIndexScanDirection scan_direction,
+											const CColRef *colref,
+											COrderSpec *pos,
+											ULONG key_position);
 
 };	// class CXformUtils
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -571,6 +571,11 @@ public:
 							CTableDescriptor *ptabdesc,
 							CColRefArray *pdrgpcrOutput);
 
+	static void PosForIndexKey(const IMDIndex *pmdindex,
+							   EIndexScanDirection scan_direction,
+							   const CColRef *colref, COrderSpec *pos,
+							   ULONG key_position);
+
 };	// class CXformUtils
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -571,11 +571,10 @@ public:
 							CTableDescriptor *ptabdesc,
 							CColRefArray *pdrgpcrOutput);
 
-	static void ComputeOrderSpecForIndexKey(const IMDIndex *pmdindex,
-											EIndexScanDirection scan_direction,
-											const CColRef *colref,
-											COrderSpec *pos,
-											ULONG key_position);
+	static COrderSpec *ComputeOrderSpecForIndexKey(
+		CMemoryPool *mp, const IMDIndex *pmdindex,
+		EIndexScanDirection scan_direction, const CColRef *colref,
+		ULONG key_position);
 
 };	// class CXformUtils
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -177,15 +177,6 @@ private:
 									   CColRefSet *pcrsGrpByUsed,
 									   CColRefSet *pcrsFKey);
 
-	// construct an expression representing a new access path using the given functors for
-	// operator constructors and rewritten access path
-	static CExpression *PexprBuildBtreeIndexPlan(
-		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprGet,
-		ULONG ulOriginOpId, CExpressionArray *pdrgpexprConds,
-		CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
-		const IMDIndex *pmdindex, const IMDRelation *pmdrel,
-		EIndexScanDirection indexScanDirection, BOOL indexForOrderBy);
-
 	// create a dynamic operator for a btree index plan
 	static CLogical *
 	PopDynamicBtreeIndexOpConstructor(
@@ -432,22 +423,6 @@ public:
 			   CXform::ExfSequenceProject2Apply == exfid;
 	}
 
-	// helper for creating IndexGet/DynamicIndexGet expression
-	static CExpression *
-	PexprLogicalIndexGet(CMemoryPool *mp, CMDAccessor *md_accessor,
-						 CExpression *pexprGet, ULONG ulOriginOpId,
-						 CExpressionArray *pdrgpexprConds,
-						 CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
-						 const IMDIndex *pmdindex, const IMDRelation *pmdrel,
-						 BOOL indexForOrderBy,
-						 EIndexScanDirection indexScanDirection)
-	{
-		return PexprBuildBtreeIndexPlan(mp, md_accessor, pexprGet, ulOriginOpId,
-										pdrgpexprConds, pcrsScalarExpr,
-										outer_refs, pmdindex, pmdrel,
-										indexScanDirection, indexForOrderBy);
-	}
-
 	// helper for creating bitmap bool op expressions
 	static CExpression *PexprScalarBitmapBoolOp(
 		CMemoryPool *mp, CMDAccessor *md_accessor,
@@ -577,6 +552,15 @@ public:
 											EIndexScanDirection scan_direction,
 											const CColRef *colref,
 											ULONG key_position);
+
+	// construct an expression representing a new access path using the given functors for
+	// operator constructors and rewritten access path
+	static CExpression *PexprBuildBtreeIndexPlan(
+		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprGet,
+		ULONG ulOriginOpId, CExpressionArray *pdrgpexprConds,
+		CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
+		const IMDIndex *pmdindex, const IMDRelation *pmdrel,
+		EIndexScanDirection indexScanDirection, BOOL indexForOrderBy);
 
 };	// class CXformUtils
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -120,6 +120,7 @@
 #include "gpopt/xforms/CXformLeftSemiJoin2NLJoin.h"
 #include "gpopt/xforms/CXformLimit2IndexGet.h"
 #include "gpopt/xforms/CXformMaxOneRow2Assert.h"
+#include "gpopt/xforms/CXformMinMax2IndexGet.h"
 #include "gpopt/xforms/CXformProject2Apply.h"
 #include "gpopt/xforms/CXformProject2ComputeScalar.h"
 #include "gpopt/xforms/CXformPushDownLeftOuterJoin.h"

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -4478,6 +4478,25 @@ CUtils::PexprLimit(CMemoryPool *mp, CExpression *pexpr, ULONG ulOffSet,
 		CExpression(mp, popLimit, pexpr, pexprLimitOffset, pexprLimitCount);
 }
 
+// generate a limit expression on top of the given relational child with given offset, limit count and OrderSpec
+CExpression *
+CUtils::BuildLimitExprWithOrderSpec(CMemoryPool *mp, CExpression *pexpr,
+									COrderSpec *pos, ULONG ulOffSet,
+									ULONG count)
+{
+	GPOS_ASSERT(pexpr);
+	GPOS_ASSERT(nullptr != pos);
+
+	CLogicalLimit *popLimit = GPOS_NEW(mp)
+		CLogicalLimit(mp, pos, true /* fGlobal */, true /* fHasCount */,
+					  false /*fTopLimitUnderDML*/);
+	CExpression *pexprLimitOffset = CUtils::PexprScalarConstInt8(mp, ulOffSet);
+	CExpression *pexprLimitCount = CUtils::PexprScalarConstInt8(mp, count);
+
+	return GPOS_NEW(mp)
+		CExpression(mp, popLimit, pexpr, pexprLimitOffset, pexprLimitCount);
+}
+
 // check if a given operator is a ANY subquery
 BOOL
 CUtils::FAnySubquery(COperator *pop)

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2539,6 +2539,16 @@ CUtils::FScalarConstOrBinaryCoercible(CExpression *pexpr)
 	return CUtils::FScalarConst(pexpr) ||
 		   CCastUtils::FBinaryCoercibleCastedConst(pexpr);
 }
+
+// checks to see if expression is a NullTest check on a column (ex: col IS NULL)
+BOOL
+CUtils::FScalarIdentNullTest(CExpression *pexpr)
+{
+	GPOS_ASSERT(nullptr != pexpr);
+	return (CUtils::FScalarNullTest(pexpr) &&
+			CUtils::FScalarIdent((*pexpr)[0]));
+}
+
 // checks to see if the expression is a scalar const TRUE
 BOOL
 CUtils::FScalarConstTrue(CExpression *pexpr)

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -293,7 +293,7 @@ CTableDescriptor::OsPrint(IOstream &os) const
 //		CTableDescriptor::IndexCount
 //
 //	@doc:
-//		 Returns number of b-tree indices
+//		 Returns number of indices in the relation
 //
 //
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -34,6 +34,7 @@
 #include "gpopt/operators/CPredicateUtils.h"
 #include "gpopt/operators/CScalarIdent.h"
 #include "gpopt/optimizer/COptimizerConfig.h"
+#include "gpopt/xforms/CXformUtils.h"
 #include "naucrates/md/IMDCheckConstraint.h"
 #include "naucrates/md/IMDColumn.h"
 #include "naucrates/md/IMDIndex.h"
@@ -187,46 +188,8 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 		const ULONG ulPosTabDesc = ptabdesc->GetAttributePosition(attno);
 		CColRef *colref = (*colref_array)[ulPosTabDesc];
 
-		IMDId *mdid = nullptr;
-		COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
-		// if scan direction is forward, order spec computed should match
-		// the index's sort and nulls order.
-		if (scan_direction == EForwardScan)
-		{
-			// if sort direction of key is 0(ASC), choose MDID for less than
-			// type and vice-versa
-			mdid =
-				(pmdindex->KeySortDirectionAt(ul) == SORT_ASC)
-					? colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptL)
-					: colref->RetrieveType()->GetMdidForCmpType(
-						  IMDType::EcmptG);
-
-			// if nulls direction of key is 0, choose ENTLast and
-			// vice-versa
-			ent = (pmdindex->KeyNullsDirectionAt(ul) == COrderSpec::EntLast)
-					  ? COrderSpec::EntLast
-					  : COrderSpec::EntFirst;
-		}
-		// if scan direction is backward, order spec computed should be
-		// commutative to index's sort and nulls order.
-		else if (scan_direction == EBackwardScan)
-		{
-			// if sort order of key is 0(ASC), choose MDID for greater than
-			// type and vice-versa
-			mdid =
-				(pmdindex->KeySortDirectionAt(ul) == SORT_ASC)
-					? colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptG)
-					: colref->RetrieveType()->GetMdidForCmpType(
-						  IMDType::EcmptL);
-
-			// if nulls direction of key is 0, choose ENTFirst and
-			// vice-versa
-			ent = (pmdindex->KeyNullsDirectionAt(ul) == COrderSpec::EntLast)
-					  ? COrderSpec::EntFirst
-					  : COrderSpec::EntLast;
-		}
-		mdid->AddRef();
-		pos->Append(mdid, colref, ent);
+		// Compute OrderSpec for Index key
+		CXformUtils::PosForIndexKey(pmdindex, scan_direction, colref, pos, ul);
 	}
 
 	return pos;

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -188,20 +188,9 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 		const ULONG ulPosTabDesc = ptabdesc->GetAttributePosition(attno);
 		CColRef *colref = (*colref_array)[ulPosTabDesc];
 
-		// Compute OrderSpec for Index key
-		COrderSpec *index_key_orderspec =
-			CXformUtils::ComputeOrderSpecForIndexKey(
-				mp, pmdindex, scan_direction, colref, ul);
-
-		// Ensure orderspec contains one sort column
-		GPOS_ASSERT(index_key_orderspec->UlSortColumns() == 1);
-
-		IMDId *mdid = index_key_orderspec->GetMdIdSortOp(0);
-		mdid->AddRef();
-		pos->Append(mdid, index_key_orderspec->Pcr(0),
-					index_key_orderspec->Ent(0));
-
-		index_key_orderspec->Release();
+		// Compute and update OrderSpec for Index key
+		CXformUtils::ComputeOrderSpecForIndexKey(mp, &pos, pmdindex,
+												 scan_direction, colref, ul);
 	}
 
 	return pos;

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -189,7 +189,8 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 		CColRef *colref = (*colref_array)[ulPosTabDesc];
 
 		// Compute OrderSpec for Index key
-		CXformUtils::PosForIndexKey(pmdindex, scan_direction, colref, pos, ul);
+		CXformUtils::ComputeOrderSpecForIndexKey(pmdindex, scan_direction,
+												 colref, pos, ul);
 	}
 
 	return pos;

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -189,8 +189,19 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 		CColRef *colref = (*colref_array)[ulPosTabDesc];
 
 		// Compute OrderSpec for Index key
-		CXformUtils::ComputeOrderSpecForIndexKey(pmdindex, scan_direction,
-												 colref, pos, ul);
+		COrderSpec *index_key_orderspec =
+			CXformUtils::ComputeOrderSpecForIndexKey(
+				mp, pmdindex, scan_direction, colref, ul);
+
+		// Ensure orderspec contains one sort column
+		GPOS_ASSERT(index_key_orderspec->UlSortColumns() == 1);
+
+		IMDId *mdid = index_key_orderspec->GetMdIdSortOp(0);
+		mdid->AddRef();
+		pos->Append(mdid, index_key_orderspec->Pcr(0),
+					index_key_orderspec->Ent(0));
+
+		index_key_orderspec->Release();
 	}
 
 	return pos;

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
@@ -600,6 +600,7 @@ CLogicalGbAgg::PxfsCandidates(CMemoryPool *mp) const
 	(void) xform_set->ExchangeSet(CXform::ExfGbAgg2StreamAgg);
 	(void) xform_set->ExchangeSet(CXform::ExfGbAgg2ScalarAgg);
 	(void) xform_set->ExchangeSet(CXform::ExfEagerAgg);
+	(void) xform_set->ExchangeSet(CXform::ExfMinMax2IndexGet);
 	return xform_set;
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -2171,7 +2171,7 @@ CPredicateUtils::ExtractIndexPredicates(
 		}
 		// Expression of form 'col IS NULL' or 'col IS NOT NULL'.
 		// This check is to enable support of "IS NULL/IS NOT NULL" conditions
-		// for min/max optimization, which is possible only for btree indices.
+		// for btree indices.
 		else if (((CUtils::FScalarIdentNullTest(pexprCond)) ||
 				  (FNot(pexprCond) &&
 				   CUtils::FScalarIdentNullTest((*pexprCond)[0]))) &&

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -2172,13 +2172,9 @@ CPredicateUtils::ExtractIndexPredicates(
 		// Expression of form 'col IS NULL' or 'col IS NOT NULL'.
 		// This check is to enable support of "IS NULL/IS NOT NULL" conditions
 		// for min/max optimization, which is possible only for btree indices.
-		else if (((CUtils::FScalarNullTest(pexprCond) &&
-				   CUtils::FScalarIdent(
-					   (*pexprCond)[0]) /* IS NULL expression*/) ||
+		else if (((CUtils::FScalarIdentNullTest(pexprCond)) ||
 				  (FNot(pexprCond) &&
-				   CUtils::FScalarNullTest((*pexprCond)[0]) &&
-				   CUtils::FScalarIdent(
-					   (*(*pexprCond)[0])[0]) /* IS NOT NULL expression*/)) &&
+				   CUtils::FScalarIdentNullTest((*pexprCond)[0]))) &&
 				 pmdindex->IndexType() == gpmd::IMDIndex::EmdindBtree)
 		{
 			// Expression is not transformed to a comparison as 'col IS NULL'

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -2180,8 +2180,6 @@ CPredicateUtils::ExtractIndexPredicates(
 			// Expression is not transformed to a comparison as 'col IS NULL'
 			// or 'col IS NOT NULL' are not equivalent to 'col = NULL' or
 			// 'col!=NULL' respectively.
-			pdrgpexprTarget->Append(pexprCond);
-			continue;
 		}
 		else
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -295,6 +295,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformPushJoinBelowRightUnionAll(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLimit2IndexGet(m_mp));
 	Add(GPOS_NEW(m_mp) CXformDynamicIndexGet2DynamicIndexOnlyScan(m_mp));
+	Add(GPOS_NEW(m_mp) CXformMinMax2IndexGet(m_mp));
 
 	GPOS_ASSERT(nullptr != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -204,10 +204,10 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 	// We consider ForwardScan here because, BackwardScan is only supported
 	// in the case where we have Order by clause in the query, but this xform
 	// doesn't have one.
-	CExpression *pexprLogicalIndexGet = CXformUtils::PexprLogicalIndexGet(
+	CExpression *pexprLogicalIndexGet = CXformUtils::PexprBuildBtreeIndexPlan(
 		mp, md_accessor, pexprInner, joinOp->UlOpId(), pdrgpexprConjuncts,
-		pcrsScalarExpr, outer_refs, pmdindex, pmdrel, false /*indexForOrderBy*/,
-		EForwardScan /*indexScanDirection*/);
+		pcrsScalarExpr, outer_refs, pmdindex, pmdrel,
+		EForwardScan /*indexScanDirection*/, false /*indexForOrderBy*/);
 	if (nullptr != pexprLogicalIndexGet)
 	{
 		// second child has residual predicates, create an apply of outer and inner

--- a/src/backend/gporca/libgpopt/src/xforms/CXformLimit2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformLimit2IndexGet.cpp
@@ -142,10 +142,10 @@ CXformLimit2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		if (scan_direction != EisdSentinel)
 		{
 			// build IndexGet expression
-			CExpression *pexprIndexGet = CXformUtils::PexprLogicalIndexGet(
+			CExpression *pexprIndexGet = CXformUtils::PexprBuildBtreeIndexPlan(
 				mp, md_accessor, pexprUpdtdRltn, popLimit->UlOpId(), pdrgpexpr,
-				pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel, true,
-				scan_direction);
+				pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel,
+				scan_direction, true);
 
 			if (pexprIndexGet != nullptr)
 			{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
@@ -1,0 +1,295 @@
+//-------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2023 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CXformMinMax2IndexGet.cpp
+//
+//	@doc:
+//		Transform aggregates min, max to queries with IndexScan with
+//		Limit
+//-------------------------------------------------------------------
+
+#include "gpopt/xforms/CXformMinMax2IndexGet.h"
+
+#include "gpopt/operators/CLogicalGbAgg.h"
+#include "gpopt/operators/CLogicalGet.h"
+#include "gpopt/operators/CLogicalLimit.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+using namespace gpopt;
+
+
+//-------------------------------------------------------------------
+//	@function:
+//		CXformMinMax2IndexGet::CXformMinMax2IndexGet
+//
+//	@doc:
+//		Ctor
+//
+//-------------------------------------------------------------------
+CXformMinMax2IndexGet::CXformMinMax2IndexGet(CMemoryPool *mp)
+	:  // pattern
+	  CXformExploration(
+		  // pattern
+		  GPOS_NEW(mp) CExpression(
+			  mp, GPOS_NEW(mp) CLogicalGbAgg(mp),
+			  GPOS_NEW(mp) CExpression(
+				  mp,
+				  GPOS_NEW(mp) CLogicalGet(mp)),  // relational child
+			  GPOS_NEW(mp) CExpression(
+				  mp,
+				  GPOS_NEW(mp) CPatternTree(mp))))	// scalar project list
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMinMax2IndexGet::Exfp
+//
+//	@doc:
+//		Compute xform promise for a given expression handle;
+//		GbAgg must be global and have empty grouping columns
+//
+//---------------------------------------------------------------------------
+CXform::EXformPromise
+CXformMinMax2IndexGet::Exfp(CExpressionHandle &exprhdl) const
+{
+	CLogicalGbAgg *popAgg = CLogicalGbAgg::PopConvert(exprhdl.Pop());
+	if (!popAgg->FGlobal() || 0 < popAgg->Pdrgpcr()->Size())
+	{
+		return CXform::ExfpNone;
+	}
+
+	return CXform::ExfpHigh;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMinMax2IndexGet::Transform
+//
+//	@doc:
+//		Actual transformation
+//
+//		Input Query:  select max(b) from foo;
+//		Output Query: select max(b) from (select * from foo where b is
+//										   not null order by b limit 1);
+//---------------------------------------------------------------------------
+void
+CXformMinMax2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+								 CExpression *pexpr) const
+{
+	GPOS_ASSERT(nullptr != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CMemoryPool *mp = pxfctxt->Pmp();
+
+	CLogicalGbAgg *popAgg = CLogicalGbAgg::PopConvert(pexpr->Pop());
+
+	// extract components
+	CExpression *pexprRel = (*pexpr)[0];
+	CExpression *pexprScalarPrjList = (*pexpr)[1];
+
+	CLogicalGet *popGet = CLogicalGet::PopConvert(pexprRel->Pop());
+	// get the indices count of this relation
+	const ULONG ulIndices = popGet->Ptabdesc()->IndexCount();
+
+	// Ignore xform if relation doesn't have any b-tree indices
+	if (0 == ulIndices)
+	{
+		return;
+	}
+
+	// Check if query has no aggregate function with empty group by,
+	// or it has more than one aggregate function
+	if (pexprScalarPrjList->Arity() != 1)
+	{
+		return;
+	}
+
+	CExpression *pexprPrjEl = (*pexprScalarPrjList)[0];
+	CExpression *pexprAggFunc = (*pexprPrjEl)[0];
+	CScalarAggFunc *popScAggFunc =
+		CScalarAggFunc::PopConvert(pexprAggFunc->Pop());
+	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+
+	IMDId *agg_func_mdid = CScalar::PopConvert(popScAggFunc)->MdidType();
+	const IMDType *agg_func_type = md_accessor->RetrieveType(agg_func_mdid);
+
+	// Check if aggregate function is either min() or max()
+	if (!popScAggFunc->IsMinMax(agg_func_type))
+	{
+		return;
+	}
+
+	const IMDRelation *pmdrel =
+		md_accessor->RetrieveRel(popGet->Ptabdesc()->MDId());
+
+	const CColRef *agg_colref = CCastUtils::PcrExtractFromScIdOrCastScId(
+		(*(*pexprAggFunc)[EAggfuncChildIndices::EaggfuncIndexArgs])[0]);
+
+	// Check if min/max aggregation performed on a column or cast
+	// of column. This optimization isn't necessary for min/max on constants.
+	if (nullptr == agg_colref)
+	{
+		return;
+	}
+
+	// Generate index column not null condition.
+	CExpression *notNullExpr = nullptr;
+	notNullExpr =
+		CUtils::PexprIsNotNull(mp, CUtils::PexprScalarIdent(mp, agg_colref));
+
+	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
+	notNullExpr->AddRef();
+	pdrgpexpr->Append(notNullExpr);
+
+	popGet->AddRef();
+	CExpression *pexprUpdatedRltn =
+		GPOS_NEW(mp) CExpression(mp, popGet, notNullExpr);
+
+	CColRefSet *pcrsScalarExpr = GPOS_NEW(mp) CColRefSet(mp);
+	pcrsScalarExpr->Include(agg_colref);
+	CColRefArray *pdrgpcrIndexColumns = nullptr;
+
+	for (ULONG ul = 0; ul < ulIndices; ul++)
+	{
+		IMDId *pmdidIndex = pmdrel->IndexMDidAt(ul);
+		const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pmdidIndex);
+		// get columns in the index
+		pdrgpcrIndexColumns = CXformUtils::PdrgpcrIndexKeys(
+			mp, popGet->PdrgpcrOutput(), pmdindex, pmdrel);
+		// Check if index is applicable and get Scan direction
+		EIndexScanDirection scan_direction =
+			GetScanDirection(agg_colref, pdrgpcrIndexColumns, pmdindex,
+							 popScAggFunc, agg_func_type);
+		// Proceed if index is applicable
+		if (scan_direction != EisdSentinel)
+		{
+			// build IndexGet expression
+			CExpression *pexprIndexGet = CXformUtils::PexprLogicalIndexGet(
+				mp, md_accessor, pexprUpdatedRltn, popAgg->UlOpId(), pdrgpexpr,
+				pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel, false,
+				scan_direction);
+
+			if (pexprIndexGet != nullptr)
+			{
+				// Compute the required Order Spec
+				COrderSpec *pos = GPOS_NEW(mp) COrderSpec(mp);
+				IMDId *mdid = nullptr;
+				COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
+				// if scan direction is forward, order spec computed should match
+				// the index's sort and nulls order.
+				if (scan_direction == EForwardScan)
+				{
+					mdid = (pmdindex->KeySortDirectionAt(0) == SORT_ASC)
+							   ? agg_colref->RetrieveType()->GetMdidForCmpType(
+									 IMDType::EcmptL)
+							   : agg_colref->RetrieveType()->GetMdidForCmpType(
+									 IMDType::EcmptG);
+					ent = (pmdindex->KeyNullsDirectionAt(0) ==
+						   COrderSpec::EntLast)
+							  ? COrderSpec::EntLast
+							  : COrderSpec::EntFirst;
+				}
+				// if scan direction is backward, order spec computed should be
+				// opposite to index's sort and nulls order.
+				else
+				{
+					mdid = (pmdindex->KeySortDirectionAt(0) == SORT_ASC)
+							   ? agg_colref->RetrieveType()->GetMdidForCmpType(
+									 IMDType::EcmptG)
+							   : agg_colref->RetrieveType()->GetMdidForCmpType(
+									 IMDType::EcmptL);
+
+					ent = (pmdindex->KeyNullsDirectionAt(0) ==
+						   COrderSpec::EntLast)
+							  ? COrderSpec::EntFirst
+							  : COrderSpec::EntLast;
+				}
+				mdid->AddRef();
+				pos->Append(mdid, agg_colref, ent);
+				// Build Limit Offset expression
+				CExpression *pexprLimitOffset =
+					CUtils::PexprScalarConstInt8(mp, 0);
+				// Build Limit Count expression
+				CExpression *pexprLimitCount =
+					CUtils::PexprScalarConstInt8(mp, 1);
+
+				// build Limit expression
+				CExpression *pexprLimit = GPOS_NEW(mp) CExpression(
+					mp,
+					GPOS_NEW(mp) CLogicalLimit(mp, pos, true /* fGlobal */,
+											   true /* fHasCount */,
+											   false /*fTopLimitUnderDML*/),
+					pexprIndexGet, pexprLimitOffset, pexprLimitCount);
+
+				popAgg->AddRef();
+				pexprScalarPrjList->AddRef();
+
+				// build Aggregate expression
+				CExpression *finalpexpr = GPOS_NEW(mp)
+					CExpression(mp, popAgg, pexprLimit, pexprScalarPrjList);
+
+				pxfres->Add(finalpexpr);
+			}
+		}
+		pdrgpcrIndexColumns->Release();
+	}
+	pcrsScalarExpr->Release();
+	pdrgpexpr->Release();
+	pexprUpdatedRltn->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMinMax2IndexGet::GetScanDirection
+//
+//	@doc:
+//		Function to validate if index is applicable and determine Index Scan
+//		direction, given index columns. This function checks if aggregate column
+//		is prefix of the index columns.
+//---------------------------------------------------------------------------
+EIndexScanDirection
+CXformMinMax2IndexGet::GetScanDirection(const CColRef *agg_col,
+										CColRefArray *pdrgpcrIndexColumns,
+										const IMDIndex *pmdindex,
+										CScalarAggFunc *popScAggFunc,
+										const IMDType *agg_col_type)
+{
+	// Ordered IndexScan is only applicable for BTree index
+	if (pmdindex->IndexType() != IMDIndex::EmdindBtree)
+	{
+		return EisdSentinel;
+	}
+
+	// Check if aggregate function's column matches with first index key
+	if (!CColRef::Equals(agg_col, (*pdrgpcrIndexColumns)[0]))
+	{
+		return EisdSentinel;
+	}
+
+	// If Aggregate function is min()
+	if (popScAggFunc->MDId()->Equals(
+			agg_col_type->GetMdidForAggType(IMDType::EaggMin)))
+	{
+		// Find the minimum element by:
+		// 1. Scanning Forward, if index is sorted in ascending order.
+		// 2. Scanning Backward, if index is sorted in descending order.
+		return (pmdindex->KeySortDirectionAt(0) == SORT_DESC) ? EBackwardScan
+															  : EForwardScan;
+	}
+	// If Aggregate function is max()
+	else
+	{
+		// Find the maximum element by:
+		// 1. Scanning Forward, if index is sorted in descending order.
+		// 2. Scanning Backward, if index is sorted in ascending order.
+		return (pmdindex->KeySortDirectionAt(0) == SORT_DESC) ? EForwardScan
+															  : EBackwardScan;
+	}
+}
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
@@ -138,8 +138,7 @@ CXformMinMax2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	}
 
 	// Generate index column not null condition.
-	CExpression *notNullExpr = nullptr;
-	notNullExpr =
+	CExpression *notNullExpr =
 		CUtils::PexprIsNotNull(mp, CUtils::PexprScalarIdent(mp, agg_colref));
 
 	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
@@ -218,14 +217,10 @@ CXformMinMax2IndexGet::GetScanDirection(const CColRef *agg_col,
 										CScalarAggFunc *popScAggFunc,
 										const IMDType *agg_col_type)
 {
-	// Ordered IndexScan is only applicable for BTree index
-	if (pmdindex->IndexType() != IMDIndex::EmdindBtree)
-	{
-		return EisdSentinel;
-	}
-
-	// Check if aggregate function's column matches with first index key
-	if (!CColRef::Equals(agg_col, (*pdrgpcrIndexColumns)[0]))
+	// Ordered IndexScan is only applicable if index type is Btree and
+	// if aggregate function's column matches with first index key
+	if (pmdindex->IndexType() != IMDIndex::EmdindBtree ||
+		!CColRef::Equals(agg_col, (*pdrgpcrIndexColumns)[0]))
 	{
 		return EisdSentinel;
 	}
@@ -237,8 +232,8 @@ CXformMinMax2IndexGet::GetScanDirection(const CColRef *agg_col,
 		// Find the minimum element by:
 		// 1. Scanning Forward, if index is sorted in ascending order.
 		// 2. Scanning Backward, if index is sorted in descending order.
-		return (pmdindex->KeySortDirectionAt(0) == SORT_DESC) ? EBackwardScan
-															  : EForwardScan;
+		return pmdindex->KeySortDirectionAt(0) == SORT_DESC ? EBackwardScan
+															: EForwardScan;
 	}
 	// If Aggregate function is max()
 	else
@@ -246,8 +241,8 @@ CXformMinMax2IndexGet::GetScanDirection(const CColRef *agg_col,
 		// Find the maximum element by:
 		// 1. Scanning Forward, if index is sorted in descending order.
 		// 2. Scanning Backward, if index is sorted in ascending order.
-		return (pmdindex->KeySortDirectionAt(0) == SORT_DESC) ? EForwardScan
-															  : EBackwardScan;
+		return pmdindex->KeySortDirectionAt(0) == SORT_DESC ? EForwardScan
+															: EBackwardScan;
 	}
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
@@ -181,8 +181,8 @@ CXformMinMax2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 				CLogicalLimit *popLimit =
 					CLogicalLimit::PopConvert(pexprLimit->Pop());
 				// Compute the required OrderSpec for first index key
-				CXformUtils::PosForIndexKey(pmdindex, scan_direction,
-											agg_colref, popLimit->Pos(), 0);
+				CXformUtils::ComputeOrderSpecForIndexKey(
+					pmdindex, scan_direction, agg_colref, popLimit->Pos(), 0);
 
 				popAgg->AddRef();
 				pexprScalarPrjList->AddRef();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
@@ -170,9 +170,11 @@ CXformMinMax2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 
 		if (pexprIndexGet != nullptr)
 		{
-			// Compute the required OrderSpec for first index key
-			COrderSpec *pos = CXformUtils::ComputeOrderSpecForIndexKey(
-				mp, pmdindex, scan_direction, agg_colref, 0 /*key position*/);
+			COrderSpec *pos = nullptr;
+			// Compute and update the required OrderSpec for first index key
+			CXformUtils::ComputeOrderSpecForIndexKey(mp, &pos, pmdindex,
+													 scan_direction, agg_colref,
+													 0 /*key position*/);
 
 			// build Limit expression
 			CExpression *pexprLimit = CUtils::BuildLimitExprWithOrderSpec(

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMinMax2IndexGet.cpp
@@ -163,10 +163,10 @@ CXformMinMax2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 			GetScanDirection(pmdindex, popScAggFunc, agg_func_type);
 
 		// build IndexGet expression
-		CExpression *pexprIndexGet = CXformUtils::PexprLogicalIndexGet(
+		CExpression *pexprIndexGet = CXformUtils::PexprBuildBtreeIndexPlan(
 			mp, md_accessor, pexprGetNotNull, popAgg->UlOpId(), pdrgpexpr,
-			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel, false,
-			scan_direction);
+			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel,
+			scan_direction, false);
 
 		if (pexprIndexGet != nullptr)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
@@ -128,10 +128,12 @@ CXformSelect2DynamicIndexGet::Transform(CXformContext *pxfctxt,
 		// only supported in the case where we have Order by clause in the
 		// query, but this xform handles scenario of a filter on top of a
 		// partitioned table.
-		CExpression *pexprDynamicIndexGet = CXformUtils::PexprLogicalIndexGet(
-			mp, md_accessor, pexprRelational, pexpr->Pop()->UlOpId(), pdrgpexpr,
-			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel,
-			false /*indexForOrderBy*/, EForwardScan /*indexScanDirection*/);
+		CExpression *pexprDynamicIndexGet =
+			CXformUtils::PexprBuildBtreeIndexPlan(
+				mp, md_accessor, pexprRelational, pexpr->Pop()->UlOpId(),
+				pdrgpexpr, pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex,
+				pmdrel, EForwardScan /*indexScanDirection*/,
+				false /*indexForOrderBy*/);
 		if (nullptr != pexprDynamicIndexGet)
 		{
 			// create a redundant SELECT on top of DynamicIndexGet to be able to use predicate in partition elimination

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
@@ -112,10 +112,10 @@ CXformSelect2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		// We consider ForwardScan here because, BackwardScan is only supported
 		// in the case where we have Order by clause in the query, but this
 		// xform handles scenario of a filter on top of a regular table
-		CExpression *pexprIndexGet = CXformUtils::PexprLogicalIndexGet(
+		CExpression *pexprIndexGet = CXformUtils::PexprBuildBtreeIndexPlan(
 			mp, md_accessor, pexprRelational, pexpr->Pop()->UlOpId(), pdrgpexpr,
 			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel,
-			false /*indexForOrderBy*/, EForwardScan /*indexScanDirection*/);
+			EForwardScan /*indexScanDirection*/, false /*indexForOrderBy*/);
 		if (nullptr != pexprIndexGet)
 		{
 			pxfres->Add(pexprIndexGet);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -4163,16 +4163,17 @@ CXformUtils::FCoverIndex(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
 }
 
 //---------------------------------------------------------------------------
-// CXformUtils::PosForIndexKey
+// CXformUtils::ComputeOrderSpecForIndexKey
 //
 // Determine the OrderSpec Expression for an index key based on the
-// direction of the index scan and the position of the index key.
+// direction of the index scan and the position of the index key. This
+// function updates the passed COrderSpec argument.
 //---------------------------------------------------------------------------
 void
-CXformUtils::PosForIndexKey(const IMDIndex *pmdindex,
-							EIndexScanDirection scan_direction,
-							const CColRef *colref, COrderSpec *pos,
-							ULONG key_position)
+CXformUtils::ComputeOrderSpecForIndexKey(const IMDIndex *pmdindex,
+										 EIndexScanDirection scan_direction,
+										 const CColRef *colref, COrderSpec *pos,
+										 ULONG key_position)
 {
 	IMDId *mdid = nullptr;
 	COrderSpec::ENullTreatment ent = COrderSpec::EntLast;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -4162,4 +4162,55 @@ CXformUtils::FCoverIndex(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
 	return true;
 }
 
+//---------------------------------------------------------------------------
+// CXformUtils::PosForIndexKey
+//
+// Determine the OrderSpec Expression for an index key based on the
+// direction of the index scan and the position of the index key.
+//---------------------------------------------------------------------------
+void
+CXformUtils::PosForIndexKey(const IMDIndex *pmdindex,
+							EIndexScanDirection scan_direction,
+							const CColRef *colref, COrderSpec *pos,
+							ULONG key_position)
+{
+	IMDId *mdid = nullptr;
+	COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
+	// if scan direction is forward, order spec computed should match
+	// the index's sort and nulls order.
+	if (scan_direction == EForwardScan)
+	{
+		// if sort direction of key is 0(ASC), choose MDID for less than
+		// type and vice-versa
+		mdid = (pmdindex->KeySortDirectionAt(key_position) == SORT_ASC)
+				   ? colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptL)
+				   : colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptG);
+
+		// if nulls direction of key is 0, choose ENTLast and
+		// vice-versa
+		ent =
+			(pmdindex->KeyNullsDirectionAt(key_position) == COrderSpec::EntLast)
+				? COrderSpec::EntLast
+				: COrderSpec::EntFirst;
+	}
+	// if scan direction is backward, order spec computed should be
+	// commutative to index's sort and nulls order.
+	else if (scan_direction == EBackwardScan)
+	{
+		// if sort order of key is 0(ASC), choose MDID for greater than
+		// type and vice-versa
+		mdid = (pmdindex->KeySortDirectionAt(key_position) == SORT_ASC)
+				   ? colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptG)
+				   : colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptL);
+
+		// if nulls direction of key is 0, choose ENTFirst and
+		// vice-versa
+		ent =
+			(pmdindex->KeyNullsDirectionAt(key_position) == COrderSpec::EntLast)
+				? COrderSpec::EntFirst
+				: COrderSpec::EntLast;
+	}
+	mdid->AddRef();
+	pos->Append(mdid, colref, ent);
+}
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -4165,16 +4165,17 @@ CXformUtils::FCoverIndex(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
 //---------------------------------------------------------------------------
 // CXformUtils::ComputeOrderSpecForIndexKey
 //
-// Determine the OrderSpec Expression for an index key based on the
-// direction of the index scan and the position of the index key. This
-// function updates the passed COrderSpec argument.
+// Determine the OrderSpec for an index key based on the direction of
+// the index scan and the position of the index key.
 //---------------------------------------------------------------------------
-void
-CXformUtils::ComputeOrderSpecForIndexKey(const IMDIndex *pmdindex,
+COrderSpec *
+CXformUtils::ComputeOrderSpecForIndexKey(CMemoryPool *mp,
+										 const IMDIndex *pmdindex,
 										 EIndexScanDirection scan_direction,
-										 const CColRef *colref, COrderSpec *pos,
+										 const CColRef *colref,
 										 ULONG key_position)
 {
+	COrderSpec *order_spec = GPOS_NEW(mp) COrderSpec(mp);
 	IMDId *mdid = nullptr;
 	COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
 	// if scan direction is forward, order spec computed should match
@@ -4212,6 +4213,7 @@ CXformUtils::ComputeOrderSpecForIndexKey(const IMDIndex *pmdindex,
 				: COrderSpec::EntLast;
 	}
 	mdid->AddRef();
-	pos->Append(mdid, colref, ent);
+	order_spec->Append(mdid, colref, ent);
+	return order_spec;
 }
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -4166,16 +4166,23 @@ CXformUtils::FCoverIndex(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
 // CXformUtils::ComputeOrderSpecForIndexKey
 //
 // Determine the OrderSpec for an index key based on the direction of
-// the index scan and the position of the index key.
+// the index scan and the position of the index key. This function
+// creates a new OrderSpec object and computes its value if a nullptr is
+// passed; otherwise, it appends to the existing OrderSpec object.
 //---------------------------------------------------------------------------
-COrderSpec *
+void
 CXformUtils::ComputeOrderSpecForIndexKey(CMemoryPool *mp,
+										 COrderSpec **order_spec,
 										 const IMDIndex *pmdindex,
 										 EIndexScanDirection scan_direction,
 										 const CColRef *colref,
 										 ULONG key_position)
 {
-	COrderSpec *order_spec = GPOS_NEW(mp) COrderSpec(mp);
+	// Create a new OrderSpec object if a nullptr is passed
+	if (*order_spec == nullptr)
+	{
+		(*order_spec) = GPOS_NEW(mp) COrderSpec(mp);
+	}
 	IMDId *mdid = nullptr;
 	COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
 	// if scan direction is forward, order spec computed should match
@@ -4213,7 +4220,6 @@ CXformUtils::ComputeOrderSpecForIndexKey(CMemoryPool *mp,
 				: COrderSpec::EntLast;
 	}
 	mdid->AddRef();
-	order_spec->Append(mdid, colref, ent);
-	return order_spec;
+	(*order_spec)->Append(mdid, colref, ent);
 }
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -104,6 +104,7 @@ OBJS        = CDecorrelator.o \
               CXformLeftSemiJoin2NLJoin.o \
               CXformLimit2IndexGet.o \
               CXformMaxOneRow2Assert.o \
+              CXformMinMax2IndexGet.o \
               CXformDynamicForeignGet2DynamicForeignScan.o \
               CXformProject2Apply.o \
               CXformProject2ComputeScalar.o \

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -109,7 +109,8 @@ IndexScan-ORPredsNonPart IndexScan-ORPredsAOPart IndexScan-AndedIn SubqInIndexPr
 IndexScan-OrderBy-on-Single-IndexCol IndexScan-OrderBy-on-Multiple-IndexCols IndexScan-OrderBy-on-NonIndexCol
 Forward-IndexScan-OrderBy-on-SingleCol-Index Backward-IndexScan-OrderBy-on-SingleCol-Index
 Forward-IndexScan-OrderBy-on-MultiCol-Index Backward-IndexScan-OrderBy-on-MultiCol-Index
-IndexScan-OrderBy-on-MultiCol-NonIndex;
+IndexScan-OrderBy-on-MultiCol-NonIndex Max-Aggregate-uses-IndexScan-and-Limit
+Min-Aggregate-uses-IndexScan-and-Limit;
 
 CBitmapScanTest:
 IndexedNLJBitmap BitmapIndex-ChooseHashJoin BitmapTableScan-AO-Btree-PickOnlyHighNDV

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -110,7 +110,7 @@ IndexScan-OrderBy-on-Single-IndexCol IndexScan-OrderBy-on-Multiple-IndexCols Ind
 Forward-IndexScan-OrderBy-on-SingleCol-Index Backward-IndexScan-OrderBy-on-SingleCol-Index
 Forward-IndexScan-OrderBy-on-MultiCol-Index Backward-IndexScan-OrderBy-on-MultiCol-Index
 IndexScan-OrderBy-on-MultiCol-NonIndex Max-Aggregate-uses-IndexScan-and-Limit
-Min-Aggregate-uses-IndexScan-and-Limit;
+Min-Aggregate-uses-IndexScan-and-Limit IndexScan-IsNullPred IndexScan-IsNotNullPred;
 
 CBitmapScanTest:
 IndexedNLJBitmap BitmapIndex-ChooseHashJoin BitmapTableScan-AO-Btree-PickOnlyHighNDV

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -65,7 +65,8 @@ public:
 	{
 		GPOS_ASSERT((IsA(m_expr, OpExpr) && IsA(m_original_expr, OpExpr)) ||
 					(IsA(m_expr, ScalarArrayOpExpr) &&
-					 IsA(original_expr, ScalarArrayOpExpr)));
+					 IsA(original_expr, ScalarArrayOpExpr)) ||
+					(IsA(m_expr, NullTest) && IsA(original_expr, NullTest)));
 	}
 
 	// dtor

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -844,14 +844,17 @@ FROM bool_test;
 -- Basic cases
 explain (costs off)
   select min(unique1) from tenk1;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(5 rows)
+                              QUERY PLAN
+----------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: unique1
+               ->  Limit
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
 
 select min(unique1) from tenk1;
  min 
@@ -861,14 +864,17 @@ select min(unique1) from tenk1;
 
 explain (costs off)
   select max(unique1) from tenk1;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(5 rows)
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: unique1
+               ->  Limit
+                     ->  Index Only Scan Backward using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
 
 select max(unique1) from tenk1;
  max  
@@ -1012,14 +1018,17 @@ select f1, (select min(unique1) from tenk1 where unique1 > f1) AS gt
 -- check some cases that were handled incorrectly in 8.3.0
 explain (costs off)
   select distinct max(unique2) from tenk1;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(5 rows)
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: unique2
+               ->  Limit
+                     ->  Index Only Scan Backward using tenk1_unique2 on tenk1
+                           Index Cond: (unique2 IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
 
 select distinct max(unique2) from tenk1;
  max  
@@ -1033,12 +1042,15 @@ explain (costs off)
 ------------------------------------------------------
  Sort
    Sort Key: (max(unique2))
-   ->  Finalize Aggregate
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Partial Aggregate
-                     ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(7 rows)
+   ->  Aggregate
+         ->  Limit
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Merge Key: unique2
+                     ->  Limit
+                           ->  Index Only Scan Backward using tenk1_unique2 on tenk1
+                                 Index Cond: (unique2 IS NOT NULL)
+ Optimizer: GPORCA
+(10 rows)
 
 select max(unique2) from tenk1 order by 1;
  max  
@@ -1052,12 +1064,15 @@ explain (costs off)
 ------------------------------------------------------
  Sort
    Sort Key: (max(unique2))
-   ->  Finalize Aggregate
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Partial Aggregate
-                     ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(7 rows)
+   ->  Aggregate
+         ->  Limit
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Merge Key: unique2
+                     ->  Limit
+                           ->  Index Only Scan Backward using tenk1_unique2 on tenk1
+                                 Index Cond: (unique2 IS NOT NULL)
+ Optimizer: GPORCA
+(10 rows)
 
 select max(unique2) from tenk1 order by max(unique2);
  max  
@@ -1092,12 +1107,15 @@ explain (costs off)
  Sort
    Sort Key: (generate_series(1, 3)) DESC
    ->  ProjectSet
-         ->  Finalize Aggregate
-               ->  Gather Motion 3:1  (slice1; segments: 3)
-                     ->  Partial Aggregate
-                           ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+         ->  Aggregate
+               ->  Limit
+                     ->  Gather Motion 3:1  (slice1; segments: 3)
+                           Merge Key: unique2
+                           ->  Limit
+                                 ->  Index Only Scan Backward using tenk1_unique2 on tenk1
+                                       Index Cond: (unique2 IS NOT NULL)
+ Optimizer: GPORCA
+(11 rows)
 
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
  max  | g 

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -345,6 +345,14 @@ select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) 
 -- start_ignore
 -- Known_opt_diff: MPP-21320
 -- end_ignore
+-- Disable 'CXformSelect2DynamicIndexGet' to avoid picking Dynamic Index Scan and use this test
+-- to showcase dpe alternative
+select disable_xform('CXformSelect2DynamicIndexGet');
+              disable_xform               
+------------------------------------------
+ CXformSelect2DynamicIndexGet is disabled
+(1 row)
+
 explain (costs off, timing off, summary off, analyze) select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
@@ -391,6 +399,13 @@ select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello'
    42 | hello42 | world | drop this |    0
    48 | hello48 | world | drop this |    0
 (18 rows)
+
+-- enable xform
+select enable_xform('CXformSelect2DynamicIndexGet');
+              enable_xform               
+-----------------------------------------
+ CXformSelect2DynamicIndexGet is enabled
+(1 row)
 
 --
 -- group-by on top

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -307,7 +307,7 @@ select disable_xform('CXformSelect2DynamicIndexGet');
 (1 row)
 
 explain (costs off, timing off, summary off, analyze) select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
-                                         QUERY PLAN
+                                         QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Semi Join (actual rows=8 loops=1)
@@ -323,7 +323,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
                            ->  Seq Scan on t (actual rows=2 loops=1)
                                  Filter: (t1 = ('hello'::text || (tid)::text))
- Optimizer: GPORCA
+ Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -302,21 +302,31 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
-   ->  Hash Semi Join (actual rows=8 loops=1)
-         Hash Cond: (pt.ptid = t.tid)
-         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
-         ->  Dynamic Seq Scan on pt (actual rows=8 loops=1)
-               Number of partitions to scan: 6 (out of 6)
-               Filter: (NOT (ptid IS NULL))
-               Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
-         ->  Hash (actual rows=2 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
-               ->  Partition Selector (selector id: $0) (actual rows=2 loops=1)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
-                           ->  Seq Scan on t (actual rows=2 loops=1)
-                                 Filter: (t1 = ('hello'::text || (tid)::text))
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+   ->  Result (actual rows=8 loops=1)
+         Filter: (COALESCE((count()), '0'::bigint) > '0'::bigint)
+         ->  Hash Left Join (actual rows=20 loops=1)
+               Hash Cond: (pt.ptid = t.tid)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
+               ->  Dynamic Index Scan on ptid_idx on pt (actual rows=20 loops=1)
+                     Index Cond: (ptid IS NOT NULL)
+                     Number of partitions to scan: 6 (out of 6)
+                     Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
+               ->  Hash (actual rows=2 loops=1)
+                     Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+                     ->  Result (actual rows=2 loops=1)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
+                                 ->  GroupAggregate (actual rows=2 loops=1)
+                                       Group Key: t.tid
+                                       ->  Sort (actual rows=2 loops=1)
+                                             Sort Key: t.tid
+                                             Sort Method:  quicksort  Memory: 75kB
+                                             Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
+                                                   Hash Key: t.tid
+                                                   ->  Seq Scan on t (actual rows=2 loops=1)
+                                                         Filter: (t1 = ('hello'::text || (tid)::text))
+ Optimizer: GPORCA
+(25 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -298,35 +298,33 @@ select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) 
 -- start_ignore
 -- Known_opt_diff: MPP-21320
 -- end_ignore
+-- Disable 'CXformSelect2DynamicIndexGet' to avoid picking Dynamic Index Scan and use this test
+-- to showcase dpe alternative
+select disable_xform('CXformSelect2DynamicIndexGet');
+              disable_xform               
+------------------------------------------
+ CXformSelect2DynamicIndexGet is disabled
+(1 row)
+
 explain (costs off, timing off, summary off, analyze) select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
-                                         QUERY PLAN                                          
+                                         QUERY PLAN
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
-   ->  Result (actual rows=8 loops=1)
-         Filter: (COALESCE((count()), '0'::bigint) > '0'::bigint)
-         ->  Hash Left Join (actual rows=20 loops=1)
-               Hash Cond: (pt.ptid = t.tid)
-               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
-               ->  Dynamic Index Scan on ptid_idx on pt (actual rows=20 loops=1)
-                     Index Cond: (ptid IS NOT NULL)
-                     Number of partitions to scan: 6 (out of 6)
-                     Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
-               ->  Hash (actual rows=2 loops=1)
-                     Buckets: 262144  Batches: 1  Memory Usage: 2049kB
-                     ->  Result (actual rows=2 loops=1)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
-                                 ->  GroupAggregate (actual rows=2 loops=1)
-                                       Group Key: t.tid
-                                       ->  Sort (actual rows=2 loops=1)
-                                             Sort Key: t.tid
-                                             Sort Method:  quicksort  Memory: 75kB
-                                             Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
-                                                   Hash Key: t.tid
-                                                   ->  Seq Scan on t (actual rows=2 loops=1)
-                                                         Filter: (t1 = ('hello'::text || (tid)::text))
+   ->  Hash Semi Join (actual rows=8 loops=1)
+         Hash Cond: (pt.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
+         ->  Dynamic Seq Scan on pt (actual rows=8 loops=1)
+               Number of partitions to scan: 6 (out of 6)
+               Filter: (NOT (ptid IS NULL))
+               Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
+         ->  Hash (actual rows=2 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Partition Selector (selector id: $0) (actual rows=2 loops=1)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
+                           ->  Seq Scan on t (actual rows=2 loops=1)
+                                 Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: GPORCA
-(25 rows)
+(15 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -350,6 +348,13 @@ select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello'
     6 | hello6  | world | drop this |    0
     0 | hello0  | world | drop this |    0
 (18 rows)
+
+-- enable xform
+select enable_xform('CXformSelect2DynamicIndexGet');
+              enable_xform               
+-----------------------------------------
+ CXformSelect2DynamicIndexGet is enabled
+(1 row)
 
 --
 -- group-by on top

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -682,14 +682,17 @@ LINE 3:        lateral (select a, b, sum(v.x) from gstest_data(v.x) ...
 -- min max optimization should still work with GROUP BY ()
 explain (costs off)
   select min(unique1) from tenk1 GROUP BY ();
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+                              QUERY PLAN
+----------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: unique1
+               ->  Limit
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
 
 -- Views with GROUPING SET queries
 CREATE VIEW gstest_view AS select a, b, grouping(a,b), sum(c), count(*), max(c)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1481,13 +1481,13 @@ select * from fix_param_a left join fix_param_b on
                Hash Cond: (fix_param_b.i = fix_param_a.i)
                ->  Hash Semi Join
                      Hash Cond: ((fix_param_b.i = fix_param_c.i) AND (fix_param_b.j = fix_param_c.j))
-                     ->  Seq Scan on fix_param_b
-                           Filter: (NOT (i IS NULL))
+                     ->  Index Scan using fix_param_b_i_key on fix_param_b
+                           Index Cond: (i IS NOT NULL)
                      ->  Hash
                            ->  Seq Scan on fix_param_c
                ->  Hash
                      ->  Seq Scan on fix_param_a
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (15 rows)
 
 select * from fix_param_a left join fix_param_b on

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -3496,15 +3496,18 @@ explain (analyze, costs off, summary off, timing off) select * from ma_test wher
                Join Filter: (ma_test.a >= (min(ma_test_p2.b)))
                Rows Removed by Join Filter: 3
                ->  Broadcast Motion 1:3  (slice2) (actual rows=1 loops=1)
-                     ->  Finalize Aggregate (actual rows=1 loops=1)
-                           ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=3 loops=1)
-                                 ->  Partial Aggregate (actual rows=1 loops=1)
-                                       ->  Seq Scan on ma_test_p2 (actual rows=5 loops=1)
+                     ->  Aggregate (actual rows=1 loops=1)
+                           ->  Limit (actual rows=1 loops=1)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=1 loops=1)
+                                       Merge Key: ma_test_p2.b
+                                       ->  Limit (actual rows=1 loops=1)
+                                             ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 (actual rows=1 loops=1)
+                                                   Index Cond: (b IS NOT NULL)
                ->  Dynamic Seq Scan on ma_test (actual rows=6 loops=2)
                      Number of partitions to scan: 3 (out of 3)
                      Partitions scanned:  Avg 2.0 x 3 workers of 2 scans.  Max 2 parts (seg0).
- Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+ Optimizer: GPORCA
+(21 rows)
 
 reset enable_seqscan;
 reset enable_sort;

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -3286,7 +3286,7 @@ select max(b) from min_max_aggregates;
  
 (1 row)
 
-INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,10000)i;
+INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
 -- Positive Tests
 -- Test optimization on index_bc
@@ -3323,9 +3323,9 @@ explain(costs off) select max(b) from min_max_aggregates;
 (8 rows)
 
 select max(b) from min_max_aggregates;
-    max    
------------
- col_b9999
+   max   
+---------
+ col_b99
 (1 row)
 
 -- Create index_a and test optimization on its keys
@@ -3364,9 +3364,9 @@ explain(costs off) select max(a) from min_max_aggregates;
 (8 rows)
 
 select max(a) from min_max_aggregates;
-  max  
--------
- 10000
+ max 
+-----
+ 100
 (1 row)
 
 -- Create index_d and test optimization on its keys
@@ -3405,9 +3405,9 @@ explain(costs off) select max(d) from min_max_aggregates;
 (8 rows)
 
 select max(d) from min_max_aggregates;
-        max         
---------------------
- 3225.8064516129034
+        max        
+-------------------
+ 32.25806451612903
 (1 row)
 
 -- Create index_e and test optimization on its keys
@@ -3446,9 +3446,9 @@ explain(costs off) select max(e) from min_max_aggregates;
 (8 rows)
 
 select max(e) from min_max_aggregates;
-   max   
----------
- 16000.0
+  max  
+-------
+ 160.0
 (1 row)
 
 -- Test min/max with empty group by
@@ -3485,9 +3485,9 @@ explain(costs off) select max(e) from min_max_aggregates group by ();
 (8 rows)
 
 select max(e) from min_max_aggregates group by ();
-   max   
----------
- 16000.0
+  max  
+-------
+ 160.0
 (1 row)
 
 -- Negative Tests
@@ -3520,9 +3520,9 @@ explain(costs off) select max(c) from min_max_aggregates;
 (5 rows)
 
 select max(c) from min_max_aggregates;
-  max  
--------
- 20000
+ max 
+-----
+ 200
 (1 row)
 
 explain(costs off) select min(f) from min_max_aggregates;
@@ -3552,9 +3552,9 @@ explain(costs off) select max(f) from min_max_aggregates;
 (5 rows)
 
 select max(f) from min_max_aggregates;
- max  
-------
- 9999
+ max 
+-----
+  99
 (1 row)
 
 -- Test min/max on a constant
@@ -3610,7 +3610,7 @@ explain(costs off) select count(*) from min_max_aggregates;
 select count(*) from min_max_aggregates;
  count 
 -------
- 10001
+   101
 (1 row)
 
 explain(costs off) select avg(e) from min_max_aggregates;
@@ -3624,9 +3624,9 @@ explain(costs off) select avg(e) from min_max_aggregates;
 (5 rows)
 
 select avg(e) from min_max_aggregates;
-          avg          
------------------------
- 8000.8000000000000000
+         avg         
+---------------------
+ 80.8000000000000000
 (1 row)
 
 explain(costs off) select sum(d) from min_max_aggregates;
@@ -3640,9 +3640,9 @@ explain(costs off) select sum(d) from min_max_aggregates;
 (5 rows)
 
 select sum(d) from min_max_aggregates;
-        sum         
---------------------
- 16130645.161290325
+        sum        
+-------------------
+ 1629.032258064516
 (1 row)
 
 -- Test min/max with group by
@@ -3705,9 +3705,9 @@ explain(costs off) select min(a), max(d) from min_max_aggregates;
 (14 rows)
 
 select min(a), max(d) from min_max_aggregates;
- min |        max         
------+--------------------
-   1 | 3225.8064516129034
+ min |        max        
+-----+-------------------
+   1 | 32.25806451612903
 (1 row)
 
 -- Purpose: This section tests IS NULL predicate on btree and non-index columns
@@ -3810,7 +3810,7 @@ select * from min_max_aggregates where f is null;
 -- Tests with IS NOT NULL on btree index columns
 -- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
 -- for below queries
-delete from min_max_aggregates where a<10000;
+delete from min_max_aggregates where a<100;
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
 set enable_bitmapscan to off;
@@ -3824,9 +3824,9 @@ explain(costs off) select * from min_max_aggregates where a is not null;
 (4 rows)
 
 select * from min_max_aggregates where a is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where b is not null;
@@ -3839,9 +3839,9 @@ explain(costs off) select * from min_max_aggregates where b is not null;
 (4 rows)
 
 select * from min_max_aggregates where b is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where c is not null;
@@ -3854,9 +3854,9 @@ explain(costs off) select * from min_max_aggregates where c is not null;
 (4 rows)
 
 select * from min_max_aggregates where c is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where d is not null;
@@ -3869,9 +3869,9 @@ explain(costs off) select * from min_max_aggregates where d is not null;
 (4 rows)
 
 select * from min_max_aggregates where d is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where e is not null;
@@ -3884,9 +3884,9 @@ explain(costs off) select * from min_max_aggregates where e is not null;
 (4 rows)
 
 select * from min_max_aggregates where e is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 reset enable_seqscan;
@@ -3902,9 +3902,9 @@ explain(costs off) select * from min_max_aggregates where f is not null;
 (4 rows)
 
 select * from min_max_aggregates where f is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 -- Clean Up

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -3242,23 +3242,65 @@ reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
 -- Purpose: This section includes tests related to min(), max() aggregates optimization.
-CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
+CREATE TABLE min_max_aggregates(a int, b int, c int, d int, e int, f int);
 CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Ensure Planner picks IndexOnlyScan wherever possible
-set enable_seqscan to off;
 -- Test min() and max() optimization if table doesn't have any tuples
 -- This test is added to ensure min/max functions return 1 NULL row
 -- indicating no min or max value exists as table doesn't have any tuples.
 explain(costs off) select min(b) from min_max_aggregates;
+                   QUERY PLAN
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select min(b) from min_max_aggregates;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates;
+                   QUERY PLAN
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select max(b) from min_max_aggregates;
+ max 
+-----
+    
+(1 row)
+
+INSERT INTO min_max_aggregates select i, i*5, i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
+INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
+-- Test optimization when there are multiple indices whose leading
+-- index key matches aggregate column. This test shows that both
+-- 'index_bc' created above and 'index_b' are eligible for the xform
+-- and ORCA picks the lower cost index, which is 'index_b' in this
+-- scenario
+CREATE INDEX index_b on min_max_aggregates using btree(b DESC);
+ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as indices: 'index_bc', 'index_b',
+-- both featuring column 'b' as leading key
+-- This query leverages Backward IndexScan as column 'b' in 'index_b' is
+-- sorted in descending order and therefore, minimum value can be found
+-- at the bottom of the index
+explain(costs off) select min(b) from min_max_aggregates;
                                     QUERY PLAN
------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
                  Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan Backward using index_bc on min_max_aggregates
+                 ->  Index Only Scan Backward using index_b on min_max_aggregates
                        Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
@@ -3266,18 +3308,21 @@ explain(costs off) select min(b) from min_max_aggregates;
 select min(b) from min_max_aggregates;
  min 
 -----
- 
+   5
 (1 row)
 
+-- This query leverages Forward IndexScan as column 'b' in 'index_b' is
+-- sorted in descending order and therefore, maximum value can be found
+-- at the top of the index
 explain(costs off) select max(b) from min_max_aggregates;
-                                QUERY PLAN
---------------------------------------------------------------------------
+                               QUERY PLAN
+-------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
                  Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan using index_bc on min_max_aggregates
+                 ->  Index Only Scan using index_b on min_max_aggregates
                        Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
@@ -3285,55 +3330,21 @@ explain(costs off) select max(b) from min_max_aggregates;
 select max(b) from min_max_aggregates;
  max 
 -----
- 
-(1 row)
-
-INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
-INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
--- Positive Tests
--- Test optimization on multi-key index
-explain(costs off) select min(b) from min_max_aggregates;
-                                    QUERY PLAN
------------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan Backward using index_bc on min_max_aggregates
-                       Index Cond: (b IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(b) from min_max_aggregates;
-  min   
---------
- col_b1
-(1 row)
-
-explain(costs off) select max(b) from min_max_aggregates;
-                                QUERY PLAN
---------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan using index_bc on min_max_aggregates
-                       Index Cond: (b IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select max(b) from min_max_aggregates;
-   max   
----------
- col_b99
+ 500
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction
--- ASC NULLS FIRST
+-- ASC NULLS FIRST. Utilizing an index with "NULLS FIRST" to ensure
+-- that during a Forward IndexScan, NULL values at the beginning
+-- are filtered out, guaranteeing that a "limit" with 1 row will
+-- return a valid non-null value.
 CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_a'
+-- features column 'a' as leading key
+-- This query leverages Forward IndexScan as column 'a' in 'index_a' is
+-- sorted in ascending order and therefore, minimum value can be found
+-- at the top of the index
 explain(costs off) select min(a) from min_max_aggregates;
                                QUERY PLAN
 -------------------------------------------------------------------------
@@ -3353,6 +3364,9 @@ select min(a) from min_max_aggregates;
    1
 (1 row)
 
+-- This query leverages Backward IndexScan as column 'a' in 'index_a' is
+-- sorted in ascending order and therefore, maximum value can be found
+-- at the bottom of the index
 explain(costs off) select max(a) from min_max_aggregates;
                                     QUERY PLAN
 ----------------------------------------------------------------------------------
@@ -3373,9 +3387,17 @@ select max(a) from min_max_aggregates;
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction
--- DESC NULLS LAST
+-- DESC NULLS LAST. Utilizing an index with "NULLS LAST" to ensure
+-- that during a Backward IndexScan, NULL values at the end
+-- are filtered out, guaranteeing that a "limit" with 1 row will
+-- return a valid non-null value.
 CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_d'
+-- features column 'd' as leading key
+-- This query leverages Backward IndexScan as column 'd' in 'index_d' is
+-- sorted in descending order and therefore, minimum value can be found
+-- at the bottom of the index
 explain(costs off) select min(d) from min_max_aggregates;
                                     QUERY PLAN
 ----------------------------------------------------------------------------------
@@ -3390,11 +3412,14 @@ explain(costs off) select min(d) from min_max_aggregates;
 (8 rows)
 
 select min(d) from min_max_aggregates;
-        min         
---------------------
- 0.3225806451612903
+ min 
+-----
+   0
 (1 row)
 
+-- This query leverages Forward IndexScan as column 'd' in 'index_d' is
+-- sorted in descending order and therefore, maximum value can be found
+-- at the top of the index
 explain(costs off) select max(d) from min_max_aggregates;
                                QUERY PLAN
 -------------------------------------------------------------------------
@@ -3409,14 +3434,19 @@ explain(costs off) select max(d) from min_max_aggregates;
 (8 rows)
 
 select max(d) from min_max_aggregates;
-        max        
--------------------
- 32.25806451612903
+ max 
+-----
+  32
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction ASC
 CREATE INDEX index_e on min_max_aggregates using btree(e);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_e'
+-- features column 'e' as leading key
+-- This query leverages Forward IndexScan as column 'e' in 'index_e' is
+-- sorted in ascending order and therefore, minimum value can be found
+-- at the top of the index
 explain(costs off) select min(e) from min_max_aggregates;
                                QUERY PLAN
 -------------------------------------------------------------------------
@@ -3433,9 +3463,12 @@ explain(costs off) select min(e) from min_max_aggregates;
 select min(e) from min_max_aggregates;
  min 
 -----
- 1.6
+   2
 (1 row)
 
+-- This query leverages Backward IndexScan as column 'e' in 'index_e' is
+-- sorted in ascending order and therefore, maximum value can be found
+-- at the bottom of the index
 explain(costs off) select max(e) from min_max_aggregates;
                                     QUERY PLAN
 ----------------------------------------------------------------------------------
@@ -3450,294 +3483,14 @@ explain(costs off) select max(e) from min_max_aggregates;
 (8 rows)
 
 select max(e) from min_max_aggregates;
-  max  
--------
- 160.0
-(1 row)
-
--- Test min/max optimization behavior with empty group by
-explain(costs off) select min(e) from min_max_aggregates group by ();
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(e) from min_max_aggregates group by ();
- min 
------
- 1.6
-(1 row)
-
-explain(costs off) select max(e) from min_max_aggregates group by ();
-                                    QUERY PLAN
-----------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan Backward using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select max(e) from min_max_aggregates group by ();
-  max  
--------
- 160.0
-(1 row)
-
--- Test min/max optimization when used as part of a subquery
-explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 2 (returns $1)  (slice2)
-     ->  Result
-           InitPlan 1 (returns $0)  (slice3)
-             ->  Limit
-                   ->  Gather Motion 3:1  (slice4; segments: 3)
-                         Merge Key: min_max_aggregates_1.e
-                         ->  Index Only Scan Backward using index_e on min_max_aggregates min_max_aggregates_1
-                               Index Cond: (e IS NOT NULL)
-   ->  Index Scan using index_e on min_max_aggregates
-         Index Cond: (e = $1)
- Optimizer: Postgres-based planner
-(12 rows)
-
-select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-    b     |   e   
-----------+-------
- col_b100 | 160.0
-(1 row)
-
--- Test min/max optimization when used in CTE producer
-explain (costs off) with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
-                                       QUERY PLAN
-----------------------------------------------------------------------------------------
- Subquery Scan on cte_producer
-   ->  Result
-         InitPlan 1 (returns $0)  (slice1)
-           ->  Limit
-                 ->  Gather Motion 3:1  (slice2; segments: 3)
-                       Merge Key: min_max_aggregates.d
-                       ->  Index Only Scan Backward using index_d on min_max_aggregates
-                             Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(9 rows)
-
-with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
- ?column? 
-----------
-        1
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-                              QUERY PLAN
------------------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Only Scan using index_d on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-        min         
---------------------
- 0.3225806451612903
-(1 row)
-
--- Test min/max optimization when the result is casted to a compatible
--- data type
-explain (costs off) select min(e)::int from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(e)::int from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- Test min/max optimization in union all and joins
-CREATE TABLE table1 (a int, b text, c int);
-CREATE INDEX t1_c_idx on table1 using btree(c);
-CREATE TABLE table2 (a int, b text, c int);
-CREATE INDEX t2_c_idx on table2 using btree(c);
-INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
-INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
-ANALYZE table1;
-ANALYZE table2;
--- Test min/max optimization with union all
-explain (costs off) select min(c) from table1 union all select max(c) from table2;
-                                 QUERY PLAN
------------------------------------------------------------------------------
- Append
-   ->  Result
-         InitPlan 1 (returns $0)  (slice1)
-           ->  Limit
-                 ->  Gather Motion 3:1  (slice2; segments: 3)
-                       Merge Key: table1.c
-                       ->  Index Only Scan using t1_c_idx on table1
-                             Index Cond: (c IS NOT NULL)
-   ->  Result
-         InitPlan 2 (returns $1)  (slice3)
-           ->  Limit
-                 ->  Gather Motion 3:1  (slice4; segments: 3)
-                       Merge Key: table2.c
-                       ->  Index Only Scan Backward using t2_c_idx on table2
-                             Index Cond: (c IS NOT NULL)
- Optimizer: Postgres-based planner
-(16 rows)
-
-select min(c) from table1 union all select max(c) from table2;
- min 
------
-  -1
-  98
-(2 rows)
-
--- Test min/max optimization when used as part of predicate subquery
--- for join
-explain (costs off) select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
-                       QUERY PLAN
---------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Finalize Aggregate
-           ->  Gather Motion 3:1  (slice3; segments: 3)
-                 ->  Partial Aggregate
-                       ->  Seq Scan on table2 table2_1
-   ->  Hash Join
-         Hash Cond: (table1.a = table2.a)
-         ->  Index Scan using t1_c_idx on table1
-               Index Cond: (c > $0)
-         ->  Hash
-               ->  Seq Scan on table2
- Optimizer: Postgres-based planner
-(13 rows)
-
-select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
- b | c 
----+---
-(0 rows)
-
--- Negative Tests
-reset enable_seqscan;
--- Test min/max optimization on result of union all present as part of subquery.
--- This query is not supported by min/max optimization because for this to
--- be supported ORCA needs support of MergeAppend node which could Merge result
--- of two table's Index Scans in the sorted order and limit can be applied on top
--- of it.
-explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
-                                 QUERY PLAN
------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: table1.c
-                 ->  Merge Append
-                       Sort Key: table1.c DESC
-                       ->  Index Only Scan Backward using t1_c_idx on table1
-                             Index Cond: (c IS NOT NULL)
-                       ->  Index Only Scan Backward using t2_c_idx on table2
-                             Index Cond: (c IS NOT NULL)
- Optimizer: Postgres-based planner
-(12 rows)
-
-select max(c) from (select c from table1 union all select c from table2) subquery;
  max 
 -----
-  98
+ 160
 (1 row)
 
--- Test min/max optimization used as part of projected columns in join. This query
--- could not use the optimization as it involves join result which is not
--- guaranteed to be sorted, unless it is an NL join. Even for NL joins this
--- optimization isn't supported currently as it isn't in scope of story.
-explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
-                      QUERY PLAN
-------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (table1.a = table2.a)
-                     ->  Seq Scan on table1
-                     ->  Hash
-                           ->  Seq Scan on table2
- Optimizer: Postgres-based planner
-(9 rows)
-
-select min(table1.a) from table1 join table2 on table1.a=table2.a;
- min 
------
-   1
-(1 row)
-
--- Test min/max optimization on columns from join result. This isn't
--- supported for the same reason as above: join result is not guaranteed
--- to be sorted.
-explain (costs off) select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
-                      QUERY PLAN
-------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (table1.a = table2.a)
-                     ->  Seq Scan on table1
-                     ->  Hash
-                           ->  Seq Scan on table2
- Optimizer: Postgres-based planner
-(9 rows)
-
-select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
- min 
------
-  -1
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-         min         
----------------------
- 0.16129032258064516
-(1 row)
-
--- Clean up
-drop table table1;
-drop table table2;
--- Test optimization on non index columns. These tests use SeqScan
+-- Test optimization on non-leading keys in the index. These
+-- tests aren't eligible for IndexScan as the aggregate column
+-- isn't a leading key in the index
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3770,6 +3523,9 @@ select max(c) from min_max_aggregates;
  200
 (1 row)
 
+-- Test optimization on non index columns. These tests aren't
+-- eligible for IndexScan as there is no index on the aggregate
+-- column 'f'
 explain(costs off) select min(f) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3842,9 +3598,53 @@ select max(100) from min_max_aggregates;
  100
 (1 row)
 
--- Test min/max with group by. This test's pattern matches xform's
--- pattern and it is included to ensure if xform correctly filters
--- this case out and doesn't apply transformation to it.
+-- Test min/max optimization behavior with empty group by. Adding
+-- this test as this query's pattern matches the transforms pattern
+-- and is expected to leverage min/max optimization feature as
+-- the query has no group by columns.
+explain(costs off) select min(e) from min_max_aggregates group by ();
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(e) from min_max_aggregates group by ();
+ min 
+-----
+   2
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates group by ();
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan Backward using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(e) from min_max_aggregates group by ();
+ max 
+-----
+ 160
+(1 row)
+
+-- Test min/max with non-empty group by. This query's pattern matches
+-- xform's pattern and it is included to ensure if xform correctly filters
+-- this case out. This filtering happens while computing xform promise by
+-- checking size of grouping columns and there by avoiding application
+-- of transform
 explain(costs off) select min(e) from min_max_aggregates group by e;
                          QUERY PLAN
 ------------------------------------------------------------
@@ -3869,9 +3669,108 @@ explain(costs off) select max(e) from min_max_aggregates group by e;
  Optimizer: Postgres-based planner
 (7 rows)
 
+-- Test min/max optimization when used as part of a subquery
+explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+                                                  QUERY PLAN
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   InitPlan 2 (returns $1)  (slice2)
+     ->  Result
+           InitPlan 1 (returns $0)  (slice3)
+             ->  Limit
+                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                         Merge Key: min_max_aggregates_1.e
+                         ->  Index Only Scan Backward using index_e on min_max_aggregates min_max_aggregates_1
+                               Index Cond: (e IS NOT NULL)
+   ->  Seq Scan on min_max_aggregates
+         Filter: (e = $1)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+  b  |  e  
+-----+-----
+ 500 | 160
+(1 row)
+
+-- Test min/max optimization when used in CTE producer
+explain (costs off) with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.d
+                 ->  Index Only Scan Backward using index_d on min_max_aggregates
+                       Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
+ min_d 
+-------
+     0
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+ min 
+-----
+   0
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer. Optimization isn't
+-- applicable for this case, because the subquery projects 'col_d' as 'd/2'
+-- upon which the min is computed, but none of the indices store values
+-- of column 'd/2' so that IndexScan could be used on that index
+explain (costs off) with cte_consumer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Test min/max optimization when the result is casted to a different
+-- data type. Adding this test as a part of query's pattern matches the
+-- transforms pattern and is expected to leverage min/max optimization
+-- feature
+explain (costs off) select min(e)::int from min_max_aggregates;
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(e)::int from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
+
 -- Case with more than one min/max aggregate functions. These cases aren't
--- supported in ORCA as that would be over optimization and not supported
--- unless customer requests for it.
+-- supported in ORCA as that would be unnecessary and complex optimization
+-- which is not worth the effort, unless some customer explicitly requests
+-- for it
 explain(costs off) select min(a), max(d) from min_max_aggregates;
                                           QUERY PLAN
 ----------------------------------------------------------------------------------------------
@@ -3892,9 +3791,9 @@ explain(costs off) select min(a), max(d) from min_max_aggregates;
 (14 rows)
 
 select min(a), max(d) from min_max_aggregates;
- min |        max        
------+-------------------
-   1 | 32.25806451612903
+ min | max 
+-----+-----
+   1 |  32
 (1 row)
 
 explain(costs off) select min(a) + max(d) from min_max_aggregates;
@@ -3917,293 +3816,380 @@ explain(costs off) select min(a) + max(d) from min_max_aggregates;
 (14 rows)
 
 select min(a) + max(d) from min_max_aggregates;
-     ?column?      
--------------------
- 33.25806451612903
-(1 row)
-
--- Case with no aggregate function and empty group by. This test's
--- pattern matches xform's pattern and it is included to ensure if
--- xform correctly filters this case out and doesn't apply
--- transformation to it.
-explain(costs off) select 3 from min_max_aggregates group by ();
-            QUERY PLAN
------------------------------------
- Result
- Optimizer: Postgres-based planner
-(2 rows)
-
-select 3 from min_max_aggregates group by ();
  ?column? 
 ----------
-        3
+       33
 (1 row)
 
 -- Clean Up
 drop table min_max_aggregates;
+-- Test min/max optimization in union all, joins and outer references
+CREATE TABLE table1 (a int, b text, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b text, c int);
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
+INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization used as part of projected column in a
+-- subquery along with a predicate. This query could not use optimization
+-- as subquery has a predicate and the query pattern doesn't match
+-- the transform's pattern
+explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as min_a from table2;
+                       QUERY PLAN
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Finalize Aggregate
+           ->  Gather Motion 3:1  (slice3; segments: 3)
+                 ->  Partial Aggregate
+                       ->  Seq Scan on table1
+                             Filter: (a > 5)
+   ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(9 rows)
+
+explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_a from table2;
+                                 QUERY PLAN
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on table2
+         SubPlan 1
+           ->  Aggregate
+                 ->  Result
+                       Filter: (table1.b = table2.b)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Seq Scan on table1
+ Optimizer: Postgres-based planner
+(10 rows)
+
+-- Test min/max optimization on result of union all present as part of
+-- subquery. This query is not supported by min/max optimization as
+-- it performs min/max on result of union all, not directly on a table's
+-- column and it doesn't match the transform's pattern.
+explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
+                                 QUERY PLAN
+-----------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: table1.c
+                 ->  Merge Append
+                       Sort Key: table1.c DESC
+                       ->  Index Only Scan Backward using t1_c_idx on table1
+                             Index Cond: (c IS NOT NULL)
+                       ->  Index Only Scan Backward using t2_c_idx on table2
+                             Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+-- Test min/max optimization on outer references. This query only uses a
+-- single aggregate function on an index column and hence generates a IndexScan
+-- alternative.
+explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min(t1.c)) as min_val_for_c from table1 t1;
+                           QUERY PLAN
+-----------------------------------------------------------------
+ Result
+   InitPlan 2 (returns $1)  (slice2)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice3; segments: 3)
+                 Merge Key: t1.c
+                 ->  Index Only Scan using t1_c_idx on table1 t1
+                       Index Cond: (c IS NOT NULL)
+   SubPlan 1
+     ->  Result
+           Filter: (t1_alias.a = $1)
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Seq Scan on table1 t1_alias
+ Optimizer: Postgres-based planner
+(14 rows)
+
+-- Test min/max optimization on outer references. This query uses more
+-- than one aggregate function, which doesn't match the transforms pattern
+-- and hence min/max optimization isn't applicable to it.
+explain (costs off) select min(t1.c) as min_c,
+                            (select b from table1 t1_alias where t1_alias.c = max(t1.c)) as b_val
+                    from table1 t1;
+                                 QUERY PLAN
+----------------------------------------------------------------------------
+ Result
+   InitPlan 2 (returns $1)  (slice2)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice3; segments: 3)
+                 Merge Key: t1.c
+                 ->  Index Only Scan using t1_c_idx on table1 t1
+                       Index Cond: (c IS NOT NULL)
+   InitPlan 3 (returns $2)  (slice4)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice5; segments: 3)
+                 Merge Key: t1_1.c
+                 ->  Index Only Scan Backward using t1_c_idx on table1 t1_1
+                       Index Cond: (c IS NOT NULL)
+   SubPlan 1
+     ->  Result
+           Filter: (t1_alias.c = $2)
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Seq Scan on table1 t1_alias
+ Optimizer: Postgres-based planner
+(20 rows)
+
+-- Test min/max optimization used as part of projected columns in join. This query
+-- could not use the optimization as it involves join result which is not
+-- guaranteed to be sorted, unless it is an NL join.
+explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(9 rows)
+
+-- Clean up
+drop table table1;
+drop table table2;
 -- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
-CREATE TABLE test_nulltype_predicates(a int, b text, c int, d float, e numeric, f int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE INDEX index_bc on test_nulltype_predicates using btree(b DESC);
-INSERT INTO test_nulltype_predicates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,3)i;
-INSERT INTO test_nulltype_predicates values(null, null, null, null, null, null);
+CREATE TABLE test_nulltype_predicates(a int, b int);
+CREATE INDEX index_b on test_nulltype_predicates using btree(b DESC);
+INSERT INTO test_nulltype_predicates select i, i*2 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates values(null, null);
 ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
--- Ensure Planner picks IndexScan wherever possible
-set enable_seqscan to off;
 explain(costs off) select * from test_nulltype_predicates where b is null;
-                         QUERY PLAN
--------------------------------------------------------------
+                 QUERY PLAN
+--------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on test_nulltype_predicates
-         Index Cond: (b IS NULL)
+   ->  Seq Scan on test_nulltype_predicates
+         Filter: (b IS NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
 select * from test_nulltype_predicates where b is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
+ a | b 
+---+---
+   |  
 (1 row)
 
-reset enable_seqscan;
 -- Tests with IS NULL on non-index columns
-explain(costs off) select * from test_nulltype_predicates where f is null;
+explain(costs off) select * from test_nulltype_predicates where a is null;
+                 QUERY PLAN
+--------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on test_nulltype_predicates
+         Filter: (a IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from test_nulltype_predicates where a is null;
+ a | b 
+---+---
+   |  
+(1 row)
+
+-- Tests with IS NOT NULL on btree index columns
+explain(costs off) select * from test_nulltype_predicates where b is not null;
                  QUERY PLAN
 --------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on test_nulltype_predicates
-         Filter: (f IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from test_nulltype_predicates where f is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
--- Tests with IS NOT NULL on btree index columns
--- Ensure Planner picks IndexScan wherever possible
-set enable_seqscan to off;
-set enable_bitmapscan to off;
-explain(costs off) select * from test_nulltype_predicates where b is not null;
-                         QUERY PLAN
--------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on test_nulltype_predicates
-         Index Cond: (b IS NOT NULL)
+         Filter: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
 select * from test_nulltype_predicates where b is not null;
- a |   b    | c |         d          |  e  | f 
----+--------+---+--------------------+-----+---
- 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
- 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
- 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+ a | b 
+---+---
+ 2 | 4
+ 3 | 6
+ 1 | 2
 (3 rows)
 
-reset enable_seqscan;
-reset enable_bitmapscan;
 -- Tests with IS NOT NULL on non-index columns
-explain(costs off) select * from test_nulltype_predicates where f is not null;
+explain(costs off) select * from test_nulltype_predicates where a is not null;
                  QUERY PLAN
 --------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on test_nulltype_predicates
-         Filter: (f IS NOT NULL)
+         Filter: (a IS NOT NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from test_nulltype_predicates where f is not null;
- a |   b    | c |         d          |  e  | f 
----+--------+---+--------------------+-----+---
- 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
- 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
- 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
+select * from test_nulltype_predicates where a is not null;
+ a | b 
+---+---
+ 2 | 4
+ 3 | 6
+ 1 | 2
 (3 rows)
 
 -- Clean Up
 drop table test_nulltype_predicates;
 -- Purpose: Test min/max optimization on AO table with mixed data type columns.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
-CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE TABLE test_ao_table(a int, b int) WITH (appendonly=true) DISTRIBUTED BY (a);
 -- multi col index with mixed index keys properties
-CREATE INDEX ao_index_cb on test_ao_table using btree(c desc, b);
-INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
+CREATE INDEX ao_index_b on test_ao_table using btree(b desc);
+INSERT INTO test_ao_table SELECT i, i+3 from generate_series(1,100) i;
 ANALYZE test_ao_table;
 -- Test max() aggregate
-explain(costs off) select max(c) from test_ao_table;
-                               QUERY PLAN
-------------------------------------------------------------------------
+explain(costs off) select max(b) from test_ao_table;
+                              QUERY PLAN
+-----------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: test_ao_table.c
-                 ->  Index Only Scan using ao_index_cb on test_ao_table
-                       Index Cond: (c IS NOT NULL)
+                 Merge Key: test_ao_table.b
+                 ->  Index Only Scan using ao_index_b on test_ao_table
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(c) from test_ao_table;
-        max        
--------------------
- 23.80952380952381
+select max(b) from test_ao_table;
+ max 
+-----
+ 103
 (1 row)
 
 -- Test min() aggregate
-explain(costs off) select min(c) from test_ao_table;
+explain(costs off) select min(b) from test_ao_table;
                                    QUERY PLAN
----------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: test_ao_table.c
-                 ->  Index Only Scan Backward using ao_index_cb on test_ao_table
-                       Index Cond: (c IS NOT NULL)
+                 Merge Key: test_ao_table.b
+                 ->  Index Only Scan Backward using ao_index_b on test_ao_table
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select min(c) from test_ao_table;
-         min         
----------------------
- 0.23809523809523808
+select min(b) from test_ao_table;
+ min 
+-----
+   4
 (1 row)
 
 -- Clean Up
 drop table test_ao_table;
 -- Purpose: Test min/max optimization on partition tables.
-CREATE TABLE test_partition_table(a int, b int, c float, d text) DISTRIBUTED BY (a) PARTITION BY range(a);
+CREATE TABLE test_partition_table(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b);
 CREATE TABLE partition1 PARTITION OF test_partition_table FOR VALUES FROM (1) TO (3);
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE partition2 PARTITION OF test_partition_table FOR VALUES FROM (3) TO (6);
 NOTICE:  table has parent, setting distribution columns to match parent table
-CREATE INDEX part_index_c on test_partition_table using btree(c desc);
-INSERT INTO test_partition_table SELECT i, i+3, i/4.2, concat('sample_text ',i) from generate_series(1,4) i;
+CREATE TABLE default_partition PARTITION OF test_partition_table DEFAULT;
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE INDEX part_index_b on test_partition_table using btree(b desc);
+INSERT INTO test_partition_table SELECT i+3, i from generate_series(1,4) i;
 -- Inserting nulls to verify results match when index key specifies nulls first or desc
-INSERT INTO test_partition_table values (5, null, null, null);
+INSERT INTO test_partition_table values (null, 5);
+-- Insert into default partition to show partition pruning
+-- for IS NULL conditions
+INSERT INTO test_partition_table values (0, NULL);
 ANALYZE test_partition_table;
--- Test max() aggregate
-explain(costs off) select max(c) from test_partition_table;
-                   QUERY PLAN
-------------------------------------------------
+-- Test min/max aggregate. This optimization isn't applicable for
+-- partition tables because query's pattern doesn't match xforms pattern.
+-- Moreover, ORCA currently, doesn't consider order property of
+-- B-tree indices for order by and limit clause on top of a partitioned
+-- table. This is because, data for non-partition order by column is spread across
+-- multiple partitions and DynamicIndexScan cannot determine the correct
+-- order of partitions to produce sorted result. For partition column(s),
+-- table could have a default partition, which contains various different
+-- unordered values.
+explain(costs off) select max(b) from test_partition_table;
+                      QUERY PLAN
+-------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
                      ->  Seq Scan on partition1
                      ->  Seq Scan on partition2
+                     ->  Seq Scan on default_partition
  Optimizer: Postgres-based planner
-(7 rows)
+(8 rows)
 
-select max(c) from test_partition_table;
-        max         
---------------------
- 0.9523809523809523
+select max(b) from test_partition_table;
+ max 
+-----
+   5
 (1 row)
 
 -- Test min() aggregate
-explain(costs off) select min(c) from test_partition_table;
-                   QUERY PLAN
-------------------------------------------------
+explain(costs off) select min(b) from test_partition_table;
+                      QUERY PLAN
+-------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
                      ->  Seq Scan on partition1
                      ->  Seq Scan on partition2
+                     ->  Seq Scan on default_partition
  Optimizer: Postgres-based planner
-(7 rows)
+(8 rows)
 
-select min(c) from test_partition_table;
-         min         
----------------------
- 0.23809523809523808
+select min(b) from test_partition_table;
+ min 
+-----
+   1
 (1 row)
 
 -- Test IS NULL, IS NOT NULL on partition table btree index column
-explain(costs off) select * from test_partition_table where c is null;
+-- For, IS NULL predicate on partition column, pruning happens
+-- whereas, for predicates on non-partition column, that doesn't, because
+-- non-partition column's values distribution is unknown to eliminate
+-- any partitions.
+explain(costs off) select * from test_partition_table where b is null;
                 QUERY PLAN
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on partition1
-               Filter: (c IS NULL)
-         ->  Seq Scan on partition2
-               Filter: (c IS NULL)
+   ->  Seq Scan on default_partition
+         Filter: (b IS NULL)
  Optimizer: Postgres-based planner
-(7 rows)
-
-select * from test_partition_table where c is null;
- a | b | c | d 
----+---+---+---
- 5 |   |   | 
-(1 row)
-
-explain(costs off) select * from test_partition_table where c is not null;
-                QUERY PLAN
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on partition1
-               Filter: (c IS NOT NULL)
-         ->  Seq Scan on partition2
-               Filter: (c IS NOT NULL)
- Optimizer: Postgres-based planner
-(7 rows)
-
-select * from test_partition_table where c is not null;
- a | b |          c          |       d       
----+---+---------------------+---------------
- 2 | 5 | 0.47619047619047616 | sample_text 2
- 3 | 6 |  0.7142857142857143 | sample_text 3
- 4 | 7 |  0.9523809523809523 | sample_text 4
- 1 | 4 | 0.23809523809523808 | sample_text 1
 (4 rows)
 
--- Test IS NULL, IS NOT NULL on partition table non-index column
-explain(costs off) select * from test_partition_table where d is null;
-                QUERY PLAN
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on partition1
-               Filter: (d IS NULL)
-         ->  Seq Scan on partition2
-               Filter: (d IS NULL)
- Optimizer: Postgres-based planner
-(7 rows)
-
-select * from test_partition_table where d is null;
- a | b | c | d 
----+---+---+---
- 5 |   |   | 
+select * from test_partition_table where b is null;
+ a | b 
+---+---
+ 0 |  
 (1 row)
 
-explain(costs off) select * from test_partition_table where d is not null;
+explain(costs off) select * from test_partition_table where b is not null;
                 QUERY PLAN
-------------------------------------------
+-------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Seq Scan on partition1
-               Filter: (d IS NOT NULL)
+               Filter: (b IS NOT NULL)
          ->  Seq Scan on partition2
-               Filter: (d IS NOT NULL)
+               Filter: (b IS NOT NULL)
+         ->  Seq Scan on default_partition
+               Filter: (b IS NOT NULL)
  Optimizer: Postgres-based planner
-(7 rows)
+(9 rows)
 
-select * from test_partition_table where d is not null;
- a | b |          c          |       d       
----+---+---------------------+---------------
- 1 | 4 | 0.23809523809523808 | sample_text 1
- 2 | 5 | 0.47619047619047616 | sample_text 2
- 3 | 6 |  0.7142857142857143 | sample_text 3
- 4 | 7 |  0.9523809523809523 | sample_text 4
-(4 rows)
+select * from test_partition_table where b is not null;
+ a | b 
+---+---
+ 5 | 2
+ 6 | 3
+ 4 | 1
+ 7 | 4
+   | 5
+(5 rows)
 
 -- Clean Up
 drop table test_partition_table;

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -3241,3 +3241,1115 @@ explain(costs off) select a from part_table1 union all select a from part_table2
 reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
+-- Purpose: This section includes tests related to min(), max() aggregates optimization.
+CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
+CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
+ANALYZE min_max_aggregates;
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+-- Test min() and max() optimization if table doesn't have any tuples
+explain(costs off) select min(b) from min_max_aggregates;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using index_bc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(b) from min_max_aggregates;
+ min 
+-----
+ 
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates;
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan using index_bc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(b) from min_max_aggregates;
+ max 
+-----
+ 
+(1 row)
+
+INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,10000)i;
+INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
+-- Positive Tests
+-- Test optimization on index_bc
+explain(costs off) select min(b) from min_max_aggregates;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using index_bc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(b) from min_max_aggregates;
+  min   
+--------
+ col_b1
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates;
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan using index_bc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(b) from min_max_aggregates;
+    max    
+-----------
+ col_b9999
+(1 row)
+
+-- Create index_a and test optimization on its keys
+CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(a) from min_max_aggregates;
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.a
+                 ->  Index Only Scan using index_a on min_max_aggregates
+                       Index Cond: (a IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(a) from min_max_aggregates;
+ min 
+-----
+   1
+(1 row)
+
+explain(costs off) select max(a) from min_max_aggregates;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.a
+                 ->  Index Only Scan Backward using index_a on min_max_aggregates
+                       Index Cond: (a IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(a) from min_max_aggregates;
+  max  
+-------
+ 10000
+(1 row)
+
+-- Create index_d and test optimization on its keys
+CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(d) from min_max_aggregates;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.d
+                 ->  Index Only Scan Backward using index_d on min_max_aggregates
+                       Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(d) from min_max_aggregates;
+        min         
+--------------------
+ 0.3225806451612903
+(1 row)
+
+explain(costs off) select max(d) from min_max_aggregates;
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.d
+                 ->  Index Only Scan using index_d on min_max_aggregates
+                       Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(d) from min_max_aggregates;
+        max         
+--------------------
+ 3225.8064516129034
+(1 row)
+
+-- Create index_e and test optimization on its keys
+CREATE INDEX index_e on min_max_aggregates using btree(e);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(e) from min_max_aggregates;
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(e) from min_max_aggregates;
+ min 
+-----
+ 1.6
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan Backward using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(e) from min_max_aggregates;
+   max   
+---------
+ 16000.0
+(1 row)
+
+-- Test min/max with empty group by
+explain(costs off) select min(e) from min_max_aggregates group by ();
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(e) from min_max_aggregates group by ();
+ min 
+-----
+ 1.6
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates group by ();
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan Backward using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(e) from min_max_aggregates group by ();
+   max   
+---------
+ 16000.0
+(1 row)
+
+-- Negative Tests
+reset enable_seqscan;
+-- Test optimization on non index columns
+explain(costs off) select min(c) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(c) from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
+
+explain(costs off) select max(c) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(c) from min_max_aggregates;
+  max  
+-------
+ 20000
+(1 row)
+
+explain(costs off) select min(f) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(f) from min_max_aggregates;
+ min 
+-----
+   0
+(1 row)
+
+explain(costs off) select max(f) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(f) from min_max_aggregates;
+ max  
+------
+ 9999
+(1 row)
+
+-- Test min/max on a constant
+explain(costs off) select min(100) from min_max_aggregates;
+                        QUERY PLAN
+----------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 ->  Result
+                       One-Time Filter: (100 IS NOT NULL)
+                       ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(100) from min_max_aggregates;
+ min 
+-----
+ 100
+(1 row)
+
+explain(costs off) select max(100) from min_max_aggregates;
+                        QUERY PLAN
+----------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 ->  Result
+                       One-Time Filter: (100 IS NOT NULL)
+                       ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(100) from min_max_aggregates;
+ max 
+-----
+ 100
+(1 row)
+
+-- Test if optimization is applicable on other aggregates
+explain(costs off) select count(*) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select count(*) from min_max_aggregates;
+ count 
+-------
+ 10001
+(1 row)
+
+explain(costs off) select avg(e) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select avg(e) from min_max_aggregates;
+          avg          
+-----------------------
+ 8000.8000000000000000
+(1 row)
+
+explain(costs off) select sum(d) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select sum(d) from min_max_aggregates;
+        sum         
+--------------------
+ 16130645.161290325
+(1 row)
+
+-- Test min/max with group by
+explain(costs off) select min(e) from min_max_aggregates group by e;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: e
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(7 rows)
+
+explain(costs off) select max(e) from min_max_aggregates group by e;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: e
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(7 rows)
+
+-- Case with no aggregate function and empty group by
+explain(costs off) select 3 from min_max_aggregates group by ();
+            QUERY PLAN
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+select 3 from min_max_aggregates group by ();
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Case with more than one aggregate functions
+explain(costs off) select min(a), max(d) from min_max_aggregates;
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.a
+                 ->  Index Only Scan using index_a on min_max_aggregates
+                       Index Cond: (a IS NOT NULL)
+   InitPlan 2 (returns $1)  (slice3)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice4; segments: 3)
+                 Merge Key: min_max_aggregates_1.d
+                 ->  Index Only Scan using index_d on min_max_aggregates min_max_aggregates_1
+                       Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+select min(a), max(d) from min_max_aggregates;
+ min |        max         
+-----+--------------------
+   1 | 3225.8064516129034
+(1 row)
+
+-- Purpose: This section tests IS NULL predicate on btree and non-index columns
+-- Tests with IS NULL on btree index columns
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+explain(costs off) select * from min_max_aggregates where a is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Scan using index_a on min_max_aggregates
+         Index Cond: (a IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where a is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where b is null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (b IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where b is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where c is null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (c IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where c is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where d is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_d on min_max_aggregates
+         Index Cond: (d IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where d is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where e is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_e on min_max_aggregates
+         Index Cond: (e IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where e is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+reset enable_seqscan;
+-- Tests with IS NULL on non-index columns
+explain(costs off) select * from min_max_aggregates where f is null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on min_max_aggregates
+         Filter: (f IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where f is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+-- Purpose: This section tests IS NOT NULL predicate on btree and non-index columns
+-- Tests with IS NOT NULL on btree index columns
+-- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
+-- for below queries
+delete from min_max_aggregates where a<10000;
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+set enable_bitmapscan to off;
+explain(costs off) select * from min_max_aggregates where a is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_a on min_max_aggregates
+         Index Cond: (a IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where a is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where b is not null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where b is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where c is not null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where c is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where d is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_d on min_max_aggregates
+         Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where d is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where e is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_e on min_max_aggregates
+         Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where e is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+reset enable_seqscan;
+reset enable_bitmapscan;
+-- Tests with IS NOT NULL on non-index columns
+explain(costs off) select * from min_max_aggregates where f is not null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on min_max_aggregates
+         Filter: (f IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+select * from min_max_aggregates where f is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Purpose: Test min/max optimization on non-btree indices
+CREATE TABLE test_multi_index_types_table(a int, b int, c float, d text, e tsquery, f tsvector);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- create a bitmap index
+create index bitmap_a on test_multi_index_types_table using bitmap(a);
+-- create a hash index
+create index hash_b on test_multi_index_types_table using hash(b);
+-- create a brin index
+create index brin_c on test_multi_index_types_table using brin(c);
+-- create a spgist index
+create index spgist_d on test_multi_index_types_table using spgist(d);
+-- create a gin index
+create index gist_e on test_multi_index_types_table using gist(e);
+-- create a gin index
+create index gin_f on test_multi_index_types_table using gin(f);
+-- Test max optimization
+explain(costs off) select max(a) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(a) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(b) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(b) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(c) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(c) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(d) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select max(d) from test_multi_index_types_table;
+ max 
+-----
+ 
+(1 row)
+
+-- Test min optimization
+explain(costs off) select min(a) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(a) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(b) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(b) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(c) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(c) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(d) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: Postgres-based planner
+(5 rows)
+
+select min(d) from test_multi_index_types_table;
+ min 
+-----
+ 
+(1 row)
+
+-- max/min functions are not associated with complex data types
+-- of gin, gist indices.
+-- Test IS NULL, IS NOT NULL on non-btree indices
+-- Expected to use SeqScan with Filter
+explain(costs off) select * from test_multi_index_types_table where a is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (a IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where b is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (b IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where c is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (c IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where d is null;
+                       QUERY PLAN
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test_multi_index_types_table
+         Recheck Cond: (d IS NULL)
+         ->  Bitmap Index Scan on spgist_d
+               Index Cond: (d IS NULL)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+explain(costs off) select * from test_multi_index_types_table where e is null;
+                       QUERY PLAN
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test_multi_index_types_table
+         Recheck Cond: (e IS NULL)
+         ->  Bitmap Index Scan on gist_e
+               Index Cond: (e IS NULL)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+explain(costs off) select * from test_multi_index_types_table where f is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (f IS NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where a is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (a IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where b is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where c is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where d is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where e is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where f is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (f IS NOT NULL)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+-- Clean Up
+drop table test_multi_index_types_table;
+-- Purpose: Test min/max optimization on AO table with mixed data type columns.
+-- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
+CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);
+-- multi col index with mixed index keys properties
+CREATE INDEX ao_index_cb on test_ao_table using btree(c desc, b);
+INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
+ANALYZE test_ao_table;
+-- Test max() aggregate
+explain(costs off) select max(c) from test_ao_table;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: test_ao_table.c
+                 ->  Index Only Scan using ao_index_cb on test_ao_table
+                       Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(c) from test_ao_table;
+        max        
+-------------------
+ 23.80952380952381
+(1 row)
+
+-- Test min() aggregate
+explain(costs off) select min(c) from test_ao_table;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: test_ao_table.c
+                 ->  Index Only Scan Backward using ao_index_cb on test_ao_table
+                       Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(c) from test_ao_table;
+         min         
+---------------------
+ 0.23809523809523808
+(1 row)
+
+-- Clean Up
+drop table test_ao_table;
+-- Purpose: Test min/max optimization on partition tables.
+CREATE TABLE test_partition_table(a int, b int, c float, d text) DISTRIBUTED BY (a) PARTITION BY range(a);
+CREATE TABLE partition1 PARTITION OF test_partition_table FOR VALUES FROM (1) TO (3);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE partition2 PARTITION OF test_partition_table FOR VALUES FROM (3) TO (6);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE INDEX part_index_c on test_partition_table using btree(c desc);
+INSERT INTO test_partition_table SELECT i, i+3, i/4.2, concat('sample_text ',i) from generate_series(1,4) i;
+-- Inserting nulls to verify results match when index key specifies nulls first or desc
+INSERT INTO test_partition_table values (5, null, null, null);
+ANALYZE test_partition_table;
+-- Test max() aggregate
+explain(costs off) select max(c) from test_partition_table;
+                   QUERY PLAN
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on partition1
+                     ->  Seq Scan on partition2
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select max(c) from test_partition_table;
+        max         
+--------------------
+ 0.9523809523809523
+(1 row)
+
+-- Test min() aggregate
+explain(costs off) select min(c) from test_partition_table;
+                   QUERY PLAN
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on partition1
+                     ->  Seq Scan on partition2
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select min(c) from test_partition_table;
+         min         
+---------------------
+ 0.23809523809523808
+(1 row)
+
+-- Test IS NULL, IS NOT NULL on partition table btree index column
+explain(costs off) select * from test_partition_table where c is null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on partition1
+               Filter: (c IS NULL)
+         ->  Seq Scan on partition2
+               Filter: (c IS NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select * from test_partition_table where c is null;
+ a | b | c | d 
+---+---+---+---
+ 5 |   |   | 
+(1 row)
+
+explain(costs off) select * from test_partition_table where c is not null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on partition1
+               Filter: (c IS NOT NULL)
+         ->  Seq Scan on partition2
+               Filter: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select * from test_partition_table where c is not null;
+ a | b |          c          |       d       
+---+---+---------------------+---------------
+ 2 | 5 | 0.47619047619047616 | sample_text 2
+ 3 | 6 |  0.7142857142857143 | sample_text 3
+ 4 | 7 |  0.9523809523809523 | sample_text 4
+ 1 | 4 | 0.23809523809523808 | sample_text 1
+(4 rows)
+
+-- Test IS NULL, IS NOT NULL on partition table non-index column
+explain(costs off) select * from test_partition_table where d is null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on partition1
+               Filter: (d IS NULL)
+         ->  Seq Scan on partition2
+               Filter: (d IS NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select * from test_partition_table where d is null;
+ a | b | c | d 
+---+---+---+---
+ 5 |   |   | 
+(1 row)
+
+explain(costs off) select * from test_partition_table where d is not null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on partition1
+               Filter: (d IS NOT NULL)
+         ->  Seq Scan on partition2
+               Filter: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+select * from test_partition_table where d is not null;
+ a | b |          c          |       d       
+---+---+---------------------+---------------
+ 1 | 4 | 0.23809523809523808 | sample_text 1
+ 2 | 5 | 0.47619047619047616 | sample_text 2
+ 3 | 6 |  0.7142857142857143 | sample_text 3
+ 4 | 7 |  0.9523809523809523 | sample_text 4
+(4 rows)
+
+-- Clean Up
+drop table test_partition_table;

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -3245,9 +3245,11 @@ DROP TABLE part_table2;
 CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
 CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Ensure Planner picks IndexScan wherever possible
+-- Ensure Planner picks IndexOnlyScan wherever possible
 set enable_seqscan to off;
 -- Test min() and max() optimization if table doesn't have any tuples
+-- This test is added to ensure min/max functions return 1 NULL row
+-- indicating no min or max value exists as table doesn't have any tuples.
 explain(costs off) select min(b) from min_max_aggregates;
                                     QUERY PLAN
 -----------------------------------------------------------------------------------
@@ -3289,7 +3291,7 @@ select max(b) from min_max_aggregates;
 INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
 -- Positive Tests
--- Test optimization on index_bc
+-- Test optimization on multi-key index
 explain(costs off) select min(b) from min_max_aggregates;
                                     QUERY PLAN
 -----------------------------------------------------------------------------------
@@ -3328,7 +3330,8 @@ select max(b) from min_max_aggregates;
  col_b99
 (1 row)
 
--- Create index_a and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction
+-- ASC NULLS FIRST
 CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(a) from min_max_aggregates;
@@ -3369,7 +3372,8 @@ select max(a) from min_max_aggregates;
  100
 (1 row)
 
--- Create index_d and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction
+-- DESC NULLS LAST
 CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(d) from min_max_aggregates;
@@ -3410,7 +3414,7 @@ select max(d) from min_max_aggregates;
  32.25806451612903
 (1 row)
 
--- Create index_e and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction ASC
 CREATE INDEX index_e on min_max_aggregates using btree(e);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(e) from min_max_aggregates;
@@ -3451,7 +3455,7 @@ select max(e) from min_max_aggregates;
  160.0
 (1 row)
 
--- Test min/max with empty group by
+-- Test min/max optimization behavior with empty group by
 explain(costs off) select min(e) from min_max_aggregates group by ();
                                QUERY PLAN
 -------------------------------------------------------------------------
@@ -3490,9 +3494,250 @@ select max(e) from min_max_aggregates group by ();
  160.0
 (1 row)
 
+-- Test min/max optimization when used as part of a subquery
+explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+                                                  QUERY PLAN
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   InitPlan 2 (returns $1)  (slice2)
+     ->  Result
+           InitPlan 1 (returns $0)  (slice3)
+             ->  Limit
+                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                         Merge Key: min_max_aggregates_1.e
+                         ->  Index Only Scan Backward using index_e on min_max_aggregates min_max_aggregates_1
+                               Index Cond: (e IS NOT NULL)
+   ->  Index Scan using index_e on min_max_aggregates
+         Index Cond: (e = $1)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+    b     |   e   
+----------+-------
+ col_b100 | 160.0
+(1 row)
+
+-- Test min/max optimization when used in CTE producer
+explain (costs off) with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
+ Subquery Scan on cte_producer
+   ->  Result
+         InitPlan 1 (returns $0)  (slice1)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       Merge Key: min_max_aggregates.d
+                       ->  Index Only Scan Backward using index_d on min_max_aggregates
+                             Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+                              QUERY PLAN
+-----------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Index Only Scan using index_d on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+        min         
+--------------------
+ 0.3225806451612903
+(1 row)
+
+-- Test min/max optimization when the result is casted to a compatible
+-- data type
+explain (costs off) select min(e)::int from min_max_aggregates;
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.e
+                 ->  Index Only Scan using index_e on min_max_aggregates
+                       Index Cond: (e IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(e)::int from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
+
+-- Test min/max optimization in union all and joins
+CREATE TABLE table1 (a int, b text, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b text, c int);
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
+INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization with union all
+explain (costs off) select min(c) from table1 union all select max(c) from table2;
+                                 QUERY PLAN
+-----------------------------------------------------------------------------
+ Append
+   ->  Result
+         InitPlan 1 (returns $0)  (slice1)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       Merge Key: table1.c
+                       ->  Index Only Scan using t1_c_idx on table1
+                             Index Cond: (c IS NOT NULL)
+   ->  Result
+         InitPlan 2 (returns $1)  (slice3)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice4; segments: 3)
+                       Merge Key: table2.c
+                       ->  Index Only Scan Backward using t2_c_idx on table2
+                             Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(16 rows)
+
+select min(c) from table1 union all select max(c) from table2;
+ min 
+-----
+  -1
+  98
+(2 rows)
+
+-- Test min/max optimization when used as part of predicate subquery
+-- for join
+explain (costs off) select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
+                       QUERY PLAN
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Finalize Aggregate
+           ->  Gather Motion 3:1  (slice3; segments: 3)
+                 ->  Partial Aggregate
+                       ->  Seq Scan on table2 table2_1
+   ->  Hash Join
+         Hash Cond: (table1.a = table2.a)
+         ->  Index Scan using t1_c_idx on table1
+               Index Cond: (c > $0)
+         ->  Hash
+               ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(13 rows)
+
+select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
+ b | c 
+---+---
+(0 rows)
+
 -- Negative Tests
 reset enable_seqscan;
--- Test optimization on non index columns
+-- Test min/max optimization on result of union all present as part of subquery.
+-- This query is not supported by min/max optimization because for this to
+-- be supported ORCA needs support of MergeAppend node which could Merge result
+-- of two table's Index Scans in the sorted order and limit can be applied on top
+-- of it.
+explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
+                                 QUERY PLAN
+-----------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: table1.c
+                 ->  Merge Append
+                       Sort Key: table1.c DESC
+                       ->  Index Only Scan Backward using t1_c_idx on table1
+                             Index Cond: (c IS NOT NULL)
+                       ->  Index Only Scan Backward using t2_c_idx on table2
+                             Index Cond: (c IS NOT NULL)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select max(c) from (select c from table1 union all select c from table2) subquery;
+ max 
+-----
+  98
+(1 row)
+
+-- Test min/max optimization used as part of projected columns in join. This query
+-- could not use the optimization as it involves join result which is not
+-- guaranteed to be sorted, unless it is an NL join. Even for NL joins this
+-- optimization isn't supported currently as it isn't in scope of story.
+explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(9 rows)
+
+select min(table1.a) from table1 join table2 on table1.a=table2.a;
+ min 
+-----
+   1
+(1 row)
+
+-- Test min/max optimization on columns from join result. This isn't
+-- supported for the same reason as above: join result is not guaranteed
+-- to be sorted.
+explain (costs off) select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(9 rows)
+
+select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
+ min 
+-----
+  -1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+         min         
+---------------------
+ 0.16129032258064516
+(1 row)
+
+-- Clean up
+drop table table1;
+drop table table2;
+-- Test optimization on non index columns. These tests use SeqScan
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3557,7 +3802,8 @@ select max(f) from min_max_aggregates;
   99
 (1 row)
 
--- Test min/max on a constant
+-- Test min/max on a constant. Aggregates optimization isn't necessary
+-- for min/max on constants
 explain(costs off) select min(100) from min_max_aggregates;
                         QUERY PLAN
 ----------------------------------------------------------
@@ -3596,56 +3842,9 @@ select max(100) from min_max_aggregates;
  100
 (1 row)
 
--- Test if optimization is applicable on other aggregates
-explain(costs off) select count(*) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-select count(*) from min_max_aggregates;
- count 
--------
-   101
-(1 row)
-
-explain(costs off) select avg(e) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-select avg(e) from min_max_aggregates;
-         avg         
----------------------
- 80.8000000000000000
-(1 row)
-
-explain(costs off) select sum(d) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-select sum(d) from min_max_aggregates;
-        sum        
--------------------
- 1629.032258064516
-(1 row)
-
--- Test min/max with group by
+-- Test min/max with group by. This test's pattern matches xform's
+-- pattern and it is included to ensure if xform correctly filters
+-- this case out and doesn't apply transformation to it.
 explain(costs off) select min(e) from min_max_aggregates group by e;
                          QUERY PLAN
 ------------------------------------------------------------
@@ -3670,21 +3869,9 @@ explain(costs off) select max(e) from min_max_aggregates group by e;
  Optimizer: Postgres-based planner
 (7 rows)
 
--- Case with no aggregate function and empty group by
-explain(costs off) select 3 from min_max_aggregates group by ();
-            QUERY PLAN
------------------------------------
- Result
- Optimizer: Postgres-based planner
-(2 rows)
-
-select 3 from min_max_aggregates group by ();
- ?column? 
-----------
-        3
-(1 row)
-
--- Case with more than one aggregate functions
+-- Case with more than one min/max aggregate functions. These cases aren't
+-- supported in ORCA as that would be over optimization and not supported
+-- unless customer requests for it.
 explain(costs off) select min(a), max(d) from min_max_aggregates;
                                           QUERY PLAN
 ----------------------------------------------------------------------------------------------
@@ -3710,80 +3897,71 @@ select min(a), max(d) from min_max_aggregates;
    1 | 32.25806451612903
 (1 row)
 
--- Purpose: This section tests IS NULL predicate on btree and non-index columns
+explain(costs off) select min(a) + max(d) from min_max_aggregates;
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.a
+                 ->  Index Only Scan using index_a on min_max_aggregates
+                       Index Cond: (a IS NOT NULL)
+   InitPlan 2 (returns $1)  (slice3)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice4; segments: 3)
+                 Merge Key: min_max_aggregates_1.d
+                 ->  Index Only Scan using index_d on min_max_aggregates min_max_aggregates_1
+                       Index Cond: (d IS NOT NULL)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+select min(a) + max(d) from min_max_aggregates;
+     ?column?      
+-------------------
+ 33.25806451612903
+(1 row)
+
+-- Case with no aggregate function and empty group by. This test's
+-- pattern matches xform's pattern and it is included to ensure if
+-- xform correctly filters this case out and doesn't apply
+-- transformation to it.
+explain(costs off) select 3 from min_max_aggregates group by ();
+            QUERY PLAN
+-----------------------------------
+ Result
+ Optimizer: Postgres-based planner
+(2 rows)
+
+select 3 from min_max_aggregates group by ();
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
+CREATE TABLE test_nulltype_predicates(a int, b text, c int, d float, e numeric, f int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX index_bc on test_nulltype_predicates using btree(b DESC);
+INSERT INTO test_nulltype_predicates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates values(null, null, null, null, null, null);
+ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
-explain(costs off) select * from min_max_aggregates where a is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Index Scan using index_a on min_max_aggregates
-         Index Cond: (a IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where a is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where b is null;
-                      QUERY PLAN
--------------------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where b is null;
+                         QUERY PLAN
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
+   ->  Index Scan using index_bc on test_nulltype_predicates
          Index Cond: (b IS NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from min_max_aggregates where b is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where c is null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
-         Index Cond: (c IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where c is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where d is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_d on min_max_aggregates
-         Index Cond: (d IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where d is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where e is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_e on min_max_aggregates
-         Index Cond: (e IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where e is null;
+select * from test_nulltype_predicates where b is null;
  a | b | c | d | e | f 
 ---+---+---+---+---+---
    |   |   |   |   |  
@@ -3791,388 +3969,64 @@ select * from min_max_aggregates where e is null;
 
 reset enable_seqscan;
 -- Tests with IS NULL on non-index columns
-explain(costs off) select * from min_max_aggregates where f is null;
-                QUERY PLAN
-------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where f is null;
+                 QUERY PLAN
+--------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on min_max_aggregates
+   ->  Seq Scan on test_nulltype_predicates
          Filter: (f IS NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from min_max_aggregates where f is null;
+select * from test_nulltype_predicates where f is null;
  a | b | c | d | e | f 
 ---+---+---+---+---+---
    |   |   |   |   |  
 (1 row)
 
--- Purpose: This section tests IS NOT NULL predicate on btree and non-index columns
 -- Tests with IS NOT NULL on btree index columns
--- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
--- for below queries
-delete from min_max_aggregates where a<100;
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
 set enable_bitmapscan to off;
-explain(costs off) select * from min_max_aggregates where a is not null;
-                      QUERY PLAN
-------------------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where b is not null;
+                         QUERY PLAN
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_a on min_max_aggregates
-         Index Cond: (a IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where a is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where b is not null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
+   ->  Index Scan using index_bc on test_nulltype_predicates
          Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from min_max_aggregates where b is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where c is not null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
-         Index Cond: (c IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where c is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where d is not null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_d on min_max_aggregates
-         Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where d is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where e is not null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_e on min_max_aggregates
-         Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-select * from min_max_aggregates where e is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
+select * from test_nulltype_predicates where b is not null;
+ a |   b    | c |         d          |  e  | f 
+---+--------+---+--------------------+-----+---
+ 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
+ 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
+ 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+(3 rows)
 
 reset enable_seqscan;
 reset enable_bitmapscan;
 -- Tests with IS NOT NULL on non-index columns
-explain(costs off) select * from min_max_aggregates where f is not null;
-                QUERY PLAN
-------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where f is not null;
+                 QUERY PLAN
+--------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on min_max_aggregates
+   ->  Seq Scan on test_nulltype_predicates
          Filter: (f IS NOT NULL)
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from min_max_aggregates where f is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
+select * from test_nulltype_predicates where f is not null;
+ a |   b    | c |         d          |  e  | f 
+---+--------+---+--------------------+-----+---
+ 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
+ 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+ 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
+(3 rows)
 
 -- Clean Up
-drop table min_max_aggregates;
--- Purpose: Test min/max optimization on non-btree indices
-CREATE TABLE test_multi_index_types_table(a int, b int, c float, d text, e tsquery, f tsvector);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
--- create a bitmap index
-create index bitmap_a on test_multi_index_types_table using bitmap(a);
--- create a hash index
-create index hash_b on test_multi_index_types_table using hash(b);
--- create a brin index
-create index brin_c on test_multi_index_types_table using brin(c);
--- create a spgist index
-create index spgist_d on test_multi_index_types_table using spgist(d);
--- create a gin index
-create index gist_e on test_multi_index_types_table using gist(e);
--- create a gin index
-create index gin_f on test_multi_index_types_table using gin(f);
--- Test max optimization
-explain(costs off) select max(a) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select max(a) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(b) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select max(b) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(c) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select max(c) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(d) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select max(d) from test_multi_index_types_table;
- max 
------
- 
-(1 row)
-
--- Test min optimization
-explain(costs off) select min(a) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select min(a) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(b) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select min(b) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(c) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select min(c) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(d) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: Postgres-based planner
-(5 rows)
-
-select min(d) from test_multi_index_types_table;
- min 
------
- 
-(1 row)
-
--- max/min functions are not associated with complex data types
--- of gin, gist indices.
--- Test IS NULL, IS NOT NULL on non-btree indices
--- Expected to use SeqScan with Filter
-explain(costs off) select * from test_multi_index_types_table where a is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (a IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where b is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (b IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where c is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (c IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where d is null;
-                       QUERY PLAN
---------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on test_multi_index_types_table
-         Recheck Cond: (d IS NULL)
-         ->  Bitmap Index Scan on spgist_d
-               Index Cond: (d IS NULL)
- Optimizer: Postgres-based planner
-(6 rows)
-
-explain(costs off) select * from test_multi_index_types_table where e is null;
-                       QUERY PLAN
---------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on test_multi_index_types_table
-         Recheck Cond: (e IS NULL)
-         ->  Bitmap Index Scan on gist_e
-               Index Cond: (e IS NULL)
- Optimizer: Postgres-based planner
-(6 rows)
-
-explain(costs off) select * from test_multi_index_types_table where f is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (f IS NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where a is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (a IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where b is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (b IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where c is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (c IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where d is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where e is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where f is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (f IS NOT NULL)
- Optimizer: Postgres-based planner
-(4 rows)
-
--- Clean Up
-drop table test_multi_index_types_table;
+drop table test_nulltype_predicates;
 -- Purpose: Test min/max optimization on AO table with mixed data type columns.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
 CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -3242,12 +3242,12 @@ reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
 -- Purpose: This section includes tests related to min(), max() aggregates optimization.
-CREATE TABLE min_max_aggregates(a int, b int, c int, d int, e int, f int);
-CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
+CREATE TABLE min_max_aggregates(a int, b int, c int);
+CREATE INDEX multi_key_index_b_c on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Test min() and max() optimization if table doesn't have any tuples
--- This test is added to ensure min/max functions return 1 NULL row
--- indicating no min or max value exists as table doesn't have any tuples.
+-- Testing min/max functions when table doesn't have any tuples to
+-- ensure they return 1 NULL row indicating no min or max value exists.
+-- This test is eligible for optimization.
 explain(costs off) select min(b) from min_max_aggregates;
                    QUERY PLAN
 ------------------------------------------------
@@ -3278,219 +3278,112 @@ select max(b) from min_max_aggregates;
     
 (1 row)
 
-INSERT INTO min_max_aggregates select i, i*5, i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
-INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
--- Test optimization when there are multiple indices whose leading
--- index key matches aggregate column. This test shows that both
--- 'index_bc' created above and 'index_b' are eligible for the xform
--- and ORCA picks the lower cost index, which is 'index_b' in this
--- scenario
-CREATE INDEX index_b on min_max_aggregates using btree(b DESC);
+INSERT INTO min_max_aggregates select i, i, i from generate_series(1,100)i;
+INSERT INTO min_max_aggregates values(null, null, null);
+-- Creating this index to show that both 'multi_key_index_b_c' and
+-- 'single_key_b_desc' are eligible for min/max on column 'b' and
+-- ORCA picks the lower cost index
+CREATE INDEX single_key_b_desc on min_max_aggregates using btree(b DESC);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as indices: 'index_bc', 'index_b',
--- both featuring column 'b' as leading key
--- This query leverages Backward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, minimum value can be found at
+-- the bottom of the index
 explain(costs off) select min(b) from min_max_aggregates;
-                                    QUERY PLAN
-----------------------------------------------------------------------------------
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
                  Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan Backward using index_b on min_max_aggregates
+                 ->  Index Only Scan Backward using single_key_b_desc on min_max_aggregates
                        Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
 select min(b) from min_max_aggregates;
- min 
------
-   5
-(1 row)
-
--- This query leverages Forward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, maximum value can be found
--- at the top of the index
-explain(costs off) select max(b) from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.b
-                 ->  Index Only Scan using index_b on min_max_aggregates
-                       Index Cond: (b IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select max(b) from min_max_aggregates;
- max 
------
- 500
-(1 row)
-
--- Test min/max optimization behavior on index with key direction
--- ASC NULLS FIRST. Utilizing an index with "NULLS FIRST" to ensure
--- that during a Forward IndexScan, NULL values at the beginning
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_a'
--- features column 'a' as leading key
--- This query leverages Forward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(a) from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.a
-                 ->  Index Only Scan using index_a on min_max_aggregates
-                       Index Cond: (a IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(a) from min_max_aggregates;
  min 
 -----
    1
 (1 row)
 
--- This query leverages Backward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, maximum value can be found
--- at the bottom of the index
-explain(costs off) select max(a) from min_max_aggregates;
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, maximum value can be found
+-- at the top of the index
+explain(costs off) select max(b) from min_max_aggregates;
                                     QUERY PLAN
-----------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.a
-                 ->  Index Only Scan Backward using index_a on min_max_aggregates
-                       Index Cond: (a IS NOT NULL)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan using single_key_b_desc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(a) from min_max_aggregates;
+select max(b) from min_max_aggregates;
  max 
 -----
  100
 (1 row)
 
--- Test min/max optimization behavior on index with key direction
--- DESC NULLS LAST. Utilizing an index with "NULLS LAST" to ensure
--- that during a Backward IndexScan, NULL values at the end
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_d'
--- features column 'd' as leading key
--- This query leverages Backward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
-explain(costs off) select min(d) from min_max_aggregates;
-                                    QUERY PLAN
-----------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.d
-                 ->  Index Only Scan Backward using index_d on min_max_aggregates
-                       Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(d) from min_max_aggregates;
- min 
------
-   0
-(1 row)
-
--- This query leverages Forward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, maximum value can be found
--- at the top of the index
-explain(costs off) select max(d) from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.d
-                 ->  Index Only Scan using index_d on min_max_aggregates
-                       Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select max(d) from min_max_aggregates;
- max 
------
-  32
-(1 row)
-
+DROP INDEX single_key_b_desc;
 -- Test min/max optimization behavior on index with key direction ASC
-CREATE INDEX index_e on min_max_aggregates using btree(e);
+CREATE INDEX single_key_b_asc on min_max_aggregates using btree(b);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_e'
--- features column 'e' as leading key
--- This query leverages Forward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(e) from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(e) from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- This query leverages Backward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, maximum value can be found
--- at the bottom of the index
-explain(costs off) select max(e) from min_max_aggregates;
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, minimum value can be found at the
+-- top of the index
+explain(costs off) select min(b) from min_max_aggregates;
                                     QUERY PLAN
 ----------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan Backward using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan using single_key_b_asc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(e) from min_max_aggregates;
- max 
+select min(b) from min_max_aggregates;
+ min 
 -----
- 160
+   1
 (1 row)
 
--- Test optimization on non-leading keys in the index. These
--- tests aren't eligible for IndexScan as the aggregate column
--- isn't a leading key in the index
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, maximum value can be found
+-- at the bottom of the index
+explain(costs off) select max(b) from min_max_aggregates;
+                                        QUERY PLAN
+-------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using single_key_b_asc on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(b) from min_max_aggregates;
+ max 
+-----
+ 100
+(1 row)
+
+DROP INDEX single_key_b_asc;
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non-leading keys in the index.
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3500,12 +3393,6 @@ explain(costs off) select min(c) from min_max_aggregates;
                ->  Seq Scan on min_max_aggregates
  Optimizer: Postgres-based planner
 (5 rows)
-
-select min(c) from min_max_aggregates;
- min 
------
-   2
-(1 row)
 
 explain(costs off) select max(c) from min_max_aggregates;
                     QUERY PLAN
@@ -3517,16 +3404,9 @@ explain(costs off) select max(c) from min_max_aggregates;
  Optimizer: Postgres-based planner
 (5 rows)
 
-select max(c) from min_max_aggregates;
- max 
------
- 200
-(1 row)
-
--- Test optimization on non index columns. These tests aren't
--- eligible for IndexScan as there is no index on the aggregate
--- column 'f'
-explain(costs off) select min(f) from min_max_aggregates;
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non index column.
+explain(costs off) select min(a) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
  Finalize Aggregate
@@ -3536,13 +3416,7 @@ explain(costs off) select min(f) from min_max_aggregates;
  Optimizer: Postgres-based planner
 (5 rows)
 
-select min(f) from min_max_aggregates;
- min 
------
-   0
-(1 row)
-
-explain(costs off) select max(f) from min_max_aggregates;
+explain(costs off) select max(a) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
  Finalize Aggregate
@@ -3552,14 +3426,8 @@ explain(costs off) select max(f) from min_max_aggregates;
  Optimizer: Postgres-based planner
 (5 rows)
 
-select max(f) from min_max_aggregates;
- max 
------
-  99
-(1 row)
-
--- Test min/max on a constant. Aggregates optimization isn't necessary
--- for min/max on constants
+-- Test min/max on a constant. This query is not eligible for
+-- optimization as it is not necessary for min/max on constants
 explain(costs off) select min(100) from min_max_aggregates;
                         QUERY PLAN
 ----------------------------------------------------------
@@ -3572,12 +3440,6 @@ explain(costs off) select min(100) from min_max_aggregates;
                        ->  Seq Scan on min_max_aggregates
  Optimizer: Postgres-based planner
 (8 rows)
-
-select min(100) from min_max_aggregates;
- min 
------
- 100
-(1 row)
 
 explain(costs off) select max(100) from min_max_aggregates;
                         QUERY PLAN
@@ -3592,265 +3454,280 @@ explain(costs off) select max(100) from min_max_aggregates;
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(100) from min_max_aggregates;
+-- Test min/max optimization behavior with empty group by. This query
+-- is eligible for optimization as it doesn't specify any grouping columns
+explain(costs off) select min(b) from min_max_aggregates group by ();
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using multi_key_index_b_c on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select min(b) from min_max_aggregates group by ();
+ min 
+-----
+   1
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates group by ();
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan using multi_key_index_b_c on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select max(b) from min_max_aggregates group by ();
  max 
 -----
  100
 (1 row)
 
--- Test min/max optimization behavior with empty group by. Adding
--- this test as this query's pattern matches the transforms pattern
--- and is expected to leverage min/max optimization feature as
--- the query has no group by columns.
-explain(costs off) select min(e) from min_max_aggregates group by ();
-                               QUERY PLAN
--------------------------------------------------------------------------
+-- Test min/max with non-empty group by. This query is not eligible for
+-- optimization as it has grouping columns. This check is made while
+-- computing xform promise by validating size of grouping columns and
+-- there by avoiding application of transform
+explain(costs off) select min(b) from min_max_aggregates group by b;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: b
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(7 rows)
+
+explain(costs off) select max(b) from min_max_aggregates group by b;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: b
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(7 rows)
+
+-- Test min/max optimization with CTE
+-- Test min/max optimization when used in CTE producer. This query is
+-- eligible for optimization as producer computes min aggregate on a
+-- btree index key
+explain (costs off) with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using multi_key_index_b_c on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select min(e) from min_max_aggregates group by ();
+with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
+ min_b 
+-------
+     1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer. This query is
+-- eligible for optimization as CTE consumer computes min aggregate on a
+-- btree index key projected by CTE producer
+explain (costs off) with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
  min 
 -----
-   2
+   1
 (1 row)
 
-explain(costs off) select max(e) from min_max_aggregates group by ();
-                                    QUERY PLAN
-----------------------------------------------------------------------------------
+-- Test min/max optimization when used in CTE consumer. This query is not
+-- eligible for optimization, because the subquery projects 'col_b' as 'b/2'
+-- upon which the min is computed, but none of the indices store values
+-- of column 'b/2' so that IndexScan could be used on that index
+explain (costs off) with cte_consumer as (select b/2 as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Test min/max optimization with Casts
+-- Case where result of min/max is casted to a different data type.
+-- This query is eligible for optimization as casting happens after
+-- aggregation.
+explain (costs off) select min(b)::int8 from min_max_aggregates;
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan Backward using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using multi_key_index_b_c on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(e) from min_max_aggregates group by ();
- max 
+select min(b)::int8 from min_max_aggregates;
+ min 
 -----
- 160
+   1
 (1 row)
 
--- Test min/max with non-empty group by. This query's pattern matches
--- xform's pattern and it is included to ensure if xform correctly filters
--- this case out. This filtering happens while computing xform promise by
--- checking size of grouping columns and there by avoiding application
--- of transform
-explain(costs off) select min(e) from min_max_aggregates group by e;
-                         QUERY PLAN
-------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
-         Group Key: e
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: e
+-- Case where min/max is computed on a column casted to a different data type.
+-- This query is eligible for optimization as column type int4 and casted
+-- type int8 belong to same opfamily
+explain (costs off) select min(b::int8) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
                ->  Seq Scan on min_max_aggregates
  Optimizer: Postgres-based planner
-(7 rows)
+(5 rows)
 
-explain(costs off) select max(e) from min_max_aggregates group by e;
-                         QUERY PLAN
-------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
-         Group Key: e
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: e
+select min(b::int8) from min_max_aggregates;
+ min 
+-----
+   1
+(1 row)
+
+-- This query is not eligible for optimization as there is no operator
+-- that handles comparison of a int4 and varchar type
+explain (costs off) select min(b::varchar) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
                ->  Seq Scan on min_max_aggregates
  Optimizer: Postgres-based planner
-(7 rows)
+(5 rows)
 
--- Test min/max optimization when used as part of a subquery
-explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------
+-- Cases with more than one min/max aggregates in query
+-- These queries aren't eligible for optimization because the transform's
+-- pattern only contains a single Scalar Project Element that matches only
+-- a single aggregate function whereas, these queries have more than one
+-- aggregate function. Support for these queries is beyond the scope of
+-- the current PR
+explain(costs off) select min(b), max(b) from min_max_aggregates;
+                                                QUERY PLAN
+----------------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: min_max_aggregates.b
+                 ->  Index Only Scan Backward using multi_key_index_b_c on min_max_aggregates
+                       Index Cond: (b IS NOT NULL)
+   InitPlan 2 (returns $1)  (slice3)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice4; segments: 3)
+                 Merge Key: min_max_aggregates_1.b
+                 ->  Index Only Scan using multi_key_index_b_c on min_max_aggregates min_max_aggregates_1
+                       Index Cond: (b IS NOT NULL)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+explain(costs off) select min(a) + max(a) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Test min/max optimization with union all, subqueries, joins and outer references
+CREATE TABLE table1 (a int, b int, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, i, i from generate_series(1,100) i;
+INSERT INTO table2 select i, i, i from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization when used in subqueries
+-- This query is eligible for optimization as subquery computes max
+-- aggregate on a btree index key
+explain (costs off) select b from table1 where c = (select max(c) from table1);
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    InitPlan 2 (returns $1)  (slice2)
      ->  Result
            InitPlan 1 (returns $0)  (slice3)
              ->  Limit
                    ->  Gather Motion 3:1  (slice4; segments: 3)
-                         Merge Key: min_max_aggregates_1.e
-                         ->  Index Only Scan Backward using index_e on min_max_aggregates min_max_aggregates_1
-                               Index Cond: (e IS NOT NULL)
-   ->  Seq Scan on min_max_aggregates
-         Filter: (e = $1)
+                         Merge Key: table1_1.c
+                         ->  Index Only Scan Backward using t1_c_idx on table1 table1_1
+                               Index Cond: (c IS NOT NULL)
+   ->  Seq Scan on table1
+         Filter: (c = $1)
  Optimizer: Postgres-based planner
 (12 rows)
 
-select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-  b  |  e  
------+-----
- 500 | 160
-(1 row)
-
--- Test min/max optimization when used in CTE producer
-explain (costs off) with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
-                                    QUERY PLAN
-----------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.d
-                 ->  Index Only Scan Backward using index_d on min_max_aggregates
-                       Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
- min_d 
--------
-     0
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
-with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
- min 
+select b from table1 where c = (select max(c) from table1);
+  b  
 -----
-   0
+ 100
 (1 row)
 
--- Test min/max optimization when used in CTE consumer. Optimization isn't
--- applicable for this case, because the subquery projects 'col_d' as 'd/2'
--- upon which the min is computed, but none of the indices store values
--- of column 'd/2' so that IndexScan could be used on that index
-explain (costs off) with cte_consumer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: Postgres-based planner
-(5 rows)
-
--- Test min/max optimization when the result is casted to a different
--- data type. Adding this test as a part of query's pattern matches the
--- transforms pattern and is expected to leverage min/max optimization
--- feature
-explain (costs off) select min(e)::int from min_max_aggregates;
-                               QUERY PLAN
--------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.e
-                 ->  Index Only Scan using index_e on min_max_aggregates
-                       Index Cond: (e IS NOT NULL)
- Optimizer: Postgres-based planner
-(8 rows)
-
-select min(e)::int from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- Case with more than one min/max aggregate functions. These cases aren't
--- supported in ORCA as that would be unnecessary and complex optimization
--- which is not worth the effort, unless some customer explicitly requests
--- for it
-explain(costs off) select min(a), max(d) from min_max_aggregates;
-                                          QUERY PLAN
-----------------------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.a
-                 ->  Index Only Scan using index_a on min_max_aggregates
-                       Index Cond: (a IS NOT NULL)
-   InitPlan 2 (returns $1)  (slice3)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice4; segments: 3)
-                 Merge Key: min_max_aggregates_1.d
-                 ->  Index Only Scan using index_d on min_max_aggregates min_max_aggregates_1
-                       Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(14 rows)
-
-select min(a), max(d) from min_max_aggregates;
- min | max 
------+-----
-   1 |  32
-(1 row)
-
-explain(costs off) select min(a) + max(d) from min_max_aggregates;
-                                          QUERY PLAN
-----------------------------------------------------------------------------------------------
- Result
-   InitPlan 1 (returns $0)  (slice1)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 Merge Key: min_max_aggregates.a
-                 ->  Index Only Scan using index_a on min_max_aggregates
-                       Index Cond: (a IS NOT NULL)
-   InitPlan 2 (returns $1)  (slice3)
-     ->  Limit
-           ->  Gather Motion 3:1  (slice4; segments: 3)
-                 Merge Key: min_max_aggregates_1.d
-                 ->  Index Only Scan using index_d on min_max_aggregates min_max_aggregates_1
-                       Index Cond: (d IS NOT NULL)
- Optimizer: Postgres-based planner
-(14 rows)
-
-select min(a) + max(d) from min_max_aggregates;
- ?column? 
-----------
-       33
-(1 row)
-
--- Clean Up
-drop table min_max_aggregates;
--- Test min/max optimization in union all, joins and outer references
-CREATE TABLE table1 (a int, b text, c int);
-CREATE INDEX t1_c_idx on table1 using btree(c);
-CREATE TABLE table2 (a int, b text, c int);
-CREATE INDEX t2_c_idx on table2 using btree(c);
-INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
-INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
-ANALYZE table1;
-ANALYZE table2;
--- Test min/max optimization used as part of projected column in a
--- subquery along with a predicate. This query could not use optimization
--- as subquery has a predicate and the query pattern doesn't match
--- the transform's pattern
-explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as min_a from table2;
-                       QUERY PLAN
---------------------------------------------------------
+-- Test min/max optimization in a subquery along with a predicate.
+-- This query isn't eligible to use optimization because predicate's
+-- pattern has a Select over LogicalGet and it doesn't match with the
+-- transform's pattern
+explain (costs off) select b, (select min(c) from table1 where table1.a > 5) as min_c from table2;
+                           QUERY PLAN
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Finalize Aggregate
-           ->  Gather Motion 3:1  (slice3; segments: 3)
-                 ->  Partial Aggregate
-                       ->  Seq Scan on table1
-                             Filter: (a > 5)
+   InitPlan 2 (returns $1)  (slice2)
+     ->  Result
+           InitPlan 1 (returns $0)  (slice3)
+             ->  Limit
+                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                         Merge Key: table1.c
+                         ->  Index Scan using t1_c_idx on table1
+                               Index Cond: (c IS NOT NULL)
+                               Filter: (a > 5)
    ->  Seq Scan on table2
  Optimizer: Postgres-based planner
-(9 rows)
+(12 rows)
 
-explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_a from table2;
+explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_c from table2;
                                  QUERY PLAN
 -----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3866,9 +3743,11 @@ explain (costs off) select b, (select min(c) from table1 where table1.b = table2
 (10 rows)
 
 -- Test min/max optimization on result of union all present as part of
--- subquery. This query is not supported by min/max optimization as
--- it performs min/max on result of union all, not directly on a table's
--- column and it doesn't match the transform's pattern.
+-- subquery. This query is not eligible to use min/max optimization as
+-- it performs min/max on result of union all, and not directly on a table's
+-- column due to which there is mismatch in query and transform's pattern.
+-- The query pattern has LogicalUnionAll as first child of GbAgg whereas
+-- transforms pattern has LogicalGet.
 explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
                                  QUERY PLAN
 -----------------------------------------------------------------------------
@@ -3886,9 +3765,9 @@ explain (costs off) select max(c) from (select c from table1 union all select c 
  Optimizer: Postgres-based planner
 (12 rows)
 
--- Test min/max optimization on outer references. This query only uses a
--- single aggregate function on an index column and hence generates a IndexScan
--- alternative.
+-- Test min/max optimization on outer references.
+-- This query is eligible to use optimization as it only has single
+-- aggregate function on an index column
 explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min(t1.c)) as min_val_for_c from table1 t1;
                            QUERY PLAN
 -----------------------------------------------------------------
@@ -3908,9 +3787,9 @@ explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min
  Optimizer: Postgres-based planner
 (14 rows)
 
--- Test min/max optimization on outer references. This query uses more
--- than one aggregate function, which doesn't match the transforms pattern
--- and hence min/max optimization isn't applicable to it.
+-- This query uses more than one aggregate function, and is not eligible
+-- to use optimization. This is because, query's pattern doesn't
+-- match the transforms pattern of a single Scalar Project Element.
 explain (costs off) select min(t1.c) as min_c,
                             (select b from table1 t1_alias where t1_alias.c = max(t1.c)) as b_val
                     from table1 t1;
@@ -3938,10 +3817,10 @@ explain (costs off) select min(t1.c) as min_c,
  Optimizer: Postgres-based planner
 (20 rows)
 
--- Test min/max optimization used as part of projected columns in join. This query
--- could not use the optimization as it involves join result which is not
--- guaranteed to be sorted, unless it is an NL join.
-explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+-- Test min/max optimization used as part of projected columns in join.
+-- This query is not eligible to use the optimization as it involves
+-- join result which is not guaranteed to be sorted, unless it is an NL join.
+explain (costs off) select min(table1.c) from table1 join table2 on table1.a=table2.a;
                       QUERY PLAN
 ------------------------------------------------------
  Finalize Aggregate
@@ -3961,7 +3840,7 @@ drop table table2;
 -- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
 CREATE TABLE test_nulltype_predicates(a int, b int);
 CREATE INDEX index_b on test_nulltype_predicates using btree(b DESC);
-INSERT INTO test_nulltype_predicates select i, i*2 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates select i, i from generate_series(1,3)i;
 INSERT INTO test_nulltype_predicates values(null, null);
 ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
@@ -3990,12 +3869,6 @@ explain(costs off) select * from test_nulltype_predicates where a is null;
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from test_nulltype_predicates where a is null;
- a | b 
----+---
-   |  
-(1 row)
-
 -- Tests with IS NOT NULL on btree index columns
 explain(costs off) select * from test_nulltype_predicates where b is not null;
                  QUERY PLAN
@@ -4009,9 +3882,9 @@ explain(costs off) select * from test_nulltype_predicates where b is not null;
 select * from test_nulltype_predicates where b is not null;
  a | b 
 ---+---
- 2 | 4
- 3 | 6
- 1 | 2
+ 2 | 2
+ 3 | 3
+ 1 | 1
 (3 rows)
 
 -- Tests with IS NOT NULL on non-index columns
@@ -4024,24 +3897,15 @@ explain(costs off) select * from test_nulltype_predicates where a is not null;
  Optimizer: Postgres-based planner
 (4 rows)
 
-select * from test_nulltype_predicates where a is not null;
- a | b 
----+---
- 2 | 4
- 3 | 6
- 1 | 2
-(3 rows)
-
 -- Clean Up
 drop table test_nulltype_predicates;
--- Purpose: Test min/max optimization on AO table with mixed data type columns.
+-- Purpose: Test min/max optimization on AO table.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
 CREATE TABLE test_ao_table(a int, b int) WITH (appendonly=true) DISTRIBUTED BY (a);
--- multi col index with mixed index keys properties
 CREATE INDEX ao_index_b on test_ao_table using btree(b desc);
-INSERT INTO test_ao_table SELECT i, i+3 from generate_series(1,100) i;
+INSERT INTO test_ao_table SELECT i, i from generate_series(1,100) i;
 ANALYZE test_ao_table;
--- Test max() aggregate
+-- Test max() aggregate. This query is eligible to use optimization
 explain(costs off) select max(b) from test_ao_table;
                               QUERY PLAN
 -----------------------------------------------------------------------
@@ -4058,10 +3922,10 @@ explain(costs off) select max(b) from test_ao_table;
 select max(b) from test_ao_table;
  max 
 -----
- 103
+ 100
 (1 row)
 
--- Test min() aggregate
+-- Test min() aggregate. This query is eligible to use optimization
 explain(costs off) select min(b) from test_ao_table;
                                    QUERY PLAN
 --------------------------------------------------------------------------------
@@ -4078,7 +3942,7 @@ explain(costs off) select min(b) from test_ao_table;
 select min(b) from test_ao_table;
  min 
 -----
-   4
+   1
 (1 row)
 
 -- Clean Up
@@ -4092,22 +3956,15 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE default_partition PARTITION OF test_partition_table DEFAULT;
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE INDEX part_index_b on test_partition_table using btree(b desc);
-INSERT INTO test_partition_table SELECT i+3, i from generate_series(1,4) i;
--- Inserting nulls to verify results match when index key specifies nulls first or desc
-INSERT INTO test_partition_table values (null, 5);
+INSERT INTO test_partition_table SELECT i, i from generate_series(1,4) i;
 -- Insert into default partition to show partition pruning
 -- for IS NULL conditions
 INSERT INTO test_partition_table values (0, NULL);
 ANALYZE test_partition_table;
--- Test min/max aggregate. This optimization isn't applicable for
--- partition tables because query's pattern doesn't match xforms pattern.
--- Moreover, ORCA currently, doesn't consider order property of
--- B-tree indices for order by and limit clause on top of a partitioned
--- table. This is because, data for non-partition order by column is spread across
--- multiple partitions and DynamicIndexScan cannot determine the correct
--- order of partitions to produce sorted result. For partition column(s),
--- table could have a default partition, which contains various different
--- unordered values.
+-- Test min/max aggregate on partition tables. This query is not
+-- eligible for optimization because the query's pattern has LogicalDynamicGet
+-- as first child of LogicalGbAgg whereas transform's pattern has LogicalGet.
+-- Support for these queries is beyond the scope of the current PR.
 explain(costs off) select max(b) from test_partition_table;
                       QUERY PLAN
 -------------------------------------------------------
@@ -4121,13 +3978,6 @@ explain(costs off) select max(b) from test_partition_table;
  Optimizer: Postgres-based planner
 (8 rows)
 
-select max(b) from test_partition_table;
- max 
------
-   5
-(1 row)
-
--- Test min() aggregate
 explain(costs off) select min(b) from test_partition_table;
                       QUERY PLAN
 -------------------------------------------------------
@@ -4141,17 +3991,10 @@ explain(costs off) select min(b) from test_partition_table;
  Optimizer: Postgres-based planner
 (8 rows)
 
-select min(b) from test_partition_table;
- min 
------
-   1
-(1 row)
-
--- Test IS NULL, IS NOT NULL on partition table btree index column
--- For, IS NULL predicate on partition column, pruning happens
--- whereas, for predicates on non-partition column, that doesn't, because
--- non-partition column's values distribution is unknown to eliminate
--- any partitions.
+-- Test IS NULL, IS NOT NULL on partition table btree index column.
+-- For IS NULL predicate on partition column, pruning happens
+-- whereas, for IS NOT NULL it doesn't because the Non null values
+-- could be in all of the partitions
 explain(costs off) select * from test_partition_table where b is null;
                 QUERY PLAN
 ------------------------------------------
@@ -4184,12 +4027,11 @@ explain(costs off) select * from test_partition_table where b is not null;
 select * from test_partition_table where b is not null;
  a | b 
 ---+---
- 5 | 2
- 6 | 3
- 4 | 1
- 7 | 4
-   | 5
-(5 rows)
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 1 | 1
+(4 rows)
 
 -- Clean Up
 drop table test_partition_table;

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -3180,7 +3180,7 @@ select max(b) from min_max_aggregates;
  
 (1 row)
 
-INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,10000)i;
+INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
 -- Positive Tests
 -- Test optimization on index_bc
@@ -3215,9 +3215,9 @@ explain(costs off) select max(b) from min_max_aggregates;
 (7 rows)
 
 select max(b) from min_max_aggregates;
-    max    
------------
- col_b9999
+   max   
+---------
+ col_b99
 (1 row)
 
 -- Create index_a and test optimization on its keys
@@ -3256,9 +3256,9 @@ explain(costs off) select max(a) from min_max_aggregates;
 (8 rows)
 
 select max(a) from min_max_aggregates;
-  max  
--------
- 10000
+ max 
+-----
+ 100
 (1 row)
 
 -- Create index_d and test optimization on its keys
@@ -3297,9 +3297,9 @@ explain(costs off) select max(d) from min_max_aggregates;
 (8 rows)
 
 select max(d) from min_max_aggregates;
-        max         
---------------------
- 3225.8064516129034
+        max        
+-------------------
+ 32.25806451612903
 (1 row)
 
 -- Create index_e and test optimization on its keys
@@ -3338,9 +3338,9 @@ explain(costs off) select max(e) from min_max_aggregates;
 (8 rows)
 
 select max(e) from min_max_aggregates;
-   max   
----------
- 16000.0
+  max  
+-------
+ 160.0
 (1 row)
 
 -- Test min/max with empty group by
@@ -3377,9 +3377,9 @@ explain(costs off) select max(e) from min_max_aggregates group by ();
 (8 rows)
 
 select max(e) from min_max_aggregates group by ();
-   max   
----------
- 16000.0
+  max  
+-------
+ 160.0
 (1 row)
 
 -- Negative Tests
@@ -3412,9 +3412,9 @@ explain(costs off) select max(c) from min_max_aggregates;
 (5 rows)
 
 select max(c) from min_max_aggregates;
-  max  
--------
- 20000
+ max 
+-----
+ 200
 (1 row)
 
 explain(costs off) select min(f) from min_max_aggregates;
@@ -3444,9 +3444,9 @@ explain(costs off) select max(f) from min_max_aggregates;
 (5 rows)
 
 select max(f) from min_max_aggregates;
- max  
-------
- 9999
+ max 
+-----
+  99
 (1 row)
 
 -- Test min/max on a constant
@@ -3496,7 +3496,7 @@ explain(costs off) select count(*) from min_max_aggregates;
 select count(*) from min_max_aggregates;
  count 
 -------
- 10001
+   101
 (1 row)
 
 explain(costs off) select avg(e) from min_max_aggregates;
@@ -3510,9 +3510,9 @@ explain(costs off) select avg(e) from min_max_aggregates;
 (5 rows)
 
 select avg(e) from min_max_aggregates;
-          avg          
------------------------
- 8000.8000000000000000
+         avg         
+---------------------
+ 80.8000000000000000
 (1 row)
 
 explain(costs off) select sum(d) from min_max_aggregates;
@@ -3526,9 +3526,9 @@ explain(costs off) select sum(d) from min_max_aggregates;
 (5 rows)
 
 select sum(d) from min_max_aggregates;
-        sum         
---------------------
- 16130645.161290325
+        sum        
+-------------------
+ 1629.032258064516
 (1 row)
 
 -- Test min/max with group by
@@ -3585,9 +3585,9 @@ explain(costs off) select min(a), max(d) from min_max_aggregates;
 (5 rows)
 
 select min(a), max(d) from min_max_aggregates;
- min |        max         
------+--------------------
-   1 | 3225.8064516129034
+ min |        max        
+-----+-------------------
+   1 | 32.25806451612903
 (1 row)
 
 -- Purpose: This section tests IS NULL predicate on btree and non-index columns
@@ -3690,7 +3690,7 @@ select * from min_max_aggregates where f is null;
 -- Tests with IS NOT NULL on btree index columns
 -- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
 -- for below queries
-delete from min_max_aggregates where a<10000;
+delete from min_max_aggregates where a<100;
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
 set enable_bitmapscan to off;
@@ -3704,9 +3704,9 @@ explain(costs off) select * from min_max_aggregates where a is not null;
 (4 rows)
 
 select * from min_max_aggregates where a is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where b is not null;
@@ -3719,9 +3719,9 @@ explain(costs off) select * from min_max_aggregates where b is not null;
 (4 rows)
 
 select * from min_max_aggregates where b is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where c is not null;
@@ -3734,9 +3734,9 @@ explain(costs off) select * from min_max_aggregates where c is not null;
 (4 rows)
 
 select * from min_max_aggregates where c is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where d is not null;
@@ -3749,9 +3749,9 @@ explain(costs off) select * from min_max_aggregates where d is not null;
 (4 rows)
 
 select * from min_max_aggregates where d is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 explain(costs off) select * from min_max_aggregates where e is not null;
@@ -3764,9 +3764,9 @@ explain(costs off) select * from min_max_aggregates where e is not null;
 (4 rows)
 
 select * from min_max_aggregates where e is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 reset enable_seqscan;
@@ -3782,9 +3782,9 @@ explain(costs off) select * from min_max_aggregates where f is not null;
 (4 rows)
 
 select * from min_max_aggregates where f is not null;
-   a   |     b      |   c   |         d          |    e    |  f   
--------+------------+-------+--------------------+---------+------
- 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+  a  |    b     |  c  |         d         |   e   | f  
+-----+----------+-----+-------------------+-------+----
+ 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
 (1 row)
 
 -- Clean Up

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -2514,14 +2514,17 @@ explain(costs off) select c,d from test_yet_unsupported_backwrd_idxscan_cases or
 
 -- Since col a is asc in index, max(a) could use a backward index scan
 explain(costs off) select max(a) from test_yet_unsupported_backwrd_idxscan_cases;
-                                QUERY PLAN
---------------------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_yet_unsupported_backwrd_idxscan_cases
- Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: a
+               ->  Limit
+                     ->  Index Scan Backward using index_a on test_yet_unsupported_backwrd_idxscan_cases
+                           Index Cond: (a IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
 
 -- Cases with a predicate and order by (with/without limit). Order by columns commutating index column
 explain(costs off) select * from test_yet_unsupported_backwrd_idxscan_cases where a>997 order by c desc, d desc;
@@ -3134,3 +3137,1077 @@ explain(costs off) select a from part_table1 union all select a from part_table2
 reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
+-- Purpose: This section includes tests related to min(), max() aggregates optimization.
+CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
+CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
+ANALYZE min_max_aggregates;
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+-- Test min() and max() optimization if table doesn't have any tuples
+explain(costs off) select min(b) from min_max_aggregates;
+                                 QUERY PLAN
+----------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Index Scan Backward using index_bc on min_max_aggregates
+                     Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(7 rows)
+
+select min(b) from min_max_aggregates;
+ min 
+-----
+ 
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates;
+                            QUERY PLAN
+-------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Index Scan using index_bc on min_max_aggregates
+                     Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(7 rows)
+
+select max(b) from min_max_aggregates;
+ max 
+-----
+ 
+(1 row)
+
+INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,10000)i;
+INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
+-- Positive Tests
+-- Test optimization on index_bc
+explain(costs off) select min(b) from min_max_aggregates;
+                                 QUERY PLAN
+----------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Index Scan Backward using index_bc on min_max_aggregates
+                     Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(7 rows)
+
+select min(b) from min_max_aggregates;
+  min   
+--------
+ col_b1
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates;
+                            QUERY PLAN
+-------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Index Scan using index_bc on min_max_aggregates
+                     Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(7 rows)
+
+select max(b) from min_max_aggregates;
+    max    
+-----------
+ col_b9999
+(1 row)
+
+-- Create index_a and test optimization on its keys
+CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(a) from min_max_aggregates;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: a
+               ->  Limit
+                     ->  Index Scan using index_a on min_max_aggregates
+                           Index Cond: (a IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(a) from min_max_aggregates;
+ min 
+-----
+   1
+(1 row)
+
+explain(costs off) select max(a) from min_max_aggregates;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: a
+               ->  Limit
+                     ->  Index Scan Backward using index_a on min_max_aggregates
+                           Index Cond: (a IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(a) from min_max_aggregates;
+  max  
+-------
+ 10000
+(1 row)
+
+-- Create index_d and test optimization on its keys
+CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(d) from min_max_aggregates;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan Backward using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(d) from min_max_aggregates;
+        min         
+--------------------
+ 0.3225806451612903
+(1 row)
+
+explain(costs off) select max(d) from min_max_aggregates;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(d) from min_max_aggregates;
+        max         
+--------------------
+ 3225.8064516129034
+(1 row)
+
+-- Create index_e and test optimization on its keys
+CREATE INDEX index_e on min_max_aggregates using btree(e);
+ANALYZE min_max_aggregates;
+explain(costs off) select min(e) from min_max_aggregates;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(e) from min_max_aggregates;
+ min 
+-----
+ 1.6
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan Backward using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(e) from min_max_aggregates;
+   max   
+---------
+ 16000.0
+(1 row)
+
+-- Test min/max with empty group by
+explain(costs off) select min(e) from min_max_aggregates group by ();
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(e) from min_max_aggregates group by ();
+ min 
+-----
+ 1.6
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates group by ();
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan Backward using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(e) from min_max_aggregates group by ();
+   max   
+---------
+ 16000.0
+(1 row)
+
+-- Negative Tests
+reset enable_seqscan;
+-- Test optimization on non index columns
+explain(costs off) select min(c) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select min(c) from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
+
+explain(costs off) select max(c) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select max(c) from min_max_aggregates;
+  max  
+-------
+ 20000
+(1 row)
+
+explain(costs off) select min(f) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select min(f) from min_max_aggregates;
+ min 
+-----
+   0
+(1 row)
+
+explain(costs off) select max(f) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select max(f) from min_max_aggregates;
+ max  
+------
+ 9999
+(1 row)
+
+-- Test min/max on a constant
+explain(costs off) select min(100) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select min(100) from min_max_aggregates;
+ min 
+-----
+ 100
+(1 row)
+
+explain(costs off) select max(100) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select max(100) from min_max_aggregates;
+ max 
+-----
+ 100
+(1 row)
+
+-- Test if optimization is applicable on other aggregates
+explain(costs off) select count(*) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select count(*) from min_max_aggregates;
+ count 
+-------
+ 10001
+(1 row)
+
+explain(costs off) select avg(e) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select avg(e) from min_max_aggregates;
+          avg          
+-----------------------
+ 8000.8000000000000000
+(1 row)
+
+explain(costs off) select sum(d) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select sum(d) from min_max_aggregates;
+        sum         
+--------------------
+ 16130645.161290325
+(1 row)
+
+-- Test min/max with group by
+explain(costs off) select min(e) from min_max_aggregates group by e;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: e
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(7 rows)
+
+explain(costs off) select max(e) from min_max_aggregates group by e;
+                         QUERY PLAN
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: e
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(7 rows)
+
+-- Case with no aggregate function and empty group by
+explain(costs off) select 3 from min_max_aggregates group by ();
+                    QUERY PLAN
+--------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select 3 from min_max_aggregates group by ();
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Case with more than one aggregate functions
+explain(costs off) select min(a), max(d) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select min(a), max(d) from min_max_aggregates;
+ min |        max         
+-----+--------------------
+   1 | 3225.8064516129034
+(1 row)
+
+-- Purpose: This section tests IS NULL predicate on btree and non-index columns
+-- Tests with IS NULL on btree index columns
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+explain(costs off) select * from min_max_aggregates where a is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Scan using index_a on min_max_aggregates
+         Index Cond: (a IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where a is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where b is null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (b IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where b is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where c is null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (c IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where c is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where d is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_d on min_max_aggregates
+         Index Cond: (d IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where d is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where e is null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_e on min_max_aggregates
+         Index Cond: (e IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where e is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+reset enable_seqscan;
+-- Tests with IS NULL on non-index columns
+explain(costs off) select * from min_max_aggregates where f is null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on min_max_aggregates
+         Filter: (f IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where f is null;
+ a | b | c | d | e | f 
+---+---+---+---+---+---
+   |   |   |   |   |  
+(1 row)
+
+-- Purpose: This section tests IS NOT NULL predicate on btree and non-index columns
+-- Tests with IS NOT NULL on btree index columns
+-- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
+-- for below queries
+delete from min_max_aggregates where a<10000;
+-- Ensure Planner picks IndexScan wherever possible
+set enable_seqscan to off;
+set enable_bitmapscan to off;
+explain(costs off) select * from min_max_aggregates where a is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_a on min_max_aggregates
+         Index Cond: (a IS NOT NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where a is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where b is not null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where b is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where c is not null;
+                      QUERY PLAN
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_bc on min_max_aggregates
+         Index Cond: (c IS NOT NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where c is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where d is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_d on min_max_aggregates
+         Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where d is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+explain(costs off) select * from min_max_aggregates where e is not null;
+                      QUERY PLAN
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Scan using index_e on min_max_aggregates
+         Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where e is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+reset enable_seqscan;
+reset enable_bitmapscan;
+-- Tests with IS NOT NULL on non-index columns
+explain(costs off) select * from min_max_aggregates where f is not null;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on min_max_aggregates
+         Filter: (NOT (f IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+select * from min_max_aggregates where f is not null;
+   a   |     b      |   c   |         d          |    e    |  f   
+-------+------------+-------+--------------------+---------+------
+ 10000 | col_b10000 | 20000 | 3225.8064516129034 | 16000.0 | 9999
+(1 row)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Purpose: Test min/max optimization on non-btree indices
+CREATE TABLE test_multi_index_types_table(a int, b int, c float, d text, e tsquery, f tsvector);
+-- create a bitmap index
+create index bitmap_a on test_multi_index_types_table using bitmap(a);
+-- create a hash index
+create index hash_b on test_multi_index_types_table using hash(b);
+-- create a brin index
+create index brin_c on test_multi_index_types_table using brin(c);
+-- create a spgist index
+create index spgist_d on test_multi_index_types_table using spgist(d);
+-- create a gin index
+create index gist_e on test_multi_index_types_table using gist(e);
+-- create a gin index
+create index gin_f on test_multi_index_types_table using gin(f);
+-- Test max optimization
+explain(costs off) select max(a) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(5 rows)
+
+select max(a) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(b) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select max(b) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(c) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select max(c) from test_multi_index_types_table;
+ max 
+-----
+    
+(1 row)
+
+explain(costs off) select max(d) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select max(d) from test_multi_index_types_table;
+ max 
+-----
+ 
+(1 row)
+
+-- Test min optimization
+explain(costs off) select min(a) from test_multi_index_types_table;
+                         QUERY PLAN
+------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(5 rows)
+
+select min(a) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(b) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select min(b) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(c) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select min(c) from test_multi_index_types_table;
+ min 
+-----
+    
+(1 row)
+
+explain(costs off) select min(d) from test_multi_index_types_table;
+                      QUERY PLAN
+------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on test_multi_index_types_table
+ Optimizer: GPORCA
+(4 rows)
+
+select min(d) from test_multi_index_types_table;
+ min 
+-----
+ 
+(1 row)
+
+-- max/min functions are not associated with complex data types
+-- of gin, gist indices.
+-- Test IS NULL, IS NOT NULL on non-btree indices
+-- Expected to use SeqScan with Filter
+explain(costs off) select * from test_multi_index_types_table where a is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (a IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where b is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (b IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where c is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (c IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where d is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (d IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where e is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (e IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where f is null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (f IS NULL)
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where a is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (a IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where b is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (b IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where c is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (c IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where d is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (d IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where e is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (e IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+explain(costs off) select * from test_multi_index_types_table where f is not null;
+                   QUERY PLAN
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on test_multi_index_types_table
+         Filter: (NOT (f IS NULL))
+ Optimizer: GPORCA
+(4 rows)
+
+-- Clean Up
+drop table test_multi_index_types_table;
+-- Purpose: Test min/max optimization on AO table with mixed data type columns.
+-- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
+CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);
+-- multi col index with mixed index keys properties
+CREATE INDEX ao_index_cb on test_ao_table using btree(c desc, b);
+INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
+ANALYZE test_ao_table;
+-- Test max() aggregate
+explain(costs off) select max(c) from test_ao_table;
+                                 QUERY PLAN
+----------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: c
+               ->  Limit
+                     ->  Index Only Scan using ao_index_cb on test_ao_table
+                           Index Cond: (c IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(c) from test_ao_table;
+        max        
+-------------------
+ 23.80952380952381
+(1 row)
+
+-- Test min() aggregate
+explain(costs off) select min(c) from test_ao_table;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: c
+               ->  Limit
+                     ->  Index Only Scan Backward using ao_index_cb on test_ao_table
+                           Index Cond: (c IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(c) from test_ao_table;
+         min         
+---------------------
+ 0.23809523809523808
+(1 row)
+
+-- Clean Up
+drop table test_ao_table;
+-- Purpose: Test min/max optimization on partition tables.
+CREATE TABLE test_partition_table(a int, b int, c float, d text) DISTRIBUTED BY (a) PARTITION BY range(a);
+CREATE TABLE partition1 PARTITION OF test_partition_table FOR VALUES FROM (1) TO (3);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE partition2 PARTITION OF test_partition_table FOR VALUES FROM (3) TO (6);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE INDEX part_index_c on test_partition_table using btree(c desc);
+INSERT INTO test_partition_table SELECT i, i+3, i/4.2, concat('sample_text ',i) from generate_series(1,4) i;
+-- Inserting nulls to verify results match when index key specifies nulls first or desc
+INSERT INTO test_partition_table values (5, null, null, null);
+ANALYZE test_partition_table;
+-- Test max() aggregate
+explain(costs off) select max(c) from test_partition_table;
+                           QUERY PLAN
+----------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Dynamic Seq Scan on test_partition_table
+                     Number of partitions to scan: 2 (out of 2)
+ Optimizer: GPORCA
+(6 rows)
+
+select max(c) from test_partition_table;
+        max         
+--------------------
+ 0.9523809523809523
+(1 row)
+
+-- Test min() aggregate
+explain(costs off) select min(c) from test_partition_table;
+                           QUERY PLAN
+----------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Dynamic Seq Scan on test_partition_table
+                     Number of partitions to scan: 2 (out of 2)
+ Optimizer: GPORCA
+(6 rows)
+
+select min(c) from test_partition_table;
+         min         
+---------------------
+ 0.23809523809523808
+(1 row)
+
+-- Test IS NULL, IS NOT NULL on partition table btree index column
+explain(costs off) select * from test_partition_table where c is null;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Index Scan on part_index_c on test_partition_table
+         Index Cond: (c IS NULL)
+         Number of partitions to scan: 2 (out of 2)
+ Optimizer: GPORCA
+(5 rows)
+
+select * from test_partition_table where c is null;
+ a | b | c | d 
+---+---+---+---
+ 5 |   |   | 
+(1 row)
+
+explain(costs off) select * from test_partition_table where c is not null;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Index Scan on part_index_c on test_partition_table
+         Index Cond: (c IS NOT NULL)
+         Number of partitions to scan: 2 (out of 2)
+ Optimizer: GPORCA
+(5 rows)
+
+select * from test_partition_table where c is not null;
+ a | b |          c          |       d       
+---+---+---------------------+---------------
+ 2 | 5 | 0.47619047619047616 | sample_text 2
+ 4 | 7 |  0.9523809523809523 | sample_text 4
+ 3 | 6 |  0.7142857142857143 | sample_text 3
+ 1 | 4 | 0.23809523809523808 | sample_text 1
+(4 rows)
+
+-- Test IS NULL, IS NOT NULL on partition table non-index column
+explain(costs off) select * from test_partition_table where d is null;
+                     QUERY PLAN
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Seq Scan on test_partition_table
+         Number of partitions to scan: 2 (out of 2)
+         Filter: (d IS NULL)
+ Optimizer: GPORCA
+(5 rows)
+
+select * from test_partition_table where d is null;
+ a | b | c | d 
+---+---+---+---
+ 5 |   |   | 
+(1 row)
+
+explain(costs off) select * from test_partition_table where d is not null;
+                     QUERY PLAN
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Seq Scan on test_partition_table
+         Number of partitions to scan: 2 (out of 2)
+         Filter: (NOT (d IS NULL))
+ Optimizer: GPORCA
+(5 rows)
+
+select * from test_partition_table where d is not null;
+ a | b |          c          |       d       
+---+---+---------------------+---------------
+ 1 | 4 | 0.23809523809523808 | sample_text 1
+ 2 | 5 | 0.47619047619047616 | sample_text 2
+ 3 | 6 |  0.7142857142857143 | sample_text 3
+ 4 | 7 |  0.9523809523809523 | sample_text 4
+(4 rows)
+
+-- Clean Up
+drop table test_partition_table;

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -3141,9 +3141,11 @@ DROP TABLE part_table2;
 CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
 CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Ensure Planner picks IndexScan wherever possible
+-- Ensure Planner picks IndexOnlyScan wherever possible
 set enable_seqscan to off;
 -- Test min() and max() optimization if table doesn't have any tuples
+-- This test is added to ensure min/max functions return 1 NULL row
+-- indicating no min or max value exists as table doesn't have any tuples.
 explain(costs off) select min(b) from min_max_aggregates;
                                  QUERY PLAN
 ----------------------------------------------------------------------------
@@ -3183,7 +3185,7 @@ select max(b) from min_max_aggregates;
 INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
 -- Positive Tests
--- Test optimization on index_bc
+-- Test optimization on multi-key index
 explain(costs off) select min(b) from min_max_aggregates;
                                  QUERY PLAN
 ----------------------------------------------------------------------------
@@ -3220,7 +3222,8 @@ select max(b) from min_max_aggregates;
  col_b99
 (1 row)
 
--- Create index_a and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction
+-- ASC NULLS FIRST
 CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(a) from min_max_aggregates;
@@ -3261,7 +3264,8 @@ select max(a) from min_max_aggregates;
  100
 (1 row)
 
--- Create index_d and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction
+-- DESC NULLS LAST
 CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(d) from min_max_aggregates;
@@ -3302,7 +3306,7 @@ select max(d) from min_max_aggregates;
  32.25806451612903
 (1 row)
 
--- Create index_e and test optimization on its keys
+-- Test min/max optimization behavior on index with key direction ASC
 CREATE INDEX index_e on min_max_aggregates using btree(e);
 ANALYZE min_max_aggregates;
 explain(costs off) select min(e) from min_max_aggregates;
@@ -3343,7 +3347,7 @@ select max(e) from min_max_aggregates;
  160.0
 (1 row)
 
--- Test min/max with empty group by
+-- Test min/max optimization behavior with empty group by
 explain(costs off) select min(e) from min_max_aggregates group by ();
                                QUERY PLAN
 ------------------------------------------------------------------------
@@ -3382,9 +3386,251 @@ select max(e) from min_max_aggregates group by ();
  160.0
 (1 row)
 
+-- Test min/max optimization when used as part of a subquery
+explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Aggregate
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Merge Key: min_max_aggregates.e
+                                 ->  Limit
+                                       ->  Index Scan Backward using index_e on min_max_aggregates
+                                             Index Cond: (e IS NOT NULL)
+         ->  Index Scan using index_e on min_max_aggregates min_max_aggregates_1
+               Index Cond: (e = (max(min_max_aggregates.e)))
+ Optimizer: GPORCA
+(14 rows)
+
+select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+    b     |   e   
+----------+-------
+ col_b100 | 160.0
+(1 row)
+
+-- Test min/max optimization when used in CTE producer
+explain (costs off) with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan Backward using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan Backward using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+        min         
+--------------------
+ 0.3225806451612903
+(1 row)
+
+-- Test min/max optimization when the result is casted to a compatible
+-- data type
+explain (costs off) select min(e)::int from min_max_aggregates;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(e)::int from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
+
+-- Test min/max optimization in union all and joins
+CREATE TABLE table1 (a int, b text, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b text, c int);
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
+INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization with union all
+explain (costs off) select min(c) from table1 union all select max(c) from table2;
+                                 QUERY PLAN
+----------------------------------------------------------------------------
+ Append
+   ->  Aggregate
+         ->  Limit
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Merge Key: table1.c
+                     ->  Limit
+                           ->  Index Scan using t1_c_idx on table1
+                                 Index Cond: (c IS NOT NULL)
+   ->  Aggregate
+         ->  Limit
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     Merge Key: table2.c
+                     ->  Limit
+                           ->  Index Scan Backward using t2_c_idx on table2
+                                 Index Cond: (c IS NOT NULL)
+ Optimizer: GPORCA
+(16 rows)
+
+select min(c) from table1 union all select max(c) from table2;
+ min 
+-----
+  -1
+  98
+(2 rows)
+
+-- Test min/max optimization when used as part of predicate subquery
+-- for join
+explain (costs off) select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
+                                  QUERY PLAN
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table2.a = table1.a)
+         ->  Seq Scan on table2
+         ->  Hash
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 1:3  (slice2)
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Seq Scan on table2 table2_1
+                     ->  Index Scan using t1_c_idx on table1
+                           Index Cond: (c > (max(table2_1.a)))
+ Optimizer: GPORCA
+(15 rows)
+
+select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
+ b | c 
+---+---
+(0 rows)
+
 -- Negative Tests
 reset enable_seqscan;
--- Test optimization on non index columns
+-- Test min/max optimization on result of union all present as part of subquery.
+-- This query is not supported by min/max optimization because for this to
+-- be supported ORCA needs support of MergeAppend node which could Merge result
+-- of two table's Index Scans in the sorted order and limit can be applied on top
+-- of it.
+explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
+                   QUERY PLAN
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on table1
+                     ->  Seq Scan on table2
+ Optimizer: GPORCA
+(7 rows)
+
+select max(c) from (select c from table1 union all select c from table2) subquery;
+ max 
+-----
+  98
+(1 row)
+
+-- Test min/max optimization used as part of projected columns in join. This query
+-- could not use the optimization as it involves join result which is not
+-- guaranteed to be sorted, unless it is an NL join. Even for NL joins this
+-- optimization isn't supported currently as it isn't in scope of story.
+explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: GPORCA
+(9 rows)
+
+select min(table1.a) from table1 join table2 on table1.a=table2.a;
+ min 
+-----
+   1
+(1 row)
+
+-- Test min/max optimization on columns from join result. This isn't
+-- supported for the same reason as above: join result is not guaranteed
+-- to be sorted.
+explain (costs off) select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: GPORCA
+(9 rows)
+
+select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
+ min 
+-----
+  -1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
+         min         
+---------------------
+ 0.16129032258064516
+(1 row)
+
+-- Clean up
+drop table table1;
+drop table table2;
+-- Test optimization on non index columns. These tests use SeqScan
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3449,7 +3695,8 @@ select max(f) from min_max_aggregates;
   99
 (1 row)
 
--- Test min/max on a constant
+-- Test min/max on a constant. Aggregates optimization isn't necessary
+-- for min/max on constants
 explain(costs off) select min(100) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3482,56 +3729,9 @@ select max(100) from min_max_aggregates;
  100
 (1 row)
 
--- Test if optimization is applicable on other aggregates
-explain(costs off) select count(*) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select count(*) from min_max_aggregates;
- count 
--------
-   101
-(1 row)
-
-explain(costs off) select avg(e) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select avg(e) from min_max_aggregates;
-         avg         
----------------------
- 80.8000000000000000
-(1 row)
-
-explain(costs off) select sum(d) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select sum(d) from min_max_aggregates;
-        sum        
--------------------
- 1629.032258064516
-(1 row)
-
--- Test min/max with group by
+-- Test min/max with group by. This test's pattern matches xform's
+-- pattern and it is included to ensure if xform correctly filters
+-- this case out and doesn't apply transformation to it.
 explain(costs off) select min(e) from min_max_aggregates group by e;
                          QUERY PLAN
 ------------------------------------------------------------
@@ -3556,24 +3756,9 @@ explain(costs off) select max(e) from min_max_aggregates group by e;
  Optimizer: GPORCA
 (7 rows)
 
--- Case with no aggregate function and empty group by
-explain(costs off) select 3 from min_max_aggregates group by ();
-                    QUERY PLAN
---------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select 3 from min_max_aggregates group by ();
- ?column? 
-----------
-        3
-(1 row)
-
--- Case with more than one aggregate functions
+-- Case with more than one min/max aggregate functions. These cases aren't
+-- supported in ORCA as that would be over optimization and not supported
+-- unless customer requests for it.
 explain(costs off) select min(a), max(d) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3590,80 +3775,65 @@ select min(a), max(d) from min_max_aggregates;
    1 | 32.25806451612903
 (1 row)
 
--- Purpose: This section tests IS NULL predicate on btree and non-index columns
+explain(costs off) select min(a) + max(d) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select min(a) + max(d) from min_max_aggregates;
+     ?column?      
+-------------------
+ 33.25806451612903
+(1 row)
+
+-- Case with no aggregate function and empty group by. This test's
+-- pattern matches xform's pattern and it is included to ensure if
+-- xform correctly filters this case out and doesn't apply
+-- transformation to it.
+explain(costs off) select 3 from min_max_aggregates group by ();
+                    QUERY PLAN
+--------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+select 3 from min_max_aggregates group by ();
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
+CREATE TABLE test_nulltype_predicates(a int, b text, c int, d float, e numeric, f int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX index_bc on test_nulltype_predicates using btree(b DESC);
+INSERT INTO test_nulltype_predicates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates values(null, null, null, null, null, null);
+ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
-explain(costs off) select * from min_max_aggregates where a is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Index Scan using index_a on min_max_aggregates
-         Index Cond: (a IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where a is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where b is null;
-                      QUERY PLAN
--------------------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where b is null;
+                         QUERY PLAN
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
+   ->  Index Scan using index_bc on test_nulltype_predicates
          Index Cond: (b IS NULL)
  Optimizer: GPORCA
 (4 rows)
 
-select * from min_max_aggregates where b is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where c is null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
-         Index Cond: (c IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where c is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where d is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_d on min_max_aggregates
-         Index Cond: (d IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where d is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where e is null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_e on min_max_aggregates
-         Index Cond: (e IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where e is null;
+select * from test_nulltype_predicates where b is null;
  a | b | c | d | e | f 
 ---+---+---+---+---+---
    |   |   |   |   |  
@@ -3671,376 +3841,64 @@ select * from min_max_aggregates where e is null;
 
 reset enable_seqscan;
 -- Tests with IS NULL on non-index columns
-explain(costs off) select * from min_max_aggregates where f is null;
-                QUERY PLAN
-------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where f is null;
+                 QUERY PLAN
+--------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on min_max_aggregates
+   ->  Seq Scan on test_nulltype_predicates
          Filter: (f IS NULL)
  Optimizer: GPORCA
 (4 rows)
 
-select * from min_max_aggregates where f is null;
+select * from test_nulltype_predicates where f is null;
  a | b | c | d | e | f 
 ---+---+---+---+---+---
    |   |   |   |   |  
 (1 row)
 
--- Purpose: This section tests IS NOT NULL predicate on btree and non-index columns
 -- Tests with IS NOT NULL on btree index columns
--- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
--- for below queries
-delete from min_max_aggregates where a<100;
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
 set enable_bitmapscan to off;
-explain(costs off) select * from min_max_aggregates where a is not null;
-                      QUERY PLAN
-------------------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where b is not null;
+                         QUERY PLAN
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_a on min_max_aggregates
-         Index Cond: (a IS NOT NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where a is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where b is not null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
+   ->  Index Scan using index_bc on test_nulltype_predicates
          Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (4 rows)
 
-select * from min_max_aggregates where b is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where c is not null;
-                      QUERY PLAN
--------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on min_max_aggregates
-         Index Cond: (c IS NOT NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where c is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where d is not null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_d on min_max_aggregates
-         Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where d is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
-
-explain(costs off) select * from min_max_aggregates where e is not null;
-                      QUERY PLAN
-------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_e on min_max_aggregates
-         Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(4 rows)
-
-select * from min_max_aggregates where e is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
+select * from test_nulltype_predicates where b is not null;
+ a |   b    | c |         d          |  e  | f 
+---+--------+---+--------------------+-----+---
+ 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
+ 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
+ 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+(3 rows)
 
 reset enable_seqscan;
 reset enable_bitmapscan;
 -- Tests with IS NOT NULL on non-index columns
-explain(costs off) select * from min_max_aggregates where f is not null;
-                QUERY PLAN
-------------------------------------------
+explain(costs off) select * from test_nulltype_predicates where f is not null;
+                 QUERY PLAN
+--------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on min_max_aggregates
+   ->  Seq Scan on test_nulltype_predicates
          Filter: (NOT (f IS NULL))
  Optimizer: GPORCA
 (4 rows)
 
-select * from min_max_aggregates where f is not null;
-  a  |    b     |  c  |         d         |   e   | f  
------+----------+-----+-------------------+-------+----
- 100 | col_b100 | 200 | 32.25806451612903 | 160.0 | 99
-(1 row)
+select * from test_nulltype_predicates where f is not null;
+ a |   b    | c |         d          |  e  | f 
+---+--------+---+--------------------+-----+---
+ 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+ 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
+ 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
+(3 rows)
 
 -- Clean Up
-drop table min_max_aggregates;
--- Purpose: Test min/max optimization on non-btree indices
-CREATE TABLE test_multi_index_types_table(a int, b int, c float, d text, e tsquery, f tsvector);
--- create a bitmap index
-create index bitmap_a on test_multi_index_types_table using bitmap(a);
--- create a hash index
-create index hash_b on test_multi_index_types_table using hash(b);
--- create a brin index
-create index brin_c on test_multi_index_types_table using brin(c);
--- create a spgist index
-create index spgist_d on test_multi_index_types_table using spgist(d);
--- create a gin index
-create index gist_e on test_multi_index_types_table using gist(e);
--- create a gin index
-create index gin_f on test_multi_index_types_table using gin(f);
--- Test max optimization
-explain(costs off) select max(a) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(5 rows)
-
-select max(a) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(b) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select max(b) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(c) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select max(c) from test_multi_index_types_table;
- max 
------
-    
-(1 row)
-
-explain(costs off) select max(d) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select max(d) from test_multi_index_types_table;
- max 
------
- 
-(1 row)
-
--- Test min optimization
-explain(costs off) select min(a) from test_multi_index_types_table;
-                         QUERY PLAN
-------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(5 rows)
-
-select min(a) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(b) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select min(b) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(c) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select min(c) from test_multi_index_types_table;
- min 
------
-    
-(1 row)
-
-explain(costs off) select min(d) from test_multi_index_types_table;
-                      QUERY PLAN
-------------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on test_multi_index_types_table
- Optimizer: GPORCA
-(4 rows)
-
-select min(d) from test_multi_index_types_table;
- min 
------
- 
-(1 row)
-
--- max/min functions are not associated with complex data types
--- of gin, gist indices.
--- Test IS NULL, IS NOT NULL on non-btree indices
--- Expected to use SeqScan with Filter
-explain(costs off) select * from test_multi_index_types_table where a is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (a IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where b is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (b IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where c is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (c IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where d is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (d IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where e is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (e IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where f is null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (f IS NULL)
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where a is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (a IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where b is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (b IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where c is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (c IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where d is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (d IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where e is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (e IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
-explain(costs off) select * from test_multi_index_types_table where f is not null;
-                   QUERY PLAN
-------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on test_multi_index_types_table
-         Filter: (NOT (f IS NULL))
- Optimizer: GPORCA
-(4 rows)
-
--- Clean Up
-drop table test_multi_index_types_table;
+drop table test_nulltype_predicates;
 -- Purpose: Test min/max optimization on AO table with mixed data type columns.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
 CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -3138,11 +3138,9 @@ reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
 -- Purpose: This section includes tests related to min(), max() aggregates optimization.
-CREATE TABLE min_max_aggregates(a int, b text, c int, d float, e numeric, f int);
+CREATE TABLE min_max_aggregates(a int, b int, c int, d int, e int, f int);
 CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Ensure Planner picks IndexOnlyScan wherever possible
-set enable_seqscan to off;
 -- Test min() and max() optimization if table doesn't have any tuples
 -- This test is added to ensure min/max functions return 1 NULL row
 -- indicating no min or max value exists as table doesn't have any tuples.
@@ -3161,7 +3159,7 @@ explain(costs off) select min(b) from min_max_aggregates;
 select min(b) from min_max_aggregates;
  min 
 -----
- 
+    
 (1 row)
 
 explain(costs off) select max(b) from min_max_aggregates;
@@ -3179,53 +3177,76 @@ explain(costs off) select max(b) from min_max_aggregates;
 select max(b) from min_max_aggregates;
  max 
 -----
- 
+    
 (1 row)
 
-INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
+INSERT INTO min_max_aggregates select i, i*5, i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
--- Positive Tests
--- Test optimization on multi-key index
+-- Test optimization when there are multiple indices whose leading
+-- index key matches aggregate column. This test shows that both
+-- 'index_bc' created above and 'index_b' are eligible for the xform
+-- and ORCA picks the lower cost index, which is 'index_b' in this
+-- scenario
+CREATE INDEX index_b on min_max_aggregates using btree(b DESC);
+ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as indices: 'index_bc', 'index_b',
+-- both featuring column 'b' as leading key
+-- This query leverages Backward IndexScan as column 'b' in 'index_b' is
+-- sorted in descending order and therefore, minimum value can be found
+-- at the bottom of the index
 explain(costs off) select min(b) from min_max_aggregates;
-                                 QUERY PLAN
-----------------------------------------------------------------------------
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: b
-               ->  Index Scan Backward using index_bc on min_max_aggregates
-                     Index Cond: (b IS NOT NULL)
+               ->  Limit
+                     ->  Index Scan Backward using index_b on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
-(7 rows)
+(8 rows)
 
 select min(b) from min_max_aggregates;
-  min   
---------
- col_b1
+ min 
+-----
+   5
 (1 row)
 
+-- This query leverages Forward IndexScan as column 'b' in 'index_b' is
+-- sorted in descending order and therefore, maximum value can be found
+-- at the top of the index
 explain(costs off) select max(b) from min_max_aggregates;
-                            QUERY PLAN
--------------------------------------------------------------------
+                               QUERY PLAN
+------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: b
-               ->  Index Scan using index_bc on min_max_aggregates
-                     Index Cond: (b IS NOT NULL)
+               ->  Limit
+                     ->  Index Scan using index_b on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
-(7 rows)
+(8 rows)
 
 select max(b) from min_max_aggregates;
-   max   
----------
- col_b99
+ max 
+-----
+ 500
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction
--- ASC NULLS FIRST
+-- ASC NULLS FIRST. Utilizing an index with "NULLS FIRST" to ensure
+-- that during a Forward IndexScan, NULL values at the beginning
+-- are filtered out, guaranteeing that a "limit" with 1 row will
+-- return a valid non-null value.
 CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_a'
+-- features column 'a' as leading key
+-- This query leverages Forward IndexScan as column 'a' in 'index_a' is
+-- sorted in ascending order and therefore, minimum value can be found
+-- at the top of the index
 explain(costs off) select min(a) from min_max_aggregates;
                                QUERY PLAN
 ------------------------------------------------------------------------
@@ -3245,6 +3266,9 @@ select min(a) from min_max_aggregates;
    1
 (1 row)
 
+-- This query leverages Backward IndexScan as column 'a' in 'index_a' is
+-- sorted in ascending order and therefore, maximum value can be found
+-- at the bottom of the index
 explain(costs off) select max(a) from min_max_aggregates;
                                    QUERY PLAN
 ---------------------------------------------------------------------------------
@@ -3265,9 +3289,17 @@ select max(a) from min_max_aggregates;
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction
--- DESC NULLS LAST
+-- DESC NULLS LAST. Utilizing an index with "NULLS LAST" to ensure
+-- that during a Backward IndexScan, NULL values at the end
+-- are filtered out, guaranteeing that a "limit" with 1 row will
+-- return a valid non-null value.
 CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_d'
+-- features column 'd' as leading key
+-- This query leverages Backward IndexScan as column 'd' in 'index_d' is
+-- sorted in descending order and therefore, minimum value can be found
+-- at the bottom of the index
 explain(costs off) select min(d) from min_max_aggregates;
                                    QUERY PLAN
 ---------------------------------------------------------------------------------
@@ -3282,11 +3314,14 @@ explain(costs off) select min(d) from min_max_aggregates;
 (8 rows)
 
 select min(d) from min_max_aggregates;
-        min         
---------------------
- 0.3225806451612903
+ min 
+-----
+   0
 (1 row)
 
+-- This query leverages Forward IndexScan as column 'd' in 'index_d' is
+-- sorted in descending order and therefore, maximum value can be found
+-- at the top of the index
 explain(costs off) select max(d) from min_max_aggregates;
                                QUERY PLAN
 ------------------------------------------------------------------------
@@ -3301,14 +3336,19 @@ explain(costs off) select max(d) from min_max_aggregates;
 (8 rows)
 
 select max(d) from min_max_aggregates;
-        max        
--------------------
- 32.25806451612903
+ max 
+-----
+  32
 (1 row)
 
 -- Test min/max optimization behavior on index with key direction ASC
 CREATE INDEX index_e on min_max_aggregates using btree(e);
 ANALYZE min_max_aggregates;
+-- Below queries are eligible for IndexScan as index: 'index_e'
+-- features column 'e' as leading key
+-- This query leverages Forward IndexScan as column 'e' in 'index_e' is
+-- sorted in ascending order and therefore, minimum value can be found
+-- at the top of the index
 explain(costs off) select min(e) from min_max_aggregates;
                                QUERY PLAN
 ------------------------------------------------------------------------
@@ -3325,9 +3365,12 @@ explain(costs off) select min(e) from min_max_aggregates;
 select min(e) from min_max_aggregates;
  min 
 -----
- 1.6
+   2
 (1 row)
 
+-- This query leverages Backward IndexScan as column 'e' in 'index_e' is
+-- sorted in ascending order and therefore, maximum value can be found
+-- at the bottom of the index
 explain(costs off) select max(e) from min_max_aggregates;
                                    QUERY PLAN
 ---------------------------------------------------------------------------------
@@ -3342,295 +3385,14 @@ explain(costs off) select max(e) from min_max_aggregates;
 (8 rows)
 
 select max(e) from min_max_aggregates;
-  max  
--------
- 160.0
-(1 row)
-
--- Test min/max optimization behavior with empty group by
-explain(costs off) select min(e) from min_max_aggregates group by ();
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
-               ->  Limit
-                     ->  Index Scan using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(e) from min_max_aggregates group by ();
- min 
------
- 1.6
-(1 row)
-
-explain(costs off) select max(e) from min_max_aggregates group by ();
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
-               ->  Limit
-                     ->  Index Scan Backward using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select max(e) from min_max_aggregates group by ();
-  max  
--------
- 160.0
-(1 row)
-
--- Test min/max optimization when used as part of a subquery
-explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-                                            QUERY PLAN
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         Join Filter: true
-         ->  Broadcast Motion 1:3  (slice2)
-               ->  Aggregate
-                     ->  Limit
-                           ->  Gather Motion 3:1  (slice3; segments: 3)
-                                 Merge Key: min_max_aggregates.e
-                                 ->  Limit
-                                       ->  Index Scan Backward using index_e on min_max_aggregates
-                                             Index Cond: (e IS NOT NULL)
-         ->  Index Scan using index_e on min_max_aggregates min_max_aggregates_1
-               Index Cond: (e = (max(min_max_aggregates.e)))
- Optimizer: GPORCA
-(14 rows)
-
-select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-    b     |   e   
-----------+-------
- col_b100 | 160.0
-(1 row)
-
--- Test min/max optimization when used in CTE producer
-explain (costs off) with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan Backward using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-with cte_producer as (select min(d) from min_max_aggregates) select 1 from cte_producer;
- ?column? 
-----------
-        1
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan Backward using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-with cte_producer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-        min         
---------------------
- 0.3225806451612903
-(1 row)
-
--- Test min/max optimization when the result is casted to a compatible
--- data type
-explain (costs off) select min(e)::int from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
-               ->  Limit
-                     ->  Index Scan using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(e)::int from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- Test min/max optimization in union all and joins
-CREATE TABLE table1 (a int, b text, c int);
-CREATE INDEX t1_c_idx on table1 using btree(c);
-CREATE TABLE table2 (a int, b text, c int);
-CREATE INDEX t2_c_idx on table2 using btree(c);
-INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
-INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
-ANALYZE table1;
-ANALYZE table2;
--- Test min/max optimization with union all
-explain (costs off) select min(c) from table1 union all select max(c) from table2;
-                                 QUERY PLAN
-----------------------------------------------------------------------------
- Append
-   ->  Aggregate
-         ->  Limit
-               ->  Gather Motion 3:1  (slice1; segments: 3)
-                     Merge Key: table1.c
-                     ->  Limit
-                           ->  Index Scan using t1_c_idx on table1
-                                 Index Cond: (c IS NOT NULL)
-   ->  Aggregate
-         ->  Limit
-               ->  Gather Motion 3:1  (slice2; segments: 3)
-                     Merge Key: table2.c
-                     ->  Limit
-                           ->  Index Scan Backward using t2_c_idx on table2
-                                 Index Cond: (c IS NOT NULL)
- Optimizer: GPORCA
-(16 rows)
-
-select min(c) from table1 union all select max(c) from table2;
- min 
------
-  -1
-  98
-(2 rows)
-
--- Test min/max optimization when used as part of predicate subquery
--- for join
-explain (costs off) select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
-                                  QUERY PLAN
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: (table2.a = table1.a)
-         ->  Seq Scan on table2
-         ->  Hash
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 1:3  (slice2)
-                           ->  Finalize Aggregate
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Seq Scan on table2 table2_1
-                     ->  Index Scan using t1_c_idx on table1
-                           Index Cond: (c > (max(table2_1.a)))
- Optimizer: GPORCA
-(15 rows)
-
-select table1.b, table2.c from table1 join table2 on table1.a = table2.a where table1.c > (select max(table2.a) from table2);
- b | c 
----+---
-(0 rows)
-
--- Negative Tests
-reset enable_seqscan;
--- Test min/max optimization on result of union all present as part of subquery.
--- This query is not supported by min/max optimization because for this to
--- be supported ORCA needs support of MergeAppend node which could Merge result
--- of two table's Index Scans in the sorted order and limit can be applied on top
--- of it.
-explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
-                   QUERY PLAN
-------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Append
-                     ->  Seq Scan on table1
-                     ->  Seq Scan on table2
- Optimizer: GPORCA
-(7 rows)
-
-select max(c) from (select c from table1 union all select c from table2) subquery;
  max 
 -----
-  98
+ 160
 (1 row)
 
--- Test min/max optimization used as part of projected columns in join. This query
--- could not use the optimization as it involves join result which is not
--- guaranteed to be sorted, unless it is an NL join. Even for NL joins this
--- optimization isn't supported currently as it isn't in scope of story.
-explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
-                      QUERY PLAN
-------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (table1.a = table2.a)
-                     ->  Seq Scan on table1
-                     ->  Hash
-                           ->  Seq Scan on table2
- Optimizer: GPORCA
-(9 rows)
-
-select min(table1.a) from table1 join table2 on table1.a=table2.a;
- min 
------
-   1
-(1 row)
-
--- Test min/max optimization on columns from join result. This isn't
--- supported for the same reason as above: join result is not guaranteed
--- to be sorted.
-explain (costs off) select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
-                      QUERY PLAN
-------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (table1.a = table2.a)
-                     ->  Seq Scan on table1
-                     ->  Hash
-                           ->  Seq Scan on table2
- Optimizer: GPORCA
-(9 rows)
-
-select min(table1_c) from (select table1.c as table1_c from table1 join table2 on table1.a=table2.a) as join_relation;
- min 
------
-  -1
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-with cte_producer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_producer;
-         min         
----------------------
- 0.16129032258064516
-(1 row)
-
--- Clean up
-drop table table1;
-drop table table2;
--- Test optimization on non index columns. These tests use SeqScan
+-- Test optimization on non-leading keys in the index. These
+-- tests aren't eligible for IndexScan as the aggregate column
+-- isn't a leading key in the index
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3663,6 +3425,9 @@ select max(c) from min_max_aggregates;
  200
 (1 row)
 
+-- Test optimization on non index columns. These tests aren't
+-- eligible for IndexScan as there is no index on the aggregate
+-- column 'f'
 explain(costs off) select min(f) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3729,36 +3494,188 @@ select max(100) from min_max_aggregates;
  100
 (1 row)
 
--- Test min/max with group by. This test's pattern matches xform's
--- pattern and it is included to ensure if xform correctly filters
--- this case out and doesn't apply transformation to it.
-explain(costs off) select min(e) from min_max_aggregates group by e;
-                         QUERY PLAN
-------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
-         Group Key: e
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: e
-               ->  Seq Scan on min_max_aggregates
+-- Test min/max optimization behavior with empty group by. Adding
+-- this test as this query's pattern matches the transforms pattern
+-- and is expected to leverage min/max optimization feature as
+-- the query has no group by columns.
+explain(costs off) select min(e) from min_max_aggregates group by ();
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
  Optimizer: GPORCA
-(7 rows)
+(8 rows)
+
+select min(e) from min_max_aggregates group by ();
+ min 
+-----
+   2
+(1 row)
+
+explain(costs off) select max(e) from min_max_aggregates group by ();
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan Backward using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(e) from min_max_aggregates group by ();
+ max 
+-----
+ 160
+(1 row)
+
+-- Test min/max with non-empty group by. This query's pattern matches
+-- xform's pattern and it is included to ensure if xform correctly filters
+-- this case out. This filtering happens while computing xform promise by
+-- checking size of grouping columns and there by avoiding application
+-- of transform
+explain(costs off) select min(e) from min_max_aggregates group by e;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: e
+         ->  Sort
+               Sort Key: e
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: e
+                     ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(9 rows)
 
 explain(costs off) select max(e) from min_max_aggregates group by e;
-                         QUERY PLAN
-------------------------------------------------------------
+                            QUERY PLAN
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  GroupAggregate
          Group Key: e
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: e
+         ->  Sort
+               Sort Key: e
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: e
+                     ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(9 rows)
+
+-- Test min/max optimization when used as part of a subquery
+explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Aggregate
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Merge Key: min_max_aggregates.e
+                                 ->  Limit
+                                       ->  Index Scan Backward using index_e on min_max_aggregates
+                                             Index Cond: (e IS NOT NULL)
+         ->  Index Scan using index_e on min_max_aggregates min_max_aggregates_1
+               Index Cond: (e = (max(min_max_aggregates.e)))
+ Optimizer: GPORCA
+(14 rows)
+
+select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+  b  |  e  
+-----+-----
+ 500 | 160
+(1 row)
+
+-- Test min/max optimization when used in CTE producer
+explain (costs off) with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan Backward using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
+ min_d 
+-------
+     0
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer
+explain (costs off) with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: d
+               ->  Limit
+                     ->  Index Scan Backward using index_d on min_max_aggregates
+                           Index Cond: (d IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+ min 
+-----
+   0
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer. Optimization isn't
+-- applicable for this case, because the subquery projects 'col_d' as 'd/2'
+-- upon which the min is computed, but none of the indices store values
+-- of column 'd/2' so that IndexScan could be used on that index
+explain (costs off) with cte_consumer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
                ->  Seq Scan on min_max_aggregates
  Optimizer: GPORCA
-(7 rows)
+(5 rows)
+
+-- Test min/max optimization when the result is casted to a different
+-- data type. Adding this test as a part of query's pattern matches the
+-- transforms pattern and is expected to leverage min/max optimization
+-- feature
+explain (costs off) select min(e)::int from min_max_aggregates;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: e
+               ->  Limit
+                     ->  Index Scan using index_e on min_max_aggregates
+                           Index Cond: (e IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(e)::int from min_max_aggregates;
+ min 
+-----
+   2
+(1 row)
 
 -- Case with more than one min/max aggregate functions. These cases aren't
--- supported in ORCA as that would be over optimization and not supported
--- unless customer requests for it.
+-- supported in ORCA as that would be unnecessary and complex optimization
+-- which is not worth the effort, unless some customer explicitly requests
+-- for it
 explain(costs off) select min(a), max(d) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3770,9 +3687,9 @@ explain(costs off) select min(a), max(d) from min_max_aggregates;
 (5 rows)
 
 select min(a), max(d) from min_max_aggregates;
- min |        max        
------+-------------------
-   1 | 32.25806451612903
+ min | max 
+-----+-----
+   1 |  32
 (1 row)
 
 explain(costs off) select min(a) + max(d) from min_max_aggregates;
@@ -3786,286 +3703,365 @@ explain(costs off) select min(a) + max(d) from min_max_aggregates;
 (5 rows)
 
 select min(a) + max(d) from min_max_aggregates;
-     ?column?      
--------------------
- 33.25806451612903
-(1 row)
-
--- Case with no aggregate function and empty group by. This test's
--- pattern matches xform's pattern and it is included to ensure if
--- xform correctly filters this case out and doesn't apply
--- transformation to it.
-explain(costs off) select 3 from min_max_aggregates group by ();
-                    QUERY PLAN
---------------------------------------------------
- Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select 3 from min_max_aggregates group by ();
  ?column? 
 ----------
-        3
+       33
 (1 row)
 
 -- Clean Up
 drop table min_max_aggregates;
+-- Test min/max optimization in union all, joins and outer references
+CREATE TABLE table1 (a int, b text, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b text, c int);
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
+INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization used as part of projected column in a
+-- subquery along with a predicate. This query could not use optimization
+-- as subquery has a predicate and the query pattern doesn't match
+-- the transform's pattern
+explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as min_a from table2;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Join
+         Join Filter: true
+         ->  Seq Scan on table2
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Finalize Aggregate
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Partial Aggregate
+                                       ->  Seq Scan on table1
+                                             Filter: (a > 5)
+ Optimizer: GPORCA
+(12 rows)
+
+explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_a from table2;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Left Join
+         Hash Cond: (table2.b = table1.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: table2.b
+               ->  Seq Scan on table2
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: table1.b
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: table1.b
+                           ->  Seq Scan on table1
+ Optimizer: GPORCA
+(13 rows)
+
+-- Test min/max optimization on result of union all present as part of
+-- subquery. This query is not supported by min/max optimization as
+-- it performs min/max on result of union all, not directly on a table's
+-- column and it doesn't match the transform's pattern.
+explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
+                   QUERY PLAN
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on table1
+                     ->  Seq Scan on table2
+ Optimizer: GPORCA
+(7 rows)
+
+-- Test min/max optimization on outer references. This query only uses a
+-- single aggregate function on an index column and hence generates a IndexScan
+-- alternative.
+explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min(t1.c)) as min_val_for_c from table1 t1;
+                          QUERY PLAN
+--------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: table1.c
+               ->  Limit
+                     ->  Index Scan using t1_c_idx on table1
+                           Index Cond: (c IS NOT NULL)
+   SubPlan 1
+     ->  Result
+           Filter: (table1_1.a = min(table1.c))
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  Seq Scan on table1 table1_1
+ Optimizer: GPORCA
+(14 rows)
+
+-- Test min/max optimization on outer references. This query uses more
+-- than one aggregate function, which doesn't match the transforms pattern
+-- and hence min/max optimization isn't applicable to it.
+explain (costs off) select min(t1.c) as min_c,
+                            (select b from table1 t1_alias where t1_alias.c = max(t1.c)) as b_val
+                    from table1 t1;
+                          QUERY PLAN
+--------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on table1
+   SubPlan 1
+     ->  Result
+           Filter: (table1_1.c = max(table1.c))
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  Seq Scan on table1 table1_1
+ Optimizer: GPORCA
+(11 rows)
+
+-- Test min/max optimization used as part of projected columns in join. This query
+-- could not use the optimization as it involves join result which is not
+-- guaranteed to be sorted, unless it is an NL join.
+explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+                      QUERY PLAN
+------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (table1.a = table2.a)
+                     ->  Seq Scan on table1
+                     ->  Hash
+                           ->  Seq Scan on table2
+ Optimizer: GPORCA
+(9 rows)
+
+-- Clean up
+drop table table1;
+drop table table2;
 -- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
-CREATE TABLE test_nulltype_predicates(a int, b text, c int, d float, e numeric, f int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE INDEX index_bc on test_nulltype_predicates using btree(b DESC);
-INSERT INTO test_nulltype_predicates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,3)i;
-INSERT INTO test_nulltype_predicates values(null, null, null, null, null, null);
+CREATE TABLE test_nulltype_predicates(a int, b int);
+CREATE INDEX index_b on test_nulltype_predicates using btree(b DESC);
+INSERT INTO test_nulltype_predicates select i, i*2 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates values(null, null);
 ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
--- Ensure Planner picks IndexScan wherever possible
-set enable_seqscan to off;
 explain(costs off) select * from test_nulltype_predicates where b is null;
                          QUERY PLAN
--------------------------------------------------------------
+------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on test_nulltype_predicates
+   ->  Index Scan using index_b on test_nulltype_predicates
          Index Cond: (b IS NULL)
  Optimizer: GPORCA
 (4 rows)
 
 select * from test_nulltype_predicates where b is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
+ a | b 
+---+---
+   |  
 (1 row)
 
-reset enable_seqscan;
 -- Tests with IS NULL on non-index columns
-explain(costs off) select * from test_nulltype_predicates where f is null;
+explain(costs off) select * from test_nulltype_predicates where a is null;
                  QUERY PLAN
 --------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on test_nulltype_predicates
-         Filter: (f IS NULL)
+         Filter: (a IS NULL)
  Optimizer: GPORCA
 (4 rows)
 
-select * from test_nulltype_predicates where f is null;
- a | b | c | d | e | f 
----+---+---+---+---+---
-   |   |   |   |   |  
+select * from test_nulltype_predicates where a is null;
+ a | b 
+---+---
+   |  
 (1 row)
 
 -- Tests with IS NOT NULL on btree index columns
--- Ensure Planner picks IndexScan wherever possible
-set enable_seqscan to off;
-set enable_bitmapscan to off;
 explain(costs off) select * from test_nulltype_predicates where b is not null;
                          QUERY PLAN
--------------------------------------------------------------
+------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using index_bc on test_nulltype_predicates
+   ->  Index Scan using index_b on test_nulltype_predicates
          Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (4 rows)
 
 select * from test_nulltype_predicates where b is not null;
- a |   b    | c |         d          |  e  | f 
----+--------+---+--------------------+-----+---
- 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
- 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
- 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
+ a | b 
+---+---
+ 3 | 6
+ 2 | 4
+ 1 | 2
 (3 rows)
 
-reset enable_seqscan;
-reset enable_bitmapscan;
 -- Tests with IS NOT NULL on non-index columns
-explain(costs off) select * from test_nulltype_predicates where f is not null;
+explain(costs off) select * from test_nulltype_predicates where a is not null;
                  QUERY PLAN
 --------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on test_nulltype_predicates
-         Filter: (NOT (f IS NULL))
+         Filter: (NOT (a IS NULL))
  Optimizer: GPORCA
 (4 rows)
 
-select * from test_nulltype_predicates where f is not null;
- a |   b    | c |         d          |  e  | f 
----+--------+---+--------------------+-----+---
- 2 | col_b2 | 4 | 0.6451612903225806 | 3.2 | 1
- 3 | col_b3 | 6 |  0.967741935483871 | 4.8 | 2
- 1 | col_b1 | 2 | 0.3225806451612903 | 1.6 | 0
+select * from test_nulltype_predicates where a is not null;
+ a | b 
+---+---
+ 1 | 2
+ 2 | 4
+ 3 | 6
 (3 rows)
 
 -- Clean Up
 drop table test_nulltype_predicates;
 -- Purpose: Test min/max optimization on AO table with mixed data type columns.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
-CREATE TABLE test_ao_table(a int, b int, c float, d text, e numeric) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE TABLE test_ao_table(a int, b int) WITH (appendonly=true) DISTRIBUTED BY (a);
 -- multi col index with mixed index keys properties
-CREATE INDEX ao_index_cb on test_ao_table using btree(c desc, b);
-INSERT INTO test_ao_table SELECT i, i+3, i/4.2, concat('sample_text ',i), i/5 from generate_series(1,100) i;
+CREATE INDEX ao_index_b on test_ao_table using btree(b desc);
+INSERT INTO test_ao_table SELECT i, i+3 from generate_series(1,100) i;
 ANALYZE test_ao_table;
 -- Test max() aggregate
-explain(costs off) select max(c) from test_ao_table;
-                                 QUERY PLAN
-----------------------------------------------------------------------------
+explain(costs off) select max(b) from test_ao_table;
+                                QUERY PLAN
+---------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: c
+               Merge Key: b
                ->  Limit
-                     ->  Index Only Scan using ao_index_cb on test_ao_table
-                           Index Cond: (c IS NOT NULL)
+                     ->  Index Only Scan using ao_index_b on test_ao_table
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select max(c) from test_ao_table;
-        max        
--------------------
- 23.80952380952381
+select max(b) from test_ao_table;
+ max 
+-----
+ 103
 (1 row)
 
 -- Test min() aggregate
-explain(costs off) select min(c) from test_ao_table;
+explain(costs off) select min(b) from test_ao_table;
                                      QUERY PLAN
--------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: c
+               Merge Key: b
                ->  Limit
-                     ->  Index Only Scan Backward using ao_index_cb on test_ao_table
-                           Index Cond: (c IS NOT NULL)
+                     ->  Index Only Scan Backward using ao_index_b on test_ao_table
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select min(c) from test_ao_table;
-         min         
----------------------
- 0.23809523809523808
+select min(b) from test_ao_table;
+ min 
+-----
+   4
 (1 row)
 
 -- Clean Up
 drop table test_ao_table;
 -- Purpose: Test min/max optimization on partition tables.
-CREATE TABLE test_partition_table(a int, b int, c float, d text) DISTRIBUTED BY (a) PARTITION BY range(a);
+CREATE TABLE test_partition_table(a int, b int) DISTRIBUTED BY (a) PARTITION BY range(b);
 CREATE TABLE partition1 PARTITION OF test_partition_table FOR VALUES FROM (1) TO (3);
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE partition2 PARTITION OF test_partition_table FOR VALUES FROM (3) TO (6);
 NOTICE:  table has parent, setting distribution columns to match parent table
-CREATE INDEX part_index_c on test_partition_table using btree(c desc);
-INSERT INTO test_partition_table SELECT i, i+3, i/4.2, concat('sample_text ',i) from generate_series(1,4) i;
+CREATE TABLE default_partition PARTITION OF test_partition_table DEFAULT;
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE INDEX part_index_b on test_partition_table using btree(b desc);
+INSERT INTO test_partition_table SELECT i+3, i from generate_series(1,4) i;
 -- Inserting nulls to verify results match when index key specifies nulls first or desc
-INSERT INTO test_partition_table values (5, null, null, null);
+INSERT INTO test_partition_table values (null, 5);
+-- Insert into default partition to show partition pruning
+-- for IS NULL conditions
+INSERT INTO test_partition_table values (0, NULL);
 ANALYZE test_partition_table;
--- Test max() aggregate
-explain(costs off) select max(c) from test_partition_table;
+-- Test min/max aggregate. This optimization isn't applicable for
+-- partition tables because query's pattern doesn't match xforms pattern.
+-- Moreover, ORCA currently, doesn't consider order property of
+-- B-tree indices for order by and limit clause on top of a partitioned
+-- table. This is because, data for non-partition order by column is spread across
+-- multiple partitions and DynamicIndexScan cannot determine the correct
+-- order of partitions to produce sorted result. For partition column(s),
+-- table could have a default partition, which contains various different
+-- unordered values.
+explain(costs off) select max(b) from test_partition_table;
                            QUERY PLAN
 ----------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Dynamic Seq Scan on test_partition_table
-                     Number of partitions to scan: 2 (out of 2)
+                     Number of partitions to scan: 3 (out of 3)
  Optimizer: GPORCA
 (6 rows)
 
-select max(c) from test_partition_table;
-        max         
---------------------
- 0.9523809523809523
+select max(b) from test_partition_table;
+ max 
+-----
+   5
 (1 row)
 
 -- Test min() aggregate
-explain(costs off) select min(c) from test_partition_table;
+explain(costs off) select min(b) from test_partition_table;
                            QUERY PLAN
 ----------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Dynamic Seq Scan on test_partition_table
-                     Number of partitions to scan: 2 (out of 2)
+                     Number of partitions to scan: 3 (out of 3)
  Optimizer: GPORCA
 (6 rows)
 
-select min(c) from test_partition_table;
-         min         
----------------------
- 0.23809523809523808
+select min(b) from test_partition_table;
+ min 
+-----
+   1
 (1 row)
 
 -- Test IS NULL, IS NOT NULL on partition table btree index column
-explain(costs off) select * from test_partition_table where c is null;
+-- For, IS NULL predicate on partition column, pruning happens
+-- whereas, for predicates on non-partition column, that doesn't, because
+-- non-partition column's values distribution is unknown to eliminate
+-- any partitions.
+explain(costs off) select * from test_partition_table where b is null;
                             QUERY PLAN
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Dynamic Index Scan on part_index_c on test_partition_table
-         Index Cond: (c IS NULL)
-         Number of partitions to scan: 2 (out of 2)
+   ->  Dynamic Index Scan on part_index_b on test_partition_table
+         Index Cond: (b IS NULL)
+         Number of partitions to scan: 1 (out of 3)
  Optimizer: GPORCA
 (5 rows)
 
-select * from test_partition_table where c is null;
- a | b | c | d 
----+---+---+---
- 5 |   |   | 
+select * from test_partition_table where b is null;
+ a | b 
+---+---
+ 0 |  
 (1 row)
 
-explain(costs off) select * from test_partition_table where c is not null;
+explain(costs off) select * from test_partition_table where b is not null;
                             QUERY PLAN
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Dynamic Index Scan on part_index_c on test_partition_table
-         Index Cond: (c IS NOT NULL)
-         Number of partitions to scan: 2 (out of 2)
+   ->  Dynamic Index Scan on part_index_b on test_partition_table
+         Index Cond: (b IS NOT NULL)
+         Number of partitions to scan: 3 (out of 3)
  Optimizer: GPORCA
 (5 rows)
 
-select * from test_partition_table where c is not null;
- a | b |          c          |       d       
----+---+---------------------+---------------
- 2 | 5 | 0.47619047619047616 | sample_text 2
- 4 | 7 |  0.9523809523809523 | sample_text 4
- 3 | 6 |  0.7142857142857143 | sample_text 3
- 1 | 4 | 0.23809523809523808 | sample_text 1
-(4 rows)
-
--- Test IS NULL, IS NOT NULL on partition table non-index column
-explain(costs off) select * from test_partition_table where d is null;
-                     QUERY PLAN
-----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Dynamic Seq Scan on test_partition_table
-         Number of partitions to scan: 2 (out of 2)
-         Filter: (d IS NULL)
- Optimizer: GPORCA
+select * from test_partition_table where b is not null;
+ a | b 
+---+---
+ 5 | 2
+ 6 | 3
+ 4 | 1
+   | 5
+ 7 | 4
 (5 rows)
-
-select * from test_partition_table where d is null;
- a | b | c | d 
----+---+---+---
- 5 |   |   | 
-(1 row)
-
-explain(costs off) select * from test_partition_table where d is not null;
-                     QUERY PLAN
-----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Dynamic Seq Scan on test_partition_table
-         Number of partitions to scan: 2 (out of 2)
-         Filter: (NOT (d IS NULL))
- Optimizer: GPORCA
-(5 rows)
-
-select * from test_partition_table where d is not null;
- a | b |          c          |       d       
----+---+---------------------+---------------
- 1 | 4 | 0.23809523809523808 | sample_text 1
- 2 | 5 | 0.47619047619047616 | sample_text 2
- 3 | 6 |  0.7142857142857143 | sample_text 3
- 4 | 7 |  0.9523809523809523 | sample_text 4
-(4 rows)
 
 -- Clean Up
 drop table test_partition_table;

--- a/src/test/regress/expected/qp_indexscan_optimizer.out
+++ b/src/test/regress/expected/qp_indexscan_optimizer.out
@@ -3138,20 +3138,20 @@ reset enable_seqscan;
 DROP TABLE part_table1;
 DROP TABLE part_table2;
 -- Purpose: This section includes tests related to min(), max() aggregates optimization.
-CREATE TABLE min_max_aggregates(a int, b int, c int, d int, e int, f int);
-CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
+CREATE TABLE min_max_aggregates(a int, b int, c int);
+CREATE INDEX multi_key_index_b_c on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
--- Test min() and max() optimization if table doesn't have any tuples
--- This test is added to ensure min/max functions return 1 NULL row
--- indicating no min or max value exists as table doesn't have any tuples.
+-- Testing min/max functions when table doesn't have any tuples to
+-- ensure they return 1 NULL row indicating no min or max value exists.
+-- This test is eligible for optimization.
 explain(costs off) select min(b) from min_max_aggregates;
-                                 QUERY PLAN
-----------------------------------------------------------------------------
+                                      QUERY PLAN
+---------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: b
-               ->  Index Scan Backward using index_bc on min_max_aggregates
+               ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
                      Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (7 rows)
@@ -3163,13 +3163,13 @@ select min(b) from min_max_aggregates;
 (1 row)
 
 explain(costs off) select max(b) from min_max_aggregates;
-                            QUERY PLAN
--------------------------------------------------------------------
+                                  QUERY PLAN
+------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: b
-               ->  Index Scan using index_bc on min_max_aggregates
+               ->  Index Scan using multi_key_index_b_c on min_max_aggregates
                      Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (7 rows)
@@ -3180,219 +3180,112 @@ select max(b) from min_max_aggregates;
     
 (1 row)
 
-INSERT INTO min_max_aggregates select i, i*5, i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
-INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
--- Test optimization when there are multiple indices whose leading
--- index key matches aggregate column. This test shows that both
--- 'index_bc' created above and 'index_b' are eligible for the xform
--- and ORCA picks the lower cost index, which is 'index_b' in this
--- scenario
-CREATE INDEX index_b on min_max_aggregates using btree(b DESC);
+INSERT INTO min_max_aggregates select i, i, i from generate_series(1,100)i;
+INSERT INTO min_max_aggregates values(null, null, null);
+-- Creating this index to show that both 'multi_key_index_b_c' and
+-- 'single_key_b_desc' are eligible for min/max on column 'b' and
+-- ORCA picks the lower cost index
+CREATE INDEX single_key_b_desc on min_max_aggregates using btree(b DESC);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as indices: 'index_bc', 'index_b',
--- both featuring column 'b' as leading key
--- This query leverages Backward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, minimum value can be found at
+-- the bottom of the index
 explain(costs off) select min(b) from min_max_aggregates;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
+                                        QUERY PLAN
+-------------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: b
                ->  Limit
-                     ->  Index Scan Backward using index_b on min_max_aggregates
+                     ->  Index Scan Backward using single_key_b_desc on min_max_aggregates
                            Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
 select min(b) from min_max_aggregates;
- min 
------
-   5
-(1 row)
-
--- This query leverages Forward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, maximum value can be found
--- at the top of the index
-explain(costs off) select max(b) from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: b
-               ->  Limit
-                     ->  Index Scan using index_b on min_max_aggregates
-                           Index Cond: (b IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select max(b) from min_max_aggregates;
- max 
------
- 500
-(1 row)
-
--- Test min/max optimization behavior on index with key direction
--- ASC NULLS FIRST. Utilizing an index with "NULLS FIRST" to ensure
--- that during a Forward IndexScan, NULL values at the beginning
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_a'
--- features column 'a' as leading key
--- This query leverages Forward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(a) from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: a
-               ->  Limit
-                     ->  Index Scan using index_a on min_max_aggregates
-                           Index Cond: (a IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(a) from min_max_aggregates;
  min 
 -----
    1
 (1 row)
 
--- This query leverages Backward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, maximum value can be found
--- at the bottom of the index
-explain(costs off) select max(a) from min_max_aggregates;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, maximum value can be found
+-- at the top of the index
+explain(costs off) select max(b) from min_max_aggregates;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: a
+               Merge Key: b
                ->  Limit
-                     ->  Index Scan Backward using index_a on min_max_aggregates
-                           Index Cond: (a IS NOT NULL)
+                     ->  Index Scan using single_key_b_desc on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select max(a) from min_max_aggregates;
+select max(b) from min_max_aggregates;
  max 
 -----
  100
 (1 row)
 
--- Test min/max optimization behavior on index with key direction
--- DESC NULLS LAST. Utilizing an index with "NULLS LAST" to ensure
--- that during a Backward IndexScan, NULL values at the end
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_d'
--- features column 'd' as leading key
--- This query leverages Backward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
-explain(costs off) select min(d) from min_max_aggregates;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan Backward using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(d) from min_max_aggregates;
- min 
------
-   0
-(1 row)
-
--- This query leverages Forward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, maximum value can be found
--- at the top of the index
-explain(costs off) select max(d) from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select max(d) from min_max_aggregates;
- max 
------
-  32
-(1 row)
-
+DROP INDEX single_key_b_desc;
 -- Test min/max optimization behavior on index with key direction ASC
-CREATE INDEX index_e on min_max_aggregates using btree(e);
+CREATE INDEX single_key_b_asc on min_max_aggregates using btree(b);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_e'
--- features column 'e' as leading key
--- This query leverages Forward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(e) from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
-               ->  Limit
-                     ->  Index Scan using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(e) from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- This query leverages Backward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, maximum value can be found
--- at the bottom of the index
-explain(costs off) select max(e) from min_max_aggregates;
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, minimum value can be found at the
+-- top of the index
+explain(costs off) select min(b) from min_max_aggregates;
                                    QUERY PLAN
 ---------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
+               Merge Key: b
                ->  Limit
-                     ->  Index Scan Backward using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
+                     ->  Index Scan using single_key_b_asc on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select max(e) from min_max_aggregates;
- max 
+select min(b) from min_max_aggregates;
+ min 
 -----
- 160
+   1
 (1 row)
 
--- Test optimization on non-leading keys in the index. These
--- tests aren't eligible for IndexScan as the aggregate column
--- isn't a leading key in the index
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, maximum value can be found
+-- at the bottom of the index
+explain(costs off) select max(b) from min_max_aggregates;
+                                        QUERY PLAN
+------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Limit
+                     ->  Index Scan Backward using single_key_b_asc on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(b) from min_max_aggregates;
+ max 
+-----
+ 100
+(1 row)
+
+DROP INDEX single_key_b_asc;
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non-leading keys in the index.
 explain(costs off) select min(c) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3402,12 +3295,6 @@ explain(costs off) select min(c) from min_max_aggregates;
                ->  Seq Scan on min_max_aggregates
  Optimizer: GPORCA
 (5 rows)
-
-select min(c) from min_max_aggregates;
- min 
------
-   2
-(1 row)
 
 explain(costs off) select max(c) from min_max_aggregates;
                     QUERY PLAN
@@ -3419,16 +3306,9 @@ explain(costs off) select max(c) from min_max_aggregates;
  Optimizer: GPORCA
 (5 rows)
 
-select max(c) from min_max_aggregates;
- max 
------
- 200
-(1 row)
-
--- Test optimization on non index columns. These tests aren't
--- eligible for IndexScan as there is no index on the aggregate
--- column 'f'
-explain(costs off) select min(f) from min_max_aggregates;
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non index column.
+explain(costs off) select min(a) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
  Finalize Aggregate
@@ -3438,13 +3318,7 @@ explain(costs off) select min(f) from min_max_aggregates;
  Optimizer: GPORCA
 (5 rows)
 
-select min(f) from min_max_aggregates;
- min 
------
-   0
-(1 row)
-
-explain(costs off) select max(f) from min_max_aggregates;
+explain(costs off) select max(a) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
  Finalize Aggregate
@@ -3454,14 +3328,8 @@ explain(costs off) select max(f) from min_max_aggregates;
  Optimizer: GPORCA
 (5 rows)
 
-select max(f) from min_max_aggregates;
- max 
------
-  99
-(1 row)
-
--- Test min/max on a constant. Aggregates optimization isn't necessary
--- for min/max on constants
+-- Test min/max on a constant. This query is not eligible for
+-- optimization as it is not necessary for min/max on constants
 explain(costs off) select min(100) from min_max_aggregates;
                     QUERY PLAN
 --------------------------------------------------
@@ -3471,12 +3339,6 @@ explain(costs off) select min(100) from min_max_aggregates;
                ->  Seq Scan on min_max_aggregates
  Optimizer: GPORCA
 (5 rows)
-
-select min(100) from min_max_aggregates;
- min 
------
- 100
-(1 row)
 
 explain(costs off) select max(100) from min_max_aggregates;
                     QUERY PLAN
@@ -3488,91 +3350,237 @@ explain(costs off) select max(100) from min_max_aggregates;
  Optimizer: GPORCA
 (5 rows)
 
-select max(100) from min_max_aggregates;
+-- Test min/max optimization behavior with empty group by. This query
+-- is eligible for optimization as it doesn't specify any grouping columns
+explain(costs off) select min(b) from min_max_aggregates group by ();
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Limit
+                     ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select min(b) from min_max_aggregates group by ();
+ min 
+-----
+   1
+(1 row)
+
+explain(costs off) select max(b) from min_max_aggregates group by ();
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Limit
+                     ->  Index Scan using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+select max(b) from min_max_aggregates group by ();
  max 
 -----
  100
 (1 row)
 
--- Test min/max optimization behavior with empty group by. Adding
--- this test as this query's pattern matches the transforms pattern
--- and is expected to leverage min/max optimization feature as
--- the query has no group by columns.
-explain(costs off) select min(e) from min_max_aggregates group by ();
-                               QUERY PLAN
-------------------------------------------------------------------------
+-- Test min/max with non-empty group by. This query is not eligible for
+-- optimization as it has grouping columns. This check is made while
+-- computing xform promise by validating size of grouping columns and
+-- there by avoiding application of transform
+explain(costs off) select min(b) from min_max_aggregates group by b;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: b
+         ->  Sort
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b
+                     ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(9 rows)
+
+explain(costs off) select max(b) from min_max_aggregates group by b;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: b
+         ->  Sort
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b
+                     ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(9 rows)
+
+-- Test min/max optimization with CTE
+-- Test min/max optimization when used in CTE producer. This query is
+-- eligible for optimization as producer computes min aggregate on a
+-- btree index key
+explain (costs off) with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
+               Merge Key: b
                ->  Limit
-                     ->  Index Scan using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
+                     ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select min(e) from min_max_aggregates group by ();
+with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
+ min_b 
+-------
+     1
+(1 row)
+
+-- Test min/max optimization when used in CTE consumer. This query is
+-- eligible for optimization as CTE consumer computes min aggregate on a
+-- btree index key projected by CTE producer
+explain (costs off) with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Limit
+                     ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
+ Optimizer: GPORCA
+(8 rows)
+
+with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
  min 
 -----
-   2
+   1
 (1 row)
 
-explain(costs off) select max(e) from min_max_aggregates group by ();
-                                   QUERY PLAN
----------------------------------------------------------------------------------
+-- Test min/max optimization when used in CTE consumer. This query is not
+-- eligible for optimization, because the subquery projects 'col_b' as 'b/2'
+-- upon which the min is computed, but none of the indices store values
+-- of column 'b/2' so that IndexScan could be used on that index
+explain (costs off) with cte_consumer as (select b/2 as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+-- Test min/max optimization with Casts
+-- Case where result of min/max is casted to a different data type.
+-- This query is eligible for optimization as casting happens after
+-- aggregation.
+explain (costs off) select min(b)::int8 from min_max_aggregates;
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
+               Merge Key: b
                ->  Limit
-                     ->  Index Scan Backward using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
+                     ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
 (8 rows)
 
-select max(e) from min_max_aggregates group by ();
- max 
+select min(b)::int8 from min_max_aggregates;
+ min 
 -----
- 160
+   1
 (1 row)
 
--- Test min/max with non-empty group by. This query's pattern matches
--- xform's pattern and it is included to ensure if xform correctly filters
--- this case out. This filtering happens while computing xform promise by
--- checking size of grouping columns and there by avoiding application
--- of transform
-explain(costs off) select min(e) from min_max_aggregates group by e;
-                            QUERY PLAN
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: e
-         ->  Sort
-               Sort Key: e
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: e
-                     ->  Seq Scan on min_max_aggregates
+-- Case where min/max is computed on a column casted to a different data type.
+-- This query is eligible for optimization as column type int4 and casted
+-- type int8 belong to same opfamily
+explain (costs off) select min(b::int8) from min_max_aggregates;
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: b
+               ->  Limit
+                     ->  Index Scan Backward using multi_key_index_b_c on min_max_aggregates
+                           Index Cond: (b IS NOT NULL)
  Optimizer: GPORCA
-(9 rows)
+(8 rows)
 
-explain(costs off) select max(e) from min_max_aggregates group by e;
-                            QUERY PLAN
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: e
-         ->  Sort
-               Sort Key: e
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: e
-                     ->  Seq Scan on min_max_aggregates
+select min(b::int8) from min_max_aggregates;
+ min 
+-----
+   1
+(1 row)
+
+-- This query is not eligible for optimization as there is no operator
+-- that handles comparison of a int4 and varchar type
+explain (costs off) select min(b::varchar) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
  Optimizer: GPORCA
-(9 rows)
+(5 rows)
 
--- Test min/max optimization when used as part of a subquery
-explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-                                            QUERY PLAN
----------------------------------------------------------------------------------------------------
+-- Cases with more than one min/max aggregates in query
+-- These queries aren't eligible for optimization because the transform's
+-- pattern only contains a single Scalar Project Element that matches only
+-- a single aggregate function whereas, these queries have more than one
+-- aggregate function. Support for these queries is beyond the scope of
+-- the current PR
+explain(costs off) select min(b), max(b) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+explain(costs off) select min(a) + max(a) from min_max_aggregates;
+                    QUERY PLAN
+--------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on min_max_aggregates
+ Optimizer: GPORCA
+(5 rows)
+
+-- Clean Up
+drop table min_max_aggregates;
+-- Test min/max optimization with union all, subqueries, joins and outer references
+CREATE TABLE table1 (a int, b int, c int);
+CREATE INDEX t1_c_idx on table1 using btree(c);
+CREATE TABLE table2 (a int, b int, c int);
+CREATE INDEX t2_c_idx on table2 using btree(c);
+INSERT INTO table1 select i, i, i from generate_series(1,100) i;
+INSERT INTO table2 select i, i, i from generate_series(1,100) i;
+ANALYZE table1;
+ANALYZE table2;
+-- Test min/max optimization when used in subqueries
+-- This query is eligible for optimization as subquery computes max
+-- aggregate on a btree index key
+explain (costs off) select b from table1 where c = (select max(c) from table1);
+                                       QUERY PLAN
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
@@ -3580,150 +3588,26 @@ explain (costs off) select b,e from min_max_aggregates where e = (select max(e) 
                ->  Aggregate
                      ->  Limit
                            ->  Gather Motion 3:1  (slice3; segments: 3)
-                                 Merge Key: min_max_aggregates.e
+                                 Merge Key: table1.c
                                  ->  Limit
-                                       ->  Index Scan Backward using index_e on min_max_aggregates
-                                             Index Cond: (e IS NOT NULL)
-         ->  Index Scan using index_e on min_max_aggregates min_max_aggregates_1
-               Index Cond: (e = (max(min_max_aggregates.e)))
+                                       ->  Index Scan Backward using t1_c_idx on table1
+                                             Index Cond: (c IS NOT NULL)
+         ->  Index Scan using t1_c_idx on table1 table1_1
+               Index Cond: (c = (max(table1.c)))
  Optimizer: GPORCA
 (14 rows)
 
-select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-  b  |  e  
------+-----
- 500 | 160
-(1 row)
-
--- Test min/max optimization when used in CTE producer
-explain (costs off) with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan Backward using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
- min_d 
--------
-     0
-(1 row)
-
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
-                                   QUERY PLAN
----------------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: d
-               ->  Limit
-                     ->  Index Scan Backward using index_d on min_max_aggregates
-                           Index Cond: (d IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
- min 
+select b from table1 where c = (select max(c) from table1);
+  b  
 -----
-   0
+ 100
 (1 row)
 
--- Test min/max optimization when used in CTE consumer. Optimization isn't
--- applicable for this case, because the subquery projects 'col_d' as 'd/2'
--- upon which the min is computed, but none of the indices store values
--- of column 'd/2' so that IndexScan could be used on that index
-explain (costs off) with cte_consumer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
--- Test min/max optimization when the result is casted to a different
--- data type. Adding this test as a part of query's pattern matches the
--- transforms pattern and is expected to leverage min/max optimization
--- feature
-explain (costs off) select min(e)::int from min_max_aggregates;
-                               QUERY PLAN
-------------------------------------------------------------------------
- Aggregate
-   ->  Limit
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: e
-               ->  Limit
-                     ->  Index Scan using index_e on min_max_aggregates
-                           Index Cond: (e IS NOT NULL)
- Optimizer: GPORCA
-(8 rows)
-
-select min(e)::int from min_max_aggregates;
- min 
------
-   2
-(1 row)
-
--- Case with more than one min/max aggregate functions. These cases aren't
--- supported in ORCA as that would be unnecessary and complex optimization
--- which is not worth the effort, unless some customer explicitly requests
--- for it
-explain(costs off) select min(a), max(d) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select min(a), max(d) from min_max_aggregates;
- min | max 
------+-----
-   1 |  32
-(1 row)
-
-explain(costs off) select min(a) + max(d) from min_max_aggregates;
-                    QUERY PLAN
---------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on min_max_aggregates
- Optimizer: GPORCA
-(5 rows)
-
-select min(a) + max(d) from min_max_aggregates;
- ?column? 
-----------
-       33
-(1 row)
-
--- Clean Up
-drop table min_max_aggregates;
--- Test min/max optimization in union all, joins and outer references
-CREATE TABLE table1 (a int, b text, c int);
-CREATE INDEX t1_c_idx on table1 using btree(c);
-CREATE TABLE table2 (a int, b text, c int);
-CREATE INDEX t2_c_idx on table2 using btree(c);
-INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
-INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
-ANALYZE table1;
-ANALYZE table2;
--- Test min/max optimization used as part of projected column in a
--- subquery along with a predicate. This query could not use optimization
--- as subquery has a predicate and the query pattern doesn't match
--- the transform's pattern
-explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as min_a from table2;
+-- Test min/max optimization in a subquery along with a predicate.
+-- This query isn't eligible to use optimization because predicate's
+-- pattern has a Select over LogicalGet and it doesn't match with the
+-- transform's pattern
+explain (costs off) select b, (select min(c) from table1 where table1.a > 5) as min_c from table2;
                                QUERY PLAN
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3740,7 +3624,7 @@ explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as 
  Optimizer: GPORCA
 (12 rows)
 
-explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_a from table2;
+explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_c from table2;
                                QUERY PLAN
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3759,9 +3643,11 @@ explain (costs off) select b, (select min(c) from table1 where table1.b = table2
 (13 rows)
 
 -- Test min/max optimization on result of union all present as part of
--- subquery. This query is not supported by min/max optimization as
--- it performs min/max on result of union all, not directly on a table's
--- column and it doesn't match the transform's pattern.
+-- subquery. This query is not eligible to use min/max optimization as
+-- it performs min/max on result of union all, and not directly on a table's
+-- column due to which there is mismatch in query and transform's pattern.
+-- The query pattern has LogicalUnionAll as first child of GbAgg whereas
+-- transforms pattern has LogicalGet.
 explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
                    QUERY PLAN
 ------------------------------------------------
@@ -3774,9 +3660,9 @@ explain (costs off) select max(c) from (select c from table1 union all select c 
  Optimizer: GPORCA
 (7 rows)
 
--- Test min/max optimization on outer references. This query only uses a
--- single aggregate function on an index column and hence generates a IndexScan
--- alternative.
+-- Test min/max optimization on outer references.
+-- This query is eligible to use optimization as it only has single
+-- aggregate function on an index column
 explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min(t1.c)) as min_val_for_c from table1 t1;
                           QUERY PLAN
 --------------------------------------------------------------
@@ -3796,9 +3682,9 @@ explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min
  Optimizer: GPORCA
 (14 rows)
 
--- Test min/max optimization on outer references. This query uses more
--- than one aggregate function, which doesn't match the transforms pattern
--- and hence min/max optimization isn't applicable to it.
+-- This query uses more than one aggregate function, and is not eligible
+-- to use optimization. This is because, query's pattern doesn't
+-- match the transforms pattern of a single Scalar Project Element.
 explain (costs off) select min(t1.c) as min_c,
                             (select b from table1 t1_alias where t1_alias.c = max(t1.c)) as b_val
                     from table1 t1;
@@ -3817,10 +3703,10 @@ explain (costs off) select min(t1.c) as min_c,
  Optimizer: GPORCA
 (11 rows)
 
--- Test min/max optimization used as part of projected columns in join. This query
--- could not use the optimization as it involves join result which is not
--- guaranteed to be sorted, unless it is an NL join.
-explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+-- Test min/max optimization used as part of projected columns in join.
+-- This query is not eligible to use the optimization as it involves
+-- join result which is not guaranteed to be sorted, unless it is an NL join.
+explain (costs off) select min(table1.c) from table1 join table2 on table1.a=table2.a;
                       QUERY PLAN
 ------------------------------------------------------
  Finalize Aggregate
@@ -3840,7 +3726,7 @@ drop table table2;
 -- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
 CREATE TABLE test_nulltype_predicates(a int, b int);
 CREATE INDEX index_b on test_nulltype_predicates using btree(b DESC);
-INSERT INTO test_nulltype_predicates select i, i*2 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates select i, i from generate_series(1,3)i;
 INSERT INTO test_nulltype_predicates values(null, null);
 ANALYZE test_nulltype_predicates;
 -- Tests with IS NULL on btree index columns
@@ -3869,12 +3755,6 @@ explain(costs off) select * from test_nulltype_predicates where a is null;
  Optimizer: GPORCA
 (4 rows)
 
-select * from test_nulltype_predicates where a is null;
- a | b 
----+---
-   |  
-(1 row)
-
 -- Tests with IS NOT NULL on btree index columns
 explain(costs off) select * from test_nulltype_predicates where b is not null;
                          QUERY PLAN
@@ -3888,9 +3768,9 @@ explain(costs off) select * from test_nulltype_predicates where b is not null;
 select * from test_nulltype_predicates where b is not null;
  a | b 
 ---+---
- 3 | 6
- 2 | 4
- 1 | 2
+ 1 | 1
+ 3 | 3
+ 2 | 2
 (3 rows)
 
 -- Tests with IS NOT NULL on non-index columns
@@ -3903,24 +3783,15 @@ explain(costs off) select * from test_nulltype_predicates where a is not null;
  Optimizer: GPORCA
 (4 rows)
 
-select * from test_nulltype_predicates where a is not null;
- a | b 
----+---
- 1 | 2
- 2 | 4
- 3 | 6
-(3 rows)
-
 -- Clean Up
 drop table test_nulltype_predicates;
--- Purpose: Test min/max optimization on AO table with mixed data type columns.
+-- Purpose: Test min/max optimization on AO table.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
 CREATE TABLE test_ao_table(a int, b int) WITH (appendonly=true) DISTRIBUTED BY (a);
--- multi col index with mixed index keys properties
 CREATE INDEX ao_index_b on test_ao_table using btree(b desc);
-INSERT INTO test_ao_table SELECT i, i+3 from generate_series(1,100) i;
+INSERT INTO test_ao_table SELECT i, i from generate_series(1,100) i;
 ANALYZE test_ao_table;
--- Test max() aggregate
+-- Test max() aggregate. This query is eligible to use optimization
 explain(costs off) select max(b) from test_ao_table;
                                 QUERY PLAN
 ---------------------------------------------------------------------------
@@ -3937,10 +3808,10 @@ explain(costs off) select max(b) from test_ao_table;
 select max(b) from test_ao_table;
  max 
 -----
- 103
+ 100
 (1 row)
 
--- Test min() aggregate
+-- Test min() aggregate. This query is eligible to use optimization
 explain(costs off) select min(b) from test_ao_table;
                                      QUERY PLAN
 ------------------------------------------------------------------------------------
@@ -3957,7 +3828,7 @@ explain(costs off) select min(b) from test_ao_table;
 select min(b) from test_ao_table;
  min 
 -----
-   4
+   1
 (1 row)
 
 -- Clean Up
@@ -3971,22 +3842,15 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE default_partition PARTITION OF test_partition_table DEFAULT;
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE INDEX part_index_b on test_partition_table using btree(b desc);
-INSERT INTO test_partition_table SELECT i+3, i from generate_series(1,4) i;
--- Inserting nulls to verify results match when index key specifies nulls first or desc
-INSERT INTO test_partition_table values (null, 5);
+INSERT INTO test_partition_table SELECT i, i from generate_series(1,4) i;
 -- Insert into default partition to show partition pruning
 -- for IS NULL conditions
 INSERT INTO test_partition_table values (0, NULL);
 ANALYZE test_partition_table;
--- Test min/max aggregate. This optimization isn't applicable for
--- partition tables because query's pattern doesn't match xforms pattern.
--- Moreover, ORCA currently, doesn't consider order property of
--- B-tree indices for order by and limit clause on top of a partitioned
--- table. This is because, data for non-partition order by column is spread across
--- multiple partitions and DynamicIndexScan cannot determine the correct
--- order of partitions to produce sorted result. For partition column(s),
--- table could have a default partition, which contains various different
--- unordered values.
+-- Test min/max aggregate on partition tables. This query is not
+-- eligible for optimization because the query's pattern has LogicalDynamicGet
+-- as first child of LogicalGbAgg whereas transform's pattern has LogicalGet.
+-- Support for these queries is beyond the scope of the current PR.
 explain(costs off) select max(b) from test_partition_table;
                            QUERY PLAN
 ----------------------------------------------------------------
@@ -3998,13 +3862,6 @@ explain(costs off) select max(b) from test_partition_table;
  Optimizer: GPORCA
 (6 rows)
 
-select max(b) from test_partition_table;
- max 
------
-   5
-(1 row)
-
--- Test min() aggregate
 explain(costs off) select min(b) from test_partition_table;
                            QUERY PLAN
 ----------------------------------------------------------------
@@ -4016,17 +3873,10 @@ explain(costs off) select min(b) from test_partition_table;
  Optimizer: GPORCA
 (6 rows)
 
-select min(b) from test_partition_table;
- min 
------
-   1
-(1 row)
-
--- Test IS NULL, IS NOT NULL on partition table btree index column
--- For, IS NULL predicate on partition column, pruning happens
--- whereas, for predicates on non-partition column, that doesn't, because
--- non-partition column's values distribution is unknown to eliminate
--- any partitions.
+-- Test IS NULL, IS NOT NULL on partition table btree index column.
+-- For IS NULL predicate on partition column, pruning happens
+-- whereas, for IS NOT NULL it doesn't because the Non null values
+-- could be in all of the partitions
 explain(costs off) select * from test_partition_table where b is null;
                             QUERY PLAN
 ------------------------------------------------------------------
@@ -4056,12 +3906,11 @@ explain(costs off) select * from test_partition_table where b is not null;
 select * from test_partition_table where b is not null;
  a | b 
 ---+---
- 5 | 2
- 6 | 3
- 4 | 1
-   | 5
- 7 | 4
-(5 rows)
+ 2 | 2
+ 4 | 4
+ 3 | 3
+ 1 | 1
+(4 rows)
 
 -- Clean Up
 drop table test_partition_table;

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -362,14 +362,17 @@ explain (costs off)
                ->  Nested Loop
                      Join Filter: true
                      ->  Broadcast Motion 1:3  (slice2)
-                           ->  Finalize Aggregate
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Seq Scan on tenk2
+                           ->  Aggregate
+                                 ->  Limit
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             Merge Key: tenk2.unique1
+                                             ->  Limit
+                                                   ->  Index Scan Backward using tenk2_unique1 on tenk2
+                                                         Index Cond: (unique1 IS NOT NULL)
                      ->  Index Only Scan using tenk1_unique1 on tenk1
                            Index Cond: (unique1 = (max(tenk2.unique1)))
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+ Optimizer: GPORCA
+(16 rows)
 
 select count(*) from tenk1
     where tenk1.unique1 = (Select max(tenk2.unique1) from tenk2);

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -124,10 +124,15 @@ select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) 
 -- start_ignore
 -- Known_opt_diff: MPP-21320
 -- end_ignore
+-- Disable 'CXformSelect2DynamicIndexGet' to avoid picking Dynamic Index Scan and use this test
+-- to showcase dpe alternative
+select disable_xform('CXformSelect2DynamicIndexGet');
 explain (costs off, timing off, summary off, analyze) select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
 
+-- enable xform
+select enable_xform('CXformSelect2DynamicIndexGet');
 --
 -- group-by on top
 --

--- a/src/test/regress/sql/qp_indexscan.sql
+++ b/src/test/regress/sql/qp_indexscan.sql
@@ -805,7 +805,7 @@ select min(b) from min_max_aggregates;
 explain(costs off) select max(b) from min_max_aggregates;
 select max(b) from min_max_aggregates;
 
-INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,10000)i;
+INSERT INTO min_max_aggregates select i, concat('col_b', i), i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
 INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
 
 -- Positive Tests
@@ -917,7 +917,7 @@ select * from min_max_aggregates where f is null;
 -- Tests with IS NOT NULL on btree index columns
 -- Ensure 1 NON NULL and NULL row exists in table to exactly determine output
 -- for below queries
-delete from min_max_aggregates where a<10000;
+delete from min_max_aggregates where a<100;
 -- Ensure Planner picks IndexScan wherever possible
 set enable_seqscan to off;
 set enable_bitmapscan to off;

--- a/src/test/regress/sql/qp_indexscan.sql
+++ b/src/test/regress/sql/qp_indexscan.sql
@@ -793,219 +793,191 @@ DROP TABLE part_table1;
 DROP TABLE part_table2;
 
 -- Purpose: This section includes tests related to min(), max() aggregates optimization.
-CREATE TABLE min_max_aggregates(a int, b int, c int, d int, e int, f int);
-CREATE INDEX index_bc on min_max_aggregates using btree(b DESC, c);
+CREATE TABLE min_max_aggregates(a int, b int, c int);
+CREATE INDEX multi_key_index_b_c on min_max_aggregates using btree(b DESC, c);
 ANALYZE min_max_aggregates;
 
--- Test min() and max() optimization if table doesn't have any tuples
--- This test is added to ensure min/max functions return 1 NULL row
--- indicating no min or max value exists as table doesn't have any tuples.
+-- Testing min/max functions when table doesn't have any tuples to
+-- ensure they return 1 NULL row indicating no min or max value exists.
+-- This test is eligible for optimization.
 explain(costs off) select min(b) from min_max_aggregates;
 select min(b) from min_max_aggregates;
 explain(costs off) select max(b) from min_max_aggregates;
 select max(b) from min_max_aggregates;
 
-INSERT INTO min_max_aggregates select i, i*5, i*2, i/3.1, i*1.6, i-1 from generate_series(1,100)i;
-INSERT INTO min_max_aggregates values(null, null, null, null, null, null);
+INSERT INTO min_max_aggregates select i, i, i from generate_series(1,100)i;
+INSERT INTO min_max_aggregates values(null, null, null);
 
--- Test optimization when there are multiple indices whose leading
--- index key matches aggregate column. This test shows that both
--- 'index_bc' created above and 'index_b' are eligible for the xform
--- and ORCA picks the lower cost index, which is 'index_b' in this
--- scenario
-CREATE INDEX index_b on min_max_aggregates using btree(b DESC);
+-- Creating this index to show that both 'multi_key_index_b_c' and
+-- 'single_key_b_desc' are eligible for min/max on column 'b' and
+-- ORCA picks the lower cost index
+CREATE INDEX single_key_b_desc on min_max_aggregates using btree(b DESC);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as indices: 'index_bc', 'index_b',
--- both featuring column 'b' as leading key
 
--- This query leverages Backward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, minimum value can be found at
+-- the bottom of the index
 explain(costs off) select min(b) from min_max_aggregates;
 select min(b) from min_max_aggregates;
--- This query leverages Forward IndexScan as column 'b' in 'index_b' is
--- sorted in descending order and therefore, maximum value can be found
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_desc' is sorted in
+-- descending order and therefore, maximum value can be found
 -- at the top of the index
 explain(costs off) select max(b) from min_max_aggregates;
 select max(b) from min_max_aggregates;
 
--- Test min/max optimization behavior on index with key direction
--- ASC NULLS FIRST. Utilizing an index with "NULLS FIRST" to ensure
--- that during a Forward IndexScan, NULL values at the beginning
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_a on min_max_aggregates using btree(a NULLS FIRST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_a'
--- features column 'a' as leading key
-
--- This query leverages Forward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(a) from min_max_aggregates;
-select min(a) from min_max_aggregates;
--- This query leverages Backward IndexScan as column 'a' in 'index_a' is
--- sorted in ascending order and therefore, maximum value can be found
--- at the bottom of the index
-explain(costs off) select max(a) from min_max_aggregates;
-select max(a) from min_max_aggregates;
-
--- Test min/max optimization behavior on index with key direction
--- DESC NULLS LAST. Utilizing an index with "NULLS LAST" to ensure
--- that during a Backward IndexScan, NULL values at the end
--- are filtered out, guaranteeing that a "limit" with 1 row will
--- return a valid non-null value.
-CREATE INDEX index_d on min_max_aggregates using btree(d DESC NULLS LAST);
-ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_d'
--- features column 'd' as leading key
-
--- This query leverages Backward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, minimum value can be found
--- at the bottom of the index
-explain(costs off) select min(d) from min_max_aggregates;
-select min(d) from min_max_aggregates;
--- This query leverages Forward IndexScan as column 'd' in 'index_d' is
--- sorted in descending order and therefore, maximum value can be found
--- at the top of the index
-explain(costs off) select max(d) from min_max_aggregates;
-select max(d) from min_max_aggregates;
+DROP INDEX single_key_b_desc;
 
 -- Test min/max optimization behavior on index with key direction ASC
-CREATE INDEX index_e on min_max_aggregates using btree(e);
+CREATE INDEX single_key_b_asc on min_max_aggregates using btree(b);
 ANALYZE min_max_aggregates;
--- Below queries are eligible for IndexScan as index: 'index_e'
--- features column 'e' as leading key
 
--- This query leverages Forward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, minimum value can be found
--- at the top of the index
-explain(costs off) select min(e) from min_max_aggregates;
-select min(e) from min_max_aggregates;
--- This query leverages Backward IndexScan as column 'e' in 'index_e' is
--- sorted in ascending order and therefore, maximum value can be found
+-- This query is eligible for optimization and it leverages Forward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, minimum value can be found at the
+-- top of the index
+explain(costs off) select min(b) from min_max_aggregates;
+select min(b) from min_max_aggregates;
+-- This query is eligible for optimization and it leverages Backward
+-- IndexScan as column 'b' in 'single_key_b_asc' is sorted in
+-- ascending order and therefore, maximum value can be found
 -- at the bottom of the index
-explain(costs off) select max(e) from min_max_aggregates;
-select max(e) from min_max_aggregates;
+explain(costs off) select max(b) from min_max_aggregates;
+select max(b) from min_max_aggregates;
 
--- Test optimization on non-leading keys in the index. These
--- tests aren't eligible for IndexScan as the aggregate column
--- isn't a leading key in the index
+DROP INDEX single_key_b_asc;
+
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non-leading keys in the index.
 explain(costs off) select min(c) from min_max_aggregates;
-select min(c) from min_max_aggregates;
 explain(costs off) select max(c) from min_max_aggregates;
-select max(c) from min_max_aggregates;
 
--- Test optimization on non index columns. These tests aren't
--- eligible for IndexScan as there is no index on the aggregate
--- column 'f'
-explain(costs off) select min(f) from min_max_aggregates;
-select min(f) from min_max_aggregates;
-explain(costs off) select max(f) from min_max_aggregates;
-select max(f) from min_max_aggregates;
+-- This query is not eligible for optimization as min/max aggregates
+-- are applied on non index column.
+explain(costs off) select min(a) from min_max_aggregates;
+explain(costs off) select max(a) from min_max_aggregates;
 
--- Test min/max on a constant. Aggregates optimization isn't necessary
--- for min/max on constants
+-- Test min/max on a constant. This query is not eligible for
+-- optimization as it is not necessary for min/max on constants
 explain(costs off) select min(100) from min_max_aggregates;
-select min(100) from min_max_aggregates;
 explain(costs off) select max(100) from min_max_aggregates;
-select max(100) from min_max_aggregates;
 
--- Test min/max optimization behavior with empty group by. Adding
--- this test as this query's pattern matches the transforms pattern
--- and is expected to leverage min/max optimization feature as
--- the query has no group by columns.
-explain(costs off) select min(e) from min_max_aggregates group by ();
-select min(e) from min_max_aggregates group by ();
-explain(costs off) select max(e) from min_max_aggregates group by ();
-select max(e) from min_max_aggregates group by ();
+-- Test min/max optimization behavior with empty group by. This query
+-- is eligible for optimization as it doesn't specify any grouping columns
+explain(costs off) select min(b) from min_max_aggregates group by ();
+select min(b) from min_max_aggregates group by ();
+explain(costs off) select max(b) from min_max_aggregates group by ();
+select max(b) from min_max_aggregates group by ();
 
--- Test min/max with non-empty group by. This query's pattern matches
--- xform's pattern and it is included to ensure if xform correctly filters
--- this case out. This filtering happens while computing xform promise by
--- checking size of grouping columns and there by avoiding application
--- of transform
-explain(costs off) select min(e) from min_max_aggregates group by e;
-explain(costs off) select max(e) from min_max_aggregates group by e;
+-- Test min/max with non-empty group by. This query is not eligible for
+-- optimization as it has grouping columns. This check is made while
+-- computing xform promise by validating size of grouping columns and
+-- there by avoiding application of transform
+explain(costs off) select min(b) from min_max_aggregates group by b;
+explain(costs off) select max(b) from min_max_aggregates group by b;
 
--- Test min/max optimization when used as part of a subquery
-explain (costs off) select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
-select b,e from min_max_aggregates where e = (select max(e) from min_max_aggregates);
+-- Test min/max optimization with CTE
 
--- Test min/max optimization when used in CTE producer
-explain (costs off) with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
-with cte_producer as (select min(d) as min_d from min_max_aggregates) select min_d from cte_producer;
+-- Test min/max optimization when used in CTE producer. This query is
+-- eligible for optimization as producer computes min aggregate on a
+-- btree index key
+explain (costs off) with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
+with cte_producer as (select min(b) as min_b from min_max_aggregates) select min_b from cte_producer;
 
--- Test min/max optimization when used in CTE consumer
-explain (costs off) with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
-with cte_consumer as (select d as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+-- Test min/max optimization when used in CTE consumer. This query is
+-- eligible for optimization as CTE consumer computes min aggregate on a
+-- btree index key projected by CTE producer
+explain (costs off) with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
+with cte_consumer as (select b as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
 
--- Test min/max optimization when used in CTE consumer. Optimization isn't
--- applicable for this case, because the subquery projects 'col_d' as 'd/2'
+-- Test min/max optimization when used in CTE consumer. This query is not
+-- eligible for optimization, because the subquery projects 'col_b' as 'b/2'
 -- upon which the min is computed, but none of the indices store values
--- of column 'd/2' so that IndexScan could be used on that index
-explain (costs off) with cte_consumer as (select d/2 as col_d from min_max_aggregates) select min(col_d) from cte_consumer;
+-- of column 'b/2' so that IndexScan could be used on that index
+explain (costs off) with cte_consumer as (select b/2 as col_b from min_max_aggregates) select min(col_b) from cte_consumer;
 
--- Test min/max optimization when the result is casted to a different
--- data type. Adding this test as a part of query's pattern matches the
--- transforms pattern and is expected to leverage min/max optimization
--- feature
-explain (costs off) select min(e)::int from min_max_aggregates;
-select min(e)::int from min_max_aggregates;
+-- Test min/max optimization with Casts
 
--- Case with more than one min/max aggregate functions. These cases aren't
--- supported in ORCA as that would be unnecessary and complex optimization
--- which is not worth the effort, unless some customer explicitly requests
--- for it
-explain(costs off) select min(a), max(d) from min_max_aggregates;
-select min(a), max(d) from min_max_aggregates;
+-- Case where result of min/max is casted to a different data type.
+-- This query is eligible for optimization as casting happens after
+-- aggregation.
+explain (costs off) select min(b)::int8 from min_max_aggregates;
+select min(b)::int8 from min_max_aggregates;
 
-explain(costs off) select min(a) + max(d) from min_max_aggregates;
-select min(a) + max(d) from min_max_aggregates;
+-- Case where min/max is computed on a column casted to a different data type.
+-- This query is eligible for optimization as column type int4 and casted
+-- type int8 belong to same opfamily
+explain (costs off) select min(b::int8) from min_max_aggregates;
+select min(b::int8) from min_max_aggregates;
+
+-- This query is not eligible for optimization as there is no operator
+-- that handles comparison of a int4 and varchar type
+explain (costs off) select min(b::varchar) from min_max_aggregates;
+
+-- Cases with more than one min/max aggregates in query
+
+-- These queries aren't eligible for optimization because the transform's
+-- pattern only contains a single Scalar Project Element that matches only
+-- a single aggregate function whereas, these queries have more than one
+-- aggregate function. Support for these queries is beyond the scope of
+-- the current PR
+explain(costs off) select min(b), max(b) from min_max_aggregates;
+explain(costs off) select min(a) + max(a) from min_max_aggregates;
 
 -- Clean Up
 drop table min_max_aggregates;
 
--- Test min/max optimization in union all, joins and outer references
-CREATE TABLE table1 (a int, b text, c int);
+-- Test min/max optimization with union all, subqueries, joins and outer references
+CREATE TABLE table1 (a int, b int, c int);
 CREATE INDEX t1_c_idx on table1 using btree(c);
-CREATE TABLE table2 (a int, b text, c int);
+CREATE TABLE table2 (a int, b int, c int);
 CREATE INDEX t2_c_idx on table2 using btree(c);
-INSERT INTO table1 select i, concat('b', i), i-2 from generate_series(1,100) i;
-INSERT INTO table2 select i, concat('b', i), i-2 from generate_series(1,100) i;
+INSERT INTO table1 select i, i, i from generate_series(1,100) i;
+INSERT INTO table2 select i, i, i from generate_series(1,100) i;
 ANALYZE table1;
 ANALYZE table2;
 
--- Test min/max optimization used as part of projected column in a
--- subquery along with a predicate. This query could not use optimization
--- as subquery has a predicate and the query pattern doesn't match
--- the transform's pattern
-explain (costs off) select b, (select min(a) from table1 where table1.a > 5) as min_a from table2;
+-- Test min/max optimization when used in subqueries
 
-explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_a from table2;
+-- This query is eligible for optimization as subquery computes max
+-- aggregate on a btree index key
+explain (costs off) select b from table1 where c = (select max(c) from table1);
+select b from table1 where c = (select max(c) from table1);
+
+-- Test min/max optimization in a subquery along with a predicate.
+-- This query isn't eligible to use optimization because predicate's
+-- pattern has a Select over LogicalGet and it doesn't match with the
+-- transform's pattern
+explain (costs off) select b, (select min(c) from table1 where table1.a > 5) as min_c from table2;
+
+explain (costs off) select b, (select min(c) from table1 where table1.b = table2.b) as min_c from table2;
 
 -- Test min/max optimization on result of union all present as part of
--- subquery. This query is not supported by min/max optimization as
--- it performs min/max on result of union all, not directly on a table's
--- column and it doesn't match the transform's pattern.
+-- subquery. This query is not eligible to use min/max optimization as
+-- it performs min/max on result of union all, and not directly on a table's
+-- column due to which there is mismatch in query and transform's pattern.
+-- The query pattern has LogicalUnionAll as first child of GbAgg whereas
+-- transforms pattern has LogicalGet.
 explain (costs off) select max(c) from (select c from table1 union all select c from table2) subquery;
 
--- Test min/max optimization on outer references. This query only uses a
--- single aggregate function on an index column and hence generates a IndexScan
--- alternative.
+-- Test min/max optimization on outer references.
+
+-- This query is eligible to use optimization as it only has single
+-- aggregate function on an index column
 explain (costs off) select (select b from table1 t1_alias where t1_alias.a = min(t1.c)) as min_val_for_c from table1 t1;
 
--- Test min/max optimization on outer references. This query uses more
--- than one aggregate function, which doesn't match the transforms pattern
--- and hence min/max optimization isn't applicable to it.
+-- This query uses more than one aggregate function, and is not eligible
+-- to use optimization. This is because, query's pattern doesn't
+-- match the transforms pattern of a single Scalar Project Element.
 explain (costs off) select min(t1.c) as min_c,
                             (select b from table1 t1_alias where t1_alias.c = max(t1.c)) as b_val
                     from table1 t1;
 
--- Test min/max optimization used as part of projected columns in join. This query
--- could not use the optimization as it involves join result which is not
--- guaranteed to be sorted, unless it is an NL join.
-explain (costs off) select min(table1.a) from table1 join table2 on table1.a=table2.a;
+-- Test min/max optimization used as part of projected columns in join.
+-- This query is not eligible to use the optimization as it involves
+-- join result which is not guaranteed to be sorted, unless it is an NL join.
+explain (costs off) select min(table1.c) from table1 join table2 on table1.a=table2.a;
 
 -- Clean up
 drop table table1;
@@ -1014,7 +986,7 @@ drop table table2;
 -- Purpose: This section tests IS NULL/IS NOT NULL predicate on btree and non-index columns
 CREATE TABLE test_nulltype_predicates(a int, b int);
 CREATE INDEX index_b on test_nulltype_predicates using btree(b DESC);
-INSERT INTO test_nulltype_predicates select i, i*2 from generate_series(1,3)i;
+INSERT INTO test_nulltype_predicates select i, i from generate_series(1,3)i;
 INSERT INTO test_nulltype_predicates values(null, null);
 ANALYZE test_nulltype_predicates;
 
@@ -1024,7 +996,6 @@ select * from test_nulltype_predicates where b is null;
 
 -- Tests with IS NULL on non-index columns
 explain(costs off) select * from test_nulltype_predicates where a is null;
-select * from test_nulltype_predicates where a is null;
 
 -- Tests with IS NOT NULL on btree index columns
 explain(costs off) select * from test_nulltype_predicates where b is not null;
@@ -1032,24 +1003,22 @@ select * from test_nulltype_predicates where b is not null;
 
 -- Tests with IS NOT NULL on non-index columns
 explain(costs off) select * from test_nulltype_predicates where a is not null;
-select * from test_nulltype_predicates where a is not null;
 
 -- Clean Up
 drop table test_nulltype_predicates;
 
--- Purpose: Test min/max optimization on AO table with mixed data type columns.
+-- Purpose: Test min/max optimization on AO table.
 -- IndexOnlyScans are supported but IndexScans aren't supported on AO tables
 CREATE TABLE test_ao_table(a int, b int) WITH (appendonly=true) DISTRIBUTED BY (a);
--- multi col index with mixed index keys properties
 CREATE INDEX ao_index_b on test_ao_table using btree(b desc);
-INSERT INTO test_ao_table SELECT i, i+3 from generate_series(1,100) i;
+INSERT INTO test_ao_table SELECT i, i from generate_series(1,100) i;
 ANALYZE test_ao_table;
 
--- Test max() aggregate
+-- Test max() aggregate. This query is eligible to use optimization
 explain(costs off) select max(b) from test_ao_table;
 select max(b) from test_ao_table;
 
--- Test min() aggregate
+-- Test min() aggregate. This query is eligible to use optimization
 explain(costs off) select min(b) from test_ao_table;
 select min(b) from test_ao_table;
 
@@ -1063,35 +1032,24 @@ CREATE TABLE partition1 PARTITION OF test_partition_table FOR VALUES FROM (1) TO
 CREATE TABLE partition2 PARTITION OF test_partition_table FOR VALUES FROM (3) TO (6);
 CREATE TABLE default_partition PARTITION OF test_partition_table DEFAULT;
 CREATE INDEX part_index_b on test_partition_table using btree(b desc);
-INSERT INTO test_partition_table SELECT i+3, i from generate_series(1,4) i;
--- Inserting nulls to verify results match when index key specifies nulls first or desc
-INSERT INTO test_partition_table values (null, 5);
+INSERT INTO test_partition_table SELECT i, i from generate_series(1,4) i;
 -- Insert into default partition to show partition pruning
 -- for IS NULL conditions
 INSERT INTO test_partition_table values (0, NULL);
 ANALYZE test_partition_table;
 
--- Test min/max aggregate. This optimization isn't applicable for
--- partition tables because query's pattern doesn't match xforms pattern.
--- Moreover, ORCA currently, doesn't consider order property of
--- B-tree indices for order by and limit clause on top of a partitioned
--- table. This is because, data for non-partition order by column is spread across
--- multiple partitions and DynamicIndexScan cannot determine the correct
--- order of partitions to produce sorted result. For partition column(s),
--- table could have a default partition, which contains various different
--- unordered values.
+-- Test min/max aggregate on partition tables. This query is not
+-- eligible for optimization because the query's pattern has LogicalDynamicGet
+-- as first child of LogicalGbAgg whereas transform's pattern has LogicalGet.
+-- Support for these queries is beyond the scope of the current PR.
 explain(costs off) select max(b) from test_partition_table;
-select max(b) from test_partition_table;
 
--- Test min() aggregate
 explain(costs off) select min(b) from test_partition_table;
-select min(b) from test_partition_table;
 
--- Test IS NULL, IS NOT NULL on partition table btree index column
--- For, IS NULL predicate on partition column, pruning happens
--- whereas, for predicates on non-partition column, that doesn't, because
--- non-partition column's values distribution is unknown to eliminate
--- any partitions.
+-- Test IS NULL, IS NOT NULL on partition table btree index column.
+-- For IS NULL predicate on partition column, pruning happens
+-- whereas, for IS NOT NULL it doesn't because the Non null values
+-- could be in all of the partitions
 explain(costs off) select * from test_partition_table where b is null;
 select * from test_partition_table where b is null;
 explain(costs off) select * from test_partition_table where b is not null;


### PR DESCRIPTION
As part of this commit, added support for min/max aggregates optimization, where in ORCA uses Index Scans(Forward/Backward) along with a limit operator to perform min() or max() on a btree index key. Prior to this commit, ORCA uses regular aggregates with  Sequential Scan to accomplish this. Along with this optimization, this PR also adds support for `IS NULL` and `IS NOT NULL` conditions on a btree index column and uses an Index Scan for such predicates instead of falling back to Sequential Scan. This support was required(at least for `IS NOT NULL` condition) in order to proceed with min/max optimization. Below are the plan changes with and without this commit.

This commit fixes issue https://github.com/greenplum-db/gpdb/issues/10508

Set Up
```
create table bar(a int, b text, c numeric);
create index on bar(c);
insert into bar select i, concat('col_b', i), i/3.2 from generate_series(1,1000)i;
analyze bar;
```

Plan for `min` function on a btree index column before this commit
```
explain select min(c) from bar;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=0.00..431.01 rows=1 width=8)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=1 width=8)
         ->  Partial Aggregate  (cost=0.00..431.01 rows=1 width=8)
               ->  Seq Scan on bar  (cost=0.00..431.01 rows=334 width=6)
 Optimizer: GPORCA
(5 rows)

```
Plan after this commit

```
explain select min(c) from bar;
                                          QUERY PLAN                                           
-----------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..6.12 rows=1 width=8)
   ->  Limit  (cost=0.00..6.12 rows=1 width=6)
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.12 rows=1 width=6)
               Merge Key: c
               ->  Limit  (cost=0.00..6.12 rows=1 width=6)
                     ->  Index Scan using bar_c_idx on bar  (cost=0.00..6.11 rows=334 width=6)
                           Index Cond: (c IS NOT NULL)
 Optimizer: GPORCA
(8 rows)
```

Plans for `IS NULL`, `IS NOT NULL` predicates on btree index columns before this commit
```
explain select * from bar where c is null;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.02 rows=1 width=18)
   ->  Seq Scan on bar  (cost=0.00..431.02 rows=1 width=18)
         Filter: (c IS NULL)
 Optimizer: GPORCA
(4 rows)

explain select * from bar where c is not null;
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.10 rows=1000 width=18)
   ->  Seq Scan on bar  (cost=0.00..431.03 rows=334 width=18)
         Filter: (NOT (c IS NULL))
 Optimizer: GPORCA
(4 rows)
```
Plans after this commit
```
explain select * from bar where c is null;
                                 QUERY PLAN                                  
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=18)
   ->  Index Scan using bar_c_idx on bar  (cost=0.00..6.00 rows=1 width=18)
         Index Cond: (c IS NULL)
 Optimizer: GPORCA
(4 rows)

explain select * from bar where c is not null;
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.19 rows=1000 width=18)
   ->  Index Scan using bar_c_idx on bar  (cost=0.00..6.11 rows=334 width=18)
         Index Cond: (c IS NOT NULL)
 Optimizer: GPORCA
(4 rows)

```