### PR TITLE
[6x] To raise exception when gprecoverseg ran with -F option with -r or -p 

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -625,7 +625,21 @@ Feature: gprecoverseg tests
     Then gprecoverseg should print "No basebackup running" to stdout
     And gprecoverseg should return a return code of 0
     Then the cluster is rebalanced
-
+    
+    Scenario: rebalance and recovery to new host with -F option shows error and exits
+      Given the database is running
+      And user stops all primary processes
+      When user can start transactions
+      And the user runs "gprecoverseg -a -F -r"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "Invalid -F provided with -r argument" to stdout
+      When the user runs "gprecoverseg -a -p localhost -F"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "Invalid -F provided with -p argument" to stdout
+      When the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 0
+      And the segments are synchronized
+      And the cluster is rebalanced
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
This is a cherry-pick of: https://github.com/greenplum-db/gpdb/pull/16329 

**Issue:**
Currently, gprecoverseg performs rebalance operation (-r option) which is an incremental operation. 
To recover segments to a new host (-p option) operation is always a full recovery operation.
Providing the -F flag along with -p and -r is not a valid conbination.

**Solution:**
To raise the exception when the Full Recovery option (-F) is specified along with:

    Recovery to a new host (-p option)
    Rebalance Operation (-r option)

**Changes in this PR:**

    Raise error when -F option is passed with -r or -p
    Moved gprecoverseg flags validation to a separate function.
    Added tests to verify rebalance and new host options.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
