### PR TITLE
[7X] Improve runtime performance for gprecoverseg differential recovery

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -492,8 +492,9 @@ def canonicalize(addr):
 class Rsync(Command):
     def __init__(self, name, srcFile, dstFile, srcHost=None, dstHost=None, recursive=False,
                  verbose=True, archive_mode=True, checksum=False, delete=False, progress=False,
-                 stats=False, dry_run=False, bwlimit=None, exclude_list={}, ctxt=LOCAL,
-                 remoteHost=None, compress=False, progress_file=None, ignore_times=False, whole_file=False):
+                 stats=False, dry_run=False, bwlimit=None, exclude_list=[], ctxt=LOCAL,
+                 ignore_times=False, whole_file=False,remoteHost=None, compress=False,
+                 progress_file=None, files_from = None):
 
         """
             rsync options:
@@ -557,6 +558,10 @@ class Rsync(Command):
 
         if compress:
             cmd_tokens.append('--compress')
+
+        if files_from is not None:
+            filestr = "--files-from={}".format(files_from)
+            cmd_tokens.append(filestr)
 
         if srcHost:
             cmd_tokens.append(canonicalize(srcHost) + ":" + srcFile)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -553,6 +553,17 @@ class DifferentialRecoveryClsTestCase(GpTestCase):
                           call('List of modified files : []')],
                          self.mock_logger.debug.call_args_list)
 
+    @patch('gppylib.commands.base.Command.run')
+    @patch('gppylib.commands.base.Command.get_stdout', return_value='')
+    def test_sync_sync_updated_files_success(self,mock1,mock2):
+        self.diff_recovery_cmd.sync_updated_files()
+        self.assertEqual(1, self.mock_rsync_init.call_count)
+        self.assertEqual(1, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        self.assertEqual([call('Syncing Updated files of dbid 2'),
+                          call('List of modified files : []')],
+                         self.mock_logger.debug.call_args_list)
+
     def tearDown(self):
         super(DifferentialRecoveryClsTestCase, self).tearDown()
 
@@ -737,6 +748,15 @@ class DifferentialRecoveryRunTestCase(GpTestCase):
 
     @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', side_effect=Exception())
     def test_diff_recovery_sync_pg_data_exception(self, mock1):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pg_stop_backup.call_count)
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_updated_files', side_effect=Exception())
+    def test_diff_recovery_sync_updated_files_exception(self, mock1):
         self.diff_recovery_cmd.run()
         self.assertEqual(1, self.mock_pg_stop_backup.call_count)
         self.assertEqual(1, self.mock_logger.info.call_count)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -26,7 +26,7 @@ class ValidationForFullRecoveryTestCase(GpTestCase):
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
                                               p.getSegmentDataDirectory(),
-                                              True, False, '/tmp/test_progress_file')
+                                              True, False, None,'/tmp/test_progress_file')
 
         self.validation_recovery_cmd = gpsegsetuprecovery.ValidationForFullRecovery(
             name='test validation for full recovery', recovery_info=self.seg_recovery_info,
@@ -160,7 +160,7 @@ class SetupForIncrementalRecoveryTestCase(GpTestCase):
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
                                               p.getSegmentDataDirectory(),
-                                              True, False, '/tmp/test_progress_file')
+                                              True, False, None, '/tmp/test_progress_file')
 
         self.setup_for_incremental_recovery_cmd = gpsegsetuprecovery.SetupForIncrementalRecovery(
             name='setup for incremental recovery', recovery_info=self.seg_recovery_info, logger=self.mock_logger)
@@ -226,7 +226,7 @@ class SetupForDifferentialRecoveryTestCase(GpTestCase):
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
                                               p.getSegmentDataDirectory(),
-                                              True, False, '/tmp/test_progress_file')
+                                              True, False,'2023-09-04 12:44:39', '/tmp/test_progress_file')
 
         self.setup_for_differential_recovery_cmd = gpsegsetuprecovery.SetupForDifferentialRecovery(
             name='setup for differential recovery', recovery_info=self.seg_recovery_info, logger=self.mock_logger)
@@ -271,17 +271,17 @@ class SegSetupRecoveryTestCase(GpTestCase):
     def setUp(self):
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, 'source_datadir1', True, False, '/tmp/progress_file1')
+                                    6001, 'source_datadir1', True, False, None, '/tmp/progress_file1')
         self.incr_r1 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, None, '/tmp/progress_file2')
         self.full_r2 = RecoveryInfo('target_data_dir3', 5003, 3, 'source_hostname3',
-                                    6003, 'source_datadir3', True, False, '/tmp/progress_file3')
+                                    6003, 'source_datadir3', True, False, None,'/tmp/progress_file3')
         self.incr_r2 = RecoveryInfo('target_data_dir4', 5004, 4, 'source_hostname4',
-                                    6004, 'source_datadir4', False, False, '/tmp/progress_file4')
+                                    6004, 'source_datadir4', False, False, None, '/tmp/progress_file4')
         self.diff_r1 = RecoveryInfo('target_data_dir5', 5005, 5, 'source_hostname5',
-                                    6005, 'source_datadir5', False, True, '/tmp/progress_file5')
+                                    6005, 'source_datadir5', False, True, None, '/tmp/progress_file5')
         self.diff_r2 = RecoveryInfo('target_data_dir6', 5006, 6, 'source_hostname6',
-                                    6006, 'source_datadir6', False, True, '/tmp/progress_file6')
+                                    6006, 'source_datadir6', False, True, None, '/tmp/progress_file6')
 
     def tearDown(self):
         super(SegSetupRecoveryTestCase, self).tearDown()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
@@ -32,9 +32,9 @@ class RecoveryBaseTestCase(GpTestCase):
         self.mock_enable_verbose_logging = self.get_mock_from_apply_patch('enable_verbose_logging')
 
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, 'source_datadir1', True, False, '/tmp/progress_file1')
+                                    6001, 'source_datadir1', True, False, None, '/tmp/progress_file1')
         self.incr_r2 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, None, '/tmp/progress_file2')
         self.confinfo = gppylib.recoveryinfo.serialize_list([self.full_r1,
                                                              self.incr_r2])
 
@@ -324,7 +324,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.error_type = 10
             raise Exception('running the cmd failed')
 
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None,None, '/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)
@@ -339,7 +339,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.name = 'new name'
             cmd.error_type = None
             raise Exception('running the cmd failed')
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, None,'/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -29,7 +29,8 @@ class BuildRecoveryInfoTestCase(GpTestCase):
 
         self.apply_patches([
             patch('recoveryinfo.gplog.get_logger_dir', return_value='/tmp/logdir'),
-            patch('recoveryinfo.datetime.datetime')
+            patch('recoveryinfo.datetime.datetime'),
+            patch('gppylib.recoveryinfo.get_target_down_time', return_value='2023-09-04 12:44:39')
         ])
         self.mock_logdir = self.get_mock_from_apply_patch('get_logger_dir')
 
@@ -47,38 +48,38 @@ class BuildRecoveryInfoTestCase(GpTestCase):
                                      GpMirrorToBuild(self.m4, self.p4, None, False, False),
                                      GpMirrorToBuild(self.m3, self.p3, None, False, True)],
                 "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
                                       RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
-                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid8.out'),
+                                                    False, False, None, '/tmp/logdir/pg_rewind.111.dbid8.out'),
                                       RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
-                                                    False, True, '/tmp/logdir/rsync.111.dbid7.out')]}
+                                                    False, True, '2023-09-04 12:44:39', '/tmp/logdir/rsync.111.dbid7.out')]}
             },
             {
                 "name": "single_target_hosts_suggest_full_and_incr_with_failover",
                 "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True, False),
                                      GpMirrorToBuild(self.m2, self.p2, self.m6, False, False)],
                 "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
                                       RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000, '/data/primary2',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                                                    True, False,None, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full",
                 "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True, False),
                                      GpMirrorToBuild(self.m2, self.p2, None, True, False)],
                 "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
                              'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_differential",
                 "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, False, True),
                                      GpMirrorToBuild(self.m2, self.p2, None, False, True)],
                 "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
-                                                   False, True, '/tmp/logdir/rsync.111.dbid5.out')],
+                                                   False, True, '2023-09-04 12:44:39', '/tmp/logdir/rsync.111.dbid5.out')],
                              'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
-                                                   False, True, '/tmp/logdir/rsync.111.dbid6.out')]}
+                                                   False, True, '2023-09-04 12:44:39', '/tmp/logdir/rsync.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_and_incr_and_differential",
@@ -87,22 +88,22 @@ class BuildRecoveryInfoTestCase(GpTestCase):
                                      GpMirrorToBuild(self.m4, self.p4, None, True, False),
                                      GpMirrorToBuild(self.m2, self.p2, None, False, True)],
                 "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
                              'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
-                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
+                                                    False, False,None, '/tmp/logdir/pg_rewind.111.dbid7.out'),
                                       RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')],
+                                                    True, False, None,'/tmp/logdir/pg_basebackup.111.dbid8.out')],
                              'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
-                                                   False, True, '/tmp/logdir/rsync.111.dbid6.out'),]}
+                                                   False, True,'2023-09-04 12:44:39', '/tmp/logdir/rsync.111.dbid6.out'),]}
             },
             {
                 "name": "multiple_target_hosts_suggest_incr_failover_same_as_failed",
                 "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False, False),
                                      GpMirrorToBuild(self.m2, self.p2, self.m2, False, False)],
                 "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                                                    True, False, None,'/tmp/logdir/pg_basebackup.111.dbid5.out')],
                              'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                                                    True, False, None,'/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_failover_same_as_failed",
@@ -110,11 +111,11 @@ class BuildRecoveryInfoTestCase(GpTestCase):
                                      GpMirrorToBuild(self.m3, self.p3, self.m3, True, False),
                                      GpMirrorToBuild(self.m4, self.p4, None, True, False)],
                 "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
                              'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
                                       RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_and_incr",
@@ -123,15 +124,15 @@ class BuildRecoveryInfoTestCase(GpTestCase):
                                      GpMirrorToBuild(self.m3, self.p3, self.m3, False, False),
                                      GpMirrorToBuild(self.m4, self.p4, self.m8, True, False)],
                 "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
-                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                                    True, False, None, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
                                       ],
                              'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
-                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid6.out'),
+                                                    False, False, None, '/tmp/logdir/pg_rewind.111.dbid6.out'),
                                       RecoveryInfo('/data/mirror8', 12000, 8,
-                                                    'sdw3', 4000, '/data/primary4', True, False,
+                                                    'sdw3', 4000, '/data/primary4', True, False, None,
                                                     '/tmp/logdir/pg_basebackup.111.dbid8.out')],
                              'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
-                                                     True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
+                                                     True, False, None, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
                              }
             },
         ]

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4131,7 +4131,7 @@ cat >/usr/local/bin/rsync <<EOL
 arguments="\$@"
 
 # Insert data into table and run checkpoint just before syncing pg_control
-if [[ "\$arguments" == *"pg_wal"* ]]
+if [[ "\$arguments" == *"pg_wal"* && "\$arguments" != *"--exclude"* ]]
 then
     ssh cdw "psql -c 'INSERT INTO test_recoverseg SELECT generate_series(1, 1000)' -d postgres -p 5432 -h cdw"
 


### PR DESCRIPTION
Issue: current differential recovery uses rsync checksum(-c) option in
rsync. this option was added to avoid any data loss as the rsync
checksum scans for diff even if the size and timestamp are the same. so -c
option was used to prevent the scenario when the size and time
stamp are the same for a file in src and target but the content is different.
This scenario can happen when some query is running on primary and the
coordinator connection to primary is lost but still, the query is
running. at the same time, the mirror got promoted to primary and there
is some other query running. so in this scenario, there is the possibility
that the file on primary and mirror can be updated at the same time with
the same size content but the content is different. In this case without -c
option the rsync will ignore the file to be transferred from source to
target and can cause a data loss scenario.

Fix: to avoid the above scenario of data loss and improve the performance at
the same time. there is an approach in which instead of syncing all the files
using checksum we can do the checksum for only target files, those
target files can be the files that got updated after the primary got down.
other files can be synced without the checksum option.
for the same, I added a new function sync_updated_files().

we were also syncing pg_wal twice which can be done at the end.
there is no point in syncing the pg_control file as the file will have wrong
information because it will have primary related pg_control info.
also, we are reading checkpoints from backup.label file for wal replay
point.

Updated existing test cases for the above-related changes.

Added new test to support the code changes.
1. unit test to verify success and exception state of the newly added
   function
2.  behave test case to validate the sync of updated file with and
    without tablespace.
    
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
