### PR TITLE
[6X_BACKPORT] Fix flaky basebackup tap test that relied on pg_current_xlog_location

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -123,7 +123,7 @@ ok(compare($primary_wal_file_path, $mirror_wal_file_path) eq 0, "wal file compar
 my $total_bytes_cmd = 'pg_controldata ' . $node_wal_compare_standby_datadir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
 my $total_allocated_bytes = `$total_bytes_cmd`;
 
-my $current_lsn_cmd = 'pg_xlogdump -f ' . $primary_wal_file_path . ' | grep "xlog switch" | awk \'{print $10}\' | sed "s/,//"';
+my $current_lsn_cmd = 'pg_xlogdump ' . $primary_wal_file_path . ' | grep "xlog switch" | awk \'{print $10}\' | sed "s/,//"';
 my $current_lsn = `$current_lsn_cmd`;
 chomp($current_lsn);
 

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -4,6 +4,7 @@ use Cwd;
 use TestLib;
 use File::Compare;
 use File::Path qw(rmtree);
+use PostgresNode;
 use Test::More tests => 48 + 4;
 
 program_help_ok('pg_basebackup');
@@ -74,9 +75,19 @@ command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup", '-Ft',
 ok(-f "$tempdir/tarbackup/base.tar", 'backup tar was created');
 
 ########################## Test that the headers are zeroed out in both the primary and mirror WAL files
-my $compare_tempdir = "$tempdir/checksum_test";
+my $node_wal_compare_primary = get_new_node('wal_compare_primary');
+# We need to enable archiving for this test because we depend on the backup history
+# file created by pg_basebackup to retrieve the "STOP WAL LOCATION". This file only
+# gets persisted if archiving is turned on.
+$node_wal_compare_primary->init(
+	has_archiving    => 1,
+	allows_streaming => 1);
+$node_wal_compare_primary->start;
 
-# Ensure that when pg_basebackup is run that the last WAL segment file
+my $node_wal_compare_primary_datadir = $node_wal_compare_primary->data_dir;
+my $node_wal_compare_standby_datadir = "$tempdir/wal_compare_standby";
+
+# Ensure that when pg_basebackup is run, the last WAL segment file
 # containing the XLOG_BACKUP_END and XLOG_SWITCH records match on both
 # the primary and mirror segment. We want to ensure that all pages after
 # the XLOG_SWITCH record are all zeroed out. Previously, the primary
@@ -86,31 +97,41 @@ my $compare_tempdir = "$tempdir/checksum_test";
 # and would lead to checksum mismatches for external tools that checked
 # for that.
 
-#Insert data and then run pg_basebackup
-psql 'postgres',  'CREATE TABLE zero_header_test as SELECT generate_series(1,1000);';
-command_ok([ 'pg_basebackup', '-D', $compare_tempdir, '--target-gp-dbid', '123' , '-X', 'stream'],
+# Insert data and then run pg_basebackup
+$node_wal_compare_primary->psql('postgres',  'CREATE TABLE zero_header_test as SELECT generate_series(1,1000);');
+$node_wal_compare_primary->command_ok([ 'pg_basebackup', '-D', $node_wal_compare_standby_datadir, '--target-gp-dbid', '123' , '-X', 'stream'],
 	'pg_basebackup wal file comparison test');
-ok( -f "$compare_tempdir/PG_VERSION", 'pg_basebackup ran successfully');
+ok( -f "$node_wal_compare_standby_datadir/PG_VERSION", 'pg_basebackup ran successfully');
 
-my $current_wal_file = psql 'postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());";
-my $primary_wal_file_path = "$tempdir/pgdata/pg_xlog/$current_wal_file";
-my $mirror_wal_file_path = "$compare_tempdir/pg_xlog/$current_wal_file";
+# We can't rely on `pg_current_xlog_location()` to get the last WAL filename that was
+# copied over to the standby. This is because it's possible for newer WAL files
+# to get created after pg_basebackup is run.
+# So instead, we rely on the backup history file created by pg_basebackup to get
+# this information. We can safely assume that there's only one backup history
+# file in the primary's xlog dir
+my $backup_history_file = "$node_wal_compare_primary_datadir/pg_xlog/*.backup";
+my $stop_wal_file_cmd = 'sed -n "s/STOP WAL LOCATION.*(file //p" ' . $backup_history_file . ' | sed "s/)//g"';
+my $stop_wal_file = `$stop_wal_file_cmd`;
+chomp($stop_wal_file);
+my $primary_wal_file_path = "$node_wal_compare_primary_datadir/pg_xlog/$stop_wal_file";
+my $mirror_wal_file_path = "$node_wal_compare_standby_datadir/pg_xlog/$stop_wal_file";
 
-## Test that primary and mirror WAL file is the same
+# Test that primary and mirror WAL file is the same
 ok(compare($primary_wal_file_path, $mirror_wal_file_path) eq 0, "wal file comparison");
 
-## Test that all the bytes after the last written record in the WAL file are zeroed out
-my $total_bytes_cmd = 'pg_controldata ' . $compare_tempdir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
+# Test that all the bytes after the last written record in the WAL file are zeroed out
+my $total_bytes_cmd = 'pg_controldata ' . $node_wal_compare_standby_datadir .  ' | grep "Bytes per WAL segment:" |  awk \'{print $5}\'';
 my $total_allocated_bytes = `$total_bytes_cmd`;
 
 my $current_lsn_cmd = 'pg_xlogdump -f ' . $primary_wal_file_path . ' | grep "xlog switch" | awk \'{print $10}\' | sed "s/,//"';
 my $current_lsn = `$current_lsn_cmd`;
 chomp($current_lsn);
-my $current_byte_offset = psql 'postgres', "SELECT file_offset FROM pg_xlogfile_name_offset('$current_lsn');";
 
-#Get offset of last written record
+my $current_byte_offset = $node_wal_compare_primary->safe_psql('postgres', "SELECT file_offset FROM pg_xlogfile_name_offset('$current_lsn');");
+
+# Get offset of last written record
 open my $fh, '<:raw', $primary_wal_file_path;
-#Since pg_xlogfile_name_offset does not account for the xlog switch record, we need to add it ourselves
+# Since pg_xlogfile_name_offset does not account for the xlog switch record, we need to add it ourselves
 my $xlog_switch_record_len = 32;
 seek $fh, $current_byte_offset + $xlog_switch_record_len, 0;
 my $bytes_read = "";
@@ -118,6 +139,8 @@ my $len_bytes_to_validate = $total_allocated_bytes - $current_byte_offset;
 read($fh, $bytes_read, $len_bytes_to_validate);
 close $fh;
 ok($bytes_read =~ /\A\x00*+\z/, 'make sure wal segment is zeroed');
+
+############################## End header test #####################################
 
 # The following tests test symlinks. Windows doesn't have symlinks, so
 # skip on Windows.


### PR DESCRIPTION
Backported from GPDB main: https://github.com/greenplum-db/gpdb/commit/5f7452103edd20ed93f948416f0d34d544f374f1 and https://github.com/greenplum-db/gpdb/commit/bd1a975dcd962c42efb15e9f7b444f787fb16587
Note that we haven't observed this test being flaky on gpdb6 but it was flaky
on gpdb7. So we fixed it for gpdb7 and are backporting this since this is a
better way to compare wal files. More details on the flaky test can be
found on the 7X PR https://github.com/greenplum-db/gpdb/pull/16445

**CONTEXT:**
A previous commit
https://github.com/greenplum-db/gpdb/commit/a62bba858bad3395d1ecea14fe1ac3828dbb66ff
had added a basebackup tap test to ensure that the primary XLOG file
containing the xlog switch record (created by pg_basebackup) exactly
matched the XLOG file on the standby.

**PROBLEM:**
In order to get the name of the WAL file to compare, we used to rely on
`pg_current_xlog_location()` to return the "last WAL file" copied over by
pg_basebackup to the standby server. This wasn't always reliable because
because it's possible for newer WAL files to get created after pg_basebackup is
run.  Because of this, the pg_basebackup test could be flaky and get stuck

**FIX:**
Instead of relying on `pg_current_xlog_location()`, we can rely on the backup
history file created by pg_basebackup which contains information about
the "STOP WAL LOCATION". This will always give us accurate information
about the last wal file that was shipped by pg_basebackup to the standby
server.
In order for pg_basebackup to retain this backup history file, we need
to enable archiving because otherwise, the file gets deleted.

Sample backup history file

cat 000000010000000000000014.00000028.backup
```
START WAL LOCATION: 0/50000028 (file 000000010000000000000014)
STOP WAL LOCATION: 0/50000110 (file 000000010000000000000014)
CHECKPOINT LOCATION: 0/50000060
BACKUP METHOD: streamed
BACKUP FROM: master
START TIME: 2023-09-13 12:36:01 PDT
LABEL: pg_basebackup base backup
STOP TIME: 2023-09-13 12:36:02 PDT
```