### PR TITLE
6X: Check peer listener failed in IC-PROXY mode

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -34,6 +34,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/ml_ipc.h"
 #include "executor/execdesc.h"
+#include "storage/shmem.h"
 
 #include "ic_proxy.h"
 #include "ic_proxy_backend.h"
@@ -515,6 +516,25 @@ ic_proxy_backend_init_context(ChunkTransportState *state)
 	uv_timer_init(&context->loop, &context->connectTimer);
 	uv_timer_start(&context->connectTimer, ic_proxy_backend_on_connect_timer, 0, CONNECT_TIMER_TIMEOUT);
 	uv_unref((uv_handle_t *)&context->connectTimer);
+}
+
+/*
+ * Check if current Segment's IC_PROXY listener failed
+ */
+bool
+ic_proxy_backend_check_listener_failed(void)
+{
+	bool found;
+	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
+											sizeof(*ic_proxy_peer_listener_failed),
+											&found);
+
+	Assert(ic_proxy_peer_listener_failed != NULL);
+	/* init it to 0 when the backend accesses it firstly */
+	if (!found)
+		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
+
+	return pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0;
 }
 
 /*

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -519,25 +519,6 @@ ic_proxy_backend_init_context(ChunkTransportState *state)
 }
 
 /*
- * Check if current Segment's IC_PROXY listener failed
- */
-bool
-ic_proxy_backend_check_listener_failed(void)
-{
-	bool found;
-	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
-											sizeof(*ic_proxy_peer_listener_failed),
-											&found);
-
-	Assert(ic_proxy_peer_listener_failed != NULL);
-	/* init it to 0 when the backend accesses it firstly */
-	if (!found)
-		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
-
-	return pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0;
-}
-
-/*
  * Close the icproxy backend context
  */
 void

--- a/src/backend/cdb/motion/ic_proxy_backend.h
+++ b/src/backend/cdb/motion/ic_proxy_backend.h
@@ -13,6 +13,7 @@
 #define IC_PROXY_BACKEND_H
 
 #include "postgres.h"
+#include "port/atomics.h"
 
 #include "cdb/cdbinterconnect.h"
 
@@ -38,6 +39,8 @@ typedef struct ICProxyBackendContext
 	ChunkTransportState   *transportState;
 } ICProxyBackendContext;
 
+extern pg_atomic_uint32 *ic_proxy_peer_listener_failed;
+
 extern void ic_proxy_backend_connect(ICProxyBackendContext *context,
 									 ChunkTransportStateEntry *pEntry,
 									 MotionConn *conn, bool isSender);
@@ -45,5 +48,6 @@ extern void ic_proxy_backend_connect(ICProxyBackendContext *context,
 extern void ic_proxy_backend_init_context(ChunkTransportState *state);
 extern void ic_proxy_backend_close_context(ChunkTransportState *state);
 extern void ic_proxy_backend_run_loop(ICProxyBackendContext *context);
+extern bool ic_proxy_backend_check_listener_failed(void);
 
 #endif   /* IC_PROXY_BACKEND_H */

--- a/src/backend/cdb/motion/ic_proxy_backend.h
+++ b/src/backend/cdb/motion/ic_proxy_backend.h
@@ -14,7 +14,6 @@
 
 #include "postgres.h"
 #include "port/atomics.h"
-
 #include "cdb/cdbinterconnect.h"
 
 #include <uv.h>
@@ -48,6 +47,5 @@ extern void ic_proxy_backend_connect(ICProxyBackendContext *context,
 extern void ic_proxy_backend_init_context(ChunkTransportState *state);
 extern void ic_proxy_backend_close_context(ChunkTransportState *state);
 extern void ic_proxy_backend_run_loop(ICProxyBackendContext *context);
-extern bool ic_proxy_backend_check_listener_failed(void);
 
 #endif   /* IC_PROXY_BACKEND_H */

--- a/src/backend/cdb/motion/ic_proxy_bgworker.c
+++ b/src/backend/cdb/motion/ic_proxy_bgworker.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "storage/ipc.h"
+#include "storage/shmem.h"
 
 #include "cdb/ic_proxy_bgworker.h"
 #include "ic_proxy_server.h"
@@ -34,4 +35,29 @@ ICProxyMain(Datum main_arg)
 {
 	/* main loop */
 	proc_exit(ic_proxy_server_main());
+}
+
+/*
+ * the size of ICProxy SHM structure
+ */
+Size
+ICProxyShmemSize(void)
+{
+	Size		size = 0;
+	size = add_size(size, sizeof(*ic_proxy_peer_listener_failed));
+	return size;
+}
+
+/*
+ * initialize ICProxy's SHM structure: only one flag variable
+ */
+void
+ICProxyShmemInit(void)
+{
+	bool		found;
+	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
+													sizeof(*ic_proxy_peer_listener_failed),
+													&found);
+	if (!found)
+		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
 }

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -442,19 +442,10 @@ int
 ic_proxy_server_main(void)
 {
 	char		path[MAXPGPATH];
-	bool		found;
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_TERSE,
 		   LOG, "ic-proxy: server setting up");
 
-	/* get and init failure flag */
-	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
-													sizeof(*ic_proxy_peer_listener_failed),
-													&found);
-	if (!found)
-		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
-	else
-		pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
-
+	pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
 	ic_proxy_pkt_cache_init(IC_PROXY_MAX_PKT_SIZE);
 
 	uv_loop_init(&ic_proxy_server_loop);

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -18,6 +18,8 @@
 #include "storage/ipc.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
