### PR TITLE
ao/co: Consider all blocks as all-visible in ORCA

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnAppendOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllowIndexOnlyScanOnAppendOnlyTable.mdp
@@ -631,7 +631,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.005581" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.005535" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -642,7 +642,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.005546" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.005500" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
@@ -572,7 +572,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.072012" Rows="13.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.071726" Rows="13.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -583,7 +583,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.071785" Rows="13.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.071500" Rows="13.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
@@ -216,7 +216,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="15.365435" Rows="1683.942093" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="15.320238" Rows="1683.942093" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -227,7 +227,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="15.306879" Rows="1683.942093" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="15.261682" Rows="1683.942093" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -1833,6 +1833,10 @@ CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *mp GPOS_UNUSED,	  // mp
 	const CDouble dTableWidth =
 		CPhysicalScan::PopConvert(pop)->PstatsBaseTable()->Width();
 
+	BOOL isAO = CPhysicalScan::PopConvert(exprhdl.Pop())
+					->Ptabdesc()
+					->IsAORowOrColTable();
+
 	CDouble dIndexFilterCostUnit =
 		pcmgpdb->GetCostModelParams()
 			->PcpLookup(CCostModelParamsGPDB::EcpIndexFilterCostUnit)
@@ -1853,9 +1857,7 @@ CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *mp GPOS_UNUSED,	  // mp
 	GPOS_ASSERT(0 < dIndexScanTupCostUnit);
 	GPOS_ASSERT(0 < dIndexScanTupRandomFactor);
 
-	if (CPhysicalScan::PopConvert(exprhdl.Pop())
-			->Ptabdesc()
-			->IsAORowOrColTable())
+	if (isAO)
 	{
 		// AO specific costs related to index-scan/index-only-scan:
 		//
@@ -1939,9 +1941,17 @@ CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *mp GPOS_UNUSED,	  // mp
 	// approximately equal to the precent of tuples in all-visible blocks
 	// compared to total blocks. It is approximate because there is no
 	// guarantee that blocks are equally filled with live tuples.
+	//
+	// We never scan the underlying append-optimized table relfile for
+	// performing visibility checks. It's as if all blocks are all-visible. See
+	// cdb_estimate_rel_size(). So consider dPartialVisFrac as 0.
 
 	CDouble dPartialVisFrac(1);
-	if (stats->RelPages() != 0)
+	if (isAO)
+	{
+		dPartialVisFrac = 0;
+	}
+	else if (stats->RelPages() != 0)
 	{
 		dPartialVisFrac =
 			1 - (CDouble(stats->RelAllVisible()) / CDouble(stats->RelPages()));


### PR DESCRIPTION
We never scan the underlying append-optimized table relfile for
performing visibility checks. It's as if all blocks are all-visible. See
cdb_estimate_rel_size(). So consider dPartialVisFrac as 0.

This will make Index Only Scans more favorable on AO and CO tables.

Co-authored-by: David Kimura <dkimura@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/orca_ios