### PR TITLE
[7X] gprecoverseg: Fix behaviour of -o flag 

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -247,6 +247,12 @@ class GpRecoverSegmentProgram:
         if self.__options.differentialResynchronization and self.__options.outputSampleConfigFile:
             raise ProgramArgumentValidationException("Invalid -o provided with --differential argument")
 
+        if self.__options.recoveryConfigFile and self.__options.outputSampleConfigFile:
+            raise ProgramArgumentValidationException("Invalid -i provided with -o argument")
+
+        if self.__options.rebalanceSegments and self.__options.outputSampleConfigFile:
+            raise ProgramArgumentValidationException("Invalid -r provided with -o argument")
+
         if self.__options.disableReplayLag and not self.__options.rebalanceSegments:
             raise ProgramArgumentValidationException("--disable-replay-lag should be used only with -r")
 

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -102,15 +102,15 @@ class GpRecoverSegmentProgram:
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.disableReplayLag, self.__options.replayLag)
-        else:
-            instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
-            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization) for t in instance.getTriplets()]
-            return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                       self.__options.parallelDegree,
-                                       instance.getInterfaceHostnameWarnings(),
-                                       forceoverwrite=True,
-                                       progressMode=self.getProgressMode(),
-                                       parallelPerHost=self.__options.parallelPerHost)
+
+        instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.outputSampleConfigFile, self.__options.parallelDegree)
+        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization) for t in instance.getTriplets()]
+        return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
+                                   self.__options.parallelDegree,
+                                   instance.getInterfaceHostnameWarnings(),
+                                   forceoverwrite=True,
+                                   progressMode=self.getProgressMode(),
+                                   parallelPerHost=self.__options.parallelPerHost)
 
     def syncPackages(self, new_hosts):
         # The design decision here is to squash any exceptions resulting from the

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -159,7 +159,7 @@ class RecoveryTripletRequest:
 # TODO: Note that gparray is mutated for all triplets, even if we skip recovery for them(if they are unreachable)
 class RecoveryTripletsFactory:
     @staticmethod