+#include "storage/shmem.h"
+#include "port/atomics.h"
 
 #include "ic_proxy_server.h"
 #include "ic_proxy_addr.h"
@@ -36,6 +38,8 @@ static uv_timer_t	ic_proxy_server_timer;
 
 static uv_tcp_t		ic_proxy_peer_listener;
 static bool			ic_proxy_peer_listening;
+/* flag (in SHM) for incidaing if peer listener bind/listen failed */
+pg_atomic_uint32 	*ic_proxy_peer_listener_failed;
 
 static uv_pipe_t	ic_proxy_client_listener;
 static bool			ic_proxy_client_listening;
@@ -144,8 +148,12 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	if (ic_proxy_addrs == NIL)
 		return;
 
+	Assert(ic_proxy_peer_listener_failed != NULL);
 	if (ic_proxy_peer_listening)
+	{
+		Assert(pg_atomic_read_u32(ic_proxy_peer_listener_failed) == 0);
 		return;
+	}
 
 	/* Get the addr from the gp_interconnect_proxy_addresses */
 	addr = ic_proxy_get_my_addr();
@@ -185,6 +193,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	{
 		elog(WARNING, "ic-proxy: tcp: fail to bind: %s",
 					 uv_strerror(ret));
+		pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 1);
 		return;
 	}
 
@@ -194,6 +203,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	{
 		elog(WARNING, "ic-proxy: tcp: fail to listen: %s",
 					 uv_strerror(ret));
+		pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 1);
 		return;
 	}
 
@@ -201,6 +211,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
 		   "ic-proxy: tcp: listening on socket %d", fd);
 
+	pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
 	ic_proxy_peer_listening = true;
 }
 
@@ -431,9 +442,18 @@ int
 ic_proxy_server_main(void)
 {
 	char		path[MAXPGPATH];
-
+	bool		found;
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_TERSE,
 		   LOG, "ic-proxy: server setting up");
+
+	/* get and init failure flag */
+	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
+													sizeof(*ic_proxy_peer_listener_failed),
+													&found);
+	if (!found)
+		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
+	else
+		pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
 
 	ic_proxy_pkt_cache_init(IC_PROXY_MAX_PKT_SIZE);
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1277,7 +1277,8 @@ SetupTCPInterconnect(EState *estate)
 	interconnect_context->doSendStopMessage = doSendStopMessageTCP;
 
 #ifdef ENABLE_IC_PROXY
