### PR TITLE
6X: Fix Insert Error with unknown type

### DIFF
--- a/src/test/regress/expected/strings.out
+++ b/src/test/regress/expected/strings.out
@@ -1933,6 +1933,15 @@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 
  Th\000o\x02\x03
 (1 row)
 
+-- copy unknown-type column from targetlist rather than reference to subquery outputs
+CREATE DOMAIN public.date_timestamp AS timestamp without time zone;
+create table dt1(a int, b int, c public.date_timestamp, d public.date_timestamp);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dt1 values(1, 1, now(), now());
+insert into dt1 select a, b, 'Thu Sep 14 03:19:54 EDT 2023' as c, 'Thu Sep 14 03:19:54 EDT 2023' as d from dt1;
+DROP TABLE dt1;
+DROP DOMAIN public.date_timestamp;
 -- Clean up GPDB-added tables
 DROP TABLE char_strings_tbl;
 DROP TABLE varchar_strings_tbl;

--- a/src/test/regress/sql/strings.sql
+++ b/src/test/regress/sql/strings.sql
@@ -644,6 +644,13 @@ SELECT encode(overlay(E'Th\\000omas'::bytea placing E'Th\\001omas'::bytea from 2
 SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 8),'escape');
 SELECT encode(overlay(E'Th\\000omas'::bytea placing E'\\002\\003'::bytea from 5 for 3),'escape');
 
+-- copy unknown-type column from targetlist rather than reference to subquery outputs
+CREATE DOMAIN public.date_timestamp AS timestamp without time zone;
+create table dt1(a int, b int, c public.date_timestamp, d public.date_timestamp);
+insert into dt1 values(1, 1, now(), now());
+insert into dt1 select a, b, 'Thu Sep 14 03:19:54 EDT 2023' as c, 'Thu Sep 14 03:19:54 EDT 2023' as d from dt1;
+DROP TABLE dt1;
+DROP DOMAIN public.date_timestamp;
 
 -- Clean up GPDB-added tables
 DROP TABLE char_strings_tbl;


### PR DESCRIPTION
unknown-type constants and params in the SELECT's targetlist
are copied up as-is rather than being referenced as subquery
outputs.  This is to ensure that when we try to coerce them to
the target column's datatype.
This issued has been fixed in 7X in PR https://github.com/greenplum-db/gpdb/pull/9686



## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
