### PR TITLE
Enable distributed transaction for foreign table

### DIFF
--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -14,7 +14,14 @@ CREATE SERVER pgserver FOREIGN DATA WRAPPER postgres_fdw
   OPTIONS (host 'dummy', port '0',
            dbname 'contrib_regression', multi_hosts 'localhost  localhost',
            multi_ports '5432  5555', num_segments '2', mpp_execute 'all segments');
+-- pgserver1 is used to test distributed transaction.
+-- In case of build 4 remote postgres servers, we write to a table three times.
+CREATE SERVER pgserver1 FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host 'dummy', port '0',
+           dbname 'contrib_regression', multi_hosts 'localhost  localhost localhost localhost',
+           multi_ports '5432 5432 5432 5555', num_segments '4', mpp_execute 'all segments');
 CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver1;
 -- ===================================================================
 -- create objects used through FDW pgserver server
 -- ===================================================================
@@ -60,6 +67,10 @@ CREATE FOREIGN TABLE mpp_ft2 (
 	c6 double precision,
 	c7 numeric
 ) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 2');
+CREATE FOREIGN TABLE mpp_ft3 (
+	c1 int,
+	c2 int
+) SERVER pgserver1 OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
 -- ===================================================================
 -- tests for validator
 -- ===================================================================
@@ -148,15 +159,6 @@ ALTER FOREIGN TABLE mpp_ft1 OPTIONS (drop use_remote_estimate);
 CREATE SCHEMA mpp_import_dest;
 IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO mpp_import_dest;
 ERROR:  If there are multiple remote servers, gpdb doesn't support import foreign schema
--- ===================================================================
--- When there are multiple remote servers, we don't support INSERT/UPDATE/DELETE
--- ===================================================================
-INSERT INTO mpp_ft1 VALUES (1, 1);
-ERROR:  foreign table "mpp_ft1" does not allow inserts
-UPDATE mpp_ft1 SET c1 = c1 + 1;
-ERROR:  foreign table "mpp_ft1" does not allow updates
-DELETE FROM mpp_ft1;
-ERROR:  foreign table "mpp_ft1" does not allow deletes
 -- ===================================================================
 -- Aggregate and grouping queries
 -- ===================================================================
@@ -1027,5 +1029,28 @@ SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on
  count | sum |        avg         
 -------+-----+--------------------
      1 |   2 | 2.0000000000000000
+(1 row)
+
+-- ===================================================================
+-- Test distributed transaction for multi-server foreign table
+-- ===================================================================
+select count(*) from mpp_ft3;
+ count 
+-------
+    20
+(1 row)
+
+--  drop column c2 in remote postgres server listening port 5555
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -c 'alter table "MPP_S 1"."T 1" drop column c2'
+ALTER TABLE
+insert into mpp_ft3 select i,i from generate_series(1,100) i;
+ERROR:  column "c2" of relation "T 1" does not exist  (seg0 127.0.0.1:7002 pid=29246)
+CONTEXT:  remote SQL command: INSERT INTO "MPP_S 1"."T 1"(c1, c2) VALUES ($1, $2)
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -c 'alter table "MPP_S 1"."T 1" add column c2 int'
+ALTER TABLE
+select count(*) from mpp_ft3;
+ count 
+-------
+    20
 (1 row)
 

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -2226,13 +2226,6 @@ postgresIsForeignRelUpdatable(Relation rel)
 	table = GetForeignTable(RelationGetRelid(rel));
 	server = GetForeignServer(table->serverid);
 
-	/*
-	 * Now if there are multiple remote servers,, we don't support INSERT/UPDATE/DELETE.
-	 * We plan to support it later.
-	 */
-	if (is_multi_servers(server, table->exec_location))
-		return 0;
-
 	foreach(lc, server->options)
 	{
 		DefElem    *def = (DefElem *) lfirst(lc);

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -19,7 +19,15 @@ CREATE SERVER pgserver FOREIGN DATA WRAPPER postgres_fdw
            dbname 'contrib_regression', multi_hosts 'localhost  localhost',
            multi_ports '5432  5555', num_segments '2', mpp_execute 'all segments');
 
+-- pgserver1 is used to test distributed transaction.
+-- In case of build 4 remote postgres servers, we write to a table three times.
+CREATE SERVER pgserver1 FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host 'dummy', port '0',
+           dbname 'contrib_regression', multi_hosts 'localhost  localhost localhost localhost',
+           multi_ports '5432 5432 5432 5555', num_segments '4', mpp_execute 'all segments');
+
 CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pgserver1;
 
 -- ===================================================================
 -- create objects used through FDW pgserver server
@@ -46,6 +54,11 @@ CREATE FOREIGN TABLE mpp_ft2 (
 	c6 double precision,
 	c7 numeric
 ) SERVER pgserver OPTIONS (schema_name 'MPP_S 1', table_name 'T 2');
