### PR TITLE
6X: Handle parallel retrieve cursor errors via timeout mechanism

### DIFF
--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -24,6 +24,7 @@
 #include "cdbendpoint_private.h"
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
+#include "utils/timeout.h"
 
 
 /*
@@ -167,4 +168,51 @@ generate_endpoint_name(char *name, const char *cursorName)
 	len += ENDPOINT_NAME_COMMANDID_LEN;
 
 	name[len] = '\0';
+}
+
+/*
+ * Check every parallel retrieve cursor status and cancel QEs if it has error.
+ *
+ * Also return true if it has error.
+ */
+bool
+gp_check_parallel_retrieve_cursor_error(void)
+{
+	List		*portals;
+	ListCell	*lc;
+	bool		has_error = false;
+	EState		*estate = NULL;
+
+	portals = GetAllParallelRetrieveCursorPortals();
+
+	foreach(lc, portals)
+	{
+		Portal portal = (Portal)lfirst(lc);
+
+		estate = portal->queryDesc->estate;
+
+		if (estate->dispatcherState->primaryResults->errcode)
+			has_error = true;
+		else
+			has_error = cdbdisp_checkForCancel(estate->dispatcherState);
+	}
+
+	/* free the list to avoid memory leak */
+	list_free(portals);
+
+	return has_error;
+}
+
+/*
+ * Enable the timeout of parallel retrieve cursor check if not yet
+ */
+void
+enable_parallel_retrieve_cursor_check_timeout(void)
+{
+	if (Gp_role == GP_ROLE_DISPATCH &&
+		!get_timeout_active(GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT))
+	{
+		enable_timeout_after(GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT,
+							 GP_PARALLEL_RETRIEVE_CURSOR_CHECK_PERIOD_MS);
+	}
 }

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -191,7 +191,12 @@ PerformCursorOpen(PlannedStmt *stmt, ParamListInfo params,
 	Assert(portal->strategy == PORTAL_ONE_SELECT);
 
 	if (PortalIsParallelRetrieveCursor(portal))
+	{
 		WaitEndpointsReady(portal->queryDesc->estate);
+
+		/* Enable the check error timer if the alarm is not active */
+		enable_parallel_retrieve_cursor_check_timeout();
+	}
 
 	/*
 	 * We're done; the query won't actually be run until PerformPortalFetch is

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -90,6 +90,7 @@ static void CheckMyDatabase(const char *name, bool am_superuser);
 static void InitCommunication(void);
 static void ShutdownPostgres(int code, Datum arg);
 static void StatementTimeoutHandler(void);
+static void GpParallelRetrieveCursorCheckTimeoutHandler(void);
 static void LockTimeoutHandler(void);
 static void ClientCheckTimeoutHandler(void);
 static bool ThereIsAtLeastOneRole(void);
@@ -686,6 +687,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	{
 		RegisterTimeout(DEADLOCK_TIMEOUT, CheckDeadLock);
 		RegisterTimeout(STATEMENT_TIMEOUT, StatementTimeoutHandler);
+		RegisterTimeout(GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT, GpParallelRetrieveCursorCheckTimeoutHandler);
 		RegisterTimeout(LOCK_TIMEOUT, LockTimeoutHandler);
 		RegisterTimeout(GANG_TIMEOUT, IdleGangTimeoutHandler);
 		RegisterTimeout(CLIENT_CONNECTION_CHECK_TIMEOUT, ClientCheckTimeoutHandler);
@@ -1437,6 +1439,36 @@ StatementTimeoutHandler(void)
 	kill(-MyProcPid, SIGINT);
 #endif
 	kill(MyProcPid, SIGINT);
+}
+extern bool DoingCommandRead;
+static void
+GpParallelRetrieveCursorCheckTimeoutHandler(void)
+{
+	/*
+	 * issue: https://github.com/greenplum-db/gpdb/issues/15143
+	 *
+	 * handle errors of parallel retrieve cursor's non-root slices
+	 */
+	if (DoingCommandRead)
+	{
+		Assert(Gp_role == GP_ROLE_DISPATCH);
+
+		/* It calls cdbdisp_checkForCancel(), which doesn't raise error */
+		gp_check_parallel_retrieve_cursor_error();
+		int num = GetNumOfParallelRetrieveCursors();
+
+		/* Reset the alarm to check after a timeout */
+		if (num > 0)
+		{
+			elog(DEBUG1, "There are still %d parallel retrieve cursors alive", num);
+			enable_parallel_retrieve_cursor_check_timeout();
+		}
+	}
+	else
+	{
+		elog(DEBUG1, "DoingCommandRead is false, check parallel cursor timeout delay");
+		enable_parallel_retrieve_cursor_check_timeout();
+	}
 }
 
 /*

--- a/src/backend/utils/misc/timeout.c
+++ b/src/backend/utils/misc/timeout.c
@@ -417,13 +417,23 @@ RegisterTimeout(TimeoutId id, timeout_handler_proc handler)
 
 	/* There's no need to disable the signal handler here. */
 
