### PR TITLE
Add assertions in GetTableAmRoutine to check greenplum-specific tableAM routines

### DIFF
--- a/src/backend/access/table/tableamapi.c
+++ b/src/backend/access/table/tableamapi.c
@@ -106,6 +106,8 @@ GetTableAmRoutine(Oid amhandler)
 		   (routine->scan_bitmap_next_tuple == NULL));
 	Assert(routine->scan_sample_next_block != NULL);
 	Assert(routine->scan_sample_next_tuple != NULL);
+	Assert(routine->dml_init != NULL);
+	Assert(routine->dml_finish != NULL);
 
 	return routine;
 }


### PR DESCRIPTION
if somebody defines TableAM method in Greenplum, without specifying dml_init/dml_finish functions, this will cause segfault (for example, `table_dml_finish` call in ExecEndModifyTable method)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
