### PR TITLE
[6X] Add GUC gp_workfile_compression_overhead_limit for ZSTD buffer

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -312,6 +312,12 @@ int			gp_workfile_limit_per_query = 0;
 /* Maximum number of workfiles to be created by a query */
 int			gp_workfile_limit_files_per_query = 0;
 
+/*
+ * The overhead memory (kB) used by all compressed workfiles of a single
+ * workfile_set
+ */
+int         gp_workfile_compression_overhead_limit = 0;
+
 /* Gpmon */
 bool		gp_enable_gpperfmon = false;
 int			gp_gpperfmon_send_interval = 1;

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -1007,6 +1007,8 @@ BufFilePledgeSequential(BufFile *buffile)
 	if (buffile->maxoffset != 0)
 		elog(ERROR, "cannot pledge sequential access to a temporary file after writing it");
 
+	AssertImply(work_set->compression_buf_total > 0, gp_workfile_compression);
+
 	/*
 	 * If gp_workfile_compression_overhead_limit is 0, it means no limit for
 	 * memory used by compressed work files. Othersize, compress the work file

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -132,7 +132,19 @@ struct BufFile
 	/* This holds holds compressed input, during decompression. */
 	ZSTD_inBuffer compressed_buffer;
 	bool		decompression_finished;
+
+	/* Memory usage by ZSTD compression buffer */
+	size_t      compressed_buffer_size;
 #endif
+
+	/*
+	 * workfile_set for the files in current buffile. The workfile_set creator
+	 * should take care of the workfile_set's lifecycle. So, no need to call
+	 * workfile_mgr_close_set under the buffile logic.
+	 * If the workfile_set is created in BufFileCreateTemp. The workfile_set
+	 * should get freed once all the files in it are closed in BufFileClose.
+	 */
+	workfile_set *work_set;
 };
 
 /*
@@ -174,6 +186,10 @@ makeBufFile(File firstfile)
 	file->nbytes = 0;
 	file->maxoffset = 0L;
 	file->buffer = palloc(BLCKSZ);
+
+#ifdef USE_ZSTD
+	file->compressed_buffer_size = 0;
+#endif
 
 	return file;
 }
@@ -225,6 +241,7 @@ BufFileCreateTempInSet(workfile_set *work_set, bool interXact)
 	file = makeBufFile(pfile);
 	file->isTemp = true;
 
+	file->work_set = work_set;
 	FileSetIsWorkfile(file->file);
 	RegisterFileWithSet(file->file, work_set);
 
@@ -286,6 +303,7 @@ BufFileCreateNamedTemp(const char *fileName, bool interXact, workfile_set *work_
 
 	if (work_set)
 	{
+		file->work_set = work_set;
 		FileSetIsWorkfile(file->file);
 		RegisterFileWithSet(file->file, work_set);
 	}
@@ -984,11 +1002,24 @@ bool gp_workfile_compression;		/* GUC */
 void
 BufFilePledgeSequential(BufFile *buffile)
 {
+	workfile_set *work_set = buffile->work_set;
+
 	if (buffile->maxoffset != 0)
 		elog(ERROR, "cannot pledge sequential access to a temporary file after writing it");
 
-	if (gp_workfile_compression)
+	/*
+	 * If gp_workfile_compression_overhead_limit is 0, it means no limit for
+	 * memory used by compressed work files. Othersize, compress the work file
+	 * only when the used memory size is under the limit.
+	 */
+	if (gp_workfile_compression &&
+		(gp_workfile_compression_overhead_limit == 0 ||
+		 work_set->compression_buf_total <
+			gp_workfile_compression_overhead_limit * 1024UL))
+	{
 		BufFileStartCompression(buffile);
+		work_set->num_files_compressed++;
+	}
 }
 
 /*
@@ -1054,6 +1085,7 @@ static void
 BufFileDumpCompressedBuffer(BufFile *file, const void *buffer, Size nbytes)
 {
 	ZSTD_inBuffer input;
+	size_t compressed_buffer_size = 0;
 
 	file->uncompressed_bytes += nbytes;
 
@@ -1086,6 +1118,24 @@ BufFileDumpCompressedBuffer(BufFile *file, const void *buffer, Size nbytes)
 			file->maxoffset += wrote;
 		}
 	}
+
+	/*
+	 * Calculate the delta of buffer used by ZSTD stream and take it into
+	 * account to work_set->comp_buf_total.
+	 */
+
+	compressed_buffer_size = ZSTD_sizeof_CStream(file->zstd_context->cctx);
+
+	/*
+	 * As ZSTD comments said, the memory usage can evolve (increase or
+	 * decrease) over time. We update work_set->compressed_buffer_size only
+	 * when compressed_buffer_size increases. It means we apply the comp buff
+	 * limit to max ever memory usage and ignore the case of memory decreasing.
+	 */
+	if (compressed_buffer_size > file->compressed_buffer_size)
+		file->work_set->compression_buf_total
+			+= compressed_buffer_size - file->compressed_buffer_size;
+	file->compressed_buffer_size = compressed_buffer_size;
 }
 
 /*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3507,6 +3507,17 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_workfile_compression_overhead_limit", PGC_USERSET, RESOURCES,
+			gettext_noop("The overhead memory (kB) limit for all compressed workfiles of a single workfile_set."),
+			gettext_noop("0 for no limit. Once the limit is hit, the following files will not be compressed."),
+			GUC_UNIT_KB
+		},
+		&gp_workfile_compression_overhead_limit,
+		2048 * 1024, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_workfile_limit_per_segment", PGC_POSTMASTER, RESOURCES,
 			gettext_noop("Maximum disk space (in KB) used for workfiles per segment."),
 			gettext_noop("0 for no limit. Current query is terminated when limit is exceeded."),

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -634,6 +634,8 @@ workfile_mgr_create_set_internal(const char *operator_name, const char *prefix)
 	work_set->total_bytes = 0;
 	work_set->active = true;
 	work_set->pinned = false;
+	work_set->compression_buf_total = 0;
+	work_set->num_files_compressed = 0;
 
 	/* Track all workfile_sets created in current process */
 	if (!localCtl.initialized)

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -836,6 +836,7 @@ extern int gpperfmon_log_alert_level;
 extern int gp_workfile_limit_per_segment;
 extern int gp_workfile_limit_per_query;
 extern int gp_workfile_limit_files_per_query;
