### PR TITLE
Compute statistics for a column of table

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
@@ -1488,7 +1488,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
     <dxl:Plan Id="0" SpaceSize="50">
       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="75.124253" Rows="337.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="75.123856" Rows="337.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="pg_toast_relidx">
@@ -1501,7 +1501,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
         </dxl:JoinFilter>
         <dxl:Assert ErrorCode="P0003">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.464146" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.464047" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="48" Alias="reltoastidxid">
@@ -1518,7 +1518,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
           </dxl:AssertConstraintList>
           <dxl:Window PartitionColumns="">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12.464142" Rows="337.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="12.464043" Rows="337.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="115" Alias="row_number">
@@ -1531,7 +1531,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
             <dxl:Filter/>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="12.464142" Rows="337.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="12.464043" Rows="337.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="48" Alias="reltoastidxid">
@@ -1544,7 +1544,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
               </dxl:JoinFilter>
               <dxl:Assert ErrorCode="P0003">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.147225" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.147126" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="85" Alias="reltoastrelid">
@@ -1561,7 +1561,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
                 </dxl:AssertConstraintList>
                 <dxl:Window PartitionColumns="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.147221" Rows="134.800000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6.147122" Rows="134.800000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="114" Alias="row_number">
@@ -1574,7 +1574,7 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
                   <dxl:Filter/>
                   <dxl:IndexScan IndexScanDirection="Forward">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.146218" Rows="134.800000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="6.146119" Rows="134.800000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="85" Alias="reltoastrelid">

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
@@ -241,7 +241,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.044256" Rows="284.444444" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.043956" Rows="284.444444" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -255,7 +255,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.034365" Rows="284.444444" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.034065" Rows="284.444444" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
@@ -1042,7 +1042,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.217460" Rows="957.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.216960" Rows="957.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1056,7 +1056,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.188929" Rows="957.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.188429" Rows="957.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
@@ -960,7 +960,7 @@
     <dxl:Plan Id="0" SpaceSize="78">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="12.000994" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.000834" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -974,7 +974,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.000965" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.000805" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -990,7 +990,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000790" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000730" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1004,7 +1004,7 @@
             <dxl:SortingColumnList/>
             <dxl:DynamicIndexOnlyScan IndexScanDirection="Forward" SelectorIds="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000360" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000300" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -1053,7 +1053,7 @@
           </dxl:BroadcastMotion>
           <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000160" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000060" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
@@ -960,7 +960,7 @@
     <dxl:Plan Id="0" SpaceSize="63">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="12.001823" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.001663" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -974,7 +974,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.001793" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.001633" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -994,7 +994,7 @@
           </dxl:HashCondList>
           <dxl:DynamicIndexOnlyScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000360" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000300" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1042,7 +1042,7 @@
           </dxl:DynamicIndexOnlyScan>
           <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000644" Rows="9.090900" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000544" Rows="9.090900" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScanCosting.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScanCosting.mdp
@@ -568,7 +568,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="461.004987" Rows="5.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="461.003487" Rows="5.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -594,7 +594,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="461.004539" Rows="5.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="461.003039" Rows="5.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -653,7 +653,7 @@
           </dxl:TableScan>
           <dxl:DynamicIndexOnlyScan IndexScanDirection="Forward" SelectorIds="">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="30.003975" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="30.002475" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -1457,7 +1457,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="888838.915100" Rows="42.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="888838.913054" Rows="42.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c">
@@ -1483,7 +1483,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="888838.911343" Rows="42.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="888838.909298" Rows="42.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c">
@@ -1520,7 +1520,7 @@
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.001152" Rows="3.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.001150" Rows="3.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -1537,7 +1537,7 @@
             <dxl:SortingColumnList/>
             <dxl:IndexScan IndexScanDirection="Forward">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000486" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000484" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -418,7 +418,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 12;
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000491" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000391" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -444,7 +444,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 12;
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000402" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000302" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScanCosting.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScanCosting.mdp
@@ -227,10 +227,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000568" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000268" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -247,7 +247,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000516" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000216" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
@@ -1437,7 +1437,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.002520" Rows="1.774224" Width="88"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.001822" Rows="1.774224" Width="88"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="some_id">
@@ -1514,7 +1514,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.001841" Rows="1.774224" Width="88"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.001144" Rows="1.774224" Width="88"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="some_id">

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
@@ -385,7 +385,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000436" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000236" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -405,7 +405,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000366" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000166" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-DynamicIndexOnlyScan-Range.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-DynamicIndexOnlyScan-Range.mdp
@@ -895,7 +895,7 @@
     <dxl:Plan Id="0" SpaceSize="405">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.000740" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000558" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="ptid">
