### PR TITLE
[5X][gpcloud] Backport: Update respsonse size from https://www.bing.com/

### DIFF
--- a/gpAux/extensions/gpcloud/test/s3restful_service_test.cpp
+++ b/gpAux/extensions/gpcloud/test/s3restful_service_test.cpp
@@ -25,7 +25,7 @@ TEST(S3RESTfulService, GetWithEmptyHeader) {
 
     EXPECT_EQ(RESPONSE_OK, resp.getStatus());
     EXPECT_EQ("Success", resp.getMessage());
-    EXPECT_EQ(true, resp.getRawData().size() > 10000);
+    EXPECT_EQ(true, resp.getRawData().size() > 1000);
 }
 
 TEST(S3RESTfulService, GetWithoutURL) {


### PR DESCRIPTION
When curl with empty header to https://www.bing.com/, the response size used to be more than 10000, but it's not the case anymore, it's 5594 now, so update test to be more than 1000 to match the change

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