-    def instance(gpArray, config_file=None, new_hosts=[], paralleldegree=1):
+    def instance(gpArray, config_file=None, new_hosts=[], outputConfigFile=None, paralleldegree=1):
         """
         :param gpArray: The variable gpArray may get mutated when the getMirrorTriples function is called on this instance.
         :param config_file: user passed in config file, if any
@@ -171,19 +171,20 @@ class RecoveryTripletsFactory:
             return RecoveryTripletsUserConfigFile(gpArray, config_file, paralleldegree)
         else:
             if not new_hosts:
-                return RecoveryTripletsInplace(gpArray, paralleldegree)
+                return RecoveryTripletsInplace(gpArray, outputConfigFile, paralleldegree)
             else:
-                return RecoveryTripletsNewHosts(gpArray, new_hosts, paralleldegree)
+                return RecoveryTripletsNewHosts(gpArray, new_hosts, outputConfigFile, paralleldegree)
 
 
 class RecoveryTriplets(abc.ABC):
-    def __init__(self, gpArray, paralleldegree=1):
+    def __init__(self, gpArray, outputConfigFile=None, paralleldegree=1):
         """
         :param gpArray: Needs to be a shallow copy since we may return a mutated gpArray
         """
         self.gpArray = gpArray
         self.interfaceHostnameWarnings = []
         self.paralleldegree = paralleldegree
+        self.outputConfigFile = outputConfigFile
 
     @abc.abstractmethod
     def getTriplets(self) -> List[RecoveryTriplet]:
@@ -279,7 +280,9 @@ class RecoveryTriplets(abc.ABC):
                 failover.unreachable = failover.getSegmentHostName() in unreachable_failover_hosts
             else:
                 # recovery in place, check for host reachable
-                if req.failed.unreachable:
+                # Recovery triplet should be added to the final list if output config file has been requested. As the
+                # output config file should have row for of each failed segment in segment configuration.
+                if req.failed.unreachable and self.outputConfigFile is None:
                     # skip the recovery
                     continue
 
@@ -304,8 +307,8 @@ class RecoveryTriplets(abc.ABC):
 
 
 class RecoveryTripletsInplace(RecoveryTriplets):
-    def __init__(self, gpArray, paralleldegree):
-        super().__init__(gpArray, paralleldegree)
+    def __init__(self, gpArray, outputConfigFile, paralleldegree):
+        super().__init__(gpArray, outputConfigFile, paralleldegree)
 
     def getTriplets(self):
         requests = []
@@ -321,8 +324,8 @@ class RecoveryTripletsInplace(RecoveryTriplets):
 
 
 class RecoveryTripletsNewHosts(RecoveryTriplets):
-    def __init__(self, gpArray, newHosts, paralleldegree):
-        super().__init__(gpArray, paralleldegree)
+    def __init__(self, gpArray, newHosts, outputConfigFile, paralleldegree):
+        super().__init__(gpArray, outputConfigFile, paralleldegree)
         self.newHosts = [] if not newHosts else newHosts[:]
         self.portAssigner = self._PortAssigner(gpArray)
 

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -31,14 +31,14 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
         with tempfile.NamedTemporaryFile() as f:
             f.write(test["config"].encode("utf-8"))
             f.flush()
-            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, test.get("unreachable_hosts"),
+            return self._run_single_FromGpArray_test(test["gparray"], f.name, test.get("output_config_file", None), None, test.get("unreachable_hosts"),
                                                      test.get("is_pgrewind_running", itertools.repeat(False)),
                                                      test.get("is_seg_in_backup_mode", itertools.repeat(False)),
                                                      test.get("segments_with_running_basebackup", set()),
                                                      test.get("unreachable_existing_hosts"))
 
     def run_single_GpArray_test(self, test):
-        return self._run_single_FromGpArray_test(test["gparray"], None, test["new_hosts"],
+        return self._run_single_FromGpArray_test(test["gparray"], None, test.get("output_config_file", None), test["new_hosts"],
                                                  test.get("unreachable_hosts"),
                                                  test.get("is_pgrewind_running", itertools.repeat(False)),
                                                  test.get("is_seg_in_backup_mode", itertools.repeat(False)),
@@ -118,7 +118,9 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "gparray": self.all_up_gparray_str,
                 "config": "sdw2|21000|/mirror/gpseg0",
                 "unreachable_existing_hosts": ['sdw2'],
-                "expected": []
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           None, True)]
             },
             {
                 "name": "one_mirror_inconfig_has_running_basebackup",
@@ -356,6 +358,55 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "expected": [self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
                                            '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
                                            None)]
+            },
+            {
+                "name": "output_config_file_when_one_existing_host_down",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": [],
+                "unreachable_existing_hosts": ['sdw1'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           None, True),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           None, True),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "output_config_file_when_one_existing_host_down_and_new_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": ['new_1', 'new_2'],
+                "unreachable_existing_hosts": ['sdw1'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0',
+                                           True),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1',
+                                           True),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
+            },
+            {
+                "name": "output_config_file_when_new_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": ['new_1', 'new_2'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0'),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1'),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
             },
             {
                 "name": "all_relevant_existing_hosts_down",
@@ -790,7 +841,7 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                   4|2|p|p|s|u|sdw2|sdw2|20000|/primary/gpseg2
                                   5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
 
-    def _run_single_FromGpArray_test(self, gparray_str, config_file, new_hosts, unreachable_hosts, is_pgrewind_running,
+    def _run_single_FromGpArray_test(self, gparray_str, config_file, output_config_file, new_hosts, unreachable_hosts, is_pgrewind_running,
                                      is_seg_in_backup_mode, segments_with_running_basebackup, unreachable_existing_hosts=None):
         unreachable_hosts = unreachable_hosts if unreachable_hosts else []
         gppylib.programs.clsRecoverSegment_triples.get_unreachable_segment_hosts = Mock(return_value=unreachable_hosts)
@@ -801,7 +852,8 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
 
         initial_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
         mutated_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
-        i = RecoveryTripletsFactory.instance(mutated_gparray, config_file=config_file, new_hosts=new_hosts)
+        i = RecoveryTripletsFactory.instance(mutated_gparray, config_file=config_file,
+                                             outputConfigFile=output_config_file, new_hosts=new_hosts)
         triples = i.getTriplets()
 
         warnings = i.getInterfaceHostnameWarnings()

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -559,7 +559,26 @@ Feature: gprecoverseg tests
         | incremental  | -a                 |
         | differential | -a --differential  |
         | full         | -aF                |
-      
+
+    @demo_cluster
+    @concourse_cluster
+    Scenario: gprecoverseg creates output sample config file correctly when failed segment hosts are unreachable
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And the primary on content 1 is stopped
+      And the primary on content 2 is stopped
+      And user can start transactions
+      And the status of the primary on content 1 should be "d"
+      And the status of the primary on content 2 should be "d"
+      And the host for the primary on content 1 is made unreachable
+      When the user runs "gprecoverseg -o /tmp/output_config"
+      Then gprecoverseg should return a return code of 0
+      And gprecoverseg should print "One or more hosts are not reachable via SSH." to stdout
+      And gprecoverseg should print "Host invalid_host is unreachable" to stdout
+      And the created config file /tmp/output_config contains the row for unreachable failed segment
+      And the cluster is returned to a good state
+
     @demo_cluster
     @concourse_cluster
     Scenario: gprecoverseg throws exception when -o flag used with invalid flags

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -559,6 +559,19 @@ Feature: gprecoverseg tests
         | incremental  | -a                 |
         | differential | -a --differential  |
         | full         | -aF                |
+      
+    @demo_cluster
+    @concourse_cluster
+    Scenario: gprecoverseg throws exception when -o flag used with invalid flags
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      When the user runs "gprecoverseg -o output_config -i input_config"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "Invalid -i provided with -o argument" to stdout
+      When the user runs "gprecoverseg -o /tmp/output_config -r"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "Invalid -r provided with -o argument" to stdout
 
   @concourse_cluster
   Scenario Outline: <scenario> recovery works with tablespaces on a multi-host environment


### PR DESCRIPTION
**First Commit:** Validate options with -o

Issue: There is no requirement of following flag combinations:
  -         -o with -r: No need of output config file when rebalancing
  -         -o with -i: Can't think of any valid usecase for this combination

Fix: gprecoverseg should raise an exception when invalid flags are used with -o

**Second Commit:**
Current behaviour: gprecoverseg -o outputs a config file containing the rows for each failed segment. But skips to add row for segment if failed segment is unreachable as it can't be recovered during the recovery process.

Requested behaviour: gprecoverseg -o should generate config file which contains row for each failed segment from gp_segment_configuration even if the failed segment host is unreachable. As the genarted config file can be modified according to usecase and need.

Fix: While creating the list of triplets (which will considered for recovery) a triplet is not added to list if failed host is unreachable. This triplet should not skipped if we just want to generate an output config file. So added check for -o option with the reachability check of failed segment host. This way the triplet will be added to final list even if failed host is unreachable.

Testing: Have added unit tests and a behave test



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
