### PR TITLE
docs - update query on pg_stat_all_indexes ref page to remove dup ind…

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_stat_indexes.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_stat_indexes.html.md
@@ -56,7 +56,7 @@ FROM
      SELECT *
      FROM pg_stat_all_indexes
      WHERE relid < 16384) m, pg_stat_all_indexes s
-WHERE m.relid = s.relid;
+WHERE m.relid = s.relid AND m.indexrelid = s.indexrelid;
 
 
 CREATE VIEW pg_stat_sys_indexes_gpdb6 AS 


### PR DESCRIPTION
…exes

the pg_stat_indexes ref page includes a query to display index statistics that combine the statiss from the master and the segment instances.  add a condition to the where clause that removes duplicate indexes.
