### PR TITLE
docs - update COPY sql ref page

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
@@ -60,7 +60,7 @@ table\_name
 column\_name
 :   An optional list of columns to be copied. If no column list is specified, all columns of the table except generated columns will be copied.
 
-:   XXX When copying in text format, the default, a row of data in a column of type `bytea` can be up to 256MB.
+:   When copying in text format, the default, a row of data in a column of type `bytea` can be up to 256MB.
 
 query
 :   A [SELECT](SELECT.html), [VALUES](VALUES.html), [INSERT](INSERT.html), [UPDATE](UPDATE.html), or [DELETE](DELETE.html) command whose results are to be copied. Note that parentheses are required around the query.
@@ -211,7 +211,7 @@ Similarly, to copy data from a partitioned table with a leaf partition that is a
 COPY (SELECT * from my_sales ) TO stdout;
 ```
 
-`COPY FROM` can be used with plain, foreign, or partitioned tables XXX or with views that have INSTEAD OF INSERT triggers. XXX
+`COPY FROM` can be used with plain, foreign, or partitioned tables or with views that have INSTEAD OF INSERT triggers.
 
 You must have `SELECT` privilege on the table whose values are read by `COPY TO`, and `INSERT` privilege on the table into which values are inserted by `COPY FROM`. It is sufficient to have column privileges on the columns listed in the command.
 
@@ -225,7 +225,7 @@ Always specify the file name used in `COPY` as an absolute path. This is enforce
 
 Executing a command with `PROGRAM` might be restricted by the operating system's access control mechanisms.
 
-`COPY FROM` will invoke any triggers and check constraints on the destination table. However, it will not invoke rules. XXX Note that in this release, violations of constraints are not evaluated for single row error isolation mode. XXX
+`COPY FROM` will invoke any triggers and check constraints on the destination table. However, it will not invoke rules. Note that in this release, violations of constraints are not evaluated for single row error isolation mode. 
 
 For identity columns, the `COPY FROM` command will always write the column values provided in the input data, like the `INSERT` option `OVERRIDING SYSTEM VALUE`.
 
@@ -233,11 +233,9 @@ For identity columns, the `COPY FROM` command will always write the column value
 
 Input data is interpreted according to `ENCODING` option or the current client encoding, and output data is encoded in `ENCODING` or the current client encoding, even if the data does not pass through the client but is read from or written to a file directly by the server.
 
-By default, `COPY` stops operation at the first error. This should not lead to problems in the event of a `COPY TO`, but the target table will already have received earlier rows in a `COPY FROM`. These rows will not be visible or accessible, but they still occupy disk space. This may amount to a considerable amount of wasted disk space if the failure happened well into a large `COPY FROM` operation. You may choose to invoke `VACUUM` to recover the wasted space. XXX Another option would be to use single row error isolation mode to filter out error rows while still loading good rows. XXX
+By default, `COPY` stops operation at the first error. This should not lead to problems in the event of a `COPY TO`, but the target table will already have received earlier rows in a `COPY FROM`. These rows will not be visible or accessible, but they still occupy disk space. This may amount to a considerable amount of wasted disk space if the failure happened well into a large `COPY FROM` operation. You may choose to invoke `VACUUM` to recover the wasted space. Another option would be to use single row error isolation mode to filter out error rows while still loading good rows.
 
 `FORCE_NULL` and `FORCE_NOT_NULL` can be used simultaneously on the same column. This results in converting quoted null strings to null values and unquoted null strings to empty strings.
-
-XXX
 
 The `BINARY` keyword causes all data to be stored/read as binary format rather than as text. It is somewhat faster than the normal text mode, but a binary-format file is less portable across machine architectures and Greenplum Database versions. Also, you cannot run `COPY FROM` in single row error isolation mode if the data is in binary format.
 
@@ -281,8 +279,6 @@ A non-superuser can run only these types of `COPY` commands:
 
 For information about resource queues, refer to [Using Resource Queues](../../admin_guide/workload_mgmt.html) in the *Greenplum Database Administrator Guide*.
 
-XXX
-
 ## <a id="section7"></a>File Formats 
 
 The file formats supported by `COPY` include text, CSV, and binary.
@@ -318,8 +314,6 @@ All backslash sequences are interpreted after encoding conversion. The bytes spe
 
 `COPY TO` will terminate each row with a Unix-style newline (`\n`). Servers running on Microsoft Windows instead output carriage return/newline (`\r\n`), but only for `COPY` to a server file; for consistency across platforms, `COPY TO STDOUT` always sends `\n` regardless of server platform. `COPY FROM` can handle lines ending with newlines, carriage returns, or carriage return/newlines. To reduce the risk of error due to un-backslashed newlines or carriage returns that were meant as data, `COPY FROM` issues a warning if the line endings in the input are not all alike.
 
-XXX
-
 To summarize, two reserved characters have special meaning to `COPY`:
 
 -   The designated delimiter character \(tab by default\), which is used to separate fields in the data file.
@@ -343,8 +337,6 @@ percentage sign = % | vertical bar = *| | backslash = \
 ```
 
 Notice how the pipe character that is part of the data has been escaped using the asterisk character \(\*\). Also notice that we do not need to escape the backslash since we are using an alternative escape character.
-
-XXX
 
 ### <a id="section7c"></a>CSV Format
 
@@ -422,7 +414,7 @@ To copy into a compressed file, you can pipe the output through an external comp
 COPY country TO PROGRAM 'gzip > /usr1/proj/bray/sql/country_data.gz';
 ```
 
-XXX Greenplum-specific examples START
+Greenplum-specific examples START
 
 Copy data from a file into the `sales` table using single row error isolation mode and log errors:
 
@@ -500,7 +492,7 @@ This example uses the `PROGRAM` and `ON SEGMENT` clauses to copy data from files
 COPY lineitem_4 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
 ```
 
-XXX Greenplum-specific examples END
+Greenplum-specific examples END
 
 ## <a id="section12"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
@@ -187,7 +187,7 @@ IGNORE EXTERNAL PARTITIONS
 
 ## <a id="sectiono"></a>Outputs
 
-On successful completion, a `COPY` command returns a command tag of the form, where `<count>` identifies is the number of rows copied:
+On successful completion, a `COPY` command returns a command tag of the form, where `<count>` identifies the number of rows copied:
 
 ```
 COPY <count>

--- a/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/COPY.html.md
@@ -8,23 +8,20 @@ Copies data between a file and a table.
 COPY <table_name> [(<column_name> [, ...])] 
      FROM {'<filename>' | PROGRAM '<command>' | STDIN}
      [ [ WITH ] ( <option> [, ...] ) ]
+     [ WHERE <condition> ]
      [ ON SEGMENT ]
 
 COPY { <table_name> [(<column_name> [, ...])] | (<query>)} 
      TO {'<filename>' | PROGRAM '<command>' | STDOUT}
      [ [ WITH ] ( <option> [, ...] ) ]
      [ ON SEGMENT ]
-```
 
