### PR TITLE
Fix validation of too many arguments in gprecoverseg

### DIFF
--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -294,13 +294,13 @@ def simple_main_internal(createOptionParserFn, createCommandFn, mainOptions):
 
     # at this point we have whatever lock we require
     try:
-        simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions)
+        simple_main_locked(parser, parserOptions, parserArgs, createCommandFn, mainOptions)
     finally:
         if sml is not None:
             sml.release()
 
 
-def simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions):
+def simple_main_locked(parser, parserOptions, parserArgs, createCommandFn, mainOptions):
     """
     Not to be called externally -- use simple_main instead
     """
@@ -313,7 +313,6 @@ def simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions):
     faultProberInterface.registerFaultProber(faultProberImplGpdb.GpFaultProberImplGpdb())
 
     commandObject = None
-    parser = None
 
     forceQuiet = mainOptions is not None and mainOptions.get("forceQuietOutput")
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -497,7 +497,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
-    Scenario: rebalance and recovery to new host with -F option shows error and exits
+    Scenario: gprecoverseg errors out with restricted options
       Given the database is running
         And user stops all primary processes
         And user can start transactions
@@ -507,6 +507,10 @@ Feature: gprecoverseg tests
        When the user runs "gprecoverseg -a -p localhost -F"
        Then gprecoverseg should return a return code of 2
         And gprecoverseg should print "-F option is not supported with -p option" to stdout
+       When the user runs "gprecoverseg xyz"
+       Then gprecoverseg should return a return code of 2
+       And gprecoverseg should print "Recovers a primary or mirror segment instance" to stdout
+       And gprecoverseg should print "too many arguments: only options may be specified" to stdout
        When the user runs "gprecoverseg -a"
        Then gprecoverseg should return a return code of 0
         And the segments are synchronized


### PR DESCRIPTION
**Issue:**
When gprecoverseg is run with too many arguments then it errors out with an exception stack trace.

> [~/workspace/gpdb: {gprecoverseg_throttle_network} ?]$ gprecoverseg -B 10 abc
20231004:09:42:43:029461 gprecoverseg:sshirishaXG4C7:sshirisha-[INFO]:-Starting gprecoverseg with args: -B 10 abc
Traceback (most recent call last):
  File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 351, in simple_main_locked
    commandObject = createCommandFn(parserOptions, parserArgs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/gpdb/lib/python/gppylib/programs/clsRecoverSegment.py", line 565, in createProgram
    raise ProgramArgumentValidationException("too many arguments: only options may be specified", True)
gppylib.mainUtils.ProgramArgumentValidationException: too many arguments: only options may be specified
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/gpdb/bin/gprecoverseg", line 17, in <module>
    simple_main(GpRecoverSegmentProgram.createParser,
  File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 263, in simple_main
    simple_main_internal(createOptionParserFn, createCommandFn, mainOptions)
  File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 297, in simple_main_internal
    simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions)
  File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 357, in simple_main_locked
    parser.print_help()

**RCA:**
Ideally when too many arguments are provided then gprecoverseg should raise an exception and error out gracefully. There is stack trace seen because while handling this exception another exception occurred where a non-existing attribute is accessed by a NoneType object.

**Fix:**
Instantiating the object to a proper class so that it can access its attribute.

