### PR TITLE
[6X backport] Fix ORCA nested SubLink processing during query normalization

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -687,22 +687,34 @@ CQueryMutators::RunExtractAggregatesMutator(Node *node,
 		// Handle other top-level outer references in the project element.
 		if (var->varlevelsup == context->m_current_query_level)
 		{
-			if (var->varlevelsup == context->m_agg_levels_up)
+			if (var->varlevelsup >= context->m_agg_levels_up)
 			{
-				// If Var references the top level query inside an Aggref that also
-				// references top level query, the Aggref is moved to the derived query
-				// (see comments in Aggref if-case above). Thus, these Var references
-				// are brought up to the top-query level.
+				// If Var references the top level query (varlevelsup = m_current_query_level)
+				// inside an Aggref that also references top level query, the Aggref is moved
+				// to the derived query (see comments in Aggref if-case above).
+				// And, therefore, if we are mutating such Vars inside the Aggref, we must
+				// change their varlevelsup field in order to preserve correct reference level.
+				// i.e these Vars are pulled up as the part of the Aggref by the m_agg_levels_up.
 				// e.g:
-				// explain select (select sum(foo.a) from jazz) from foo group by a, b;
+				// select (select max((select foo.a))) from foo;
 				// is transformed into
-				// select (select fnew.sum_t from jazz)
-				// from (select foo.a, foo.b, sum(foo.a) sum_t
-				//       from foo group by foo.a, foo.b) fnew;
-				//
-				// Note the foo.a var which is in sum() in a subquery must now become a
-				// var referencing the current query level.
-				var->varlevelsup = 0;
+				// select (select fnew.max_t)
+				// from (select max((select foo.a)) max_t from foo) fnew;
+				// Here the foo.a inside max referenced top level RTE foo at
+				// varlevelsup = 2 inside the Aggref at agglevelsup 1. Then the
+				// Aggref is brought up to the top-query-level of fnew and foo.a
+				// inside Aggref is bumped up by original Aggref's level.
+				// We may visualize that logic with the following diagram:
+				// Query <------┐  <--------------------┐
+				//              |                       |
+				//              | m_agg_levels_up = 1   |
+				//              |                       |
+				//     Aggref --┘                       | varlevelsup = 2
+				//                                      |
+				//                                      |
+				//                                      |
+				//         Var -------------------------┘
+				var->varlevelsup -= context->m_agg_levels_up;
 				return (Node *) var;
 			}
 

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -436,11 +436,12 @@ CQueryMutators::RunGroupingColMutator(Node *node,
 
 		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree(
-			old_sublink->subselect,
-			(MutatorWalkerFn) CQueryMutators::RunGroupingColMutator, context,
-			0  // flags -- mutate into cte-lists
-		);
+		// One need to call the Query mutator for subselect and take into
+		// account that SubLink can be multi-level. Therefore, the
+		// context->m_current_query_level must be modified properly
+		// while diving into such nested SubLink.
+		new_sublink->subselect =
+			RunGroupingColMutator(old_sublink->subselect, context);
 
 		context->m_current_query_level--;
 

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -798,15 +798,43 @@ CQueryMutators::RunExtractAggregatesMutator(Node *node,
 
 		GPOS_ASSERT(IsA(old_sublink->subselect, Query));
 
-		new_sublink->subselect = gpdb::MutateQueryOrExpressionTree(
-			old_sublink->subselect,
-			(MutatorWalkerFn) RunExtractAggregatesMutator, (void *) context,
-			0  // mutate into cte-lists
-		);
+		// One need to call the Query mutator for subselect and take into
+		// account that SubLink can be multi-level. Therefore, the
+		// context->m_current_query_level must be modified properly
+		// while diving into such nested SubLink.
+		new_sublink->subselect =
+			RunExtractAggregatesMutator(old_sublink->subselect, context);
 
 		context->m_current_query_level--;
 
 		return (Node *) new_sublink;
+	}
+
+	if (IsA(node, Query))
+	{
+		// Mutate Query tree and ignore rtable subqueries in order to modify
+		// m_current_query_level properly when mutating them below.
+		Query *query = gpdb::MutateQueryTree(
+			(Query *) node, (MutatorWalkerFn) RunExtractAggregatesMutator,
+			context, QTW_IGNORE_RT_SUBQUERIES);
+
+		ListCell *lc;
+		ForEach(lc, query->rtable)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+
+			if (RTE_SUBQUERY == rte->rtekind)
+			{
+				Query *subquery = rte->subquery;
+				context->m_current_query_level++;
+				rte->subquery = (Query *) RunExtractAggregatesMutator(
+					(Node *) subquery, context);
+				context->m_current_query_level--;
+				gpdb::GPDBFree(subquery);
+			}
+		}
+
+		return (Node *) query;
 	}
 
 	return gpdb::MutateExpressionTree(

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -373,8 +373,6 @@ LINE 4:                where sum(distinct a.four + b.four) = b.four)...
 select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1)))
 from tenk1 o;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  max  
 ------
  9999

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -638,7 +638,6 @@ select * from (select sum(a.salary) over(), count(*)
  2100 |     1
 (2 rows)
 
--- this query currently falls back, needs to be fixed
 select (select rn from (select row_number() over () as rn, name
                         from t1_github_issue_10143
                         where code = a.code

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -638,7 +638,6 @@ select * from (select sum(a.salary) over(), count(*)
  2100 |     1
 (2 rows)
 
--- this query currently falls back, needs to be fixed
 select (select rn from (select row_number() over () as rn, name
                         from t1_github_issue_10143
                         where code = a.code
@@ -647,8 +646,6 @@ select (select rn from (select row_number() over () as rn, name
 ,sum(sum(a.salary)) over()
 from t2_github_issue_10143 a
 group by a.code;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  dongnm | sum  
 --------+------
         | 2100

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1002,4 +1002,47 @@ group by i, j;
  2 | 2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink when this SubLink is inside the GROUP BY clause. Attribute, which is
+-- not grouping column (1 as c), is added to query targetList to make ORCA
+-- perform query normalization. During normalization ORCA modifies the vars of
+-- the grouping elements of targetList in order to produce a new Query tree.
+-- The modification of vars inside nested part of SubLinks should be handled
+-- correctly. ORCA shouldn't fall back due to missing variable entry as a result
+-- of incorrect query normalization.
+explain (verbose, costs off)
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t.j, 1, ((SubPlan 1))
+   ->  HashAggregate
+         Output: t.j, 1, ((SubPlan 1))
+         Group Key: t.j, ((SubPlan 1))
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: t.j, ((SubPlan 1))
+               Hash Key: t.j, ((SubPlan 1))
+               ->  HashAggregate
+                     Output: t.j, ((SubPlan 1))
+                     Group Key: t.j, (SubPlan 1)
+                     ->  Seq Scan on public.t
+                           Output: t.j, (SubPlan 1)
+                           SubPlan 1  (slice1; segments: 1)
+                             ->  Result
+                                   Output: t.j
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+ j | c | q1 
+---+---+----
+ 2 | 1 |  2
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1045,4 +1045,35 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   Output: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (max((SubPlan 1)))
+         ->  Aggregate
+               Output: max((SubPlan 1))
+               ->  Seq Scan on public.t
+                     Output: t.i
+               SubPlan 1  (slice1; segments: 1)
+                 ->  Result
+                       Output: t.i
+   SubPlan 2  (slice0)
+     ->  Result
+           Output: max((max((SubPlan 1))))
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -960,3 +960,46 @@ fetch backward all in c1;
 
 commit;
 --end_ignore
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, which contains attributes referenced in query's GROUP BY clause.
+-- Due to presence of non-grouping columns in targetList, ORCA performs query
+-- normalization, during which ORCA establishes a correspondence between vars
+-- from targetlist entries to grouping attributes. And this process should
+-- correctly handle nested structures. The inner part of SubPlan in the test
+-- should contain only t.j.
+-- start_ignore
+drop table if exists t;
+NOTICE:  table "t" does not exist, skipping
+-- end_ignore
+create table t (i int, j int) distributed by (i);
+insert into t values (1, 2);
+explain (verbose, costs off)
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t.j, ((SubPlan 1)), t.i
+   ->  HashAggregate
+         Output: t.j, (SubPlan 1), t.i
+         Group Key: t.i, t.j
+         ->  Seq Scan on public.t
+               Output: t.j, t.i
+         SubPlan 1  (slice1; segments: 1)
+           ->  Result
+                 Output: t.j
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+ j | j 
+---+---
+ 2 | 2
+(1 row)
+
+drop table t;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3112,3 +3112,37 @@ select * from r where b in (select b from s where c=10 order by c limit 2);
  1 | 2 | 3
 (1 row)
 
+-- Test nested query with aggregate inside a sublink,
+-- ORCA should correctly normalize the aggregate expression inside the
+-- sublink's nested query and the column variable accessed in aggregate should
+-- be accessible to the aggregate after the normalization of query.
+-- If the query is not supported, ORCA should gracefully fallback to postgres
+explain (COSTS OFF) with t0 AS (
+    SELECT
+       ROW_TO_JSON((SELECT x FROM (SELECT max(t.b)) x))
+       AS c
+    FROM r
+        JOIN s ON true
+        JOIN s as t ON  true
+   )
+SELECT c FROM t0;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice3; segments: 3)
+         ->  Aggregate
+               ->  Nested Loop
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Nested Loop
+                                 ->  Seq Scan on r
+                                 ->  Materialize
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                             ->  Seq Scan on s
+                     ->  Materialize
+                           ->  Seq Scan on s t
+   SubPlan 1  (slice0)
+     ->  Subquery Scan on x
+           ->  Result
+ Optimizer: Postgres query optimizer
+(16 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3253,3 +3253,37 @@ select * from r where b in (select b from s where c=10 order by c limit 2);
  1 | 2 | 3
 (1 row)
 
+-- Test nested query with aggregate inside a sublink,
+-- ORCA should correctly normalize the aggregate expression inside the
+-- sublink's nested query and the column variable accessed in aggregate should
+-- be accessible to the aggregate after the normalization of query.
+-- If the query is not supported, ORCA should gracefully fallback to postgres
+explain (COSTS OFF) with t0 AS (
+    SELECT
+       ROW_TO_JSON((SELECT x FROM (SELECT max(t.b)) x))
+       AS c
+    FROM r
+        JOIN s ON true
+        JOIN s as t ON  true
+   )
+SELECT c FROM t0;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice3; segments: 3)
+         ->  Aggregate
+               ->  Nested Loop
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Nested Loop
+                                 ->  Seq Scan on r
+                                 ->  Materialize
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                             ->  Seq Scan on s
+                     ->  Materialize
+                           ->  Seq Scan on s t
+   SubPlan 1  (slice0)
+     ->  Subquery Scan on x
+           ->  Result
+ Optimizer: Postgres query optimizer
+(16 rows)
+

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1058,4 +1058,55 @@ group by i, j;
  2 | 2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink when this SubLink is inside the GROUP BY clause. Attribute, which is
+-- not grouping column (1 as c), is added to query targetList to make ORCA
+-- perform query normalization. During normalization ORCA modifies the vars of
+-- the grouping elements of targetList in order to produce a new Query tree.
+-- The modification of vars inside nested part of SubLinks should be handled
+-- correctly. ORCA shouldn't fall back due to missing variable entry as a result
+-- of incorrect query normalization.
+explain (verbose, costs off)
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result
+   Output: j, 1, ((SubPlan 1))
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         Output: j, ((SubPlan 1))
+         ->  GroupAggregate
+               Output: j, ((SubPlan 1))
+               Group Key: t.j, ((SubPlan 1))
+               ->  Sort
+                     Output: j, ((SubPlan 1))
+                     Sort Key: t.j, ((SubPlan 1))
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Output: j, ((SubPlan 1))
+                           Hash Key: j, ((SubPlan 1))
+                           ->  Result
+                                 Output: j, ((SubPlan 1))
+                                 ->  Result
+                                       Output: (SubPlan 1), j
+                                       ->  Seq Scan on public.t
+                                             Output: j
+                                       SubPlan 1  (slice1; segments: 3)
+                                         ->  Result
+                                               Output: t.j
+                                               ->  Result
+                                                     Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(25 rows)
+
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+ j | c | q1 
+---+---+----
+ 2 | 1 |  2
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1109,4 +1109,41 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   Output: (SubPlan 2)
+   ->  Aggregate
+         Output: max((max((SubPlan 1))))
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: (max((SubPlan 1)))
+               ->  Aggregate
+                     Output: max((SubPlan 1))
+                     ->  Seq Scan on public.t
+                           Output: i
+                     SubPlan 1  (slice1; segments: 3)
+                       ->  Result
+                             Output: t.i
+                             ->  Result
+                                   Output: true
+   SubPlan 2  (slice0)
+     ->  Result
+           Output: (max((max((SubPlan 1)))))
+           ->  Result
+                 Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1009,3 +1009,53 @@ fetch backward all in c1;
 ERROR:  backward scan is not supported in this version of Greenplum Database
 commit;
 --end_ignore
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, which contains attributes referenced in query's GROUP BY clause.
+-- Due to presence of non-grouping columns in targetList, ORCA performs query
+-- normalization, during which ORCA establishes a correspondence between vars
+-- from targetlist entries to grouping attributes. And this process should
+-- correctly handle nested structures. The inner part of SubPlan in the test
+-- should contain only t.j.
+-- start_ignore
+drop table if exists t;
+NOTICE:  table "t" does not exist, skipping
+-- end_ignore
+create table t (i int, j int) distributed by (i);
+insert into t values (1, 2);
+explain (verbose, costs off)
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: j, ((SubPlan 1))
+   ->  Result
+         Output: j, (SubPlan 1)
+         ->  GroupAggregate
+               Output: j, i
+               Group Key: t.i, t.j
+               ->  Sort
+                     Output: i, j
+                     Sort Key: t.i, t.j
+                     ->  Seq Scan on public.t
+                           Output: i, j
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result
+                 Output: t.j
+                 ->  Result
+                       Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+ j | j 
+---+---
+ 2 | 2
+(1 row)
+
+drop table t;

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -420,7 +420,6 @@ select * from (select sum(a.salary) over(), count(*)
                from t2_github_issue_10143 a
                group by a.salary) T;
 
--- this query currently falls back, needs to be fixed
 select (select rn from (select row_number() over () as rn, name
                         from t1_github_issue_10143
                         where code = a.code

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -561,4 +561,13 @@ select j, 1 as c,
 from t
 group by j, q1;
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under aggregation. ORCA shouldn't fall back due
+-- to missing variable entry as a result of incorrect query normalization. ORCA
+-- should correctly process args of the aggregation during normalization.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+
+select (select max((select t.i))) from t;
+
 drop table t;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -517,3 +517,29 @@ fetch backward all in c1;
 
 commit;
 --end_ignore
+
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, which contains attributes referenced in query's GROUP BY clause.
+-- Due to presence of non-grouping columns in targetList, ORCA performs query
+-- normalization, during which ORCA establishes a correspondence between vars
+-- from targetlist entries to grouping attributes. And this process should
+-- correctly handle nested structures. The inner part of SubPlan in the test
+-- should contain only t.j.
+-- start_ignore
+drop table if exists t;
+-- end_ignore
+create table t (i int, j int) distributed by (i);
+insert into t values (1, 2);
+
+explain (verbose, costs off)
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+
+select j,
+(select j from (select j) q2)
+from t
+group by i, j;
+
+drop table t;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -542,4 +542,23 @@ select j,
 from t
 group by i, j;
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink when this SubLink is inside the GROUP BY clause. Attribute, which is
+-- not grouping column (1 as c), is added to query targetList to make ORCA
+-- perform query normalization. During normalization ORCA modifies the vars of
+-- the grouping elements of targetList in order to produce a new Query tree.
+-- The modification of vars inside nested part of SubLinks should be handled
+-- correctly. ORCA shouldn't fall back due to missing variable entry as a result
+-- of incorrect query normalization.
+explain (verbose, costs off)
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+
+select j, 1 as c,
+(select j from (select j) q2) q1
+from t
+group by j, q1;
+
 drop table t;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1215,3 +1215,18 @@ explain (costs off) select * from r where b in (select b from s where c=10 order
 select * from r where b in (select b from s where c=10 order by c);
 explain (costs off) select * from r where b in (select b from s where c=10 order by c limit 2);
 select * from r where b in (select b from s where c=10 order by c limit 2);
+
+-- Test nested query with aggregate inside a sublink,
+-- ORCA should correctly normalize the aggregate expression inside the
+-- sublink's nested query and the column variable accessed in aggregate should
+-- be accessible to the aggregate after the normalization of query.
+-- If the query is not supported, ORCA should gracefully fallback to postgres
+explain (COSTS OFF) with t0 AS (
+    SELECT
+       ROW_TO_JSON((SELECT x FROM (SELECT max(t.b)) x))
+       AS c
+    FROM r
+        JOIN s ON true
+        JOIN s as t ON  true
+   )
+SELECT c FROM t0;


### PR DESCRIPTION
This PR is a backport of 
* 3 patches related to improving ORCA behaviour when it normalizes the Query structure with nested SubLinks.
* 1 commit adding testcase for a fixed issue of panic in ORCA which is fixed by one of the patches.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