-	if (ic_proxy_backend_check_listener_failed())
+	/* check if current Segment's ICProxy listener failed */
+	if (pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0)
 		elog(ERROR, "SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check.");
 	ic_proxy_backend_init_context(interconnect_context);
 #endif /* ENABLE_IC_PROXY */

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1279,7 +1279,14 @@ SetupTCPInterconnect(EState *estate)
 #ifdef ENABLE_IC_PROXY
 	/* check if current Segment's ICProxy listener failed */
 	if (pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0)
-		elog(ERROR, "SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check.");
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+			 errmsg("Failed to setup ic_proxy interconnect"),
+			 errdetail("The ic_proxy process failed to bind or listen."),
+			 errhint("Please check the server log for related WARNING messages.")));
+	}
+
 	ic_proxy_backend_init_context(interconnect_context);
 #endif /* ENABLE_IC_PROXY */
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1277,6 +1277,8 @@ SetupTCPInterconnect(EState *estate)
 	interconnect_context->doSendStopMessage = doSendStopMessageTCP;
 
 #ifdef ENABLE_IC_PROXY
+	if (ic_proxy_backend_check_listener_failed())
+		elog(ERROR, "SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check.");
 	ic_proxy_backend_init_context(interconnect_context);
 #endif /* ENABLE_IC_PROXY */
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -421,11 +421,7 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 
 #ifdef ENABLE_IC_PROXY
 	{"ic proxy process",
-#ifdef FAULT_INJECTOR
 	 BGWORKER_SHMEM_ACCESS,
-#else
-	 0,
-#endif
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if ic proxy process exits with non-zero code */
 	 ICProxyMain, {0}, {0}, 0, 0,

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -67,6 +67,7 @@
 #include "utils/session_state.h"
 #include "cdb/cdbendpoint.h"
 #include "replication/gp_replication.h"
+#include "cdb/ic_proxy_bgworker.h"
 
 shmem_startup_hook_type shmem_startup_hook = NULL;
 
@@ -184,6 +185,10 @@ CreateSharedMemoryAndSemaphores(int port)
 #ifdef FAULT_INJECTOR
 		size = add_size(size, FaultInjector_ShmemSize());
 #endif			
+
+#ifdef ENABLE_IC_PROXY
+		size = add_size(size, ICProxyShmemSize());
+#endif
 
 		/* This elog happens before we know the name of the log file we are supposed to use */
 		elog(DEBUG1, "Size not including the buffer pool %lu",
@@ -335,6 +340,10 @@ CreateSharedMemoryAndSemaphores(int port)
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_ShmemInit();
+#endif
+
+#ifdef ENABLE_IC_PROXY
+	ICProxyShmemInit();
 #endif
 
 	/*

--- a/src/include/cdb/ic_proxy_bgworker.h
+++ b/src/include/cdb/ic_proxy_bgworker.h
@@ -13,10 +13,14 @@
 #ifndef IC_PROXY_BGWORKER_H
 #define IC_PROXY_BGWORKER_H
 
-#include "postgres.h"
+#include "port/atomics.h"
 
+/* flag (in SHM) for incidaing if peer listener bind/listen failed */
+extern pg_atomic_uint32 *ic_proxy_peer_listener_failed;
 
 extern bool ICProxyStartRule(Datum main_arg);
 extern void ICProxyMain(Datum main_arg);
+extern Size ICProxyShmemSize(void);
+extern void ICProxyShmemInit(void);
 
 #endif   /* IC_PROXY_BGWORKER_H */

--- a/src/test/isolation2/expected/ic_proxy_listen_failed.out
+++ b/src/test/isolation2/expected/ic_proxy_listen_failed.out
@@ -27,7 +27,9 @@ started a http server
 -- this output is hard to match, let's ignore it
 -- start_ignore
 2&:select count(*) from PR_16438;  <waiting ...>
-FAILED:  Forked command is not blocking; got output: ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:1282)
+FAILED:  Forked command is not blocking; got output: ERROR:  Failed to setup ic_proxy interconnect
+DETAIL:  The ic_proxy process failed to bind or listen.
+HINT:  Please check the server log for related WARNING messages.
 2<:  <... completed>
 FAILED:  Execution failed
 2q: ... <quitting>
@@ -35,7 +37,9 @@ FAILED:  Execution failed
 
 -- execute a query (should failed)
 3:select count(*) from PR_16438;
-ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:1282)
+ERROR:  Failed to setup ic_proxy interconnect
+DETAIL:  The ic_proxy process failed to bind or listen.
+HINT:  Please check the server log for related WARNING messages.
 
 -- kill the script to release port and execute query again (should successfully)
 -- Note: different from 7x here, we have to restart cluster (no need in 7x)