+
+CREATE FOREIGN TABLE mpp_ft3 (
+	c1 int,
+	c2 int
+) SERVER pgserver1 OPTIONS (schema_name 'MPP_S 1', table_name 'T 1');
 
 -- ===================================================================
 -- tests for validator
@@ -81,15 +94,6 @@ ALTER FOREIGN TABLE mpp_ft1 OPTIONS (drop use_remote_estimate);
 -- ===================================================================
 CREATE SCHEMA mpp_import_dest;
 IMPORT FOREIGN SCHEMA import_source FROM SERVER pgserver INTO mpp_import_dest;
-
--- ===================================================================
--- When there are multiple remote servers, we don't support INSERT/UPDATE/DELETE
--- ===================================================================
-INSERT INTO mpp_ft1 VALUES (1, 1);
-
-UPDATE mpp_ft1 SET c1 = c1 + 1;
-
-DELETE FROM mpp_ft1;
 
 -- ===================================================================
 -- Aggregate and grouping queries
@@ -243,3 +247,13 @@ SELECT count(c1), max(c6) FROM mpp_ft2 GROUP BY c2 order by c2 limit 3;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;
 SELECT count(*), sum(t1.c1), avg(t2.c2) FROM mpp_ft2 t1 inner join mpp_ft2 t2 on (t1.c1 = t2.c1) where t1.c1 = 2;
+
+-- ===================================================================
+-- Test distributed transaction for multi-server foreign table
+-- ===================================================================
+select count(*) from mpp_ft3;
+--  drop column c2 in remote postgres server listening port 5555
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -c 'alter table "MPP_S 1"."T 1" drop column c2'
+insert into mpp_ft3 select i,i from generate_series(1,100) i;
+\! env PGOPTIONS='' psql -p 5555 contrib_regression -c 'alter table "MPP_S 1"."T 1" add column c2 int'
+select count(*) from mpp_ft3;

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -88,7 +88,7 @@
 #include "cdb/cdbgang.h"
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbtm.h"
-#include "cdb/cdbvars.h" /* Gp_role, Gp_is_writer, interconnect_setup_timeout */
+#include "cdb/cdbvars.h" /* Gp_role, Gp_is_writer, Gp_is_first_writer, interconnect_setup_timeout */
 #include "utils/workfile_mgr.h"
 #include "utils/vmem_tracker.h"
 #include "cdb/cdbdisp.h"

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -782,6 +782,7 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 	ListCell					*prevItem = NULL;
 	MemoryContext 				oldContext;
 	bool						isWriter;
+	bool						isFirstWriter;
 
 	cdbinfo = cdbcomponent_getComponentInfo(contentId);	
 
@@ -831,8 +832,10 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 		 * other kind tables.
 		 *
 		 */
-		isWriter = contentId == -1 ? false: (cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0);
-		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, nextQEIdentifer(cdbinfo->cdbs), isWriter);
+		isWriter = contentId == -1 ? false :
+			((cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0) || segmentType == SEGMENTTYPE_EXPLICT_WRITER);
+		isFirstWriter = contentId == -1 ? false : (cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0);
+		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, nextQEIdentifer(cdbinfo->cdbs), isWriter, isFirstWriter);
 	}
 
 	cdbconn_setQEIdentifier(segdbDesc, -1);

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -54,6 +54,8 @@ char	   *gp_role_string;		/* Staging area for guc.c */
 
 bool		Gp_is_writer;		/* is this qExec a "writer" process. */
 
+bool		Gp_is_first_writer;	/* is this qExec the first "writer" process in the same segment. */
+
 int			gp_session_id;		/* global unique id for session. */
 
 char	   *qdHostname;			/* QD hostname */

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -66,7 +66,7 @@ transStatusToString(PGTransactionStatusType status)
 
 /* Initialize a QE connection descriptor in CdbComponentsContext */
 SegmentDatabaseDescriptor *
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int identifier, bool isWriter)
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int identifier, bool isWriter, bool isFirstWriter)
 {
 	MemoryContext oldContext;
 	SegmentDatabaseDescriptor *segdbDesc = NULL;
@@ -89,6 +89,7 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int id
 	segdbDesc->whoami = NULL;
 	segdbDesc->identifier = identifier;
 	segdbDesc->isWriter = isWriter;
+	segdbDesc->isFirstWriter = isFirstWriter;
 	segdbDesc->establishConnTime = 0;
 
 	MemoryContextSwitchTo(oldContext);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -453,7 +453,7 @@ makeOptions(char **options, char **diff_options)
  */
 bool
 build_gpqeid_param(char *buf, int bufsz,
-				   bool is_writer, int identifier, int hostSegs, int icHtabSize)
+				   bool is_writer, bool is_first_writer, int identifier, int hostSegs, int icHtabSize)
 {
 	int		len;
 #ifdef HAVE_INT64_TIMESTAMP
@@ -466,9 +466,10 @@ build_gpqeid_param(char *buf, int bufsz,
 #endif
 #endif
 
-	len = snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%d;%d;%d",
+	len = snprintf(buf, bufsz, "%d;" TIMESTAMP_FORMAT ";%s;%s;%d;%d;%d",
 				   gp_session_id, PgStartTime,
-				   (is_writer ? "true" : "false"), identifier, hostSegs, icHtabSize);
+				   (is_writer ? "true" : "false"),
+				   (is_first_writer ? "true" : "false"), identifier, hostSegs, icHtabSize);
 
 	return (len > 0 && len < bufsz);
 }