-	if (id >= USER_TIMEOUT)
+	/*
+	 * GP_ABI_BUMP_FIXME
+	 *
+	 * all the GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT here were MAX_TIMEOUTS,
+	 * we did the change to avoid ABI break via putting the
+	 * GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT after the reserved
+	 * USER_TIMEOUTs and before MAX_TIMEOUTS.
+	 *
+	 * restore to the original shape once we are fine to bump the ABI version.
+	 */
+	if (id >= USER_TIMEOUT && id < GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT)
 	{
 		/* Allocate a user-defined timeout reason */
-		for (id = USER_TIMEOUT; id < MAX_TIMEOUTS; id++)
+		for (id = USER_TIMEOUT; id < GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT; id++)
 			if (all_timeouts[id].timeout_handler == NULL)
 				break;
-		if (id >= MAX_TIMEOUTS)
+		if (id >= GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT)
 			ereport(FATAL,
 					(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
 					 errmsg("cannot add more timeout reasons")));

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -1282,3 +1282,40 @@ ThereAreNoReadyPortals(void)
 
 	return true;
 }
+
+/* Find all Parallel Retrieve cursors and return a list of Portals */
+List *
+GetAllParallelRetrieveCursorPortals(void)
+{
+	List		*portals;
+	PortalHashEnt	*hentry;
+	HASH_SEQ_STATUS	status;
+
+	if (PortalHashTable == NULL)
+		return NULL;
+
+	portals = NULL;
+	hash_seq_init(&status, PortalHashTable);
+	while ((hentry = hash_seq_search(&status)) != NULL)
+	{
+		if (PortalIsParallelRetrieveCursor(hentry->portal) &&
+			hentry->portal->queryDesc != NULL)
+			portals = lappend(portals, hentry->portal);
+	}
+
+	return portals;
+}
+
+/* Return the amount of parallel retrieve cursors */
+int
+GetNumOfParallelRetrieveCursors(void)
+{
+	List   *portals;
+	int		sum;
+
+	portals = GetAllParallelRetrieveCursorPortals();
+	sum = list_length(portals);
+
+	list_free(portals);
+	return sum;
+}