@@ -906,7 +906,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000725" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000543" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="ptid">
@@ -923,7 +923,7 @@
           </dxl:HashCondList>
           <dxl:DynamicIndexOnlyScan IndexScanDirection="Forward" SelectorIds="0">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000310" Rows="1.000000" Width="11"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000129" Rows="1.000000" Width="11"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="col2">

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1222,7 +1222,7 @@ WHERE
     <dxl:Plan Id="0" SpaceSize="51358">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1306.829302" Rows="199.680000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="1306.828703" Rows="199.680000" Width="148"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="oid">
@@ -1245,7 +1245,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1306.719169" Rows="199.680000" Width="148"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.718570" Rows="199.680000" Width="148"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="oid">
@@ -1276,7 +1276,7 @@ WHERE
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1306.703772" Rows="702.000000" Width="150"/>
+              <dxl:Cost StartupCost="0" TotalCost="1306.703173" Rows="702.000000" Width="150"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="ColRef_0073">
@@ -1305,7 +1305,7 @@ WHERE
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1306.668672" Rows="702.000000" Width="158"/>
+                <dxl:Cost StartupCost="0" TotalCost="1306.668073" Rows="702.000000" Width="158"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="amname">
@@ -1344,7 +1344,7 @@ WHERE
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="875.128246" Rows="702.000000" Width="150"/>
+                  <dxl:Cost StartupCost="0" TotalCost="875.127647" Rows="702.000000" Width="150"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="amname">
@@ -1378,7 +1378,7 @@ WHERE
                 </dxl:HashExprList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="874.854817" Rows="702.000000" Width="150"/>
+                    <dxl:Cost StartupCost="0" TotalCost="874.854218" Rows="702.000000" Width="150"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="amname">
@@ -1410,7 +1410,7 @@ WHERE
                   </dxl:HashCondList>
                   <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="443.223721" Rows="141.000000" Width="146"/>
+                      <dxl:Cost StartupCost="0" TotalCost="443.223122" Rows="141.000000" Width="146"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="amname">
@@ -1477,7 +1477,7 @@ WHERE
                     </dxl:TableScan>
                     <dxl:IndexScan IndexScanDirection="Forward">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="12.131806" Rows="70.500000" Width="72"/>
+                        <dxl:Cost StartupCost="0" TotalCost="12.131208" Rows="70.500000" Width="72"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="34" Alias="opcname">

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
@@ -206,7 +206,8 @@ private:
 	// for index scan & index only scan.
 	static CDouble ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 											CColRefArray *pdrgpcrIndexColumns,
-											IStatistics *stats);
+											IStatistics *pBaseTableStats,
+											CMemoryPool *mp, IMDId *rel_mdid);
 
 	// Get  count of index keys, width of included col, array of index columns
 	// and table statistics for Index Scan, Index only scan, Dynamic Index scan

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -1641,12 +1641,12 @@ CCostModelGPDB::ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 				// more weightage.
 				dUnusedIndexColWeight = (ulNoOfColumnsInIndex - ulIndexColPos);
 
-				IStatistics *UnusedIndexColStats =
+				IStatistics *unusedIndexColStats =
 					CStatistics::CastStats(pBaseTableStats)
 						->ComputeColStats(mp, colrefIndexColumn, rel_mdid);
 
 				// Finding NDV of the unused column
-				dNdv = CStatistics::CastStats(UnusedIndexColStats)
+				dNdv = CStatistics::CastStats(unusedIndexColStats)
 						   ->GetNDVs(colrefIndexColumn);
 
 				CDouble dTableRows =
@@ -1665,7 +1665,7 @@ CCostModelGPDB::ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 				dCummulativeUnusedIndexWeight =
 					dCummulativeUnusedIndexWeight + dUnusedIndexColWeight;
 