@@ -525,6 +526,10 @@ cdbgang_parse_gpqeid_params(struct Port *port pg_attribute_unused(),
 	/* Gp_is_writer */
 	if (gpqeid_next_param(&cp, &np))
 		SetConfigOption("gp_is_writer", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);
+
+	/* Gp_is_first_writer */
+	if (gpqeid_next_param(&cp, &np))
+		SetConfigOption("gp_is_first_writer", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);
 
 	/* qe_identifier */
 	if (gpqeid_next_param(&cp, &np))

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -151,6 +151,7 @@ create_gang_retry:
 			 */
 			ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
 									 segdbDesc->isWriter,
+									 segdbDesc->isFirstWriter,
 									 segdbDesc->identifier,
 									 segdbDesc->segment_database_info->hostPrimaryCount,
 									 totalSegs * 2);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1587,13 +1587,6 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 		if ((rte->requiredPerms & (~ACL_SELECT)) == 0)
 			continue;
 
-		/*
-		 * External and foreign tables don't need two phase commit which is for
-		 * local mpp tables
-		 */
-		if (get_rel_relkind(rte->relid) == RELKIND_FOREIGN_TABLE)
-			continue;
-
 		if (isTempNamespace(get_rel_namespace(rte->relid)))
 		{
 			ExecutorMarkTransactionDoesWrites();

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1290,7 +1290,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
     }
     else if (Gp_role == GP_ROLE_EXECUTE)
 	{
-		if (Gp_is_writer)
+		if (Gp_is_writer && Gp_is_first_writer)
 		{
 			addSharedSnapshot("Writer qExec", gp_session_id);
 		}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -965,6 +965,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_is_first_writer", PGC_BACKEND, GP_WORKER_IDENTITY,
+			gettext_noop("True in a worker process which is the first writer in a segment for a session"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&Gp_is_first_writer,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_write_shared_snapshot", PGC_USERSET, UNGROUPED,
 			gettext_noop("Forces the writer gang to set the shared snapshot."),
 			NULL,

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -52,14 +52,14 @@ typedef struct SegmentDatabaseDescriptor
     int32					backendPid;
     char                   *whoami;         /* QE identifier for msgs */
 	bool					isWriter;
+	bool					isFirstWriter;
 	int						identifier;		/* unique identifier in the cdbcomponent segment pool */
 	double					establishConnTime; /* the time of establish connection to the segment,
 												* -1 means this connection is cached */
 } SegmentDatabaseDescriptor;
 
 SegmentDatabaseDescriptor *
-
-cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo, int identifier, bool isWriter);
+cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo  *cdbinfo, int identifier, bool isWriter, bool isFirstWriter);
 
 /* Free all memory owned by a segment descriptor. */
 void

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -83,7 +83,7 @@ extern void ResetAllGangs(void);
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
 Gang *buildGangDefinition(List *segments, SegmentType segmentType);
-bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, int hostSegs, int icHtabSize);
+bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, bool is_first_writer, int identifier, int hostSegs, int icHtabSize);
 
 extern void makeOptions(char **options, char **diff_options);
 extern bool segment_failure_due_to_recovery(const char *error_message);

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -85,6 +85,17 @@ extern bool gp_set_proc_affinity; /* try to bind postmaster to a processor */
  */
 extern bool Gp_is_writer;
 
