### PR TITLE
docs - add gp_check_functions module docs

### DIFF
--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -29,15 +29,16 @@ You can register the following modules in this manner:
 <li class="li"><a class="xref" href="../ref_guide/modules/diskquota.html">diskquota</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/fuzzystrmatch.html">fuzzystrmatch</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_array_agg.html">gp_array_agg</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/gp_check_functions.html">gp_check_functions</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_parallel_retrieve_cursor.html">gp_parallel_retrieve_cursor</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_percentile_agg.html">gp_percentile_agg</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_sparse_vector.html">gp_sparse_vector</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/greenplum_fdw.html">greenplum_fdw</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
 </ul>
 </td>
 <td style="vertical-align:top;">
 <ul class="ul">
-<li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/ip4r.html">ip4r</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/ltree.html">ltree</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/orafce_ref.html">orafce</a> (VMware Greenplum only)</li>

--- a/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
@@ -1,0 +1,85 @@
+# gp_check_functions
+
+The `gp_check_functions` module implements views that identify missing and orphaned relation files.
+
+The `gp_check_functions` module is a Greenplum Database extension.
+
+## <a id="topic_reg"></a>Installing and Registering the Module
+
+The `gp_check_functions` module is installed when you install Greenplum Database. Before you can use the views defined in the module, you must register the `gp_check_functions` extension in each database in which you want to use the views:
+o
+
+```
+CREATE EXTENSION gp_check_functions;
+```
+
+Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
+
+
+## <a id="missingfiles"></a>Checking for Missing and Orphaned Data Files
+
+Greenplum Database considers a relation data file that is present in the catalog, but not on disk, to be missing. Conversely, when Greenplum encounters an unexpected data file on disk that is not referenced in any relation, it considers that file to be orphaned.
+
+Greenplum Database provides the following views to help identify if missing or orphaned files exist in the current database:
+
+- [gp_check_orphaned_files](#orphaned)
+- [gp_check_missing_files](#missing)
+- [gp_check_missing_files_ext](#missing_ext)
+
+Consider it a best practice to check for these conditions prior to expanding the cluster or before offline maintenance.
+
+By default, the views in this module are available to `PUBLIC`.
+
+### <a id="orphaned"></a>gp_check_orphaned_files
+
+The `gp_check_orphaned_files` view scans the default and user-defined tablespaces for orphaned data files. Greenplum Database considers normal data files, files with an underscore (`_`) in the name, and extended numbered files (files that contain a `.<N>` in the name) in this check. `gp_check_orphaned_files` gathers results from the Greenplum Database master and all segments.
+
+|Column|Description|
+|------|-----------|
+| gp_segment_id | The Greenplum Database segment identifier. |
+| tablespace | The identifier of the tablespace in which the orphaned file resides. |
+| filename | The file name of the orphaned data file. |
+| filepath | The file system path of the orphaned data file, relative to `$MASTER_DATA_DIRECTORY`. |
+
+> **Caution** Use this view as one of many data points to identify orphaned data files. Do not delete files based solely on results from querying this view.
+
+
+### <a id="missing"></a>gp_check_missing_files
+
+The `gp_check_missing_files` view scans heap and append-optimized, column-oriented tables for missing data files. Greenplum considers only normal data files (files that do not contain a `.` or an `_` in the name) in this check. `gp_check_missing_files` gathers results from the Greenplum Database master and all segments.
+
+|Column|Description|
+|------|-----------|
+| gp_segment_id | The Greenplum Database segment identifier. |
+| tablespace | The identifier of the tablespace in which the table resides. |
+| relname | The name of the table that has a missing data file(s). |
+| filename | The file name of the missing data file. |
+
+
+### <a id="missing_ext"></a>gp_check_missing_files_ext
+
+The `gp_check_missing_files_ext` view scans only append-optimized, column-oriented tables for missing extended data files. Greenplum Database considers both normal data files and extended numbered files (files that contain a `.<N>` in the name) in this check. Files that contain an `_` in the name, and `.fsm`, `.vm`, and other supporting files, are not considered. `gp_check_missing_files_ext` gathers results from the Greenplum Database segments only.
+
+|Column|Description|
+|------|-----------|
+| gp_segment_id | The Greenplum Database segment identifier. |
+| tablespace | The identifier of the tablespace in which the table resides. |
+| relname | The name of the table that has a missing extended data file(s). |
+| filename | The file name of the missing extended data file. |
+
+
+## <a id="examples"></a>Examples
+
+Check for missing and orphaned non-extended files:
+
+``` sql
+SELECT * FROM gp_check_missing_files;
+SELECT * FROM gp_check_orphaned_files;
+```
+
+Check for missing extended data files for append-optimized, column-oriented tables:
+
+``` sql
+SELECT * FROM gp_check_missing_files_ext;
+```
+

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -16,6 +16,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [diskquota](diskquota.html) - Allows administrators to set disk usage quotas for Greenplum Database roles and schemas.
 -   [fuzzystrmatch](fuzzystrmatch.html) - Determines similarities and differences between strings.
 -   [gp\_array\_agg](gp_array_agg.html) - Implements a parallel `array_agg()` aggregate function for Greenplum Database.
+-   [gp\_check\_functions](gp_check_functions.html) - Provides views to check for orphaned and missing relation files.
 -   [gp\_legacy\_string\_agg](gp_legacy_string_agg.html) - Implements a legacy, single-argument `string_agg()` aggregate function that was present in Greenplum Database 5.
 -   [gp\_parallel\_retrieve\_cursor](gp_parallel_retrieve_cursor.html) - Provides extended cursor functionality to retrieve data, in parallel, directly from Greenplum Database segments.
 -   [gp\_percentile\_agg](gp_percentile_agg.html) - Improves GPORCA performance for ordered-set aggregate functions.

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -177,6 +177,7 @@ Doc Index
         - [diskquota](./modules/diskquota.md)
         - [fuzzystrmatch](./modules/fuzzystrmatch.md)
         - [gp\_array\_agg](./modules/gp_array_agg.md)
+        - [gp\_check\_functions](./modules/gp_check_functions.md)
         - [gp\_legacy\_string\_agg](./modules/gp_legacy_string_agg.md)
         - [gp\_parallel\_retrieve\_cursor (Beta)](./modules/gp_parallel_retrieve_cursor.md)
         - [gp\_percentile\_agg](./modules/gp_percentile_agg.md)


### PR DESCRIPTION
documents https://github.com/greenplum-db/gpdb/pull/15343.
  
in this PR:
- ported content from main PR (https://github.com/greenplum-db/gpdb/pull/16076) that added this info to gp_toolkit docs.
- noticed a new filepath column in gp_check_orphaned_files, added it.  is this column in 7/main?  i looked but didn't find it.
  
doc review site link (behind vpn): https://docs-staging.vmware.com/en/draft/VMware-Greenplum/gp_check_functions/greenplum-database/GUID-ref_guide-modules-gp_check_functions.html