-				UnusedIndexColStats->Release();
+				unusedIndexColStats->Release();
 			}
 		}
 	}

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -1593,10 +1593,11 @@ CCostModelGPDB::CostSequenceProject(CMemoryPool *mp, CExpressionHandle &exprhdl,
 CDouble
 CCostModelGPDB::ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 										 CColRefArray *pdrgpcrIndexColumns,
-										 IStatistics *stats)
+										 IStatistics *pBaseTableStats,
+										 CMemoryPool *mp, IMDId *rel_mdid)
 
 {
-	GPOS_ASSERT(nullptr != stats);
+	GPOS_ASSERT(nullptr != pBaseTableStats);
 
 	CDouble dCummulativeUnusedIndexWeight = 0;
 	CDouble dNdv(1.0);
@@ -1640,11 +1641,16 @@ CCostModelGPDB::ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 				// more weightage.
 				dUnusedIndexColWeight = (ulNoOfColumnsInIndex - ulIndexColPos);
 
-				// Finding NDV of the unused column
-				dNdv =
-					CStatistics::CastStats(stats)->GetNDVs(colrefIndexColumn);
+				IStatistics *UnusedIndexColStats =
+					CStatistics::CastStats(pBaseTableStats)
+						->ComputeColStats(mp, colrefIndexColumn, rel_mdid);
 
-				CDouble dTableRows = CStatistics::CastStats(stats)->Rows();
+				// Finding NDV of the unused column
+				dNdv = CStatistics::CastStats(UnusedIndexColStats)
+						   ->GetNDVs(colrefIndexColumn);
+
+				CDouble dTableRows =
+					CStatistics::CastStats(pBaseTableStats)->Rows();
 
 				GPOS_ASSERT(0 != dTableRows);
 
@@ -1658,6 +1664,8 @@ CCostModelGPDB::ComputeUnusedIndexWeight(CExpressionHandle &exprhdl,
 
 				dCummulativeUnusedIndexWeight =
 					dCummulativeUnusedIndexWeight + dUnusedIndexColWeight;
+
+				UnusedIndexColStats->Release();
 			}
 		}
 	}