+/* Parameter Gp_is_first_writer
+ *
+ * This run_time parameter indicates whether session is a qExec that is the first
+ * "writer" process in a group of segmates.
+ *
+ * It defaults to false, but may be specified as true using a connect option.
+ * This should only ever be set by a QD connecting to a QE, rather than
+ * directly.
+ */
+extern bool Gp_is_first_writer;
+
 /* Parameter gp_session_id
  *
  * This run time parameter indicates a unique id to identify a particular user

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -190,6 +190,7 @@
 		"gp_heap_require_relhasoids_match",
 		"gp_instrument_shmem_size",
 		"gp_is_writer",
+		"gp_is_first_writer",
 		"gp_local_distributed_cache_stats",
 		"gp_log_dynamic_partition_pruning",
 		"gp_log_format",

--- a/src/test/regress/expected/gangsize.out
+++ b/src/test/regress/expected/gangsize.out
@@ -189,13 +189,13 @@ INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTI
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 2 0 1
 begin;
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 2 0 1
 update replicate_2_1 set a = a + 1;
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTIAL contents: 0 1

--- a/src/test/regress/expected/gangsize_optimizer.out
+++ b/src/test/regress/expected/gangsize_optimizer.out
@@ -189,13 +189,13 @@ INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTI
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 2 0 1
 begin;
 update random_2_0 set a = 1 from hash_3_3_2 where hash_3_3_2.b = random_2_0.c;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 end;
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 2 0 1
 update replicate_2_1 set a = a + 1;
 INFO:  (slice 0) Dispatch command to PARTIAL contents: 0 1
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to PARTIAL contents: 0 1


### PR DESCRIPTION
### 1. Current issue
Now GPDB disabled distributed transaction for foreign table.
https://github.com/greenplum-db/gpdb/blob/e9fb858f69b40308168f63d2f8ac35465f4f6644/src/backend/executor/execMain.c#L1590-L1595

When writing a foreign table distributed in multiple destinations, it's possible that some destinations are written successfully but others fail.

For example, foreign table `f_tbl` is distributed in **4** remote servers. Issue above can be reproduced as follows.
```
// step 1: in local gpdb
testdb=# create extension postgres_fdw;
CREATE EXTENSION
testdb=# create server multi_pg_servers foreign data wrapper postgres_fdw options (mpp_execute 'all segments', num_segments '4', multi_hosts '10.117.190.206 10.117.190.206 10.117.190.206 10.117.190.206', multi_ports '5432 5555 6666 7777', dbname 'pg_testdb');
CREATE SERVER
testdb=# create user mapping for gpadmin server multi_pg_servers options (user 'postgres');
CREATE USER MAPPING
testdb=# create foreign table f_tbl (c1 int, c2 int) server multi_pg_servers options (table_name 'demo_local_table');
CREATE FOREIGN TABLE

// step 2: in remote server with port 5432
pg_testdb=# create table demo_local_table (c1 int);

// step 3: in remote server with port 5555, 6666 or 7777
testdb=# create table demo_local_table (c1 int);

// step 4: in local gpdb
testdb=# insert into f_tbl values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
ERROR:  column "c1" of relation "demo_local_table" does not exist  (seg0 127.0.0.1:7005 pid=13885)
CONTEXT:  remote SQL command: INSERT INTO public.demo_local_table(c1, c2) VALUES ($1, $2)

// step 5: in remote server with port 5555, 6666 or 7777
// !!! It's written successfully.
pg_testdb=# select * from demo_local_table;
 c1 | c2
----+----
  1 |  1
  5 |  5
```
#### Note:
gpdb disables distributed transaction for foreign table, so it's unsafe to INSERT/UPDATE/DELETE foreign table.
We disable INSERT/UPDATE/DELETE foreign table distributed in multiple remote postgres servers before.

So we need to change codes to reproduce this issue simply according to above steps.
```diff
--git a/contrib/postgres_fdw/postgres_fdw.c b/contrib/postgres_fdw/postgres_fdw.c
index 398186ed23..b860d02737 100644
--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -2226,13 +2226,6 @@ postgresIsForeignRelUpdatable(Relation rel)
        table = GetForeignTable(RelationGetRelid(rel));
        server = GetForeignServer(table->serverid);

-       /*
-        * Now if there are multiple remote servers,, we don't support INSERT/UPDATE/DELETE.
-        * We plan to support it later.
-        */
-       if (is_multi_servers(server, table->exec_location))
-               return 0;
-
        foreach(lc, server->options)
        {
                DefElem    *def = (DefElem *) lfirst(lc);
```

### 2. Main changes
- **Let QEs join in a distributed transaction when writing foreign table.**

- **Handle the value of option num_segments is larger than the number of local segments.**
  1.  Enable that the number of writer QEs is more than the number of segments.
  
  2. Modify function `addToGxactDtxSegments()` so that we can dispatch dtx protocol command to all writer QEs.
  
  3. Add global variable Gp_is_first_writer to identify extra writers in the writer gang
      when there are more than one writer QE in a segment for a session.
      If Gp_is_first_writer is false, call `lookupSharedSnapshot()` instead of `addSharedSnapshot()`.
      
      Because writing foreign table won't write xlog, it's ok to make such changes.
      
- **Enable INSERT/UPDATE/DELETE for foreign table distributed in multiple remote postgres servers.**