### PR TITLE
Fix orphaned temp namespace catalog entry left on coordinator

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4244,6 +4244,28 @@ DropTempTableNamespaceForResetSession(Oid namespaceOid)
 }
 
 /*
+ * Remove temp namespace entry from pg_namespace.
+ */
+void
+DropTempTableNamespaceEntryForResetSession(Oid namespaceOid, Oid toastNamespaceOid)
+{
+	if (IsTransactionOrTransactionBlock())
+		elog(ERROR, "Called within a transaction");
+
+	StartTransactionCommand();
+
+	/* Make sure the temp namespace is valid. */
+	if (SearchSysCacheExists1(NAMESPACEOID,
+							  ObjectIdGetDatum(namespaceOid)))
+	{
+		RemoveSchemaById(namespaceOid);
+		RemoveSchemaById(toastNamespaceOid);
+	}
+
+	CommitTransactionCommand();
+}
+
+/*
  * Called by CreateSchemaCommand when creating a temporary schema 
  */
 void

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -77,6 +77,7 @@ CreateGangFunc pCreateGangFunc = cdbgang_createGang_async;
 
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
+static Oid	OldTempToastNamespace = InvalidOid;
 
 /* WaitEventSet for dispatch */
 WaitEventSet *DispWaitSet = NULL;
@@ -761,6 +762,7 @@ GpDropTempTables(void)
 	int			oldSessionId = 0;
 	int			newSessionId = 0;
 	Oid			dropTempNamespaceOid;
+	Oid			dropTempToastNamespaceOid;
 
 	/* No need to reset session or drop temp tables */
 	if (!NeedResetSession && OldTempNamespace == InvalidOid)
@@ -802,14 +804,20 @@ GpDropTempTables(void)
 	}
 
 	dropTempNamespaceOid = OldTempNamespace;
+	dropTempToastNamespaceOid = OldTempToastNamespace;
 	OldTempNamespace = InvalidOid;
+	OldTempToastNamespace = InvalidOid;
 	NeedResetSession = false;
 
 	if (dropTempNamespaceOid != InvalidOid)
 	{
+		MemoryContext oldcontext = CurrentMemoryContext;
+
 		PG_TRY();
 		{
 			DropTempTableNamespaceForResetSession(dropTempNamespaceOid);
+			/* drop pg_temp_N schema entry from pg_namespace */
+			DropTempTableNamespaceEntryForResetSession(dropTempNamespaceOid, dropTempToastNamespaceOid);
 		} PG_CATCH();
 		{
 			/*
@@ -822,7 +830,10 @@ GpDropTempTables(void)
 			}
 
 			EmitErrorReport();
+
+			MemoryContextSwitchTo(oldcontext);
 			FlushErrorState();
+			AbortCurrentTransaction();
 		} PG_END_TRY();
 	}
 }
@@ -830,7 +841,13 @@ GpDropTempTables(void)
 void
 resetSessionForPrimaryGangLoss(void)
 {
-	if (ProcCanSetMppSessionId())
+	/*
+ 	 * resetSessionForPrimaryGangLoss could be called twice in a transacion,
+ 	 * we need to use NeedResetSession to double check if we should do the
+ 	 * real work to avoid that OldTempToastNamespace be makred invalid before
+ 	 * cleaning up the temp namespace.
+ 	 */
+	if (ProcCanSetMppSessionId() && !NeedResetSession)
 	{
 		/*
 		 * Not too early.
@@ -846,6 +863,8 @@ resetSessionForPrimaryGangLoss(void)
 		 */
 		if (TempNamespaceOidIsValid())
 		{
+
+			OldTempToastNamespace = GetTempToastNamespace();
 			/*
 			 * Here we indicate we don't have a temporary table namespace
 			 * anymore so all temporary tables of the previous session will be
@@ -861,7 +880,10 @@ resetSessionForPrimaryGangLoss(void)
 				 gp_session_id);
 		}
 		else
+		{
 			OldTempNamespace = InvalidOid;
+			OldTempToastNamespace = InvalidOid;
+		}
 	}
 }
 

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -104,10 +104,13 @@ test__resetSessionForPrimaryGangLoss(void **state)
 
 	/* Assum we have created a temporary namespace. */
 	will_return(TempNamespaceOidIsValid, true);
+	will_return(GetTempToastNamespace, 9998);
 	will_return(ResetTempNamespace, 9999);
 	OldTempNamespace = InvalidOid;
+	OldTempToastNamespace = InvalidOid;
 
 	resetSessionForPrimaryGangLoss();
+	assert_int_equal(OldTempToastNamespace, 9998);
 	assert_int_equal(OldTempNamespace, 9999);
 }
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -136,6 +136,7 @@ extern Oid	LookupExplicitNamespace(const char *nspname, bool missing_ok);
 extern Oid	get_namespace_oid(const char *nspname, bool missing_ok);
 
 extern void DropTempTableNamespaceForResetSession(Oid namespaceOid);
+extern void DropTempTableNamespaceEntryForResetSession(Oid namespaceOid, Oid toastNamespaceOid);
 extern void SetTempNamespace(Oid namespaceOid, Oid toastNamespaceOid);
 extern Oid  ResetTempNamespace(void);
 extern bool TempNamespaceOidIsValid(void);  /* GPDB only:  used by cdbgang.c */

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -21,6 +21,12 @@ ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0
  oid | relname | relnamespace 
 -----+---------+--------------
 (0 rows)
+-- we should not see the temp namespace on the coordinator
+1: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
+ count 
+-------
+ 0     
+(1 row)
 
 
 -- the temp table is left on segment 0, it should be dropped by autovacuum later

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -12,6 +12,8 @@
 
 -- we should not see the temp table on the coordinator
 1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+-- we should not see the temp namespace on the coordinator
+1: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
 
 
 -- the temp table is left on segment 0, it should be dropped by autovacuum later


### PR DESCRIPTION
Note that, commit e88ceb8e399074189160a8a2a2eb906bdfebbb12 fixed orphaned temp table left on coordinator, but it did't handle orphaned namespace catalog entry left on coordinator. This commit fix that.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