--- a/src/include/cdb/cdbendpoint.h
+++ b/src/include/cdb/cdbendpoint.h
@@ -140,6 +140,8 @@ extern enum EndPointExecPosition GetParallelCursorEndpointPosition(PlannedStmt *
 extern void WaitEndpointsReady(EState *estate);
 extern void AtAbort_EndpointExecState(void);
 extern void allocEndpointExecState(void);
+extern bool gp_check_parallel_retrieve_cursor_error(void);
+extern void enable_parallel_retrieve_cursor_check_timeout(void);
 
 /*
  * Below functions should run on Endpoints(QE/Entry DB).

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -253,5 +253,7 @@ extern bool ThereAreNoReadyPortals(void);
 extern void AtExitCleanup_ResPortals(void);
 extern void TotalResPortalIncrements(int pid, Oid queueid,
 									 Cost *totalIncrements, int *num);
+extern List *GetAllParallelRetrieveCursorPortals(void);
+extern int GetNumOfParallelRetrieveCursors(void);
 
 #endif   /* PORTAL_H */

--- a/src/include/utils/timeout.h
+++ b/src/include/utils/timeout.h
@@ -16,6 +16,9 @@
 
 #include "datatype/timestamp.h"
 
+/* GPDB: the period of parallel retrieve cursor check */
+#define GP_PARALLEL_RETRIEVE_CURSOR_CHECK_PERIOD_MS (10000)
+
 /*
  * Identifiers for timeout reasons.  Note that in case multiple timeouts
  * trigger at the same time, they are serviced in the order of this enum.
@@ -33,8 +36,14 @@ typedef enum TimeoutId
 	CLIENT_CONNECTION_CHECK_TIMEOUT,
 	/* First user-definable timeout reason */
 	USER_TIMEOUT,
-	/* Maximum number of timeout reasons */
-	MAX_TIMEOUTS = 16
+	/*
+	 * GP_ABI_BUMP_FIXME
+	 * To not break ABI, we have to reserve the timeouts from the **original**
+	 * USER_TIMEOUT (included) and the **original** MAX_TIMEOUTS, [9, 16) in
+	 * this case.
+	 */
+	GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT = 16,
+	MAX_TIMEOUTS
 } TimeoutId;
 
 /* callback function signature */

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -256,3 +256,15 @@ insert into t1 select generate_series(1,100);
 2: CLOSE c8;
 2: END;
 
+---------- Test9: Test parallel retrieve cursor auto-check
+1: drop table if exists t1;
+1: create table t1(a int, b int);
+1: insert into t1 values (generate_series(1,100000), 1);
+1: insert into t1 values (-1, 1);
+1: BEGIN;
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
+-- GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT is 10s, we sleep 12 to check all QEs are already finished.
+1: ! sleep 12;
+1: SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
+1: rollback;
+1q:

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -1392,3 +1392,29 @@ CLOSE
 2: END;
 END
 
+---------- Test9: Test parallel retrieve cursor auto-check
+1: drop table if exists t1;
+DROP
+1: create table t1(a int, b int);
+CREATE
+1: insert into t1 values (generate_series(1,100000), 1);
+INSERT 100000
+1: insert into t1 values (-1, 1);
+INSERT 1
+1: BEGIN;
+BEGIN
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
+ count 
+-------
+ 3     
+(1 row)
+-- GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT is 10s, we sleep 12 to check all QEs are already finished.
+1: ! sleep 12;
+
+1: SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
+ endpointname | auth_token | hostname | port | state 
+--------------+------------+----------+------+-------
+(0 rows)
+1: rollback;
+ERROR:  cannot take square root of a negative number  (seg2 slice1 127.0.1.1:6004 pid=83657)
+1q: ... <quitting>


### PR DESCRIPTION
After the Parallel Retrieve Cursor was declared the session enters "idle in transaction" state and waits for new commands. 
And we can retrieve data from the root QE using a retrieve connection. However, If other QE raises an error, it will abort and
send the error to QD. But, QD remains in an "idle in transaction" state and does not handle the QE error, causing the root QE
was not  aware of the mistake, and continue running.
```
create table t1(a int);
insert into t1 values (-1);
begin;
explain declare c1 parallel retrieve cursor for  select count(*) from t1 group by  sqrt(a);
                                           QUERY PLAN
------------------------------------------------------------------------------------------------
 Finalize HashAggregate  (cost=716.00..721.00 rows=333 width=16)
   Group Key: (sqrt((a)::double precision))
   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=676.00..711.00 rows=1000 width=16)
         Hash Key: (sqrt((a)::double precision))
         ->  Partial HashAggregate  (cost=676.00..691.00 rows=1000 width=16)
               Group Key: sqrt((a)::double precision)
               ->  Seq Scan on t1  (cost=0.00..515.50 rows=32100 width=8)
 Optimizer: Postgres query optimizer
 Endpoint: on all 3 segments
(9 rows)

declare c1 parallel retrieve cursor for  select count(*) from t1 group by  sqrt(a);
```
Because t1.a has negative value, slice 1 will raise ERROR and abort. But QD are waiting for new command from client,
and do not handle the error. QEs in root slice can not get more data and retrieve conn will hang.

Solution：
Use timeout mechanism in QD to checkout error from QEs periodically.

Fix issue:  #15143 

backport from https://github.com/greenplum-db/gpdb/pull/15203