-where option can be one of:
-
-```
+where <option> can be one of:
 
 FORMAT <format_name>
-OIDS [ <boolean> ]
 FREEZE [ <boolean> ]
 DELIMITER '<delimiter_character>'
-NULL '<null string>'
+NULL '<null_string>'
 HEADER [ <boolean> ]
 QUOTE '<quote_character>'
 ESCAPE '<escape_character>'
@@ -39,11 +36,11 @@ IGNORE EXTERNAL PARTITIONS
 
 ## <a id="section3"></a>Description 
 
-`COPY` moves data between Greenplum Database tables and standard file-system files. `COPY TO` copies the contents of a table to a file \(or multiple files based on the segment ID if copying `ON SEGMENT`\), while `COPY FROM` copies data from a file to a table \(appending the data to whatever is in the table already\). `COPY TO` can also copy the results of a `SELECT` query.
+`COPY` moves data between Greenplum Database tables and standard file-system files. `COPY TO` copies the contents of a table *to* a file \(or multiple files based on the segment ID if copying `ON SEGMENT`\), while `COPY FROM` copies data *from* a file to a table \(appending the data to whatever is in the table already\). `COPY TO` can also copy the results of a `SELECT` query.
 
-If a list of columns is specified, `COPY` will only copy the data in the specified columns to or from the file. If there are any columns in the table that are not in the column list, `COPY FROM` will insert the default values for those columns.
+If a list of columns is specified, `COPY TO` copies only the data in the specified columns to the file. For COPY FROM, each field in the file is inserted, in order, into the specified column. Table columns not specified in the `COPY FROM` column list will receive their default values.
 
-`COPY` with a file name instructs the Greenplum Database coordinator host to directly read from or write to a file. The file must be accessible to the coordinator host and the name must be specified from the viewpoint of the coordinator host.
+`COPY` with a file name instructs the Greenplum Database coordinator host to directly read from or write to a file. The file must be accessible by the operating system user running Greenplum Database (typically `gpadmin`) on the coordinator host and the name must be specified from the viewpoint of the server. When `PROGRAM` is specified, the server runs the given command and reads from the standard output of the program, or writes to the standard input of the program. The command must be specified from the viewpoint of the server, and be executable by the `gpadmin` user. When `STDIN` or `STDOUT` is specified, data is transmitted via the connection between the client and the coordinator. `STDIN` and `STDOUT` cannot be used with the `ON SEGMENT` clause.
 
 When `COPY` is used with the `ON SEGMENT` clause, the `COPY TO` causes segments to create individual segment-oriented files, which remain on the segment hosts. The filename argument for `ON SEGMENT` takes the string literal `<SEGID>` \(required\) and uses either the absolute path or the `<SEG_DATA_DIR>` string literal. When the `COPY` operation is run, the segment IDs and the paths of the segment data directories are substituted for the string literal values.
 
@@ -53,25 +50,7 @@ The `ON SEGMENT` clause allows you to copy table data to files on segment hosts 
 
 > **Caution** Use of the `ON SEGMENT` clause is recommended for expert users only.
 
-When `PROGRAM` is specified, the server runs the given command and reads from the standard output of the program, or writes to the standard input of the program. The command must be specified from the viewpoint of the server, and be executable by the `gpadmin` user.
-
-When `STDIN` or `STDOUT` is specified, data is transmitted via the connection between the client and the coordinator. `STDIN` and `STDOUT` cannot be used with the `ON SEGMENT` clause.
-
-If `SEGMENT REJECT LIMIT` is used, then a `COPY FROM` operation will operate in single row error isolation mode. In this release, single row error isolation mode only applies to rows in the input file with format errors — for example, extra or missing attributes, attributes of a wrong data type, or invalid client encoding sequences. Constraint errors such as violation of a `NOT NULL`, `CHECK`, or `UNIQUE` constraint will still be handled in 'all-or-nothing' input mode. The user can specify the number of error rows acceptable \(on a per-segment basis\), after which the entire `COPY FROM` operation will be cancelled and no rows will be loaded. The count of error rows is per-segment, not per entire load operation. If the per-segment reject limit is not reached, then all rows not containing an error will be loaded and any error rows discarded. To keep error rows for further examination, specify the `LOG ERRORS` clause to capture error log information. The error information and the row is stored internally in Greenplum Database.
-
-**Outputs**
-
-On successful completion, a `COPY` command returns a command tag of the form, where count is the number of rows copied:
-
-```
-COPY <count>
-```
-
-If running a `COPY FROM` command in single row error isolation mode, the following notice message will be returned if any rows were not loaded due to format errors, where count is the number of rows rejected:
-
-```
-NOTICE: Rejected <count> badly formatted rows.
-```
+If `SEGMENT REJECT LIMIT` is provided, then a `COPY FROM` operation will operate in single row error isolation mode. In this release, single row error isolation mode only applies to rows in the input file with format errors — for example, extra or missing attributes, attributes of a wrong data type, or invalid client encoding sequences. Constraint errors such as violation of a `NOT NULL`, `CHECK`, or `UNIQUE` constraint will still be handled in 'all-or-nothing' input mode. The user can specify the number of error rows acceptable \(on a per-segment basis\), after which the entire `COPY FROM` operation will be cancelled and no rows will be loaded. The count of error rows is per-segment, not per entire load operation. If the per-segment reject limit is not reached, then all rows not containing an error will be loaded and any error rows discarded. To keep error rows for further examination, specify the `LOG ERRORS` clause to capture error log information. The error information and the row is stored internally in Greenplum Database.
 
 ## <a id="section5"></a>Parameters 
 
@@ -79,20 +58,21 @@ table\_name
 :   The name \(optionally schema-qualified\) of an existing table.
 
 column\_name
-:   An optional list of columns to be copied. If no column list is specified, all columns of the table will be copied.
+:   An optional list of columns to be copied. If no column list is specified, all columns of the table except generated columns will be copied.
 
-:   When copying in text format, the default, a row of data in a column of type `bytea` can be up to 256MB.
+:   XXX When copying in text format, the default, a row of data in a column of type `bytea` can be up to 256MB.
 
 query
-:   A `SELECT` or `VALUES` command whose results are to be copied. Note that parentheses are required around the query.
+:   A [SELECT](SELECT.html), [VALUES](VALUES.html), [INSERT](INSERT.html), [UPDATE](UPDATE.html), or [DELETE](DELETE.html) command whose results are to be copied. Note that parentheses are required around the query.
+:   For `INSERT`, `UPDATE`, and `DELETE` queries a `RETURNING` clause must be provided, and the target relation must not have a conditional rule, nor an `ALSO` rule, nor an `INSTEAD` rule that expands to multiple statements.
 
 filename
 :   The path name of the input or output file. An input file name can be an absolute or relative path, but an output file name must be an absolute path. Windows users might need to use an `E''` string and double any backslashes used in the path name.
 
 PROGRAM 'command'
-:   Specify a command to run. In `COPY FROM`, the input is read from standard output of the command, and in `COPY TO`, the output is written to the standard input of the command. The command must be specified from the viewpoint of the Greenplum Database coordinator host system, and must be executable by the Greenplum Database administrator user \(`gpadmin`\).
+:   Specify a command to run. In `COPY FROM`, the input is read from standard output of the command, and in `COPY TO`, the output is written to the standard input of the command. The command must be specified from the viewpoint of the Greenplum Database coordinator host system, and must be executable by the Greenplum Database administrator operating system user \(`gpadmin`\).
 
-:   The command is invoked by a shell. When passing arguments to the shell, strip or escape any special characters that have a special meaning for the shell. For security reasons, it is best to use a fixed command string, or at least avoid passing any user input in the string.
+:   The command is invoked by a shell. When passing arguments to the shell command that come from an untrusted source, strip or escape any special characters that have a special meaning for the shell. For security reasons, it is best to use a fixed command string, or at least avoid passing any user input in the string.
 
 :   When `ON SEGMENT` is specified, the command must be executable on all Greenplum Database primary segment hosts by the Greenplum Database administrator user \(`gpadmin`\). The command is run by each Greenplum segment instance. The `<SEGID>` is required in the command.
 
@@ -105,16 +85,13 @@ STDOUT
 :   Specifies that output goes to the client application. The `ON SEGMENT` clause is not supported with `STDOUT`.
 
 boolean
-:   Specifies whether the selected option should be turned on or off. You can write `TRUE`, `ON`, or `1` to enable the option, and `FALSE`, `OFF`, or `0` to deactivate it. The boolean value can also be omitted, in which case `TRUE` is assumed.
+:   Specifies whether the selected option should be turned on or off. You can specify `TRUE`, `ON`, or `1` to enable the option, and `FALSE`, `OFF`, or `0` to deactivate it. The boolean value can also be omitted, in which case `TRUE` is assumed.
 
 FORMAT
-:   Selects the data format to be read or written: `text`, `csv` \(Comma Separated Values\), or `binary`. The default is `text`.
-
-OIDS
-:   Specifies copying the OID for each row. \(An error is raised if OIDS is specified for a table that does not have OIDs, or in the case of copying a query.\)
+:   Selects the data format to be read or written: `text`, `csv` \(Comma Separated Values\), or `binary`. The default is `text`. See [File Formats](#section7) for more information.
 
 FREEZE
-:   Requests copying the data with rows already frozen, just as they would be after running the `VACUUM FREEZE` command. This is intended as a performance option for initial data loading. Rows will be frozen only if the table being loaded has been created or truncated in the current subtransaction, there are no cursors open, and there are no older snapshots held by this transaction.
+:   Requests copying the data with rows already frozen, just as they would be after running the `VACUUM FREEZE` command. This is intended as a performance option for initial data loading. Rows will be frozen only if the table being loaded has been created or truncated in the current subtransaction, there are no cursors open, and there are no older snapshots held by this transaction. It is not currently possible to perform a `COPY FREEZE` on a partitioned table.
 
 :   Note that all other sessions will immediately be able to see the data once it has been successfully loaded. This violates the normal rules of MVCC visibility and users specifying this option should be aware of the potential problems this might cause.
 
@@ -124,7 +101,7 @@ DELIMITER
 NULL
 :   Specifies the string that represents a null value. The default is `\N` \(backslash-N\) in `text` format, and an unquoted empty string in `CSV` format. You might prefer an empty string even in `text` format for cases where you don't want to distinguish nulls from empty strings. This option is not allowed when using `binary` format.
 
-    > **Note** When using `COPY FROM`, any data item that matches this string will be stored as a null value, so you should make sure that you use the same string as you used with `COPY TO`.
+    > **Note** When using `COPY FROM`, Greenplum Database stores any data item that matches this string as a null value, so be sure that you use the same string that you specified in `COPY TO`.
 
 HEADER
 :   Specifies that a file contains a header line with the names of each column in the file. On output, the first line contains the column names from the table, and on input, the first line is ignored. This option is allowed only when using `CSV` format.
@@ -136,7 +113,7 @@ ESCAPE
 :   Specifies the character that should appear before a data character that matches the `QUOTE` value. The default is the same as the `QUOTE` value \(so that the quoting character is doubled if it appears in the data\). This must be a single one-byte character. This option is allowed only when using `CSV` format.
 
 FORCE\_QUOTE
-:   Forces quoting to be used for all non-`NULL` values in each specified column. `NULL` output is never quoted. If `*`is specified, non-`NULL` values will be quoted in all columns. This option is allowed only in `COPY TO`, and only when using `CSV` format.
+:   Forces quoting to be used for all non-`NULL` values in each specified column. `NULL` output is never quoted. If `*` is specified, non-`NULL` values will be quoted in all columns. This option is allowed only in `COPY TO`, and only when using `CSV` format.
 
 FORCE\_NOT\_NULL
 :   Do not match the specified columns' values against the null string. In the default case where the null string is empty, this means that empty values will be read as zero-length strings rather than nulls, even when they are not quoted. This option is allowed only in `COPY FROM`, and only when using `CSV` format.
@@ -144,8 +121,17 @@ FORCE\_NOT\_NULL
 FORCE\_NULL
 :   Match the specified columns' values against the null string, even if it has been quoted, and if a match is found set the value to `NULL`. In the default case where the null string is empty, this converts a quoted empty string into `NULL`. This option is allowed only in `COPY FROM`, and only when using `CSV` format.
 
-ENCODING
-:   Specifies that the file is encoded in the encoding\_name. If this option is omitted, the current client encoding is used. See the Notes below for more details.
+ENCODING 'encoding\_name'
+:   Specifies that the file is encoded in the encoding\_name. If this option is omitted, the current client encoding is used. See the [Notes](#section6) below for more details.
+
+WHERE
+:   The optional `WHERE` clause has the general form:
+
+    ```
+    WHERE condition
+    ```
+:   where condition is any expression that evaluates to a result of type `boolean`. Any row that does not satisfy this condition will not be inserted to the table. A row satisfies the condition if it returns `true` when the actual row values are substituted for any variable references.
+:   Currently, subqueries are not allowed in `WHERE` expressions, and the evaluation does not see any changes made by the `COPY` itself (this matters when the expression contains calls to `VOLATILE` functions).
 
 ON SEGMENT
 :   Specify individual, segment data files on the segment hosts. Each file contains the table data that is managed by the primary segment instance. For example, when copying data to files from a table with a `COPY TO...ON SEGMENT` command, the command creates a file on the segment host for each segment instance on the host. Each file contains the table data that is managed by the segment instance.
@@ -175,9 +161,6 @@ ON SEGMENT
 NEWLINE
 :   Specifies the newline used in your data files — `LF` \(Line feed, 0x0A\), `CR` \(Carriage return, 0x0D\), or `CRLF` \(Carriage return plus line feed, 0x0D 0x0A\). If not specified, a Greenplum Database segment will detect the newline type by looking at the first row of data it receives and using the first newline type encountered.
 
-CSV
-:   Selects Comma Separated Value \(CSV\) mode. See [CSV Format](#section9).
-
 FILL MISSING FIELDS
 :   In `COPY FROM` more for both `TEXT` and `CSV`, specifying `FILL MISSING FIELDS` will set missing trailing field values to `NULL` \(instead of reporting an error\) when a row of data has missing data fields at the end of a line or row. Blank rows, fields with a `NOT NULL` constraint, and trailing delimiters on a line will still report an error.
 
@@ -189,50 +172,78 @@ LOG ERRORS
 :   See [Notes](#section6) for information about the error log information and built-in functions for viewing and managing error log information.
 
 SEGMENT REJECT LIMIT count \[ROWS \| PERCENT\]
-:   Runs a `COPY FROM` operation in single row error isolation mode. If the input rows have format errors they will be discarded provided that the reject limit count is not reached on any Greenplum Database segment instance during the load operation. The reject limit count can be specified as number of rows \(the default\) or percentage of total rows \(1-100\). If `PERCENT` is used, each segment starts calculating the bad row percentage only after the number of rows specified by the parameter `gp_reject_percent_threshold` has been processed. The default for `gp_reject_percent_threshold` is 300 rows. Constraint errors such as violation of a `NOT NULL`, `CHECK`, or `UNIQUE` constraint will still be handled in 'all-or-nothing' input mode. If the limit is not reached, all good rows will be loaded and any error rows discarded.
+:   Runs a `COPY FROM` operation in single row error isolation mode. If the input rows have format errors they will be discarded provided that the reject limit count is not reached on any Greenplum Database segment instance during the load operation. The reject limit count can be specified as number of rows \(the default\) or percentage of total rows \(1-100\). If `PERCENT` is used, each segment starts calculating the bad row percentage only after the number of rows specified by the parameter [gp_reject_percent_threshold](../config_params/guc-list.html#gp_reject_percent_threshold) has been processed. The default for `gp_reject_percent_threshold` is 300 rows. Constraint errors such as violation of a `NOT NULL`, `CHECK`, or `UNIQUE` constraint will still be handled in 'all-or-nothing' input mode. If the limit is not reached, all good rows will be loaded and any error rows discarded.
 
 :   > **Note** Greenplum Database limits the initial number of rows that can contain formatting errors if the `SEGMENT REJECT LIMIT` is not triggered first or is not specified. If the first 1000 rows are rejected, the `COPY` operation is stopped and rolled back.
 
-The limit for the number of initial rejected rows can be changed with the Greenplum Database server configuration parameter `gp_initial_bad_row_limit`. See [Server Configuration Parameters](../config_params/guc_config.html) for information about the parameter.
+The limit for the number of initial rejected rows can be changed with the Greenplum Database server configuration parameter [gp_initial_bad_row_limit](../config_params/guc_config.html#gp_initial_bad_row_limit) server configuration parameter documentation for information about the parameter.
 
 IGNORE EXTERNAL PARTITIONS
 :   When copying data from partitioned tables, data are not copied from leaf partitions that are external tables. A message is added to the log file when data are not copied.
 
 :   If this clause is not specified and Greenplum Database attempts to copy data from a leaf partition that is an external table, an error is returned.
 
-:   See the next section "Notes" for information about specifying an SQL query to copy data from leaf partitions that are external tables.
+:   See the [Notes](#section6) for information about specifying an SQL query to copy data from leaf child partitions that are external tables.
+
+## <a id="sectiono"></a>Outputs
+
+On successful completion, a `COPY` command returns a command tag of the form, where `<count>` identifies is the number of rows copied:
+
+```
+COPY <count>
+```
+
+`psql` prints this command tag only if the command was not `COPY ... TO STDOUT`, or the equivalent `psql` meta-command `\copy ... to stdout`. This is to prevent confusing the command tag with the data that was just printed.
+
+If running a `COPY FROM` command in single row error isolation mode, Greenplum Database returns the following notice message if any rows were not loaded due to format errors. `<count>` identifies the number of formatting errors and <n> identfies the minimum number of rows rejected:
+
+```
+NOTICE: found <count> data formatting errors (<n> or more input rows), rejected related input data
+```
 
 ## <a id="section6"></a>Notes 
 
-`COPY` can only be used with tables, not with external tables or views. However, you can write `COPY (SELECT * FROM viewname) TO ...`
-
-`COPY` only deals with the specific table named; it does not copy data to or from child tables. Thus for example `COPY table TO` shows the same data as `SELECT * FROM ONLY `table``. But `COPY (SELECT * FROM table) TO ...` can be used to dump all of the data in an inheritance hierarchy.
+`COPY TO` can only be used with plain tables, not with external tables or views, and does not copy rows from child tables or child partitions. For example, `COPY <table> TO` copies the same rows as `SELECT * FROM ONLY <table>`. However, you can write `COPY (SELECT * FROM <viewname>) TO ...` to dump all of the rows in an inheritance hierarchy, partitioned table, or view.
 
 Similarly, to copy data from a partitioned table with a leaf partition that is an external table, use an SQL query to select the data to copy. For example, if the table `my_sales` contains a leaf partition that is an external table, this command `COPY my_sales TO stdout` returns an error. This command sends the data to `stdout`:
 
 ```