+extern int gp_workfile_compression_overhead_limit;
 extern int gp_workfile_caching_loglevel;
 extern int gp_sessionstate_loglevel;
 extern int gp_workfile_bytes_to_checksum;

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -208,6 +208,12 @@ typedef struct HashJoinTableData
 
     HashJoinState * hjstate; /* reference to the enclosing HashJoinState */
     bool first_pass; /* Is this the first pass (pre-rescan) */
+
+	/* Statistic info of work file set, copied from work_set */
+	uint32      workset_num_files;
+	uint32      workset_num_files_compressed;
+	uint64      workset_avg_file_size;
+	uint64      workset_compression_buf_total;
 }	HashJoinTableData;
 
 #endif   /* HASHJOIN_H */

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -79,6 +79,7 @@
 		"gp_vmem_idle_resource_timeout",
 		"gp_workfile_caching_loglevel",
 		"gp_workfile_compression",
+		"gp_workfile_compression_overhead_limit",
 		"gp_workfile_limit_files_per_query",
 		"gp_workfile_limit_per_query",
 		"IntervalStyle",

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -87,6 +87,12 @@ typedef struct workfile_set
 
 	/* Used to track workfile_set created in current process */
 	dlist_node	local_node;
+
+	/* Total memory usage by compression buffer */
+	uint64      compression_buf_total;
+
+	/* Number of compressed work files */
+	uint32      num_files_compressed;
 } workfile_set;
 
 /* Workfile Set operations */

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -20,6 +20,36 @@ CREATE TABLE test_zlib_hashjoin (i1 int, i2 int, i3 int, i4 int, i5 int, i6 int,
 INSERT INTO test_zlib_hashjoin SELECT i,i,i,i,i,i,i,i FROM 
 	(select generate_series(1, nsegments * 333333) as i from 
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+-- Check if compressed work file count is limited to file_count_limit
+-- If the parameter is_comp_buff_limit is true, it means the comp_workfile_created
+-- must be smaller than file_count_limit because some work files are not compressed;
+-- If the parameter is_comp_buff_limit is false, it means the comp_workfile_created
+-- must be equal to file_count_limit because all work files are compressed.
+create or replace function check_workfile_compressed(explain_query text,
+    is_comp_buff_limit bool)
+returns setof int as
+$$
+import re
+rv = plpy.execute(explain_query)
+search_text = 'Work file set'
+result = []
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        p = re.compile('(\d+) files \((\d+) compressed\)')
+        m = p.search(cur_line)
+        workfile_created = int(m.group(1))
+        comp_workfile_created = int(m.group(2))
+        if is_comp_buff_limit:
+            result.append(int(comp_workfile_created < workfile_created))
+        else:
+            result.append(int(comp_workfile_created == workfile_created))
+return result
+$$
+language plpythonu;
 SET statement_mem=5000;
 --Fail after workfile creation and before add it to workfile set
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
@@ -147,3 +177,104 @@ select gp_inject_fault('workfile_creation_failure', 'reset', 2);
  Success:
 (1 row)
 
+-- Test gp_workfile_compression_overhead_limit to control the memory limit used by
+-- compressed temp file
+DROP TABLE IF EXISTS test_zlib_memlimit;
+NOTICE:  table "test_zlib_memlimit" does not exist, skipping
+create table test_zlib_memlimit(a int, b text, c timestamp) distributed by (a);
+insert into test_zlib_memlimit select id, 'test ' || id, clock_timestamp() from
+   (select generate_series(1, nsegments * 30000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+insert into test_zlib_memlimit select 1,'test', now() from
+   (select generate_series(1, nsegments * 2000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+insert into test_zlib_memlimit select id, 'test ' || id, clock_timestamp() from
+   (select generate_series(1, nsegments * 3000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+analyze test_zlib_memlimit;
+set statement_mem='4500kB';
+set gp_workfile_compression=on;
+set gp_workfile_limit_files_per_query=0;
+-- Run the query with a large value of gp_workfile_compression_overhead_limit
+-- The compressed file number should be equal to total work file number
+set gp_workfile_compression_overhead_limit=2048000;
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+false) limit 6;
+ check_workfile_compressed 
+---------------------------
+                         1
+                         1
+                         1
+                         1
+                         1
+                         1
+(6 rows)
+
+-- Run the query with a smaller value of gp_workfile_compression_overhead_limit
+-- The compressed file number should be less than total work file number
+set gp_workfile_compression_overhead_limit=1000;
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+true) limit 6;
+ check_workfile_compressed 
+---------------------------
+                         1
+                         1
+                         1
+                         1
+                         1
+                         1
+(6 rows)
+
+-- Run the query with gp_workfile_compression_overhead_limit=0, which means
+-- no limit
+-- The compressed file number should be equal to total work file number
+set gp_workfile_compression_overhead_limit=0;
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+false) limit 6;
+ check_workfile_compressed 
+---------------------------
+                         1
+                         1
+                         1
+                         1
+                         1
+                         1
+(6 rows)
+
+DROP TABLE test_zlib_memlimit;

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -23,6 +23,38 @@ INSERT INTO test_zlib_hashjoin SELECT i,i,i,i,i,i,i,i FROM
 	(select generate_series(1, nsegments * 333333) as i from 
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+-- Check if compressed work file count is limited to file_count_limit
+-- If the parameter is_comp_buff_limit is true, it means the comp_workfile_created
+-- must be smaller than file_count_limit because some work files are not compressed;
+-- If the parameter is_comp_buff_limit is false, it means the comp_workfile_created
+-- must be equal to file_count_limit because all work files are compressed.
+create or replace function check_workfile_compressed(explain_query text,
+    is_comp_buff_limit bool)
+returns setof int as
+$$
+import re
+rv = plpy.execute(explain_query)
+search_text = 'Work file set'
+result = []
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        p = re.compile('(\d+) files \((\d+) compressed\)')
+        m = p.search(cur_line)
+        workfile_created = int(m.group(1))
+        comp_workfile_created = int(m.group(2))
+        if is_comp_buff_limit:
+            result.append(int(comp_workfile_created < workfile_created))
+        else:
+            result.append(int(comp_workfile_created == workfile_created))
+return result
+$$
+language plpythonu;
+
 SET statement_mem=5000;
 
 --Fail after workfile creation and before add it to workfile set
@@ -86,3 +118,86 @@ drop table test_zlib;
 drop table test_zlib_t1;
 
 select gp_inject_fault('workfile_creation_failure', 'reset', 2);
+
+-- Test gp_workfile_compression_overhead_limit to control the memory limit used by
+-- compressed temp file
+
+DROP TABLE IF EXISTS test_zlib_memlimit;
+create table test_zlib_memlimit(a int, b text, c timestamp) distributed by (a);
+insert into test_zlib_memlimit select id, 'test ' || id, clock_timestamp() from
+   (select generate_series(1, nsegments * 30000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+insert into test_zlib_memlimit select 1,'test', now() from
+   (select generate_series(1, nsegments * 2000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+insert into test_zlib_memlimit select id, 'test ' || id, clock_timestamp() from
+   (select generate_series(1, nsegments * 3000) as id from
+   (select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
+analyze test_zlib_memlimit;
+
+set statement_mem='4500kB';
+set gp_workfile_compression=on;
+set gp_workfile_limit_files_per_query=0;
+
+-- Run the query with a large value of gp_workfile_compression_overhead_limit
+-- The compressed file number should be equal to total work file number
+
+set gp_workfile_compression_overhead_limit=2048000;
+
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+false) limit 6;
+
+-- Run the query with a smaller value of gp_workfile_compression_overhead_limit
+-- The compressed file number should be less than total work file number
+
+set gp_workfile_compression_overhead_limit=1000;
+
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+true) limit 6;
+
+-- Run the query with gp_workfile_compression_overhead_limit=0, which means
+-- no limit
+-- The compressed file number should be equal to total work file number
+
+set gp_workfile_compression_overhead_limit=0;
+
+select * from check_workfile_compressed('
+explain (analyze)
+with B as (select distinct a+1 as a,b,c from test_zlib_memlimit)
+,C as (select distinct a+2 as a,b,c from test_zlib_memlimit)
+,D as (select a+3 as a,b,c from test_zlib_memlimit)
+,E as (select a+4 as a,b,c from test_zlib_memlimit)
+,F as (select (a+5)::text as a,b,c from test_zlib_memlimit)
+select count(*) from test_zlib_memlimit A
+inner join  B on A.a = B.a
+inner join  C on A.a = C.a
+inner join  D on A.a = D.a
+inner join  E on A.a = E.a
+inner join  F on A.a::text = F.a ;',
+false) limit 6;
+
+DROP TABLE test_zlib_memlimit;


### PR DESCRIPTION
It's a back port of https://github.com/greenplum-db/gpdb/pull/16243. However, besides the port there are still some essential changes:

1. Removed the statistic info of max/min file size, and used average file size instead;
2. Included the work file number of not only hash table (for inner table), but also outer table;
3. Updated the test case zlib to compare work file number and compressed work file number to avoid checking accurate file number on different envs (planner vs. orca, 6X vs. 7X)

The changes should be forward-ported to 7X again after the PR is merged to keep the behaviors consistent. 