### PR TITLE
[6X Backport] Fix error seen in CM utilities when invalid argument is provided

### DIFF
--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -294,13 +294,13 @@ def simple_main_internal(createOptionParserFn, createCommandFn, mainOptions):
 
     # at this point we have whatever lock we require
     try:
-        simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions)
+        simple_main_locked(parser, parserOptions, parserArgs, createCommandFn, mainOptions)
     finally:
         if sml is not None:
             sml.release()
 
 
-def simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions):
+def simple_main_locked(parser, parserOptions, parserArgs, createCommandFn, mainOptions):
     """
     Not to be called externally -- use simple_main instead
     """
@@ -313,7 +313,6 @@ def simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions):
     faultProberInterface.registerFaultProber(faultProberImplGpdb.GpFaultProberImplGpdb())
 
     commandObject = None
-    parser = None
 
     forceQuiet = mainOptions is not None and mainOptions.get("forceQuietOutput")
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -626,6 +626,18 @@ Feature: gprecoverseg tests
     And gprecoverseg should return a return code of 0
     Then the cluster is rebalanced
 
+  Scenario: gprecoverseg errors out with restricted options
+    Given the database is running
+    And user stops all primary processes
+    And user can start transactions
+    When the user runs "gprecoverseg xyz"
+    Then gprecoverseg should return a return code of 2
+    And gprecoverseg should print "Recovers a primary or mirror segment instance" to stdout
+    And gprecoverseg should print "too many arguments: only options may be specified" to stdout
+    When the user runs "gprecoverseg -a"
+    Then gprecoverseg should return a return code of 0
+    And the segments are synchronized
+    And the cluster is rebalanced
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
This is a backport of [#16543](https://github.com/greenplum-db/gpdb/pull/16543)

**Issue:**
CM utilities like gpstart, gpstop, gpstate, gprecoverseg, gpaddmirror error out with an exception stack trace, when
- Arguments are provided without any option
- or, too many arguments are provided for an option.

> [~/workspace/gpdb: {gprecoverseg_throttle_network} ?]$ gprecoverseg -B 10 abc
20231004:09:42:43:029461 gprecoverseg:sshirishaXG4C7:sshirisha-[INFO]:-Starting gprecoverseg with args: -B 10 abc
Traceback (most recent call last):
File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 351, in simple_main_locked
commandObject = createCommandFn(parserOptions, parserArgs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/gpdb/lib/python/gppylib/programs/clsRecoverSegment.py", line 565, in createProgram
raise ProgramArgumentValidationException("too many arguments: only options may be specified", True)
gppylib.mainUtils.ProgramArgumentValidationException: too many arguments: only options may be specified
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/local/gpdb/bin/gprecoverseg", line 17, in
simple_main(GpRecoverSegmentProgram.createParser,
File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 263, in simple_main
simple_main_internal(createOptionParserFn, createCommandFn, mainOptions)
File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 297, in simple_main_internal
simple_main_locked(parserOptions, parserArgs, createCommandFn, mainOptions)
File "/usr/local/gpdb/lib/python/gppylib/mainUtils.py", line 357, in simple_main_locked
parser.print_help()

**RCA:**
Ideally when too many arguments are provided or arguments are provided without any option, then utilities should raise an exception, error out gracefully and print CLI help messages on console.  
There is stack trace seen here because while handling this exception another exception occurred where a non-existing attribute is accessed by a NoneType object. This exception stack trace is seen in `simple_main_locked` function

This is a regression caused by https://github.com/greenplum-db/gpdb/pull/16433
As part of this commit the parameters of the function `simple_main_locked` were changed.
Earlier `createOptionParserFn` function was passed as a parameter and its return value `parser` was used to print help for the utility in case of an exception.
With these changes, neither function `createOptionParserFn` is passed as parameter nor its return value `parser` , so parser remains None. Hence while using parser to call a function, it leads to another exception creates a stack trace.

**Fix:**
Passing `parser` as a parameter to function `simple_main_locked`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
