### PR TITLE
Fail if recovery target is not reached

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6516,7 +6516,7 @@ StartupXLOG(void)
 	XLogCtlInsert *Insert;
 	CheckPoint	checkPoint;
 	bool		wasShutdown;
-	bool		reachedStopPoint = false;
+	bool		reachedRecoveryTarget = false;
 	bool		haveBackupLabel = false;
 	bool		haveTblspcMap = false;
 	XLogRecPtr	RecPtr,
@@ -7475,7 +7475,7 @@ StartupXLOG(void)
 				 */
 				if (recoveryStopsBefore(xlogreader))
 				{
-					reachedStopPoint = true;	/* see below */
+					reachedRecoveryTarget = true;
 					break;
 				}
 
@@ -7655,7 +7655,7 @@ StartupXLOG(void)
 				/* Exit loop if we reached inclusive recovery target */
 				if (recoveryStopsAfter(xlogreader))
 				{
-					reachedStopPoint = true;
+					reachedRecoveryTarget = true;
 					break;
 				}
 
@@ -7667,7 +7667,7 @@ StartupXLOG(void)
 			 * end of main redo apply loop
 			 */
 
-			if (reachedStopPoint)
+			if (reachedRecoveryTarget)
 			{
 				if (!reachedConsistency)
 					ereport(FATAL,
@@ -7724,7 +7724,18 @@ StartupXLOG(void)
 			/* there are no WAL records following the checkpoint */
 			ereport(LOG,
 					(errmsg("redo is not required")));
+
 		}
+
+		/*
+		 * This check is intentionally after the above log messages that
+		 * indicate how far recovery went.
+		 */
+		if (ArchiveRecoveryRequested &&
+			recoveryTarget != RECOVERY_TARGET_UNSET &&
+			!reachedRecoveryTarget)
+			ereport(FATAL,
+					(errmsg("recovery ended before configured recovery target was reached")));
 	}
 
 	/*

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -1081,7 +1081,6 @@ restore_command = '$copy_command'
 
 =pod
 
-
 =item $node->set_recovery_mode()
 
 Place recovery.signal file.

--- a/src/test/recovery/t/003_recovery_targets.pl
+++ b/src/test/recovery/t/003_recovery_targets.pl
@@ -164,8 +164,8 @@ run_log(['pg_ctl', '-D', $node_standby->data_dir, '-l',
 		$node_standby->logfile, '-o', "-c gp_role=utility --gp_dbid=$node_standby->{_dbid} --gp_contentid=0 -c maintenance_mode=on",
 			'start']);
 
-# wait up to 10 seconds for postgres to terminate
-foreach my $i (0..100)
+# wait up to 180s for postgres to terminate
+foreach my $i (0..1800)
 {
 	last if ! -f $node_standby->data_dir . '/postmaster.pid';
 	usleep(100_000);

--- a/src/test/recovery/t/003_recovery_targets.pl
+++ b/src/test/recovery/t/003_recovery_targets.pl
@@ -3,7 +3,8 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 8;
+use Test::More tests => 9;
+use Time::HiRes qw(usleep);
 
 # Create and test a standby from given backup, with a certain recovery target.
 # Choose $until_lsn later than the transaction commit that causes the row
@@ -151,3 +152,24 @@ ok(!$res, 'invalid recovery startup fails');
 my $logfile = slurp_file($node_standby->logfile());
 ok($logfile =~ qr/multiple recovery targets specified/,
 	'multiple conflicting settings');
+
+# Check behavior when recovery ends before target is reached
+
+$node_standby = get_new_node('standby_8');
+$node_standby->init_from_backup($node_master, 'my_backup',
+								has_restoring => 1, standby => 0);
+$node_standby->append_conf('postgresql.conf',
+						   "recovery_target_name = 'does_not_exist'");
+run_log(['pg_ctl', '-D', $node_standby->data_dir, '-l',
+		$node_standby->logfile, '-o', "-c gp_role=utility --gp_dbid=$node_standby->{_dbid} --gp_contentid=0 -c maintenance_mode=on",
+			'start']);
+
+# wait up to 10 seconds for postgres to terminate
+foreach my $i (0..100)
+{
+	last if ! -f $node_standby->data_dir . '/postmaster.pid';
+	usleep(100_000);
+}
+$logfile = slurp_file($node_standby->logfile());
+ok($logfile =~ qr/FATAL:  recovery ended before configured recovery target was reached/,
+	'recovery end before target reached is a fatal error');


### PR DESCRIPTION
Backported from upstream

Original commit 1:
https://github.com/postgres/postgres/commit/dc788668bb269b10a108e87d14fefd1b9301b793

Backported with the change in the test:
diff:
```
- run_log(['pg_ctl', '-D', $node_standby->data_dir,
-		 '-l', $node_standby->logfile, 'start']);
+ run_log(['pg_ctl', '-D', $node_standby->data_dir, '-l', $node_standby->logfile, '-o', "-c gp_role=utility --gp_dbid=$node_standby->{_dbid} --gp_contentid=0 -c maintenance_mode=on", 'start']);
```
Original commit message:

Before, if a recovery target is configured, but the archive ended before the target was reached, recovery would end and the server would promote without further notice.  That was deemed to be pretty wrong. With this change, if the recovery target is not reached, it is a fatal error.

Based-on-patch-by: Leif Gunnar Erlandsen <leif@lako.no>
Reviewed-by: Kyotaro Horiguchi <horikyota.ntt@gmail.com>
Discussion: https://www.postgresql.org/message-id/flat/993736dd3f1713ec1f63fc3b653839f5@lako.no

Original commit 2:
https://github.com/postgres/postgres/commit/896135512ef67cc084f5e058cfa9b4954ca26861

Original commit message:

Raise a timeout to 180s, in test 003_recovery_targets.pl.
Buildfarm member chipmunk has failed twice due to taking >30s, and
twenty-four runs of other members have used >5s.  The test is new in
v13, so no back-patch.
