### PR TITLE
[6X_BACKPORT] Fail if recovery target is not reached

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6526,7 +6526,7 @@ StartupXLOG(void)
 	XLogCtlInsert *Insert;
 	CheckPoint	checkPoint;
 	bool		wasShutdown;
-	bool		reachedStopPoint = false;
+	bool		reachedRecoveryTarget = false;
 	bool		haveBackupLabel = false;
 	XLogRecPtr	RecPtr,
 				checkPointLoc,
@@ -7353,7 +7353,7 @@ StartupXLOG(void)
 				 */
 				if (recoveryStopsBefore(record))
 				{
-					reachedStopPoint = true;	/* see below */
+					reachedRecoveryTarget = true;
 					break;
 				}
 
@@ -7529,7 +7529,7 @@ StartupXLOG(void)
 				/* Exit loop if we reached inclusive recovery target */
 				if (recoveryStopsAfter(record))
 				{
-					reachedStopPoint = true;
+					reachedRecoveryTarget = true;
 					break;
 				}
 
@@ -7541,7 +7541,7 @@ StartupXLOG(void)
 			 * end of main redo apply loop
 			 */
 
-			if (reachedStopPoint)
+			if (reachedRecoveryTarget)
 			{
 				if (!reachedConsistency)
 					ereport(FATAL,
@@ -7597,7 +7597,18 @@ StartupXLOG(void)
 			/* there are no WAL records following the checkpoint */
 			ereport(LOG,
 					(errmsg("redo is not required")));
+
 		}
+
+		/*
+		 * This check is intentionally after the above log messages that
+		 * indicate how far recovery went.
+		 */
+		if (ArchiveRecoveryRequested &&
+			recoveryTarget != RECOVERY_TARGET_UNSET &&
+			!reachedRecoveryTarget)
+			ereport(FATAL,
+					(errmsg("recovery ended before configured recovery target was reached")));
 	}
 	else
 	{

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -609,6 +609,9 @@ Restoring WAL segments from archives using restore_command can be enabled
 by passing the keyword parameter has_restoring => 1. This is disabled by
 default.
 
+If has_restoring is used, standby mode is used by default.  To use
+recovery mode instead, pass the keyword parameter standby => 0.
+
 The backup is copied, leaving the original unmodified. pg_hba.conf is
 unconditionally set to enable replication connections.
 
@@ -625,6 +628,7 @@ sub init_from_backup
 
 	$params{has_streaming} = 0 unless defined $params{has_streaming};
 	$params{has_restoring} = 0 unless defined $params{has_restoring};
+	$params{standby} = 1 unless defined $params{standby};
 
 	print
 "# Initializing node \"$node_name\" from backup \"$backup_name\" of node \"$root_name\"\n";
@@ -655,7 +659,7 @@ port = $port
 			"unix_socket_directories = '$host'");
 	}
 	$self->enable_streaming($root_node) if $params{has_streaming};
-	$self->enable_restoring($root_node) if $params{has_restoring};
+	$self->enable_restoring($root_node, $params{standby}) if $params{has_restoring};
 }
 
 =pod
@@ -849,7 +853,7 @@ standby_mode=on
 # Internal routine to enable archive recovery command on a standby node
 sub enable_restoring
 {
-	my ($self, $root_node) = @_;
+	my ($self, $root_node, $standby) = @_;
 	my $path = TestLib::perl2host($root_node->archive_dir);
 	my $name = $self->name;
 
@@ -870,8 +874,9 @@ sub enable_restoring
 	$self->append_conf(
 		'recovery.conf', qq(
 restore_command = '$copy_command'
-standby_mode = on
+standby_mode = $standby
 ));
+	return;
 }
 
 # Internal routine to enable archiving

--- a/src/test/recovery/t/003_recovery_targets.pl
+++ b/src/test/recovery/t/003_recovery_targets.pl
@@ -141,8 +141,8 @@ run_log(['pg_ctl', '-w', '-D', $node_standby->data_dir, '-l',
 		$node_standby->logfile, '-o', "-c gp_role=utility --gp_dbid=$node_standby->{_dbid} --gp_contentid=0",
 			'start']);
 
-# wait up to 10 seconds for postgres to terminate
-foreach my $i (0..100)
+# wait up to 180s for postgres to terminate
+foreach my $i (0..1800)
 {
 	last if ! -f $node_standby->data_dir . '/postmaster.pid';
 	usleep(100_000);


### PR DESCRIPTION
Backported from GPDB7: 
https://github.com/greenplum-db/gpdb/commit/a93ab09e380a62240e8ea99d1c17f5385def8673
with the following changes:
 - In the TAP test framework added the `standby` parameter for the enable_restoring function to distinguish between standby and recovery which in GPDB7 is done via .signal files.
 - In the TAP test put recovery_target_name into recovery.conf file instead of postgresql.conf
 - In the TAP test added variables declaration.

Original GPDB7 commit message:

Backported from upstream with change in the test:
diff:
```
- run_log(['pg_ctl', '-D', $node_standby->data_dir,
-		 '-l', $node_standby->logfile, 'start']);
+ run_log(['pg_ctl', '-D', $node_standby->data_dir, '-l', $node_standby->logfile, '-o', "-c gp_role=utility --gp_dbid=$node_standby->{_dbid} --gp_contentid=0 -c maintenance_mode=on", 'start']);
```

Original Postgres commit on REL_13_BETA1:
https://github.com/postgres/postgres/commit/dc788668bb269b10a108e87d14fefd1b9301b793

Original Postgres commit message:

Before, if a recovery target is configured, but the archive ended before the target was reached, recovery would end and the server would promote without further notice.  That was deemed to be pretty wrong. With this change, if the recovery target is not reached, it is a fatal error.

Based-on-patch-by: Leif Gunnar Erlandsen <leif@lako.no>
Reviewed-by: Kyotaro Horiguchi <horikyota.ntt@gmail.com>
Discussion: https://www.postgresql.org/message-id/flat/993736dd3f1713ec1f63fc3b653839f5@lako.no