### PR TITLE
Wait 3 minutes before changing cgroup in test cluster setup

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup_v2.bash
+++ b/concourse/scripts/ic_gpdb_resgroup_v2.bash
@@ -102,6 +102,11 @@ run_binary_swap_test() {
 EOF
 }
 
+# FIXME: this (sleep) is a temporary fix to work arouond systemd reloading.
+# we shouldn't change cgroup while the systemd is still doing work.
+# A daemon-reload will cause our cgroup changes to disappear if we have
+# not yet used cgroup for Greenplum.
+sleep 180
 enable_cgroup_subtree_control ccp-${CLUSTER_NAME}-0
 enable_cgroup_subtree_control ccp-${CLUSTER_NAME}-1
 run_resgroup_test cdw


### PR DESCRIPTION
  We don't want to change cgroup while the systemd is still doing work.
  A daemon-reload will cause our cgroup changes to disappear if we have
  not used it yet for Greenplum.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