-COPY (SELECT * from my_sales ) TO stdout
+COPY (SELECT * from my_sales ) TO stdout;
 ```
 
-The `BINARY` keyword causes all data to be stored/read as binary format rather than as text. It is somewhat faster than the normal text mode, but a binary-format file is less portable across machine architectures and Greenplum Database versions. Also, you cannot run `COPY FROM` in single row error isolation mode if the data is in binary format.
+`COPY FROM` can be used with plain, foreign, or partitioned tables XXX or with views that have INSTEAD OF INSERT triggers. XXX
 
 You must have `SELECT` privilege on the table whose values are read by `COPY TO`, and `INSERT` privilege on the table into which values are inserted by `COPY FROM`. It is sufficient to have column privileges on the columns listed in the command.
 
+If row-level security is enabled for the table, the relevant `SELECT` policies will apply to `COPY <table> TO` statements. Currently, `COPY FROM` is not supported for tables with row-level security. Use equivalent `INSERT` statements instead.
+
 Files named in a `COPY` command are read or written directly by the database server, not by the client application. Therefore, they must reside on or be accessible to the Greenplum Database coordinator host machine, not the client. They must be accessible to and readable or writable by the Greenplum Database system user \(the user ID the server runs as\), not the client. Only database superusers are permitted to name files with `COPY`, because this allows reading or writing any file that the server has privileges to access.
 
-`COPY FROM` will invoke any triggers and check constraints on the destination table. However, it will not invoke rewrite rules. Note that in this release, violations of constraints are not evaluated for single row error isolation mode.
+Do not confuse `COPY` with the `psql` instruction `\copy`. `\copy` invokes `COPY FROM STDIN` or `COPY TO STDOUT`, and then fetches/stores the data in a file accessible to the `psql` client. Thus, file accessibility and access rights depend on the client rather than the server when `\copy` is used.
 
-`COPY` input and output is affected by `DateStyle`. To ensure portability to other Greenplum Database installations that might use non-default `DateStyle` settings, `DateStyle` should be set to ISO before using `COPY TO`. It is also a good idea to avoid dumping data with IntervalStyle set to `sql_standard`, because negative interval values might be misinterpreted by a server that has a different setting for IntervalStyle.
+Always specify the file name used in `COPY` as an absolute path. This is enforced by the server in the case of `COPY TO`, but for `COPY FROM` you do have the option of reading from a file specified by a relative path. The path will be interpreted relative to the working directory of the server process (normally the cluster's data directory), not the client's working directory
+
+Executing a command with `PROGRAM` might be restricted by the operating system's access control mechanisms.
+
+`COPY FROM` will invoke any triggers and check constraints on the destination table. However, it will not invoke rules. XXX Note that in this release, violations of constraints are not evaluated for single row error isolation mode. XXX
+
+For identity columns, the `COPY FROM` command will always write the column values provided in the input data, like the `INSERT` option `OVERRIDING SYSTEM VALUE`.
+
+`COPY` input and output is affected by `DateStyle`. To ensure portability to other Greenplum Database installations that might use non-default `DateStyle` settings, set `DateStyle` to `ISO` before using `COPY TO`. It is also a good idea to avoid dumping data with `IntervalStyle` set to `sql_standard`, because negative interval values might be misinterpreted by a server that has a different setting for `IntervalStyle`.
 
 Input data is interpreted according to `ENCODING` option or the current client encoding, and output data is encoded in `ENCODING` or the current client encoding, even if the data does not pass through the client but is read from or written to a file directly by the server.
 
-When copying XML data from a file in text mode, the server configuration parameter [xmloption](../config_params/guc-list.html) affects the validation of the XML data that is copied. If the value is `content` \(the default\), XML data is validated as an XML content fragment. If the parameter value is `document`, XML data is validated as an XML document. If the XML data is not valid, `COPY` returns an error.
-
-By default, `COPY` stops operation at the first error. This should not lead to problems in the event of a `COPY TO`, but the target table will already have received earlier rows in a `COPY FROM`. These rows will not be visible or accessible, but they still occupy disk space. This may amount to a considerable amount of wasted disk space if the failure happened well into a large `COPY FROM` operation. You may wish to invoke `VACUUM` to recover the wasted space. Another option would be to use single row error isolation mode to filter out error rows while still loading good rows.
+By default, `COPY` stops operation at the first error. This should not lead to problems in the event of a `COPY TO`, but the target table will already have received earlier rows in a `COPY FROM`. These rows will not be visible or accessible, but they still occupy disk space. This may amount to a considerable amount of wasted disk space if the failure happened well into a large `COPY FROM` operation. You may choose to invoke `VACUUM` to recover the wasted space. XXX Another option would be to use single row error isolation mode to filter out error rows while still loading good rows. XXX
 
 `FORCE_NULL` and `FORCE_NOT_NULL` can be used simultaneously on the same column. This results in converting quoted null strings to null values and unquoted null strings to empty strings.
 
-When a `COPY FROM...ON SEGMENT` command is run, the server configuration parameter `gp_enable_segment_copy_checking` controls whether the table distribution policy \(from the table `DISTRIBUTED` clause\) is checked when data is copied into the table. The default is to check the distribution policy. An error is returned if the row of data violates the distribution policy for the segment instance. For information about the parameter, see [Server Configuration Parameters](../config_params/guc_config.html).
+XXX
+
+The `BINARY` keyword causes all data to be stored/read as binary format rather than as text. It is somewhat faster than the normal text mode, but a binary-format file is less portable across machine architectures and Greenplum Database versions. Also, you cannot run `COPY FROM` in single row error isolation mode if the data is in binary format.
+
+When copying XML data from a file in text mode, the server configuration parameter [xmloption](../config_params/guc-list.html#xmloption) affects the validation of the XML data that is copied. If the value is `content` \(the default\), XML data is validated as an XML content fragment. If the parameter value is `document`, XML data is validated as an XML document. If the XML data is not valid, `COPY` returns an error.
+
+When a `COPY FROM...ON SEGMENT` command is run, the server configuration parameter [gp_enable_segment_copy_checking](../config_params/guc-list.html#gp_enable_segment_copy_checking) controls whether Greenplum Database checks the table distribution policy \(from the table `DISTRIBUTED` clause\) when data is copied into the table. The default is to check the distribution policy. An error is returned if the row of data violates the distribution policy for the segment instance.
 
 Data from a table that is generated by a `COPY TO...ON SEGMENT` command can be used to restore table data with `COPY FROM...ON SEGMENT`. However, data restored to the segments is distributed according to the table distribution policy at the time the files were generated with the `COPY TO` command. The `COPY` command might return table distribution policy errors, if you attempt to restore table data and the table distribution policy was changed after the `COPY FROM...ON SEGMENT` was run.
 
@@ -259,8 +270,7 @@ When you specify the `LOG ERRORS` clause, Greenplum Database captures errors tha
 
     The function returns `FALSE` if table\_name does not exist.
 
-    Specify the `*` wildcard character to delete error log information for existing tables in the current database. Specify the string `*.*` to delete all database error log information, including error log information that was not deleted due to previous database issues. If \* is specified, database owner privilege is required. If `*.*` is specified, operating system super-user privilege is required.
-
+    Specify the `*` wildcard character to delete error log information for existing tables in the current database. Specify the string `*.*` to delete all database error log information, including error log information that was not deleted due to previous database issues. If `*` is specified, database owner privilege is required. If `*.*` is specified, operating system super-user privilege is required.
 
 When a Greenplum Database user who is not a superuser runs a `COPY` command, the command can be controlled by a resource queue. The resource queue must be configured with the `ACTIVE_STATEMENTS` parameter that specifies a maximum limit on the number of queries that can be run by roles assigned to that queue. Greenplum Database does not apply a cost value or memory value to a `COPY` command, resource queues with only cost or memory limits do not affect the running of `COPY` commands.
 
@@ -269,24 +279,56 @@ A non-superuser can run only these types of `COPY` commands:
 -   `COPY FROM` command where the source is `stdin`
 -   `COPY TO` command where the destination is `stdout`
 
-For information about resource queues, see "Resource Management with Resource Queues" in the *Greenplum Database Administrator Guide*.
+For information about resource queues, refer to [Using Resource Queues](../../admin_guide/workload_mgmt.html) in the *Greenplum Database Administrator Guide*.
+
+XXX
 
 ## <a id="section7"></a>File Formats 
 
-File formats supported by `COPY`.
+The file formats supported by `COPY` include text, CSV, and binary.
 
-**Text Format**
+### <a id="section7t"></a>Text Format
 
-When the `text` format is used, the data read or written is a text file with one line per table row. Columns in a row are separated by the delimiter\_character \(tab by default\). The column values themselves are strings generated by the output function, or acceptable to the input function, of each attribute's data type. The specified null string is used in place of columns that are null. `COPY FROM` will raise an error if any line of the input file contains more or fewer columns than are expected. If `OIDS` is specified, the OID is read or written as the first column, preceding the user data columns.
+When the `text` format is used, the data read or written is a text file with one line per table row. Columns in a row are separated by the delimiter\_character \(tab by default\). The column values themselves are strings generated by the output function, or acceptable to the input function, of each attribute's data type. The specified null string is used in place of columns that are null. `COPY FROM` will raise an error if any line of the input file contains more or fewer columns than are expected.
 
-The data file has two reserved characters that have special meaning to `COPY`:
+Backslash characters (`\`) can be used in the `COPY` data to quote data characters that might otherwise be taken as row or column delimiters. In particular, the following characters *must* be preceded by a backslash if they appear as part of a column value: backslash itself, newline, carriage return, and the current delimiter character.
+
+The specified null string is sent by `COPY TO` without adding any backslashes; conversely, `COPY FROM` matches the input against the null string before removing backslashes. Therefore, a null string such as `\N` cannot be confused with the actual data value `\N` (which would be represented as `\\N`).
+
+The following special backslash sequences are recognized by `COPY FROM`:
+
+|Sequence|Represents|
+|-----------|-------|
+| \b | Backspace (ASCII 8) |
+| \f | Form feed (ASCII 12) |
+| \n | Newline (ASCII 10) |
+| \r | Carriage return (ASCII 13) |
+| \t | Tab (ASCII 9) |
+| \v | Vertical tab (ASCII 11) |
+| \digits | Backslash followed by one to three octal digits specifies the byte with that numeric code |
+| \xdigits | Backslash x followed by one or two hex digits specifies the byte with that numeric code |
+
+`COPY TO` will never emit an octal or hex-digits backslash sequence, but it does use the other sequences listed above for those control characters.
+
+Any other backslashed character that is not mentioned in the above table will be taken to represent itself. However, beware of adding backslashes unnecessarily, since that might accidentally produce a string matching the end-of-data marker (`\.`) or the null string (`\N` by default). These strings will be recognized before any other backslash processing is done.
+
+Ensure that applications generating `COPY` data convert data newlines and carriage returns to the `\n` and `\r` sequences respectively. It is currently possible to represent a data carriage return by a backslash and carriage return, and to represent a data newline by a backslash and newline. However, these representations might not be accepted in future releases, and they are also highly vulnerable to corruption if the `COPY` file is transferred across different machines (for example, from Unix to Windows or vice versa).
+
+All backslash sequences are interpreted after encoding conversion. The bytes specified with the octal and hex-digit backslash sequences must form valid characters in the database encoding.
+
+`COPY TO` will terminate each row with a Unix-style newline (`\n`). Servers running on Microsoft Windows instead output carriage return/newline (`\r\n`), but only for `COPY` to a server file; for consistency across platforms, `COPY TO STDOUT` always sends `\n` regardless of server platform. `COPY FROM` can handle lines ending with newlines, carriage returns, or carriage return/newlines. To reduce the risk of error due to un-backslashed newlines or carriage returns that were meant as data, `COPY FROM` issues a warning if the line endings in the input are not all alike.
+
+XXX
+
+To summarize, two reserved characters have special meaning to `COPY`:
 
 -   The designated delimiter character \(tab by default\), which is used to separate fields in the data file.
--   A UNIX-style line feed \(`\n` or `0x0a`\), which is used to designate a new row in the data file. It is strongly recommended that applications generating `COPY` data convert data line feeds to UNIX-style line feeds rather than Microsoft Windows style carriage return line feeds \(`\r\n` or `0x0a 0x0d`\).
+-   A UNIX-style line feed \(`\n` or `0x0a`\), which is used to designate a new row in the data file.
 
-If your data contains either of these characters, you must escape the character so `COPY` treats it as data and not as a field separator or new row.
 
-By default, the escape character is a \\ \(backslash\) for text-formatted files and a `"` \(double quote\) for csv-formatted files. If you want to use a different escape character, you can do so using the `ESCAPE AS`clause. Make sure to choose an escape character that is not used anywhere in your data file as an actual data value. You can also deactivate escaping in text-formatted files by using `ESCAPE 'OFF'`.
+By default, the escape character for a text-format file is a `\\` \(backslash\). If you want to use a different escape character, you can do so using the `ESCAPE` clause. Make sure to choose an escape character that is not used anywhere in your data file as an actual data value. You can also deactivate escaping in text-formatted files by using `ESCAPE 'OFF'`.
+
+If your data contains either of these characters, you must escape the character so `COPY` treats it as data and not as a field separator or new row. The following characters must also be preceded by the escape character if they appear as part of a column value: the escape character itself, newline, carriage return, and the current delimiter character.
 
 For example, suppose you have a table with three columns and you want to load the following three fields using `COPY`.
 