@@ -1729,6 +1737,8 @@ CCostModelGPDB::CostIndexScan(CMemoryPool *mp GPOS_UNUSED,
 	COperator::EOperatorId op_id = pop->Eopid();
 	GPOS_ASSERT(COperator::EopPhysicalIndexScan == op_id ||
 				COperator::EopPhysicalDynamicIndexScan == op_id);
+
+	IMDId *rel_mdid = CPhysicalScan::PopConvert(pop)->Ptabdesc()->MDId();
 
 	const CDouble dTableWidth =
 		CPhysicalScan::PopConvert(pop)->PstatsBaseTable()->Width();
@@ -1802,7 +1812,8 @@ CCostModelGPDB::CostIndexScan(CMemoryPool *mp GPOS_UNUSED,
 	CDouble dUnindexedPredCost =
 		ulUnindexedPredCount * dIndexCostConversionFactor;
 	CDouble dUnusedIndexCost =
-		ComputeUnusedIndexWeight(exprhdl, pdrgpcrIndexColumns, stats) *
+		ComputeUnusedIndexWeight(exprhdl, pdrgpcrIndexColumns, stats, mp,
+								 rel_mdid) *
 		dIndexCostConversionFactor;
 
 	pdrgpcrIndexColumns->Release();
@@ -1829,6 +1840,8 @@ CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *mp GPOS_UNUSED,	  // mp
 	COperator *pop = exprhdl.Pop();
 	GPOS_ASSERT(COperator::EopPhysicalIndexOnlyScan == pop->Eopid() ||
 				COperator::EopPhysicalDynamicIndexOnlyScan == pop->Eopid());
+
+	IMDId *rel_mdid = CPhysicalScan::PopConvert(pop)->Ptabdesc()->MDId();
 
 	const CDouble dTableWidth =
 		CPhysicalScan::PopConvert(pop)->PstatsBaseTable()->Width();
@@ -1924,7 +1937,8 @@ CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *mp GPOS_UNUSED,	  // mp
 			->Get();
 
 	CDouble dUnusedIndexCost =
-		ComputeUnusedIndexWeight(exprhdl, pdrgpcrIndexColumns, stats) *
+		ComputeUnusedIndexWeight(exprhdl, pdrgpcrIndexColumns, stats, mp,
+								 rel_mdid) *
 		dIndexCostConversionFactor;
 
 	pdrgpcrIndexColumns->Release();

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -235,6 +235,10 @@ public:
 	// look up the width of a particular column
 	virtual const CDouble *GetWidth(ULONG colid) const;
 
+	// Compute stats of a given column
+	IStatistics *ComputeColStats(CMemoryPool *mp, CColRef *colref,
+								 IMDId *rel_mdid) override;
+
 	// the risk of errors in cardinality estimation
 	ULONG
 	StatsEstimationRisk() const override

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -137,6 +137,10 @@ public:
 
 	virtual ULONG GetNumberOfPredicates() const = 0;
 
+	// Compute stats for given column
+	virtual IStatistics *ComputeColStats(CMemoryPool *mp, CColRef *colref,
+										 IMDId *rel_mdid) = 0;
+
 	// inner join with another stats structure
 	virtual IStatistics *CalcInnerJoinStats(
 		CMemoryPool *mp, const IStatistics *other_stats,

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -886,20 +886,19 @@ CStatistics::GetNDVs(const CColRef *colref)
 IStatistics *
 CStatistics::ComputeColStats(CMemoryPool *mp, CColRef *colref, IMDId *rel_mdid)
 {
-	GPOS_ASSERT(mp != nullptr);
-	GPOS_ASSERT(colref != nullptr);
-	GPOS_ASSERT(rel_mdid != nullptr);
+	GPOS_ASSERT(nullptr != mp);
+	GPOS_ASSERT(nullptr != colref);
+	GPOS_ASSERT(nullptr != rel_mdid);
 
-	CColRefArray *pdrgpcrCol = GPOS_NEW(mp) CColRefArray(mp);
-	pdrgpcrCol->Append(colref);
+	CColRefSet *pcrsHist = GPOS_NEW(mp) CColRefSet(mp);
+	pcrsHist->Include(colref);
 
-	CColRefSet *pcrsHist = GPOS_NEW(mp) CColRefSet(mp, pdrgpcrCol);
-	CColRefSet *pcrsWidth = GPOS_NEW(mp) CColRefSet(mp, pdrgpcrCol);
+	CColRefSet *pcrsWidth = GPOS_NEW(mp) CColRefSet(mp);
+	pcrsWidth->Include(colref);
 
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 	IStatistics *stats = md_accessor->Pstats(mp, rel_mdid, pcrsHist, pcrsWidth);
 
-	pdrgpcrCol->Release();
 	pcrsHist->Release();
 	pcrsWidth->Release();
 	return stats;

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -882,5 +882,27 @@ CStatistics::GetNDVs(const CColRef *colref)
 	return std::min(m_rows, GetColUpperBoundNDVs(colref));
 }
 
+// Compute stats of a given column
+IStatistics *
+CStatistics::ComputeColStats(CMemoryPool *mp, CColRef *colref, IMDId *rel_mdid)
+{
+	GPOS_ASSERT(mp != nullptr);
+	GPOS_ASSERT(colref != nullptr);
+	GPOS_ASSERT(rel_mdid != nullptr);
+
+	CColRefArray *pdrgpcrCol = GPOS_NEW(mp) CColRefArray(mp);
+	pdrgpcrCol->Append(colref);
+
+	CColRefSet *pcrsHist = GPOS_NEW(mp) CColRefSet(mp, pdrgpcrCol);
+	CColRefSet *pcrsWidth = GPOS_NEW(mp) CColRefSet(mp, pdrgpcrCol);
+
+	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+	IStatistics *stats = md_accessor->Pstats(mp, rel_mdid, pcrsHist, pcrsWidth);
+
+	pdrgpcrCol->Release();
+	pcrsHist->Release();
+	pcrsWidth->Release();
+	return stats;
+}
 
 // EOF

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -305,10 +305,6 @@ select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
    49 | hello49 | world | drop this |    1
 (18 rows)
 
--- With the updated Index scan costing, additional rows are added to enable DPE using
--- dynamic index only scan on ptid_pt1_idx. These rows are deleted after this test.
-insert into pt select i, 'hello' || i, 'world', 'drop this', i % 6 from generate_series(54,2500) i;
-vacuum analyze pt;
 explain (costs off, timing off, summary off, analyze) select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) and pt1 = 'hello1';
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
@@ -322,7 +318,7 @@ explain (costs off, timing off, summary off, analyze) select ptid from pt where 
                      Filter: (pt1 = 'hello1'::text)
                ->  Seq Scan on pt_1_prt_3 (actual rows=1 loops=1)
                      Filter: (pt1 = 'hello1'::text)
-                     Rows Removed by Filter: 118
+                     Rows Removed by Filter: 2
                ->  Seq Scan on pt_1_prt_4 (never executed)
                      Filter: (pt1 = 'hello1'::text)
                ->  Seq Scan on pt_1_prt_5 (never executed)
@@ -346,8 +342,6 @@ select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) 
     1
 (1 row)
 
-delete from pt where dist>53;
-vacuum analyze pt;
 -- start_ignore
 -- Known_opt_diff: MPP-21320
 -- end_ignore

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -268,10 +268,6 @@ select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
    48 | hello48 | world | drop this |    0
 (18 rows)
 
--- With the updated Index scan costing, additional rows are added to enable DPE using
--- dynamic index only scan on ptid_pt1_idx. These rows are deleted after this test.
-insert into pt select i, 'hello' || i, 'world', 'drop this', i % 6 from generate_series(54,2500) i;
-vacuum analyze pt;
 explain (costs off, timing off, summary off, analyze) select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) and pt1 = 'hello1';
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
@@ -299,8 +295,6 @@ select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) 
     1
 (1 row)
 
