### PR TITLE
(6x backport) print log message with write_stderr when reach vmem or resgroup limit.

### DIFF
--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -315,7 +315,13 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	}
 	else if (ec == MemoryFailure_VmemExhausted)
 	{
-		elog(LOG, "Logging memory usage for reaching Vmem limit");
+		/*
+		 * The memory usage have reached Vmem limit, it will loop in gp_malloc
+		 * and gp_failed_to_alloc if new allocation happens, and then errors out
+		 * with "ERRORDATA_STACK_SIZE exceeded". We are therefore printing the
+		 * log message header using write_stderr.
+		 */
+		write_stderr("Logging memory usage for reaching Vmem limit");
 	}
 	else if (ec == MemoryFailure_SystemMemoryExhausted)
 	{
@@ -330,7 +336,10 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	}
 	else if (ec == MemoryFailure_ResourceGroupMemoryExhausted)
 	{
-		elog(LOG, "Logging memory usage for reaching resource group limit");
+		/*
+		 * The behavior in resgroup group mode is the same as MemoryFailure_VmemExhausted.
+		 */
+		write_stderr("Logging memory usage for reaching resource group limit");
 	}
 	else
 		elog(ERROR, "Unknown memory failure error code");


### PR DESCRIPTION
When memory usage have reached Vmem limit or resource group limit, it will loop in gp_malloc and gp_failed_to_alloc if new allocation happens, and then errors out with "ERRORDATA_STACK_SIZE exceeded".

We are therefore printing the log message header using write_stderr.

(cherry picked from commit a7210a4be2068abfe7c5e2ee135016d5b8c77cd8)
