### PR TITLE
docs - wrap up UPSERT doc changes, dump/dumpall/restore utility ref page updates

### DIFF
--- a/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
+++ b/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
@@ -231,7 +231,7 @@ For information about Greenplum features and SQL compliance, see the *Greenplum 
 |F311-03|`CREATE VIEW`|YES| |
 |F311-04|`CREATE VIEW: WITH CHECK OPTION`|NO| |
 |F311-05|`GRANT` statement|YES| |
-|F312|`MERGE` statement|NO| |
+|F312|`MERGE` statement|NO|consider `INSERT ... ON CONFLICT DO UPDATE` |
 |F313|Enhanced `MERGE` statement|NO| |
 |F321|User authorization|YES| |
 |F341|Usage Tables|NO| |

--- a/gpdb-doc/markdown/utility_guide/ref/pg_dump.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pg_dump.html.md
@@ -44,11 +44,19 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 
     > **Note** Greenplum Database does not support the PostgreSQL [large object facility](https://www.postgresql.org/docs/12/largeobjects.html) for streaming user data that is stored in large-object structures.
 
+-B \| --no-blobs
+:   Exclude large objects in the dump.
+
+:   When both `-b` and `-B` are specified, `pg_dump` outputs large objects, when data is being dumped, see the `-b` documentation.
+
+    > **Note** Greenplum Database does not support the PostgreSQL [large object facility](https://www.postgresql.org/docs/12/largeobjects.html) for streaming user data that is stored in large-object structures.
+
 -c \| --clean
 :   Adds commands to the text output file to clean \(drop\) database objects prior to outputting the commands for creating them. \(Restore might generate some harmless error messages, if any objects were not present in the destination database.\) Note that objects are not dropped before the dump operation begins, but `DROP` commands are added to the DDL dump output files so that when you use those files to do a restore, the `DROP` commands are run prior to the `CREATE` commands. This option is only meaningful for the plain-text format. For the archive formats, you may specify the option when you call [pg\_restore](pg_restore.html).
 
 -C \| --create
 :   Begin the output with a command to create the database itself and reconnect to the created database. \(With a script of this form, it doesn't matter which database in the destination installation you connect to before running the script.\) If `--clean` is also specified, the script drops and recreates the target database before reconnecting to it. This option is only meaningful for the plain-text format. For the archive formats, you may specify the option when you call [pg\_restore](pg_restore.html).
+:   With `--create`, the output also includes the database's comment if any, and any configuration variable settings that are specific to this database, that is, any `ALTER DATABASE ... SET ...` and `ALTER ROLE ... IN DATABASE ... SET ...` commands that mention this database. Access privileges for the database itself are also dumped, unless `--no-acl` is specified.
 
 -E \<encoding\> \| --encoding=\<encoding\>
 :   Create the dump in the specified character set encoding. By default, the dump is created in the database encoding. \(Another way to get the same result is to set the `PGCLIENTENCODING` environment variable to the desired dump encoding.\)
@@ -60,8 +68,8 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 :   Selects the format of the output. format can be one of the following:
 
 - p \| plain — Output a plain-text SQL script file \(the default\).
-- c \| custom — Output a custom archive suitable for input into [pg\_restore](pg_restore.html). Together with the directory output format, this is the most flexible output format in that it allows manual selection and reordering of archived items during restore. This format is compressed by default and also supports parallel dumps.
-- d \| directory — Output a directory-format archive suitable for input into `pg_restore`. This will create a directory with one file for each table and blob being dumped, plus a so-called Table of Contents file describing the dumped objects in a machine-readable format that `pg_restore` can read. A directory format archive can be manipulated with standard Unix tools; for example, files in an uncompressed archive can be compressed with the `gzip` tool. This format is compressed by default.
+- c \| custom — Output a custom archive suitable for input into [pg\_restore](pg_restore.html). Together with the directory output format, this is the most flexible output format in that it allows manual selection and reordering of archived items during restore. This format is compressed by default.
+- d \| directory — Output a directory-format archive suitable for input into `pg_restore`. This will create a directory with one file for each table and blob being dumped, plus a so-called Table of Contents file describing the dumped objects in a machine-readable format that `pg_restore` can read. A directory format archive can be manipulated with standard Unix tools; for example, files in an uncompressed archive can be compressed with the `gzip` tool. This format is compressed by default and also supports parallel dumps.
 - t \| tar — Output a tar-format archive suitable for input into [pg\_restore](pg_restore.html). The tar format is compatible with the directory format; extracting a tar-format archive produces a valid directory-format archive. However, the tar format does not support compression. Also, when using tar format the relative order of table data items cannot be changed during restore.
 
 -j \<njobs\> \| --jobs=\<njobs\>
@@ -77,18 +85,15 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 
 :   If you want to run a parallel dump of a pre-6.0 server, you need to make sure that the database content doesn't change from between the time the coordinator connects to the database until the last worker job has connected to the database. The easiest way to do this is to halt any data modifying processes \(DDL and DML\) accessing the database before starting the backup. You also need to specify the `--no-synchronized-snapshots` parameter when running `pg_dump -j` against a pre-6.0 Greenplum Database server.
 
--n \<schema\> \| --schema=\<schema\>
-:   Dump only schemas matching the schema pattern; this selects both the schema itself, and all its contained objects. When this option is not specified, all non-system schemas in the target database will be dumped. Multiple schemas can be selected by writing multiple `-n` switches. Also, the schema parameter is interpreted as a pattern according to the same rules used by `psql`'s`\d` commands, so multiple schemas can also be selected by writing wildcard characters in the pattern. When using wildcards, be careful to quote the pattern if needed to prevent the shell from expanding the wildcards.
+-n \<pattern\> \| --schema=\<pattern\>
+:   Dump only schemas matching the schema pattern; this selects both the schema itself, and all its contained objects. When this option is not specified, all non-system schemas in the target database will be dumped. Multiple schemas can be selected by writing multiple `-n` switches. Also, the pattern parameter is interpreted as a pattern according to the same rules used by `psql`'s `\d` commands, so multiple schemas can also be selected by writing wildcard characters in the pattern. When using wildcards, be careful to quote the pattern if needed to prevent the shell from expanding the wildcards.
 
-:   Note: When -n is specified, `pg_dump` makes no attempt to dump any other database objects that the selected schema\(s\) may depend upon. Therefore, there is no guarantee that the results of a specific-schema dump can be successfully restored by themselves into a clean database.
+:   When `-n` is specified, `pg_dump` makes no attempt to dump any other database objects that the selected schema\(s\) may depend upon. Therefore, there is no guarantee that the results of a specific-schema dump can be successfully restored by themselves into a clean database.
 
     > **Note** Non-schema objects such as blobs are not dumped when `-n` is specified. You can add blobs back to the dump with the `--blobs` switch.
 
--N \<schema\> \| --exclude-schema=\<schema\>
-:   Do not dump any schemas matching the schema pattern. The pattern is interpreted according to the same rules as for `-n`. `-N` can be given more than once to exclude schemas matching any of several patterns. When both `-n` and `-N` are given, the behavior is to dump just the schemas that match at least one `-n` switch but no `-N` switches. If `-N` appears without `-n`, then schemas matching `-N` are excluded from what is otherwise a normal dump.
-
--o \| --oids
-:   Dump object identifiers \(OIDs\) as part of the data for every table. Use of this option is not recommended for files that are intended to be restored into Greenplum Database.
+-N \<pattern\> \| --exclude-schema=\<pattern\>
+:   Do not dump any schemas matching the pattern. The pattern is interpreted according to the same rules as for `-n`. `-N` can be specified more than once to exclude schemas matching any of several patterns. When both `-n` and `-N` are specified, the behavior is to dump just the schemas that match at least one `-n` switch but no `-N` switches. If `-N` appears without `-n`, then schemas matching `-N` are excluded from what is otherwise a normal dump.
 
 -O \| --no-owner
 :   Do not output commands to set ownership of objects to match the original database. By default, `pg_dump` issues `ALTER OWNER` or `SET SESSION AUTHORIZATION` statements to set ownership of created database objects. These statements will fail when the script is run unless it is started by a superuser \(or the same user that owns all of the objects in the script\). To make a script that can be restored by any user, but will give that user ownership of all the objects, specify `-O`. This option is only meaningful for the plain-text format. For the archive formats, you may specify the option when you call [pg\_restore](pg_restore.html).
@@ -107,17 +112,18 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 
     > **Note** Greenplum Database does not support user-defined triggers.
 
--t \<table\> \| --table=\<table\>
-:   Dump only tables \(or views or sequences or foreign tables\) matching the table pattern. Specify the table in the format `schema.table`.
+-t \<pattern\> \| --table=\<pattern\>
+:   Dump only tables \(or views or materialized views or sequences or foreign tables\) matching the pattern. Specify the table in the format `schema.table`.
 
-:   Multiple tables can be selected by writing multiple `-t` switches. Also, the table parameter is interpreted as a pattern according to the same rules used by `psql`'s `\d` commands, so multiple tables can also be selected by writing wildcard characters in the pattern. When using wildcards, be careful to quote the pattern if needed to prevent the shell from expanding the wildcards. The `-n` and `-N` switches have no effect when `-t` is used, because tables selected by `-t` will be dumped regardless of those switches, and non-table objects will not be dumped.
+:   Multiple tables can be selected by writing multiple `-t` switches. Also, the pattern parameter is interpreted as a pattern according to the same rules used by `psql`'s `\d` commands, so multiple tables can also be selected by writing wildcard characters in the pattern. When using wildcards, be careful to quote the pattern if needed to prevent the shell from expanding the wildcards.
+:   The `-n` and `-N` switches have no effect when `-t` is used, because tables selected by `-t` will be dumped regardless of those switches, and non-table objects will not be dumped.
 
     > **Note** When `-t` is specified, `pg_dump` makes no attempt to dump any other database objects that the selected table\(s\) may depend upon. Therefore, there is no guarantee that the results of a specific-table dump can be successfully restored by themselves into a clean database.
 
     Also, `-t` cannot be used to specify a child table of a partitioned table. To dump a partitioned table, you must specify the root partitioned table name.
 
--T \<table\> \| --exclude-table=\<table\>
-:   Do not dump any tables matching the table pattern. The pattern is interpreted according to the same rules as for `-t`. `-T` can be given more than once to exclude tables matching any of several patterns. When both `-t` and `-T` are given, the behavior is to dump just the tables that match at least one `-t` switch but no `-T` switches. If `-T` appears without `-t`, then tables matching `-T` are excluded from what is otherwise a normal dump.
+-T \<pattern\> \| --exclude-table=\<pattern\>
+:   Do not dump any tables matching the table pattern. The pattern is interpreted according to the same rules as for `-t`. `-T` can be specified more than once to exclude tables matching any of several patterns. When both `-t` and `-T` are given, the behavior is to dump just the tables that match at least one `-t` switch but no `-T` switches. If `-T` appears without `-t`, then tables matching `-T` are excluded from what is otherwise a normal dump.
 
 -v \| --verbose
 :   Specifies verbose mode. This will cause `pg_dump` to output detailed object comments and start/stop times to the dump file, and progress messages to standard error.
@@ -137,7 +143,7 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 :   This option is for use by in-place upgrade utilities. Its use for other purposes is not recommended or supported. The behavior of the option may change in future releases without notice.
 
 --column-inserts \| --attribute-inserts
-:   Dump data as `INSERT` commands with explicit column names `(INSERT INTO`table`(`column`, ...) VALUES ...)`. This will make restoration very slow; it is mainly useful for making dumps that can be loaded into non-PostgreSQL-based databases. However, since this option generates a separate command for each row, an error in reloading a row causes only that row to be lost rather than the entire table contents.
+:   Dump data as `INSERT` commands with explicit column names `(INSERT INTO <table> (<column>, ...) VALUES ...)`. This will make restoration very slow; it is mainly useful for making dumps that can be loaded into non-PostgreSQL-based databases. However, since this option generates a separate command for each row, an error in reloading a row causes only that row to be lost rather than the entire table contents.
 
 --disable-dollar-quoting
 :   This option deactivates the use of dollar quoting for function bodies, and forces them to be quoted using SQL standard string syntax.
@@ -147,28 +153,45 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 
     > **Note** Greenplum Database does not support user-defined triggers.
 
---exclude-table-and-children=\<table\>
+--enable-row-security
+:   This option is relevant only when dumping the contents of a table which has row security. By default, `pg_dump` sets `row_security` to off, to ensure that all data is dumped from the table. If the user does not have sufficient privileges to bypass row security, then an error is thrown. This parameter instructs `pg_dump` to set `row_security` to on instead, allowing the user to dump the parts of the contents of the table that they have access to.
+
+:   If you use this option, you likely also want the dump be in `INSERT` format, as the `COPY FROM` during restore does not support row security.
+
+--exclude-table-and-children=\<pattern\>
 :   This option is equivalent to `-T` or `--exclude-table`, except that it also excludes any partitions of child tables that inherit from the table(s) matching the \<table\> name.
 
---exclude-table-data=\<table\>
-:   Do not dump data for any tables matching the table pattern. The pattern is interpreted according to the same rules as for `-t`. `--exclude-table-data` can be given more than once to exclude tables matching any of several patterns. This option is useful when you need the definition of a particular table even though you do not need the data in it.
+--exclude-table-data=\<pattern\>
+:   Do not dump data for any tables matching the pattern. The pattern is interpreted according to the same rules as for `-t`. `--exclude-table-data` can be specified more than once to exclude tables matching any of several patterns. This option is useful when you need the definition of a particular table even though you do not need the data in it.
 
 :   To exclude data for all tables in the database, see `--schema-only`.
 
---exclude-table-data-and-children=\<table\>
+--exclude-table-data-and-children=\<pattern\>
 :   This option is equivalent to `--exclude-table-data`, except that it also excludes any partitions of child tables that inherit from the table(s) matching the \<table\> name.
 
+--extra-float-digits=ndigits
+:   Use the specified value of `extra_float_digits` when dumping floating-point data, instead of the maximum available precision. Routine dumps made for backup purposes should not use this option.
+
 --if-exists
-:   Use conditional commands \(i.e. add an `IF EXISTS` clause\) when cleaning database objects. This option is not valid unless `--clean` is also specified.
+:   Use conditional commands \(for example, add an `IF EXISTS` clause\) when cleaning database objects. This option is not valid unless `--clean` is also specified.
 
 --inserts
 :   Dump data as `INSERT` commands \(rather than `COPY`\). This will make restoration very slow; it is mainly useful for making dumps that can be loaded into non-PostgreSQL-based databases. However, since this option generates a separate command for each row, an error in reloading a row causes only that row to be lost rather than the entire table contents. Note that the restore may fail altogether if you have rearranged column order. The `--column-inserts` option is safe against column order changes, though even slower.
 
+--load-via-partition-root
+:   When dumping data for a table partition, make the `COPY` or `INSERT` statements target the root of the partitioning hierarchy that contains it, rather than the partition itself. This causes the appropriate partition to be re-determined for each row when the data is loaded. This may be useful when restoring data on a server where rows do not always fall into the same partitions as they did on the original server. That could happen, for example, if the partitioning column is of type `text` and the two systems have different definitions of the collation used to sort the partitioning column.
+
 --lock-wait-timeout=\<timeout\>
-:   Do not wait forever to acquire shared table locks at the beginning of the dump. Instead, fail if unable to lock a table within the specified timeout. Specify timeout as a number of milliseconds.
+:   Do not wait forever to acquire shared table locks at the beginning of the dump. Instead, fail if unable to lock a table within the specified timeout. The timeout may be specified in any of the formats accepted by `SET statement_timeout`. Specify timeout as a number of milliseconds.
+
+--no-comments
+:   Do not dump comments.
 
 --no-security-labels
 :   Do not dump security labels.
+
+--no-sync
+:   By default, `pg_dump` waits for all files to be written safely to disk. This option causes `pg_dump` to return without waiting, which is faster, but could leave the dump corrupt if there is a subsequent operating system crash. This option is generally useful for testing but should not be used when dumping data from a production installation.
 
 --no-synchronized-snapshots
 :   This option allows running `pg_dump -j` against a pre-6.0 Greenplum Database server; see the documentation of the `-j` parameter for more details.
@@ -181,8 +204,14 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 --no-unlogged-table-data
 :   Do not dump the contents of unlogged tables. This option has no effect on whether or not the table definitions \(schema\) are dumped; it only suppresses dumping the table data. Data in unlogged tables is always excluded when dumping from a standby server.
 
+--on-conflict-do-nothing
+:   Add `ON CONFLICT DO NOTHING` to `INSERT` commands. This option is not valid unless `--inserts`, `--column-inserts`, or `--rows-per-insert` is also specified.
+
 --quote-all-identifiers
 :   Force quoting of all identifiers. This option is recommended when dumping a database from a server whose Greenplum Database major version is different from `pg_dump`'s, or when the output is intended to be loaded into a server of a different major version. By default, `pg_dump` quotes only identifiers that are reserved words in its own major version. This sometimes results in compatibility issues when dealing with servers of other versions that may have slightly different sets of reserved words. Using `--quote-all-identifiers` prevents such issues, at the price of a harder-to-read dump script.
+
+--rows-per-insert=\<nrows\>
+:   Dump data as `INSERT` commands (rather than `COPY`). Controls the maximum number of rows per `INSERT` command. The value specified must be a number greater than zero. Any error during restoring will cause only rows that are part of the problematic `INSERT` to be lost, rather than the entire table contents.
 
 --section=\<sectionname\>
 :   Only dump the named section. The section name can be `pre-data`, `data`, or `post-data`. This option can be specified more than once to select multiple sections. The default is to dump all sections.
@@ -190,7 +219,7 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 :   The `data` section contains actual table data and sequence values. `post-data` items include definitions of indexes, triggers, rules, and constraints other than validated check constraints. `pre-data` items include all other data definition items.
 
 --serializable-deferrable
-:   Use a serializable transaction for the dump, to ensure that the snapshot used is consistent with later database states; but do this by waiting for a point in the transaction stream at which no anomalies can be present, so that there isn't a risk of the dump failing or causing other transactions to roll back with a serialization\_failure.
+:   Use a serializable transaction for the dump, to ensure that the snapshot used is consistent with later database states; but do this by waiting for a point in the transaction stream at which no anomalies can be present, so that there isn't a risk of the dump failing or causing other transactions to roll back with a `serialization_failure`.
 
 :   This option is not beneficial for a dump which is intended only for disaster recovery. It could be useful for a dump used to load a copy of the database for reporting or other read-only load sharing while the original database continues to be updated. Without it the dump may reflect a state which is not consistent with any serial execution of the transactions eventually committed. For example, if batch processing techniques are used, a batch may show as closed in the dump without all of the items which are in the batch appearing.
 
@@ -198,11 +227,23 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 
 :   > **Note** Because Greenplum Database does not support serializable transactions, the `--serializable-deferrable` option has no effect in Greenplum Database.
 
+--snapshot=\<snapshotname\>
+:   Use the specified synchronized snapshot when making a dump of the database.
+
+:   This option is useful when you need to synchronize the dump with a concurrent session.
+
+:   In the case of a parallel dump, the snapshot name defined by this option is used rather than taking a new snapshot.
+
+--strict-names
+:   Require that each schema (`-n`/`--schema`) and table (`-t`/`--table`) qualifier match at least one schema/table in the database to be dumped. Note that if none of the schema/table qualifiers find matches, `pg_dump` generates an error even without `--strict-names`.
+
+:   This option has no effect on `-N`/`--exclude-schema`, `-T`/`--exclude-table`, or `--exclude-table-data`. An exclude pattern failing to match any objects is not considered an error.
+
 --table-and-children=\<table\>
 :   This option is equivalent to `-t` or `--table`, except that it also includes any partitions of child tables that inherit from the table(s) matching the \<table\> name.
 
 --use-set-session-authorization
-:   Output SQL-standard `SET SESSION AUTHORIZATION` commands instead of `ALTER OWNER` commands to determine object ownership. This makes the dump more standards-compatible, but depending on the history of the objects in the dump, may not restore properly. A dump using `SET SESSION AUTHORIZATION` will require superuser privileges to restore correctly, whereas `ALTER OWNER` requires lesser privileges.
+:   Output SQL-standard `SET SESSION AUTHORIZATION` commands instead of `ALTER OWNER` commands to determine object ownership. This makes the dump more standards-compatible, but depending on the history of the objects in the dump, may not restore properly. A dump using `SET SESSION AUTHORIZATION` requires superuser privileges to restore correctly, whereas `ALTER OWNER` requires lesser privileges.
 
 --gp-syntax \| --no-gp-syntax
 :   Use `--gp-syntax` to dump Greenplum Database syntax in the `CREATE TABLE` statements. This allows the distribution policy \(`DISTRIBUTED BY` or `DISTRIBUTED RANDOMLY` clauses\) of a Greenplum Database table to be dumped, which is useful for restoring into other Greenplum Database systems. The default is to include Greenplum Database syntax when connected to a Greenplum Database system, and to exclude it when connected to a regular PostgreSQL system.
@@ -225,13 +266,14 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 -d \<dbname\> \| --dbname=\<dbname\>
 :   Specifies the name of the database to connect to. This is equivalent to specifying dbname as the first non-option argument on the command line.
 
-:   If this parameter contains an `=` sign or starts with a valid URI prefix \(`postgresql://` or `postgres://`\), it is treated as a conninfo string. See [Connection Strings](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING) in the PostgreSQL documentation for more information.
+:   If this parameter contains an `=` sign or starts with a valid URI prefix \(`postgresql://` or `postgres://`\), it is treated as a conninfo string. See [Connection Strings](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING) in the PostgreSQL documentation for more information. Connection strings parameters override any conflicting command line option.
 
 -h \<host\> \| --host=\<host\>
-:   The host name of the machine on which the Greenplum Database coordinator database server is running. If not specified, reads from the environment variable `PGHOST` or defaults to localhost.
+:   The host name of the machine on which the Greenplum Database coordinator database server is running. If not specified, reads from the environment variable `PGHOST` or defaults to `localhost`.
 
 -p \<port\> \| --port=\<port\>
-:   The TCP port on which the Greenplum Database coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to 5432.
+:   The TCP port on which the Greenplum Database coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to `5432`.
+`
 
 -U \<username\> \| --username=\<username\>
 :   The database role name to connect as. If not specified, reads from the environment variable `PGUSER` or defaults to the current system role name.
@@ -239,13 +281,35 @@ When used with one of the archive file formats and combined with `pg_restore`, `
 -W \| --password
 :   Force a password prompt.
 
+:   This option is never required; `pg_dump` automatically prompts for a password if the server demands password authentication. However, `pg_dump` will waste a connection attempt determining that the server wants a password. In some cases it is worth typing `-W` to avoid the extra connection attempt.
+
 -w \| --no-password
-:   Never issue a password prompt. If the server requires password authentication and a password is not available by other means such as a `.pgpass` file the connection attempt will fail. This option can be useful in batch jobs and scripts where no user is present to enter a password.
+:   Never issue a password prompt. If the server requires password authentication and a password is not available by other means such as a `.pgpass` file, the connection attempt will fail. This option can be useful in batch jobs and scripts where no user is present to enter a password.
 
 --role=\<rolename\>
-:   Specifies a role name to be used to create the dump. This option causes `pg_dump` to issue a `SET ROLE rolename` command after connecting to the database. It is useful when the authenticated user \(specified by `-U`\) lacks privileges needed by `pg_dump`, but can switch to a role with the required rights. Some installations have a policy against logging in directly as a superuser, and use of this option allows dumps to be made without violating the policy.
+:   Specifies a role name to be used to create the dump. This option causes `pg_dump` to issue a `SET ROLE <rolename>` command after connecting to the database. It is useful when the authenticated user \(specified by `-U`\) lacks privileges needed by `pg_dump`, but can switch to a role with the required rights. Some installations have a policy against logging in directly as a superuser, and use of this option allows dumps to be made without violating the policy.
+
+## <a id="section5"></a>Environment
+
+PGDATABASE
+PGHOST
+PGOPTIONS
+PGPORT
+PGUSER
+:   Default connection parameters.
+
+PG_COLOR
+:   Specifies whether to use color in diagnostic messages. Possible values are `always`, `auto`, and `never`.
+
+This utility also uses the [environment variables supported by libpq](https://www.postgresql.org/docs/12/libpq-envars.html).
 
 ## <a id="section7"></a>Notes 
+
+If your database cluster has any local additions to the `template1` database, be careful to restore the output of `pg_dump` into a truly empty database; otherwise you are likely to get errors due to duplicate definitions of the added objects. To make an empty database without any local additions, copy from `template0` not `template1`, for example:
+
+```
+CREATE DATABASE foo WITH TEMPLATE template0;
+```
 
 When a data-only dump is chosen and the option `--disable-triggers` is used, `pg_dump` emits commands to deactivate triggers on user tables before inserting the data and commands to re-enable them after the data has been inserted. If the restore is stopped in the middle, the system catalogs may be left in the wrong state.
 
@@ -299,16 +363,46 @@ To reload an archive file into a \(freshly created\) database named `newdb`:
 pg_restore -d newdb db.dump
 ```
 
+To reload an archive file into the same database it was dumped from, discarding the current contents of that database:
+
+```
+pg_restore -d postgres --clean --create db.dump
+```
+
 To dump a single table named `mytab`:
 
 ```
 pg_dump -t mytab mydb > db.sql
 ```
 
-To specify an upper-case or mixed-case name in `-t` and related switches, you need to double-quote the name; else it will be folded to lower case. But double quotes are special to the shell, so in turn they must be quoted. Thus, to dump a single table with a mixed-case name, you need something like:
+To dump all tables whose names start with `emp` in the `detroit` schema, except for the table named `employee_log`:
 
 ```
-pg_dump -t '"MixedCaseName"' mydb > mytab.sql
+pg_dump -t 'detroit.emp*' -T detroit.employee_log mydb > db.sql
+```
+
+To dump all schemas whose names start with `east` or `west` and end in `gsm`, excluding any schemas whose names contain the word `test`:
+
+```
+pg_dump -n 'east*gsm' -n 'west*gsm' -N '*test*' mydb > db.sql
+```
+
+The same dump as above, using regular expression notation to consolidate the switches:
+
+```
+pg_dump -n '(east|west)*gsm' -N '*test*' mydb > db.sql
+```
+
+To dump all database objects except for tables whose names begin with `ts_`:
+
+```
+pg_dump -T 'ts_*' mydb > db.sql
+```
+
+To specify an upper-case or mixed-case name in `-t` and related switches, you need to double-quote the name; else it will be folded to lower case. But double quotes are special to the shell, so they in turn must be quoted. To dump a single table with a mixed-case name, you must specify something like:
+
+```
+pg_dump -t "\"MixedCaseName\"" mydb > mytab.sql
 ```
 
 ## <a id="section9"></a>See Also 

--- a/gpdb-doc/markdown/utility_guide/ref/pg_dumpall.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pg_dumpall.html.md
@@ -34,14 +34,14 @@ The SQL script will be written to the standard output. Use the `[-f | --file]` o
 -c \| --clean
 :   Output commands to clean \(drop\) database objects prior to \(the commands for\) creating them. This option is only meaningful for the plain-text format. For the archive formats, you may specify the option when you call [pg\_restore](pg_restore.html).
 
+-E encoding \| --encoding=encoding
+:   Create the dump in the specified character set encoding. By default, the dump is created in the database encoding. (An alternate method to achieve the same result is to set the `PGCLIENTENCODING` environment variable to the desired dump encoding.)
+
 -f filename \| --file=filename
-:   Send output to the specified file.
+:   Send output to the specified file. If this is omitted, `pg_dump` sends the output to standard out.
 
 -g \| --globals-only
 :   Dump only global objects \(roles and tablespaces\), no databases.
-
--o \| --oids
-:   Dump object identifiers \(OIDs\) as part of the data for every table. Use of this option is not recommended for files that are intended to be restored into Greenplum Database.
 
 -O \| --no-owner
 :   Do not output commands to set ownership of objects to match the original database. By default, [pg\_dump](pg_dump.html) issues `ALTER OWNER` or `SET SESSION AUTHORIZATION` statements to set ownership of created database objects. These statements will fail when the script is run unless it is started by a superuser \(or the same user that owns all of the objects in the script\). To make a script that can be restored by any user, but will give that user ownership of all the objects, specify `-O`. This option is only meaningful for the plain-text format. For the archive formats, you may specify the option when you call [pg\_restore](pg_restore.html).
@@ -83,20 +83,44 @@ The SQL script will be written to the standard output. Use the `[-f | --file]` o
 
     > **Note** Greenplum Database does not support user-defined triggers.
 
+--extra-float-digits=ndigits
+:   Use the specified value of `extra_float_digits` when dumping floating-point data, instead of the maximum available precision. Routine dumps made for backup purposes should not use this option.
+
+--exclude-database=pattern
+:   Do not dump databases whose name matches pattern. Multiple patterns can be excluded by writing multiple `--exclude-database` switches. The pattern parameter is interpreted as a pattern according to the same rules used by `psql`'s `\d` commands, so multiple databases can also be excluded by writing wildcard characters in the pattern. When using wildcards, be careful to quote the pattern if needed to prevent shell wildcard expansion.
+
+--if-exists
+:   Use conditional commands (for example, add an `IF EXISTS` clause) to drop databases and other objects. This option is not valid unless `--clean` is also specified.
+
 --inserts
 :   Dump data as `INSERT` commands \(rather than `COPY`\). This will make restoration very slow; it is mainly useful for making dumps that can be loaded into non-PostgreSQL-based databases. Also, since this option generates a separate command for each row, an error in reloading a row causes only that row to be lost rather than the entire table contents. Note that the restore may fail altogether if you have rearranged column order. The `--column-inserts` option is safe against column order changes, though even slower.
+
+--load-via-partition-root
+:   When dumping data for a table partition, make the `COPY` or `INSERT` statements target the root of the partitioning hierarchy that contains it, rather than the partition itself. This causes the appropriate partition to be re-determined for each row when the data is loaded. This may be useful when restoring data on a server where rows do not always fall into the same partitions as they did on the original server. That could happen, for example, if the partitioning column is of type `text` and the two systems have different definitions of the collation used to sort the partitioning column.
 
 --lock-wait-timeout=timeout
 :   Do not wait forever to acquire shared table locks at the beginning of the dump. Instead, fail if unable to lock a table within the specified timeout. The timeout may be specified in any of the formats accepted by `SET statement_timeout`. Allowed values vary depending on the server version you are dumping from, but an integer number of milliseconds is accepted by all Greenplum Database versions.
 
+--no-comments
+:   Do not dump comments.
+
+--no-role-passwords
+:   Do not dump passwords for roles. When restored, roles will have a null password, and password authentication will always fail until the password is set. Since password values are not required when this option is specified, the role information is read from the catalog view `pg_roles` instead of `pg_authid`. Consequently, this option also helps if access to `pg_authid` is restricted by some security policy.
+
 --no-security-labels
 :   Do not dump security labels.
 
+--no-sync
+:   By default, `pg_dumpall` waits for all files to be written safely to disk. Specifying this option causes `pg_dumpall` to return without waiting, which is faster, but implies that a subsequent operating system crash can leave the dump corrupt. This option is generally useful for testing, and should not be used when dumping data from a production installation.
+
 --no-tablespaces
-:   Do not output commands to select tablespaces. With this option, all objects will be created in whichever tablespace is the default during restore.
+:   Do not output commands to create tablespaces nor select tablespaces for objects. With this option, all objects will be created in whichever tablespace is the default during restore.
 
 --no-unlogged-table-data
 :   Do not dump the contents of unlogged tables. This option has no effect on whether or not the table definitions \(schema\) are dumped; it only suppresses dumping the table data.
+
+--on-conflict-do-nothing
+:   Add `ON CONFLICT DO NOTHING` to `INSERT` commands. This option is not valid unless `--inserts` or `--column-inserts` is also specified.
 
 --quote-all-identifiers
 :   Force quoting of all identifiers. This option is recommended when dumping a database from a server whose Greenplum Database major version is different from `pg_dumpall`'s, or when the output is intended to be loaded into a server of a different major version. By default, `pg_dumpall` quotes only identifiers that are reserved words in its own major version. This sometimes results in compatibility issues when dealing with servers of other versions that may have slightly different sets of reserved words. Using `--quote-all-identifiers` prevents such issues, at the price of a harder-to-read dump script.
@@ -107,8 +131,11 @@ The SQL script will be written to the standard output. Use the `[-f | --file]` o
 --resource-groups
 :   Dump resource group definitions.
 
+--rows-per-insert=nrows
+:   Dump data as `INSERT` commands (rather than `COPY)`. Controls the maximum number of rows per `INSERT` command. The value specified must be a number greater than zero. Any error during restoring will cause only rows that are part of the problematic `INSERT` to be lost, rather than the entire table contents.
+
 --use-set-session-authorization
-:   Output SQL-standard `SET SESSION AUTHORIZATION` commands instead of `ALTER OWNER` commands to determine object ownership. This makes the dump more standards compatible, but depending on the history of the objects in the dump, may not restore properly. A dump using `SET SESSION AUTHORIZATION` will require superuser privileges to restore correctly, whereas `ALTER OWNER` requires lesser privileges.
+:   Output SQL-standard `SET SESSION AUTHORIZATION` commands instead of `ALTER OWNER` commands to determine object ownership. This makes the dump more standards compatible, but depending on the history of the objects in the dump, may not restore properly. A dump using `SET SESSION AUTHORIZATION` requires superuser privileges to restore correctly, whereas `ALTER OWNER` requires lesser privileges.
 
 --gp-syntax
 :   Output Greenplum Database syntax in the `CREATE TABLE` statements. This allows the distribution policy \(`DISTRIBUTED BY` or `DISTRIBUTED RANDOMLY` clauses\) of a Greenplum Database table to be dumped, which is useful for restoring into other Greenplum Database systems.
@@ -133,7 +160,7 @@ The SQL script will be written to the standard output. Use the `[-f | --file]` o
 :   Specifies the name of the database in which to connect to dump global objects. If not specified, the `postgres` database is used. If the `postgres` database does not exist, the `template1` database is used.
 
 -p port \| --port=port
-:   The TCP port on which the Greenplum coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to 5432.
+:   The TCP port on which the Greenplum coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to `5432`.
 
 -U username \| --username= username
 :   The database role name to connect as. If not specified, reads from the environment variable `PGUSER` or defaults to the current system role name.
@@ -143,15 +170,34 @@ The SQL script will be written to the standard output. Use the `[-f | --file]` o
 
 -W \| --password
 :   Force a password prompt.
+:   This option is never essential, since `pg_dumpall` will automatically prompt for a password if the server demands password authentication. However, `pg_dumpall` will waste a connection attempt finding out that the server wants a password. In some cases it is worth typing `-W` to avoid the extra connection attempt.
+:   Note that the password prompt will occur again for each database to be dumped. It may be preferable to set up a `~/.pgpass` file rather than to rely on manual password entry.
 
 --role=rolename
 :   Specifies a role name to be used to create the dump. This option causes `pg_dumpall` to issue a `SET ROLE <rolename>` command after connecting to the database. It is useful when the authenticated user \(specified by `-U`\) lacks privileges needed by `pg_dumpall`, but can switch to a role with the required rights. Some installations have a policy against logging in directly as a superuser, and use of this option allows dumps to be made without violating the policy.
+
+## <a id="section5"></a>Environment
+
+PGHOST
+PGOPTIONS
+PGPORT
+PGUSER
+:   Default connection parameters.
+
+PG_COLOR
+:   Specifies whether to use color in diagnostic messages. Possible values are `always`, `auto`, and `never`.
+
+This utility also uses the [environment variables supported by libpq](https://www.postgresql.org/docs/12/libpq-envars.html).
 
 ## <a id="section7"></a>Notes 
 
 Since `pg_dumpall` calls [pg\_dump](pg_dump.html) internally, some diagnostic messages will refer to `pg_dump`.
 
+The `--clean` option can be useful even when your intention is to restore the dump script into a fresh cluster. Use of `--clean` authorizes the script to drop and re-create the built-in `postgres` and `template1` databases, ensuring that those databases will retain the same properties (for instance, locale and encoding) that they had in the source cluster. Without the option, those databases will retain their existing database-level properties, as well as any pre-existing contents.
+
 Once restored, it is wise to run `ANALYZE` on each database so the query planner has useful statistics. You can also run `vacuumdb -a -z` to vacuum and analyze all databases.
+
+Do no expect the dump script to run completely without errors. In particular, because the script issues `CREATE ROLE` for every role existing in the source cluster, it is certain to generate a "role already exists" error for the bootstrap superuser, unless the destination cluster was initialized with a different bootstrap superuser name. This error is harmless and can be ignored. Use of the `--clean` option is likely to produce additional harmless error messages about non-existent objects; minimize those by adding `--if-exists`.
 
 `pg_dumpall` requires all needed tablespace directories to exist before the restore; otherwise, database creation will fail for databases in non-default locations.
 
@@ -177,5 +223,5 @@ pg_dumpall -g --resource-queues
 
 ## <a id="section9"></a>See Also 
 
-[pg\_dump](pg_dump.html)
+Check [pg\_dump](pg_dump.html) for details on possible error conditions.
 

--- a/gpdb-doc/markdown/utility_guide/ref/pg_restore.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pg_restore.html.md
@@ -5,7 +5,7 @@ Restores a database from an archive file created by `pg_dump`.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#client_util_synopsis}
-pg_restore [<connection-option> ...] [<restore_option> ...] <filename>
+pg_restore [<connection-option> ...] [<restore_option> ...] [<filename>]
 
 pg_restore -? | --help
 
@@ -33,60 +33,67 @@ filename
     This option is similar to, but for historical reasons not identical to, specifying `--section=data`.
 
 -c \| --clean
-:   Clean \(drop\) database objects before recreating them. \(This might generate some harmless error messages, if any objects were not present in the destination database.\)
+:   Clean \(drop\) database objects before recreating them. \(If you do not also specify `--if-exists`, this may generate some harmless error messages if any objects were not present in the destination database.\)
 
 -C \| --create
 :   Create the database before restoring into it. If `--clean` is also specified, drop and recreate the target database before connecting to it.
 
+:   With `--create`, `pg_restore` also restores the database's comment if any, and any configuration variable settings that are specific to this database, that is, any `ALTER DATABASE ... SET ...` and `ALTER ROLE ... IN DATABASE ... SET ...` commands that mention this database. Access privileges for the database itself are also restored, unless `--no-acl` is specified.
+
 :   When this option is used, the database named with `-d` is used only to issue the initial `DROP DATABASE` and `CREATE DATABASE` commands. All data is restored into the database name that appears in the archive.
 
 -d dbname \| --dbname=dbname
-:   Connect to this database and restore directly into this database. This utility, like most other Greenplum Database utilities, also uses the environment variables supported by `libpq`. However it does not read `PGDATABASE` when a database name is not supplied.
+:   Connect to this database and restore directly into this database. The dbname can be a [Connection Strings](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING). If so, connection string parameters override any conflicting command line options.
 
 -e \| --exit-on-error
 :   Exit if an error is encountered while sending SQL commands to the database. The default is to continue and to display a count of errors at the end of the restoration.
 
 -f outfilename \| --file=outfilename
-:   Specify output file for generated script, or for the listing when used with `-l`. Default is the standard output.
+:   Specify output file for generated script, or for the listing when used with `-l`. Use `-` for `stdout`.
 
 -F c\|d\|t \| --format=\{custom \| directory \| tar\}
 :   The format of the archive produced by [pg\_dump](pg_dump.html). It is not necessary to specify the format, since `pg_restore` will determine the format automatically. Format can be `custom`, `directory`, or `tar`.
 
 -I index \| --index=index
-:   Restore definition of named index only.
+:   Restore definition of named index only. You can specify multiple indexes with multiple `-I` switches.
 
 -j \| --number-of-jobs \| --jobs=number-of-jobs
-:   Run the most time-consuming parts of `pg_restore` — those which load data, create indexes, or create constraints — using multiple concurrent jobs. This option can dramatically reduce the time to restore a large database to a server running on a multiprocessor machine.
+:   Run the most time-consuming parts of `pg_restore` — those which load data, create indexes, or create constraints — using multiple concurrent jobs. This option can dramatically reduce the time to restore a large database to a server running on a multiprocessor machine. This option is ignored when emitting a script rather than connecting directly to a database server.
 
 :   Each job is one process or one thread, depending on the operating system, and uses a separate connection to the server.
 
 :   The optimal value for this option depends on the hardware setup of the server, of the client, and of the network. Factors include the number of CPU cores and the disk setup. A good place to start is the number of CPU cores on the server, but values larger than that can also lead to faster restore times in many cases. Of course, values that are too high will lead to decreased performance because of thrashing.
 
-:   Only the custom archive format is supported with this option. The input file must be a regular file \(not, for example, a pipe\). This option is ignored when emitting a script rather than connecting directly to a database server. Also, multiple jobs cannot be used together with the option `--single-transaction`.
+:   Only the custom and directory archive formats ase supported with this option. The input file must be a regular file or directory \(not, for example, a pipe or standard input\). Also, multiple jobs cannot be used together with the option `--single-transaction`.
 
 -l \| --list
-:   List the contents of the archive. The output of this operation can be used with the `-L` option to restrict and reorder the items that are restored.
+:   List the table contents of the archive. The output of this operation can be used as input to the `-L` option. Note that if filtering switches such as `-n` or `-t` are used with `-l`, they restrict the items listed.
 
 -L list-file \| --use-list=list-file
-:   Restore elements in the list-file only, and in the order they appear in the file. Note that if filtering switches such as `-n` or `-t` are used with `-L`, they will further restrict the items restored.
+:   Restore only those archive elements that are listed in list-file, and restore them in the order they appear in the file. Note that if filtering switches such as `-n` or `-t` are used with `-L`, they further restrict the items restored.
 
-    list-file is normally created by editing the output of a previous `-l` operation. Lines can be moved or removed, and can also be commented out by placing a semicolon \(;\) at the start of the line. See below for examples.
+:   list-file is normally created by editing the output of a previous `-l` operation. Lines can be moved or removed, and can also be commented out by placing a semicolon \(`;`\) at the start of the line. See below for examples.
 
 -n schema \| --schema=schema
-:   Restore only objects that are in the named schema. This can be combined with the `-t` option to restore just a specific table.
+:   Restore only objects that are in the named schema. You can specify multiple schemas with multiple `-n` switches. Combine with the `-t` option to restore just a specific table.
+
+-N schema \| --exclude-schema=schema
+:   Do not restore objects that are in the named schema. You can specify multiple schemas to exclude with multiple `-N` switches.
+
+:   When both `-n` and `-N` are specified for the same schema name, the `-N` switch takes precedence and the schema is excluded.
 
 -O \| --no-owner
 :   Do not output commands to set ownership of objects to match the original database. By default, `pg_restore` issues `ALTER OWNER` or `SET SESSION AUTHORIZATION` statements to set ownership of created schema elements. These statements will fail unless the initial connection to the database is made by a superuser \(or the same user that owns all of the objects in the script\). With `-O`, any user name can be used for the initial connection, and this user will own all the created objects.
 
--P 'function-name\(argtype \[, ...\]\)' \| --function='function-name\(argtype \[, ...\]\)'
-:   Restore the named function only. The function name must be enclosed in quotes. Be careful to spell the function name and arguments exactly as they appear in the dump file's table of contents \(as shown by the `--list` option\).
+-P function-name\(argtype \[, ...\]\) \| --function=function-name\(argtype \[, ...\]\)
+:   Restore the named function only. The function name must be enclosed in quotes. Be careful to spell the function name and arguments exactly as they appear in the dump file's table of contents \(as shown by the `--list` option\). You can specify multiple functions with multiple `-P` switches.
 
 -s \| --schema-only
 :   Restore only the schema \(data definitions\), not data, to the extent that schema entries are present in the archive.
 
-    This option is the inverse of `--data-only`. It is similar to, but for historical reasons not identical to, specifying `--section=pre-data --section=post-data`.
+:   This option is the inverse of `--data-only`. It is similar to, but for historical reasons not identical to, specifying `--section=pre-data --section=post-data`.
 
-    \(Do not confuse this with the `--schema` option, which uses the word "schema" in a different meaning.\)
+:   \(Do not confuse this with the `--schema` option, which uses the word *schema* in a different meaning.\)
 
 -S username \| --superuser=username
 :   Specify the superuser user name to use when deactivating triggers. This is only relevant if `--disable-triggers` is used.
@@ -94,7 +101,11 @@ filename
     > **Note** Greenplum Database does not support user-defined triggers.
 
 -t table \| --table=table
-:   Restore definition and/or data of named table only. Multiple tables may be specified with multiple `-t` switches. This can be combined with the `-n` option to specify a schema.
+:   Restore definition and/or data of the named table only. "table" includes views, materialized views, sequences, and foreign tables. You can specify multiple tables with multiple `-t` switches. Combine this option with the `-n` option to specify table(s) in a particular schema.
+:   When you specify `-t`, `pg_restore` makes no attempt to restore any other database objects that the selected table(s) might depend upon. Therefore, there is no guarantee that a specific-table restore into a clean database will succeed.
+:   This option does not behave identically to the `-t` option of `pg_dump`. `pg_restore` does not currently support wild-card matching, nor can you include a schema name within its `-t`. And, while `pg_dump`'s `-t` flag will also dump subsidiary objects (such as indexes) of the selected table(s), `pg_restore`'s `-t` flag does not include such subsidiary objects.
+
+    > **Note** In versions prior to Greenplum 7, this flag matched only tables, not any other type of relation.
 
 -T trigger \| --trigger=trigger
 :   Restore named trigger only.
@@ -111,15 +122,26 @@ filename
 :   Prevent restoration of access privileges \(`GRANT/REVOKE` commands\).
 
 -1 \| --single-transaction
-:   Run the restore as a single transaction. This ensures that either all the commands complete successfully, or no changes are applied.
+:   Run the restore as a single transaction (that is, wrap the emitted commands in `BEGIN`/`COMMIT1). This ensures that either all of the commands complete successfully, or no changes are applied. This option implies `--exit-on-error`.
 
 --disable-triggers
-:   This option is relevant only when performing a data-only restore. It instructs `pg_restore` to run commands to temporarily deactivate triggers on the target tables while the data is reloaded. Use this if you have triggers on the tables that you do not want to invoke during data reload. The commands emitted for `--disable-triggers` must be done as superuser. So you should also specify a superuser name with `-S` or, preferably, run `pg_restore` as a superuser.
+:   This option is relevant only when performing a data-only restore. It instructs `pg_restore` to run commands to temporarily deactivate triggers on the target tables while the data is reloaded. Use this if you have triggers on the tables that you do not want to invoke during data reload. The commands emitted for `--disable-triggers` must be invoked as superuser. So you should also specify a superuser name with `-S` or, preferably, run `pg_restore` as a superuser.
 
     > **Note** Greenplum Database does not support user-defined triggers.
 
+--enable-row-security
+:   This option is relevant only when restoring the contents of a table which has row security. By default, `pg_restore` sets `row_security` to off, to ensure that all data is restored in to the table. If the user does not have sufficient privileges to bypass row security, then an error is thrown. This parameter instructs `pg_restore` to set `row_security` to on instead, allowing the user to attempt to restore the contents of the table with row security enabled. This might still fail if the user does not have the right to insert the rows from the dump into the table.
+
+:   This option currently also requires the dump be in `INSERT` format, as `COPY FROM` does not support row security.
+
+--if-exists
+:   Use conditional commands (for example, add an `IF EXISTS` clause) to drop database objects. This option is not valid unless `--clean` is also specified.
+
+--no-comments
+:   Do not output commands to restore comments, even if the archive contains them.
+
 --no-data-for-failed-tables
-:   By default, table data is restored even if the creation command for the table failed \(e.g., because it already exists\). With this option, data for such a table is skipped. This behavior is useful when the target database may already contain the desired table contents. Specifying this option prevents duplicate or obsolete data from being loaded. This option is effective only when restoring directly into a database, not when producing SQL script output.
+:   By default, table data is restored even if the creation command for the table failed \(for example, because it already exists\). With this option, data for such a table is skipped. This behavior is useful when the target database may already contain the desired table contents. Specifying this option prevents duplicate or obsolete data from being loaded. This option is effective only when restoring directly into a database, not when producing SQL script output.
 
 --no-security-labels
 :   Do not output commands to restore security labels, even if the archive contains them.
@@ -129,8 +151,11 @@ filename
 
 --section=sectionname
 :   Only restore the named section. The section name can be `pre-data`, `data`, or `post-data`. This option can be specified more than once to select multiple sections.
-
+:   The data section contains actual table data. Post-data items consist of definitions of indexes, triggers, rules, and constraints other than validated check constraints. Pre-data items consist of all other data definition items.
 :   The default is to restore all sections.
+
+--strict-names
+:   Require that each schema (`-n`/`--schema`) and table (`-t`/`--table`) qualifier match at least one schema/table in the backup file.
 
 --use-set-session-authorization
 :   Output SQL-standard `SET SESSION AUTHORIZATION` commands instead of `ALTER OWNER` commands to determine object ownership. This makes the dump more standards-compatible, but depending on the history of the objects in the dump, it might not restore properly.
@@ -141,10 +166,10 @@ filename
 **Connection Options**
 
 -h host \| --host host
-:   The host name of the machine on which the Greenplum coordinator database server is running. If not specified, reads from the environment variable `PGHOST` or defaults to localhost.
+:   The host name of the machine on which the Greenplum coordinator database server is running. If not specified, reads from the environment variable `PGHOST` or defaults to `localhost`.
 
 -p port \| --port port
-:   The TCP port on which the Greenplum Database coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to 5432.
+:   The TCP port on which the Greenplum Database coordinator database server is listening for connections. If not specified, reads from the environment variable `PGPORT` or defaults to `5432`.
 
 -U username \| --username username
 :   The database role name to connect as. If not specified, reads from the environment variable `PGUSER` or defaults to the current system role name.
@@ -155,8 +180,27 @@ filename
 -W \| --password
 :   Force a password prompt.
 
+:   This option is never required, since `pg_restore` automatically prompts for a password if the server demands password authentication. However, `pg_restore` will waste a connection attempt determinig that the server wants a password. In some cases it is worth typing `-W` to avoid the extra connection attempt.
+
 --role=rolename
-:   Specifies a role name to be used to perform the restore. This option causes `pg_restore` to issue a `SET ROLE rolename` command after connecting to the database. It is useful when the authenticated user \(specified by `-U`\) lacks privileges needed by `pg_restore`, but can switch to a role with the required rights. Some installations have a policy against logging in directly as a superuser, and use of this option allows restores to be performed without violating the policy.
+:   Specifies a role name to be used to perform the restore. This option causes `pg_restore` to issue a `SET ROLE <rolename>` command after connecting to the database. It is useful when the authenticated user \(specified by `-U`\) lacks privileges needed by `pg_restore`, but can switch to a role with the required rights. Some installations have a policy against logging in directly as a superuser, and use of this option allows restores to be performed without violating the policy.
+
+## <a id="section5"></a>Environment
+
+PGHOST
+PGOPTIONS
+PGPORT
+PGUSER
+:   Default connection parameters.
+
+PG_COLOR
+:   Specifies whether to use color in diagnostic messages. Possible values are `always`, `auto`, and `never`.
+
+This utility also uses the [environment variables supported by libpq](https://www.postgresql.org/docs/12/libpq-envars.html).
+
+## <a id="diagnostics"></a>Diagnostics
+
+When you specify a direct database connection using the `-d` option, `pg_restore` internally executes SQL statements. If you have problems running `pg_restore`, make sure you are able to select information from the database using, for example, `psql`. Also, any default connection settings and environment variables used by the `libpq` front-end library will apply.
 
 ## <a id="section6"></a>Notes 
 
@@ -168,7 +212,7 @@ CREATE DATABASE foo WITH TEMPLATE template0;
 
 When restoring data to a pre-existing table and the option `--disable-triggers` is used, `pg_restore` emits commands to deactivate triggers on user tables before inserting the data, then emits commands to re-enable them after the data has been inserted. If the restore is stopped in the middle, the system catalogs may be left in the wrong state.
 
-See also the `pg_dump` documentation for details on limitations of `pg_dump`.
+See also the [pg_dump](pg_dump.html) documentation for details on limitations of `pg_dump`.
 
 Once restored, it is wise to run `ANALYZE` on each restored table so the query planner has useful statistics.
 
@@ -187,14 +231,14 @@ dropdb mydb
 pg_restore -C -d template1 db.dump
 ```
 
-To reload the dump into a new database called `newdb`. Notice there is no `-C`, we instead connect directly to the database to be restored into. Also note that we clone the new database from `template0` not `template1`, to ensure it is initially empty:
+Run the following commands to reload the dump into a new database called `newdb`. Notice there is no `-C` option provided. Instead, connect directly to the database to which to restore to. Also note that the new database is cloned from `template0` not `template1`, to ensure that it is initially empty:
 
 ```
 createdb -T template0 newdb
 pg_restore -d newdb db.dump
 ```
 
-To reorder database items, it is first necessary to dump the table of contents of the archive:
+To reorder database items, you must first dump the table of contents of the archive:
 
 ```
 pg_restore -l db.dump > db.list
@@ -203,7 +247,7 @@ pg_restore -l db.dump > db.list
 The listing file consists of a header and one line for each item, for example,
 
 ```
-; Archive created at Mon Sep 14 13:55:39 2009
+; Archive created at Mon Sep 14 13:55:39 2019
 ;     dbname: DBDEMOS
 ;     TOC Entries: 81
 ;     Compression: 9
@@ -223,7 +267,7 @@ The listing file consists of a header and one line for each item, for example,
 319; 1247 25899 DOMAIN public domain0 pasha2
 ```
 
-Semicolons start a comment, and the numbers at the start of lines refer to the internal archive ID assigned to each item. Lines in the file can be commented out, deleted, and reordered. For example:
+Semicolons start a comment, and the numbers at the start of lines refer to the internal archive ID assigned to each item. You can comment out, delete, and reorder lines in the file. For example:
 
 ```
 10; 145433 TABLE map_resolutions postgres
@@ -233,7 +277,7 @@ Semicolons start a comment, and the numbers at the start of lines refer to the i
 ;8; 145416 TABLE ss_old postgres
 ```
 
-Could be used as input to `pg_restore` and would only restore items 10 and 6, in that order:
+You can use this file as input to `pg_restore`, to restore only items 10 and 6, in that order:
 
 ```
 pg_restore -L db.list db.dump
@@ -241,5 +285,5 @@ pg_restore -L db.list db.dump
 
 ## <a id="section8"></a>See Also 
 
-[pg\_dump](pg_dump.html)
+[pg\_dump](pg_dump.html), [pg\_dumpall](pg_dumpall.html), [psql](psql.html)
 


### PR DESCRIPTION
in this PR:
- finish up doc change for INSERT ... ON CONFLICT
- bring pg_dump, pg_dumpall, pg_restore utility ref pages up to postgres 12
- general:
    - omitted new --no-publications and --no-subscriptions options
    - kept trigger if as-is, there is work-in-progress on this topic
    - there are references to large objects, which greenplum doesn't support.  i followed what the pages are doing currently - include the info from postgres page, then add a note that it is unsupported (not my preference).
- pg_dump questions:
    - no --exclude-table-and-children and --exclude-table-data-and-children on postres 12 ref page, but i do see a ref in the pg_dump code.  is this supported in greenplum 7?
    - no --table-and-children option on postgres 12 ref page, i do see a ref in the pg_dump code.  is this supported in greenplum 7?
    - we document --function-oids and --relation-oids (not in postgres), they appear to be used only by minirepro.  if these aren't for end-user to use, should we remove them?

doc review site links (behind vpn):
- pg_dumpall (can get to others from here):  https://docs-staging.vmware.com/en/draft/VMware-Greenplum/more-upsert/greenplum-database/GUID-utility_guide-ref-pg_dumpall.html