--- a/src/test/isolation2/expected/ic_proxy_listen_failed.out
+++ b/src/test/isolation2/expected/ic_proxy_listen_failed.out
@@ -1,0 +1,52 @@
+-- Test case for the scenario which ic-proxy peer listener port has been occupied
+
+-- start_matchsubs
+-- m/ic_tcp.c:\d+/
+-- s/ic_tcp.c:\d+/ic_tcp.c:LINE/
+-- end_matchsubs
+
+1:create table PR_16438 (i int);
+CREATE
+1:insert into PR_16438 select generate_series(1,100);
+INSERT 100
+1q: ... <quitting>
+
+-- get one port and occupy it (start_py_httpserver.sh), then restart cluster
+!\retcode ic_proxy_port=`psql postgres -Atc "show gp_interconnect_proxy_addresses;" | awk -F ',' '{print $1}' | awk -F ':' '{print $4}'` && gpstop -ai > /dev/null && ./script/start_py_httpserver.sh $ic_proxy_port;
+-- start_ignore
+started a http server
+
+-- end_ignore
+(exited with code 0)
+!\retcode sleep 2 && gpstart -a > /dev/null;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- execute a query (should failed)
+2&:select count(*) from PR_16438;  <waiting ...>
+2<:  <... completed>
+ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:LINE)
+
+-- kill the script to release port and execute query again (should successfully)
+-- Note: different from 7x here, we have to restart cluster (no need in 7x)
+-- because 6x's icproxy code doesn't align with 7x: https://github.com/greenplum-db/gpdb/issues/14485
+!\retcode ps aux | grep SimpleHTTPServer | grep -v grep | awk '{print $2}' | xargs kill;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode sleep 2 && gpstop -ari > /dev/null;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+3:select count(*) from PR_16438;
+ count 
+-------
+ 100   
+(1 row)
+3:drop table PR_16438;
+DROP

--- a/src/test/isolation2/expected/ic_proxy_listen_failed.out
+++ b/src/test/isolation2/expected/ic_proxy_listen_failed.out
@@ -24,10 +24,18 @@ started a http server
 -- end_ignore
 (exited with code 0)
 
--- execute a query (should failed)
+-- this output is hard to match, let's ignore it
+-- start_ignore
 2&:select count(*) from PR_16438;  <waiting ...>
+FAILED:  Forked command is not blocking; got output: ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:1282)
 2<:  <... completed>
-ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:LINE)
+FAILED:  Execution failed
+2q: ... <quitting>
+-- end_ignore
+
+-- execute a query (should failed)
+3:select count(*) from PR_16438;
+ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:1282)
 
 -- kill the script to release port and execute query again (should successfully)
 -- Note: different from 7x here, we have to restart cluster (no need in 7x)
@@ -43,10 +51,10 @@ ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed
 -- end_ignore
 (exited with code 0)
 
-3:select count(*) from PR_16438;
+4:select count(*) from PR_16438;
  count 
 -------
  100   
 (1 row)
-3:drop table PR_16438;
+4:drop table PR_16438;
 DROP

--- a/src/test/isolation2/isolation2_ic_proxy_schedule
+++ b/src/test/isolation2/isolation2_ic_proxy_schedule
@@ -7,3 +7,6 @@ test: tcp_ic_teardown
 
 # test TCP proxy peer shutdown
 test: ic_proxy_peer_shutdown
+
+# test ic-proxy listen failed
+test: ic_proxy_listen_failed