@@ -294,7 +336,7 @@ For example, suppose you have a table with three columns and you want to load th
 -   vertical bar = \|
 -   backslash = \\
 
-Your designated delimiter\_character is `|` \(pipe character\), and your designated escape character is `*` \(asterisk\). The formatted row in your data file would look like this:
+Your designated delimiter\_character is `|` \(pipe character\), and your designated escape character is `*` \(asterisk\). The formatted row in your data file would appear as follows:
 
 ```
 percentage sign = % | vertical bar = *| | backslash = \
@@ -302,9 +344,9 @@ percentage sign = % | vertical bar = *| | backslash = \
 
 Notice how the pipe character that is part of the data has been escaped using the asterisk character \(\*\). Also notice that we do not need to escape the backslash since we are using an alternative escape character.
 
-The following characters must be preceded by the escape character if they appear as part of a column value: the escape character itself, newline, carriage return, and the current delimiter character. You can specify a different escape character using the `ESCAPE AS` clause.
+XXX
 
-**CSV Format**
+### <a id="section7c"></a>CSV Format
 
 This format option is used for importing and exporting the Comma Separated Value \(CSV\) file format used by many other programs, such as spreadsheets. Instead of the escaping rules used by Greenplum Database standard text format, it produces and recognizes the common CSV escaping mechanism.
 
@@ -316,33 +358,47 @@ Because backslash is not a special character in the `CSV` format, `\.`, the end-
 
 > **Note** In `CSV` format, all characters are significant. A quoted value surrounded by white space, or any characters other than `DELIMITER`, will include those characters. This can cause errors if you import data from a system that pads CSV lines with white space out to some fixed width. If such a situation arises you might need to preprocess the CSV file to remove the trailing white space, before importing the data into Greenplum Database.
 
-`CSV` format will both recognize and produce CSV files with quoted values containing embedded carriage returns and line feeds. Thus the files are not strictly one line per table row like text-format files
+`CSV` format will both recognize and produce CSV files with quoted values containing embedded carriage returns and line feeds. The files are not strictly one line per table row like text-format files.
 
-> **Note** Many programs produce strange and occasionally perverse CSV files, so the file format is more a convention than a standard. Thus you might encounter some files that cannot be imported using this mechanism, and `COPY` might produce files that other programs cannot process.
+> **Note** Many programs produce strange CSV files, so the file format is more a convention than a standard. You might encounter some files that cannot be imported using this mechanism, and `COPY` might produce files that other programs cannot process.
 
-**Binary Format**
+### <a id="section7b"></a>Binary Format
 
 The `binary` format option causes all data to be stored/read as binary format rather than as text. It is somewhat faster than the text and `CSV` formats, but a binary-format file is less portable across machine architectures and Greenplum Database versions. Also, the binary format is very data type specific; for example it will not work to output binary data from a `smallint` column and read it into an `integer` column, even though that would work fine in text format.
 
 The binary file format consists of a file header, zero or more tuples containing the row data, and a file trailer. Headers and data are in network byte order.
 
--   **File Header** — The file header consists of 15 bytes of fixed fields, followed by a variable-length header extension area. The fixed fields are:
-    -   **Signature** — 11-byte sequence PGCOPY\\n\\377\\r\\n\\0 — note that the zero byte is a required part of the signature. \(The signature is designed to allow easy identification of files that have been munged by a non-8-bit-clean transfer. This signature will be changed by end-of-line-translation filters, dropped zero bytes, dropped high bits, or parity changes.\)
-    -   **Flags field** — 32-bit integer bit mask to denote important aspects of the file format. Bits are numbered from 0 \(LSB\) to 31 \(MSB\). Note that this field is stored in network byte order \(most significant byte first\), as are all the integer fields used in the file format. Bits 16-31 are reserved to denote critical file format issues; a reader should cancel if it finds an unexpected bit set in this range. Bits 0-15 are reserved to signal backwards-compatible format issues; a reader should simply ignore any unexpected bits set in this range. Currently only one flag is defined, and the rest must be zero \(Bit 16: 1 if data has OIDs, 0 if not\).
-    -   **Header extension area length** — 32-bit integer, length in bytes of remainder of header, not including self. Currently, this is zero, and the first tuple follows immediately. Future changes to the format might allow additional data to be present in the header. A reader should silently skip over any header extension data it does not know what to do with. The header extension area is envisioned to contain a sequence of self-identifying chunks. The flags field is not intended to tell readers what is in the extension area. Specific design of header extension contents is left for a later release.
--   **Tuples** — Each tuple begins with a 16-bit integer count of the number of fields in the tuple. \(Presently, all tuples in a table will have the same count, but that might not always be true.\) Then, repeated for each field in the tuple, there is a 32-bit length word followed by that many bytes of field data. \(The length word does not include itself, and can be zero.\) As a special case, -1 indicates a NULL field value. No value bytes follow in the NULL case.
+#### <a id="fileheader"></a>File Header
 
-    There is no alignment padding or any other extra data between fields.
+The file header consists of 15 bytes of fixed fields, followed by a variable-length header extension area. The fixed fields are:
 
-    Presently, all data values in a binary-format file are assumed to be in binary format \(format code one\). It is anticipated that a future extension may add a header field that allows per-column format codes to be specified.
+**Signature**
+:   11-byte sequence `PGCOPY\\n\\377\\r\\n\\0` — note that the zero byte is a required part of the signature. \(The signature is designed to allow easy identification of files that have been munged by a non-8-bit-clean transfer. This signature will be changed by end-of-line-translation filters, dropped zero bytes, dropped high bits, or parity changes.\)
 
-    If OIDs are included in the file, the OID field immediately follows the field-count word. It is a normal field except that it is not included in the field-count. In particular it has a length word — this will allow handling of 4-byte vs. 8-byte OIDs without too much pain, and will allow OIDs to be shown as null if that ever proves desirable.
+**Flags field**
+:   32-bit integer bit mask to denote important aspects of the file format. Bits are numbered from 0 \(LSB\) to 31 \(MSB\). Note that this field is stored in network byte order \(most significant byte first\), as are all the integer fields used in the file format. Bits 16-31 are reserved to denote critical file format issues; a reader should cancel if it finds an unexpected bit set in this range. Bits 0-15 are reserved to signal backwards-compatible format issues; a reader should simply ignore any unexpected bits set in this range. Currently only one flag is defined, and the rest must be zero.
+:   Bit 16: 1 if data has OIDs, 0 if not. Greenplum Database no longer supports OID system columns, but the format still contains the indicator.
 
--   **File Trailer** — The file trailer consists of a 16-bit integer word containing `-1`. This is easily distinguished from a tuple's field-count word. A reader should report an error if a field-count word is neither `-1` nor the expected number of columns. This provides an extra check against somehow getting out of sync with the data.
+**Header extension area length**
+:   32-bit integer, length in bytes of remainder of header, not including self. Currently, this is zero, and the first tuple follows immediately. Future changes to the format might allow additional data to be present in the header. A reader should silently skip over any header extension data it does not know how to parse. The header extension area is envisioned to contain a sequence of self-identifying chunks. The flags field is not intended to tell readers what is in the extension area.
+
+#### <a id="tuples"></a>Tuples
+
+Each tuple begins with a 16-bit integer count of the number of fields in the tuple. \(All tuples in a table will have the same count, but that might not always be true.\) Then, repeated for each field in the tuple, there is a 32-bit length word followed by that many bytes of field data. \(The length word does not include itself, and can be zero.\) As a special case, -1 indicates a NULL field value. No value bytes follow in the NULL case.
+
+There is no alignment padding or any other extra data between fields.
+
+All data values in a binary-format file are assumed to be in binary format \(format code one\). It is anticipated that a future extension may add a header field that allows per-column format codes to be specified.
+
+If OIDs are included in the file, the OID field immediately follows the field-count word. It is a normal field except that it is not included in the field-count. Note that Greenplum Database no longer supports OID system columns.
+
+#### <a id="filetrail"></a>File Trailer
+
+The file trailer consists of a 16-bit integer word containing `-1`. This is easily distinguished from a tuple's field-count word. A reader should report an error if a field-count word is neither `-1` nor the expected number of columns. This provides an extra check against somehow getting out of sync with the data.
 
 ## <a id="section11"></a>Examples 
 
-Copy a table to the client using the vertical bar \(\|\) as the field delimiter:
+Copy a table to the client using the vertical bar (`|`) as the field delimiter:
 
 ```
 COPY country TO STDOUT (DELIMITER '|');
