### PR TITLE
[6x]: Cleanup orphaned directory of dropped database after differential recovery

### DIFF
--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -172,7 +172,6 @@ class DifferentialRecovery(Command):
             "current_logfiles.tmp",
             "postmaster.pid",
             "postmaster.opts",
-            "pg_internal.init",
             "internal.auto.conf",
             "pg_dynshmem",
             "pg_notify/*",

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1967,20 +1967,22 @@ Feature: gprecoverseg tests
        And the cluster is recovered in full and rebalanced
 
 
-
   @demo_cluster
+  @concourse_cluster
   Scenario: Cleanup orphaned directory of dropped database after differential recovery
       Given the database is running
         And all the segments are running
         And the segments are synchronized
         And the user runs psql with "-c 'CREATE DATABASE test_orphan_dir'" against database "template1"
         And save the information of the database "test_orphan_dir"
-        And user immediately stops all mirror processes for content 0
-        And the user waits until mirror on content 0 is down
+        And the "primary" segment information is saved
+        And the primary on content 0 is stopped
+        And user can start transactions
         And the user runs psql with "-c 'DROP DATABASE test_orphan_dir'" against database "template1"
-       When the user runs "gprecoverseg -av --differential"
+       When the user runs "gprecoverseg -a --differential"
        Then gprecoverseg should return a return code of 0
-        And the user waits until mirror on content 0 is up
+        And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "template1"
+        And the status of the primary on content 0 should be "u"
        Then verify deletion of orphaned directory of the dropped database
         And the cluster is rebalanced
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1429,7 +1429,6 @@ def stop_segments_immediate(context, where_clause):
 
     segments = filter(where_clause, gparray.getDbList())
     for seg in segments:
-        context.seg_datadir = seg.getSegmentDataDirectory()
         # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
         subprocess.check_call(['ssh', seg.getSegmentHostName(),
@@ -4334,9 +4333,8 @@ def impl(context, command, num):
 @given('save the information of the database "{dbname}"')
 def impl(context, dbname):
     with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
-        query = """SELECT datname,oid  FROM pg_database where datname='{0}';""" .format(dbname)
+        query = """SELECT datname,oid  FROM pg_database WHERE datname='{0}';""" .format(dbname)
         datname, oid = dbconn.execSQLForSingletonRow(conn, query)
         context.db_name = datname
         context.db_oid = oid
-
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1429,6 +1429,7 @@ def stop_segments_immediate(context, where_clause):
 
     segments = filter(where_clause, gparray.getDbList())
     for seg in segments:
+        context.seg_datadir = seg.getSegmentDataDirectory()
         # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
         subprocess.check_call(['ssh', seg.getSegmentHostName(),
@@ -4326,4 +4327,16 @@ def impl(context, command, num):
         if match_count != int(num):
             raise Exception(
                 "Expected %s to occur %s times but Found %d times" .format(expected_pattern, num, match_count))
+
+
+
+
+@given('save the information of the database "{dbname}"')
+def impl(context, dbname):
+    with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+        query = """SELECT datname,oid  FROM pg_database where datname='{0}';""" .format(dbname)
+        datname, oid = dbconn.execSQLForSingletonRow(conn, query)
+        context.db_name = datname
+        context.db_oid = oid
+
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -763,8 +763,13 @@ def get_host_address(hostname):
 
 @then('verify deletion of orphaned directory of the dropped database')
 def impl(context):
-    db_data_dir = "{0}/base/{1}".format(context.seg_datadir, context.db_oid)
-    if os.path.exists(db_data_dir):
-        raise Exception('Orphaned directory of dropped database: {0} exists' .format(context.db_name))
+    hostname = context.pseg_hostname
+    db_data_dir = "{0}/base/{1}".format(context.pseg_data_dir, context.db_oid)
+    cmd = Command("list directory", cmdStr="test -d {}".format(db_data_dir), ctxt=REMOTE, remoteHost=hostname)
+    cmd.run()
+    rc = cmd.get_return_code()
+    if rc == 0:
+        raise Exception('Orphaned directory:"{0}" of dropped database:"{1}" exists on host:"{2}"' .format(db_data_dir,
+                        context.db_name, hostname))
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -761,3 +761,10 @@ def get_host_address(hostname):
     return host_address[0]
 
 
+@then('verify deletion of orphaned directory of the dropped database')
+def impl(context):
+    db_data_dir = "{0}/base/{1}".format(context.seg_datadir, context.db_oid)
+    if os.path.exists(db_data_dir):
+        raise Exception('Orphaned directory of dropped database: {0} exists' .format(context.db_name))
+
+


### PR DESCRIPTION
**Issue** - Even if the database is dropped before the recovery process, differential recovery still leaves behind orphaned directory for the dropped database under base directory. This issue only exists in 6X, in 7x `pg_internal.init` file is not added to the excluded list of rsync.

**RCA** - When a database is created, a file named pg_internal.init is also generated in the database directory. During the rsync process of pg_data, we intentionally exclude this pg_internal.init file (--exclude=pg_internal.init). However, because this file remains in the database directory and is excluded from rsync, it results in an error message stating "cannot delete non-empty directory: base/db_oid". As a consequence, it becomes problematic to delete the directory of a dropped database.

**Fix** - Removed the ‘pg_internal.init’ file from the excluded list of rsync, so that it wont be problematic to delete the directory of a dropped database. pg_internal.init file is rebuilt on startup so there is no problem if its copied during sync_pg_data.

**Test** - Added behave test case to verify the fix.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