--- a/src/test/isolation2/script/start_py_httpserver.sh
+++ b/src/test/isolation2/script/start_py_httpserver.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# start a python http server (port is $1) in background
+
+which python2 > /dev/null
+if [ $? -eq 0 ] 
+then
+    python2 -m SimpleHTTPServer $1 >/dev/null 2>&1 &
+    echo "started a http server"
+    exit 0
+fi
+
+echo "no python found"
+exit 1

--- a/src/test/isolation2/sql/ic_proxy_listen_failed.sql
+++ b/src/test/isolation2/sql/ic_proxy_listen_failed.sql
@@ -1,0 +1,27 @@
+-- Test case for the scenario which ic-proxy peer listener port has been occupied
+
+-- start_matchsubs
+-- m/ic_tcp.c:\d+/
+-- s/ic_tcp.c:\d+/ic_tcp.c:LINE/
+-- end_matchsubs
+
+1:create table PR_16438 (i int);
+1:insert into PR_16438 select generate_series(1,100);
+1q:
+
+-- get one port and occupy it (start_py_httpserver.sh), then restart cluster
+!\retcode ic_proxy_port=`psql postgres -Atc "show gp_interconnect_proxy_addresses;" | awk -F ',' '{print $1}' | awk -F ':' '{print $4}'` && gpstop -ai > /dev/null && ./script/start_py_httpserver.sh $ic_proxy_port;
+!\retcode sleep 2 && gpstart -a > /dev/null;
+
+-- execute a query (should failed)
+2&:select count(*) from PR_16438;
+2<:
+
+-- kill the script to release port and execute query again (should successfully)
+-- Note: different from 7x here, we have to restart cluster (no need in 7x)
+-- because 6x's icproxy code doesn't align with 7x: https://github.com/greenplum-db/gpdb/issues/14485
+!\retcode ps aux | grep SimpleHTTPServer | grep -v grep | awk '{print $2}' | xargs kill;
+!\retcode sleep 2 && gpstop -ari > /dev/null;
+
+3:select count(*) from PR_16438;
+3:drop table PR_16438;

--- a/src/test/isolation2/sql/ic_proxy_listen_failed.sql
+++ b/src/test/isolation2/sql/ic_proxy_listen_failed.sql
@@ -13,9 +13,15 @@
 !\retcode ic_proxy_port=`psql postgres -Atc "show gp_interconnect_proxy_addresses;" | awk -F ',' '{print $1}' | awk -F ':' '{print $4}'` && gpstop -ai > /dev/null && ./script/start_py_httpserver.sh $ic_proxy_port;
 !\retcode sleep 2 && gpstart -a > /dev/null;
 
--- execute a query (should failed)
+-- this output is hard to match, let's ignore it
+-- start_ignore
 2&:select count(*) from PR_16438;
 2<:
+2q:
+-- end_ignore
+
+-- execute a query (should failed)
+3:select count(*) from PR_16438;
 
 -- kill the script to release port and execute query again (should successfully)
 -- Note: different from 7x here, we have to restart cluster (no need in 7x)
@@ -23,5 +29,5 @@
 !\retcode ps aux | grep SimpleHTTPServer | grep -v grep | awk '{print $2}' | xargs kill;
 !\retcode sleep 2 && gpstop -ari > /dev/null;
 
-3:select count(*) from PR_16438;
-3:drop table PR_16438;
+4:select count(*) from PR_16438;
+4:drop table PR_16438;


### PR DESCRIPTION
This PR backported https://github.com/greenplum-db/gpdb/pull/16438 to 6x

----

In IC-PROXY mode, user doesn't get a notification when peer listener bind/listen failed. Because the related code is in IC-PROXY process, it only records warning logs. So, the user's query just hangs here silently. This behavior may make the user very confused.

In the commit, introduced a SHM variable to check the failure and give notification in time. An output example:
```
$ nc -l 2001
...
$ PGOPTIONS="-c gp_interconnect_type=proxy" psql demo
demo=# select count(*) from test;
ERROR:  SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check. (ic_tcp.c:1296)  (seg1 slice1 127.0.1.1:6001 pid=189355) (ic_tcp.c:1296)
```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