-delete from pt where dist>53;
-vacuum analyze pt;
 -- start_ignore
 -- Known_opt_diff: MPP-21320
 -- end_ignore
@@ -1000,8 +994,9 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
                            Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                            ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
-                                       ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=1)
+                                       ->  Dynamic Index Only Scan on ptid_pt1_idx on pt (actual rows=1 loops=1)
                                              Index Cond: (pt1 = 'hello0'::text)
+                                             Heap Fetches: 0
                                              Number of partitions to scan: 6 (out of 6)
                                              Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1964,7 +1964,7 @@ explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on 
    ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=28)
          Join Filter: true
          ->  Seq Scan on foojoinpruning  (cost=0.00..431.00 rows=1 width=28)
-         ->  Index Scan using idx3 on barjoinpruning  (cost=0.00..6.00 rows=1 width=1)
+         ->  Index Scan using idx4 on barjoinpruning  (cost=0.00..6.00 rows=1 width=1)
                Index Cond: (p = foojoinpruning.a)
                Filter: (r = s)
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -117,15 +117,9 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
 
--- With the updated Index scan costing, additional rows are added to enable DPE using
--- dynamic index only scan on ptid_pt1_idx. These rows are deleted after this test.
-insert into pt select i, 'hello' || i, 'world', 'drop this', i % 6 from generate_series(54,2500) i;
-vacuum analyze pt;
 explain (costs off, timing off, summary off, analyze) select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) and pt1 = 'hello1';
 
 select ptid from pt where ptid in (select tid from t where t1 = 'hello' || tid) and pt1 = 'hello1';
-delete from pt where dist>53;
-vacuum analyze pt;
 
 -- start_ignore
 -- Known_opt_diff: MPP-21320


### PR DESCRIPTION
**MOTIVATION**

----------------------------------------------------------------------------------------------------------------------
While creating 'Physical Scan Opertors', the statistics of base table are computed in function CPhysicalScan::ComputeTableStats().But while computing these statistics, the histograms for the columns of table are not generated as the columns of the table are not sent to CMDAccessor::Pstats(,,,,).

While costing (Dynaic)Index(only) scans, NDV of columns of table is required. The NDV cannot be calculated as the histograms were not generated during creation of scan operator.

**SOLUTION**

----------------------------------------------------------------------------------------------------------------------
To overcome this, function 'CStatistics::ComputeColStats (,,) is added. This function computes the statistics for a given column. The generated statistics are used for (Dynamic)Index(only) scan costing.

**NOTE**

----------------------------------------------------------------------------------------------------------------------
This PR updates the logic required for 'computation of statistics for unused index column' introduced in the PR #16156 on Index costing.