@@ -357,9 +413,16 @@ COPY country FROM '/home/usr1/sql/country_data';
 Copy into a file just the countries whose names start with 'A':
 
 ```
-COPY (SELECT * FROM country WHERE country_name LIKE 'A%') TO 
-'/home/usr1/sql/a_list_countries.copy';
+COPY (SELECT * FROM country WHERE country_name LIKE 'A%') TO '/home/usr1/sql/a_list_countries.copy';
 ```
+
+To copy into a compressed file, you can pipe the output through an external compression program:
+
+```
+COPY country TO PROGRAM 'gzip > /usr1/proj/bray/sql/country_data.gz';
+```
+
+XXX Greenplum-specific examples START
 
 Copy data from a file into the `sales` table using single row error isolation mode and log errors:
 
@@ -368,7 +431,7 @@ COPY sales FROM '/home/usr1/sql/sales_data' LOG ERRORS
    SEGMENT REJECT LIMIT 10 ROWS;
 ```
 
-To copy segment data for later use, use the `ON SEGMENT` clause. Use of the `COPY TO ON SEGMENT` command takes the form:
+To copy segment data for later use, use the `ON SEGMENT` clause. Use of the `COPY ... TO ... ON SEGMENT` command takes the form:
 
 ```
 COPY <table> TO '<SEG_DATA_DIR>/<gpdumpname><SEGID>_<suffix>' ON SEGMENT; 
