### PR TITLE
add duration if the query is canceled when it needs to be logged

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4038,9 +4038,25 @@ ProcessInterrupts(const char* filename, int lineno)
 						(errcode(ERRCODE_GP_OPERATION_CANCELED),
 						 errmsg("canceling MPP operation%s", cancel_msg_str.data)));
 			else
-				ereport(ERROR,
-						(errcode(ERRCODE_QUERY_CANCELED),
-						 errmsg("canceling statement due to user request%s", cancel_msg_str.data)));
+			{
+				char		msec_str[32];
+
+				switch (check_log_duration(msec_str, false))
+				{
+					case 0:
+						ereport(ERROR,
+								(errcode(ERRCODE_QUERY_CANCELED),
+										errmsg("canceling statement due to user request%s", cancel_msg_str.data)));
+						break;
+					case 1:
+					case 2:
+						ereport(ERROR,
+								(errcode(ERRCODE_QUERY_CANCELED),
+										errmsg("canceling statement due to user request%s, duration:%s",
+											   cancel_msg_str.data, msec_str)));
+						break;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Add the duration time into "canceling statement due to user request" to help the user
debug when canceling the query.

The log message will be

```
2023-10-10 03:32:55.325528 UTC,"smart","postgres",p463714,th1746153216,"[local]",,2023-10-10 03:32:01 UTC,
0,con32,cmd9,seg-1,,,,sx1,"ERROR","57014","canceling statement due to user request, duration:4256.617",,,,,,
"select * from t, t as t1, t as t2;",0,,"postgres.c",4053,
```

Not change the log schema.