### PR TITLE
docs - note some partitioning ddl lock-related behaviours

### DIFF
--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
@@ -99,7 +99,7 @@ The following table provides a feature comparison to help you choose the syntax 
 | Multi-column range partitioning | Not supported. | Supported. |
 | Multi-column list partitioning | Supported (via composite type). | Not supported. |
 | Hash partitioning | Not supported. | Supported. |
-| Adding a Partition | Adding a partition acquires an `ACCESS EXCLUSIVE` lock on the parent table. | Attaching a partition acquires a less restrictive `SHARE UPDATE EXCLUSIVE LOCK` on the parent table. |
+| Adding a Partition | Adding a partition acquires an `ACCESS EXCLUSIVE` lock on the parent table. | Attaching a partition acquires a less restrictive `SHARE UPDATE EXCLUSIVE` lock on the parent table. |
 | Removing a Partition | Dropping a partition deletes the table contents. Must create a dummy table and swap. | Supported. Can directly detach a partition, retaining the table contents. |
 | Sub-partition templating | Supported. The definitions of the parent and child tables are consistent by default. | Not supported. You ensure that the table definitions are consistent. |
 | Partition maintenance | You operate on a child table via the parent, requiring knowledge of the partition hierarchy. | You operate directly on the child table, no knowledge of the partition hierarchy is required. |

--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
@@ -99,7 +99,8 @@ The following table provides a feature comparison to help you choose the syntax 
 | Multi-column range partitioning | Not supported. | Supported. |
 | Multi-column list partitioning | Supported (via composite type). | Not supported. |
 | Hash partitioning | Not supported. | Supported. |
-| Partition Removal | Dropping a partition deletes the table contents. Must create a dummy table and swap. | Supported. Can directly detach a partition, retaining the table contents. |
+| Adding a Partition | Adding a partition acquires an `ACCESS EXCLUSIVE` lock on the parent table. | Attaching a partition acquires a less restrictive `SHARE UPDATE EXCLUSIVE LOCK` on the parent table. |
+| Removing a Partition | Dropping a partition deletes the table contents. Must create a dummy table and swap. | Supported. Can directly detach a partition, retaining the table contents. |
 | Sub-partition templating | Supported. The definitions of the parent and child tables are consistent by default. | Not supported. You ensure that the table definitions are consistent. |
 | Partition maintenance | You operate on a child table via the parent, requiring knowledge of the partition hierarchy. | You operate directly on the child table, no knowledge of the partition hierarchy is required. |
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -200,7 +200,7 @@ and <subpartition_element> is:
 
 ## <a id="section3"></a>Description 
 
-`ALTER TABLE` changes the definition of an existing table. There are several subforms described below. Note that the lock level required may differ for each subform. An `ACCESS EXCLUSIVE` lock is acquired unless explicitly noted. When multiple subcommands are provided, Greenplum Database acquires the strictest lock required by any subcommand.
+`ALTER TABLE` changes the definition of an existing table. There are several subforms described below. Note that the lock level required may differ for each subform. *An `ACCESS EXCLUSIVE` lock is acquired unless explicitly noted.* When multiple subcommands are provided, Greenplum Database acquires the strictest lock required by any subcommand.
 
 ADD COLUMN [ IF NOT EXISTS ]
 :    Adds a new column to the table, using the same syntax as [CREATE TABLE](CREATE_TABLE.html). If `IF NOT EXISTS` is specified and a column already exists with this name, no error is thrown.
@@ -378,7 +378,7 @@ ATTACH PARTITION partition_name { FOR VALUES partition_bound_spec | DEFAULT }
 
 :   When a table has a default partition, defining a new partition changes the partition constraint for the default partition. The default partition can't contain any rows that would need to be moved to the new partition, and will be scanned to verify that none are present. This scan, like the scan of the new partition, can be avoided if an appropriate `CHECK` constraint is present. Also like the scan of the new partition, it is always skipped when the default partition is a foreign table.
 
-:   Attaching a partition acquires a `SHARE UPDATE EXCLUSIVE` lock on the parent table, in addition to the `ACCESS EXCLUSIVE` locks on the table being attached and on the default partition (if any).
+:   Attaching a partition acquires a `SHARE UPDATE EXCLUSIVE` lock on the parent table, in addition to the `ACCESS EXCLUSIVE` locks on the table being attached and on the default partition (if any). You can run `SELECT` and `INSERT` queries in parallel with `ATTACH PARTITION`. You can also run `UPDATE` queries in parallel with `ATTACH PARTITION` when the parent table is a heap table and the Global Deadlock Detector is enabled (the [gp_enable_global_deadlock_detector](../config_params/guc-list.html#gp_enable_global_deadlock_detector) server configuration paramer is set to `on`).
 
 :   Additional locks must also be held on all sub-partitions if the table being attached is itself a partitioned table. Likewise if the default partition is itself a partitioned table. The locking of the sub-partitions can be avoided by adding a `CHECK` constraint as described in [Partitioning Large Tables](../../admin_guide/ddl/ddl-partition.html.md).
 
@@ -502,7 +502,7 @@ ADD DEFAULT PARTITION
 :   Adds a default partition to an existing partition design. When data does not match to an existing partition, it is inserted into the default partition. Partition designs that do not have a default partition will reject incoming rows that do not match to an existing partition. Default partitions must be given a name.
 
 ADD PARTITION
-:   partition\_element - Using the existing partition type of the table (range or list), defines the boundaries of new partition you are adding.
+:   partition\_element - Using the existing partition type of the table (range or list), defines the boundaries of new partition you are adding.  `ADD PARTITION` acquires an `ACCESS EXCLUSIVE` lock on the parent table.
 
 :   name - A name for this new partition.
 


### PR DESCRIPTION
in this PR:
- note the acquired lock difference for classic/modern when adding/attaching a partition in the "choosing the syntax" topic
- update ALTER TABLE reference page with some lock info for ATTACH (modern), ADD (classic).  note that the Description states ACCESS EXCLUSIVE unless otherwise stated, i highlighted this sentence.