@@ -391,22 +454,22 @@ contentid | dbid | file segment location
 running the command:
 
 ```
-COPY mytable TO '<SEG_DATA_DIR>/gpbackup<SEGID>.txt' ON SEGMENT;
+COPY mytable TO '<SEG_DATA_DIR>/mytable_backup<SEGID>.txt' ON SEGMENT;
 ```
 
 would result in the following files:
 
 ```
-/home/usr1/data1/gpsegdir0/gpbackup0.txt
-/home/usr1/data2/gpsegdir1/gpbackup1.txt
+/home/usr1/data1/gpsegdir0/mytable_backup0.txt
+/home/usr1/data2/gpsegdir1/mytable_backup1.txt
 ```
 
-The content ID in the first column is the identifier inserted into the file path \(for example, `gpsegdir0/gpbackup0.txt` above\) Files are created on the segment hosts, rather than on the coordinator, as they would be in a standard `COPY` operation. No data files are created for the mirror segments when using `ON SEGMENT` copying.
+The content ID in the first column is the identifier inserted into the file path \(for example, `gpsegdir0/mytable_backup0.txt` above\) Files are created on the segment hosts, rather than on the coordinator, as they would be in a standard `COPY` operation. No data files are created for the mirror segments when using `ON SEGMENT` copying.
 
 If an absolute path is specified, instead of `<SEG_DATA_DIR>`, such as in the statement
 
 ```
-COPY mytable TO '/tmp/gpdir/gpbackup_<SEGID>.txt' ON SEGMENT;
+COPY mytable TO '/tmp/gpdir/mytable_backup_<SEGID>.txt' ON SEGMENT;
 ```
 
 files would be placed in `/tmp/gpdir` on every segment. The `gpfdist` tool can also be used to restore data files generated with `COPY TO` with the `ON SEGMENT` option if redistribution is necessary.
@@ -422,20 +485,22 @@ COPY (SELECT * FROM testtbl) TO '/tmp/mytst<SEGID>' ON SEGMENT;
 This example copies the data from the `lineitem` table and uses the `PROGRAM` clause to add the data to the `/tmp/lineitem_program.csv` file with `cat` utility. The file is placed on the Greenplum Database coordinator.
 
 ```
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem.csv' CSV; 
+COPY lineitem TO PROGRAM 'cat > /tmp/lineitem.csv' CSV; 
 ```
 
 This example uses the `PROGRAM` and `ON SEGMENT` clauses to copy data to files on the segment hosts. On the segment hosts, the `COPY` command replaces `<SEGID>` with the segment content ID to create a file for each segment instance on the segment host.
 
 ```
-COPY LINEITEM TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV; 
+COPY lineitem TO PROGRAM 'cat > /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
 ```
 
 This example uses the `PROGRAM` and `ON SEGMENT` clauses to copy data from files on the segment hosts. The `COPY` command replaces `<SEGID>` with the segment content ID when copying data from the files. On the segment hosts, there must be a file for each segment instance where the file name contains the segment content ID on the segment host.
 
 ```
-COPY LINEITEM_4 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
+COPY lineitem_4 FROM PROGRAM 'cat /tmp/lineitem_program<SEGID>.csv' ON SEGMENT CSV;
 ```
+
+XXX Greenplum-specific examples END
 
 ## <a id="section12"></a>Compatibility 
 
@@ -448,10 +513,9 @@ COPY <table_name> [(<column_name> [, ...])] FROM {'<filename>' | PROGRAM '<comma
      [ [WITH]  
        [ON SEGMENT]
        [BINARY]
-       [OIDS]
-       [HEADER]
        [DELIMITER [ AS ] '<delimiter_character>']
        [NULL [ AS ] '<null string>']
+       [HEADER]
        [ESCAPE [ AS ] '<escape>' | 'OFF']
        [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
        [CSV [QUOTE [ AS ] '<quote>'] 
@@ -464,17 +528,16 @@ COPY { <table_name> [(<column_name> [, ...])] | (<query>)} TO {'<filename>' | PR
       [ [WITH] 
         [ON SEGMENT]
         [BINARY]
-        [OIDS]
-        [HEADER]
         [DELIMITER [ AS ] 'delimiter_character']
         [NULL [ AS ] 'null string']
+        [HEADER]
         [ESCAPE [ AS ] '<escape>' | 'OFF']
         [CSV [QUOTE [ AS ] 'quote'] 
              [FORCE QUOTE <column_name> [, ...]] | * ]
       [IGNORE EXTERNAL PARTITIONS ]
 ```
 
-Note that in this syntax, `BINARY` and `CSV` are treated as independent keywords, not as arguments of a FORMAT option.
+Note that in this syntax, `BINARY` and `CSV` are treated as independent keywords, not as arguments of a `FORMAT` option.
 
 ## <a id="section13"></a>See Also 
 


### PR DESCRIPTION
bring the COPY sql ref page up to postgres 12 content. there is a bit of greenplum-specific content on this page, and also a bunch of new content pulled from the pg12 page.

notes/questions:
- ON SEGMENT, FILL MISSING FIELDS, LOG ERRORS, IGNORE EXTERNAL PARTITIONS - these are greenplum-specific clauses.  i am assuming that they have not changed in greenplum 7.  let me know if this is incorrect.
- Parameters section: column_name includes a statement about the max size of bytea columns - is this still true in greenplum 7?
- search for text between XXX (there is a large block in the Notes section and others in the File Formats sections) - still valid in greenplum 7?
- there are several greenplum-specific examples, i am assuming they are still valid (i called them out with XXX).
- in the Compatibility section, the pre-9.0 syntax referenced on the greenplum page is different than that on the postgres page.  i am assuming our content is correct, though i don't know its providence.

doc review site link (behind VPN):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-copy/greenplum-database/ref_guide-sql_commands-COPY.html
