### PR TITLE
resgroup use cgroup name: gpdb.slice

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -45,9 +45,9 @@ make_cgroups_dir() {
     ssh -t $gpdb_host_alias sudo bash -ex <<EOF
         for comp in cpuset cpu cpuacct memory; do
             chmod -R 777 $basedir/\$comp
-            mkdir -p $basedir/\$comp/gpdb
-            chown -R gpadmin:gpadmin $basedir/\$comp/gpdb
-            chmod -R 777 $basedir/\$comp/gpdb
+            mkdir -p $basedir/\$comp/gpdb.slice
+            chown -R gpadmin:gpadmin $basedir/\$comp/gpdb.slice
+            chmod -R 777 $basedir/\$comp/gpdb.slice
         done
 EOF
 }
@@ -98,10 +98,10 @@ keep_minimal_cgroup_dirs() {
     local basedir=$CGROUP_BASEDIR
 
     ssh -t $gpdb_master_alias sudo bash -ex <<EOF
-        rmdir $basedir/memory/gpdb/*/ || :
-        rmdir $basedir/memory/gpdb
-        rmdir $basedir/cpuset/gpdb/*/ || :
-        rmdir $basedir/cpuset/gpdb
+        rmdir $basedir/memory/gpdb.slice/*/ || :
+        rmdir $basedir/memory/gpdb.slice
+        rmdir $basedir/cpuset/gpdb.slice/*/ || :
+        rmdir $basedir/cpuset/gpdb.slice
 EOF
 }
 

--- a/concourse/scripts/ic_gpdb_resgroup_v2.bash
+++ b/concourse/scripts/ic_gpdb_resgroup_v2.bash
@@ -23,8 +23,8 @@ enable_cgroup_subtree_control() {
         echo "+cpuset" >> $basedir/cgroup.subtree_control
         echo "+memory" >> $basedir/cgroup.subtree_control
         echo "+io" >> $basedir/cgroup.subtree_control
-        mkdir $basedir/gpdb
-        chmod -R 777 $basedir/gpdb
+        mkdir $basedir/gpdb.slice
+        chmod -R 777 $basedir/gpdb.slice
 EOF
 }
 

--- a/concourse/scripts/ic_resgroup.bash
+++ b/concourse/scripts/ic_resgroup.bash
@@ -48,9 +48,9 @@ make_cgroups_dir() {
     ssh -t $gpdb_host_alias sudo bash -ex <<EOF
         for comp in cpuset cpu cpuacct memory; do
             chmod -R 777 $basedir/\$comp
-            mkdir -p $basedir/\$comp/gpdb
-            chown -R gpadmin:gpadmin $basedir/\$comp/gpdb
-            chmod -R 777 $basedir/\$comp/gpdb
+            mkdir -p $basedir/\$comp/gpdb.slice
+            chown -R gpadmin:gpadmin $basedir/\$comp/gpdb.slice
+            chmod -R 777 $basedir/\$comp/gpdb.slice
         done
 EOF
 }
@@ -106,10 +106,10 @@ keep_minimal_cgroup_dirs() {
     local basedir=$CGROUP_BASEDIR
 
     ssh -t $gpdb_master_alias sudo bash -ex <<EOF
-        rmdir $basedir/memory/gpdb/*/ || :
-        rmdir $basedir/memory/gpdb
-        rmdir $basedir/cpuset/gpdb/*/ || :
-        rmdir $basedir/cpuset/gpdb
+        rmdir $basedir/memory/gpdb.slice/*/ || :
+        rmdir $basedir/memory/gpdb.slice
+        rmdir $basedir/cpuset/gpdb.slice/*/ || :
+        rmdir $basedir/cpuset/gpdb.slice
 EOF
 }
 

--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -62,25 +62,25 @@ class CgroupValidationVersionOne(CgroupValidation):
         if not self.component_dirs:
             self.die("failed to detect cgroup component dirs.")
 
-        self.validate_permission("cpu", "gpdb/", "rwx")
-        self.validate_permission("cpu", "gpdb/cgroup.procs", "rw")
-        self.validate_permission("cpu", "gpdb/cpu.cfs_period_us", "rw")
-        self.validate_permission("cpu", "gpdb/cpu.cfs_quota_us", "rw")
-        self.validate_permission("cpu", "gpdb/cpu.shares", "rw")
+        self.validate_permission("cpu", "gpdb.slice/", "rwx")
+        self.validate_permission("cpu", "gpdb.slice/cgroup.procs", "rw")
+        self.validate_permission("cpu", "gpdb.slice/cpu.cfs_period_us", "rw")
+        self.validate_permission("cpu", "gpdb.slice/cpu.cfs_quota_us", "rw")
+        self.validate_permission("cpu", "gpdb.slice/cpu.shares", "rw")
 
-        self.validate_permission("cpuacct", "gpdb/", "rwx")
-        self.validate_permission("cpuacct", "gpdb/cgroup.procs", "rw")
-        self.validate_permission("cpuacct", "gpdb/cpuacct.usage", "r")
-        self.validate_permission("cpuacct", "gpdb/cpuacct.stat", "r")
+        self.validate_permission("cpuacct", "gpdb.slice/", "rwx")
+        self.validate_permission("cpuacct", "gpdb.slice/cgroup.procs", "rw")
+        self.validate_permission("cpuacct", "gpdb.slice/cpuacct.usage", "r")
+        self.validate_permission("cpuacct", "gpdb.slice/cpuacct.stat", "r")
 
-        self.validate_permission("cpuset", "gpdb/", "rwx")
-        self.validate_permission("cpuset", "gpdb/cgroup.procs", "rw")
-        self.validate_permission("cpuset", "gpdb/cpuset.cpus", "rw")
-        self.validate_permission("cpuset", "gpdb/cpuset.mems", "rw")
+        self.validate_permission("cpuset", "gpdb.slice/", "rwx")
+        self.validate_permission("cpuset", "gpdb.slice/cgroup.procs", "rw")
+        self.validate_permission("cpuset", "gpdb.slice/cpuset.cpus", "rw")
+        self.validate_permission("cpuset", "gpdb.slice/cpuset.mems", "rw")
 
-        self.validate_permission("memory", "gpdb/", "rwx")
-        self.validate_permission("memory", "gpdb/cgroup.procs", "rw")
-        self.validate_permission("memory", "gpdb/memory.usage_in_bytes", "r")
+        self.validate_permission("memory", "gpdb.slice/", "rwx")
+        self.validate_permission("memory", "gpdb.slice/cgroup.procs", "rw")
+        self.validate_permission("memory", "gpdb.slice/memory.usage_in_bytes", "r")
 
         self.validate_comp_hierarchy()
 
@@ -123,7 +123,7 @@ class CgroupValidationVersionOne(CgroupValidation):
                 return False
 
             component_dir = self.component_dirs[comp]
-            fullpath = os.path.join(self.mount_point, comp, component_dir, 'gpdb')
+            fullpath = os.path.join(self.mount_point, comp, component_dir, 'gpdb.slice')
 
             if not os.access(fullpath, os.R_OK | os.W_OK | os.X_OK):
                 return False

--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -43,24 +43,24 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
         self.validate_permission("cgroup.procs", "rw")
 
-        self.validate_permission("gpdb/", "rwx")
-        self.validate_permission("gpdb/cgroup.procs", "rw")
+        self.validate_permission("gpdb.slice/", "rwx")
+        self.validate_permission("gpdb.slice/cgroup.procs", "rw")
 
-        self.validate_permission("gpdb/cpu.max", "rw")
-        self.validate_permission("gpdb/cpu.pressure", "rw")
-        self.validate_permission("gpdb/cpu.weight", "rw")
-        self.validate_permission("gpdb/cpu.weight.nice", "rw")
-        self.validate_permission("gpdb/cpu.stat", "r")
+        self.validate_permission("gpdb.slice/cpu.max", "rw")
+        self.validate_permission("gpdb.slice/cpu.pressure", "rw")
+        self.validate_permission("gpdb.slice/cpu.weight", "rw")
+        self.validate_permission("gpdb.slice/cpu.weight.nice", "rw")
+        self.validate_permission("gpdb.slice/cpu.stat", "r")
 
-        self.validate_permission("gpdb/cpuset.cpus", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.partition", "rw")
-        self.validate_permission("gpdb/cpuset.mems", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.effective", "r")
-        self.validate_permission("gpdb/cpuset.mems.effective", "r")
+        self.validate_permission("gpdb.slice/cpuset.cpus", "rw")
+        self.validate_permission("gpdb.slice/cpuset.cpus.partition", "rw")
+        self.validate_permission("gpdb.slice/cpuset.mems", "rw")
+        self.validate_permission("gpdb.slice/cpuset.cpus.effective", "r")
+        self.validate_permission("gpdb.slice/cpuset.mems.effective", "r")
 
-        self.validate_permission("gpdb/memory.current", "r")
+        self.validate_permission("gpdb.slice/memory.current", "r")
 
-        self.validate_permission("gpdb/io.max", "rw")
+        self.validate_permission("gpdb.slice/io.max", "rw")
 
     def die(self, msg):
         raise ValidationException("cgroup is not properly configured: {}".format(msg))

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
@@ -38,25 +38,25 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
 
         self.cgroup_default_mntpnt = self.cgroup.detect_cgroup_mount_point()
 
-        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"), 0o700)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cgroup.procs"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_period_us"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_quota_us"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.shares"), 0o600)
+        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"), 0o700)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cgroup.procs"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_period_us"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_quota_us"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.shares"), 0o600)
 
-        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"), 0o700)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cgroup.procs"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.usage"), 0o400)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.stat"), 0o400)
+        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"), 0o700)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cgroup.procs"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.usage"), 0o400)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.stat"), 0o400)
 
-        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"), 0o700)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cgroup.procs"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.cpus"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.mems"), 0o600)
+        os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"), 0o700)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cgroup.procs"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.cpus"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.mems"), 0o600)
 
-        os.mkdir(os.path.join(self.cgroup_mntpnt, "memory", "gpdb"), 0o700)
-        self.touch(os.path.join(self.cgroup_mntpnt, "memory", "gpdb", "cgroup.procs"), 0o600)
-        self.touch(os.path.join(self.cgroup_mntpnt, "memory", "gpdb", "memory.usage_in_bytes"), 0o600)
+        os.mkdir(os.path.join(self.cgroup_mntpnt, "memory", "gpdb.slice"), 0o700)
+        self.touch(os.path.join(self.cgroup_mntpnt, "memory", "gpdb.slice", "cgroup.procs"), 0o600)
+        self.touch(os.path.join(self.cgroup_mntpnt, "memory", "gpdb.slice", "memory.usage_in_bytes"), 0o600)
 
     def tearDown(self):
         shutil.rmtree(self.cgroup_mntpnt)
@@ -84,33 +84,33 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         self.assertTrue(self.cgroup.validate_comp_dirs())
 
     def test_comp_dirs_validation_when_cpu_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"), 0o100)
         self.assertFalse(self.cgroup.validate_comp_dirs())
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"), 0o700)
 
     def test_comp_dirs_validation_when_cpu_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"))
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"))
         self.assertFalse(self.cgroup.validate_comp_dirs())
 
     def test_comp_dirs_validation_when_cpuacct_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"), 0o100)
         self.assertFalse(self.cgroup.validate_comp_dirs())
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"), 0o700)
 
     def test_comp_dirs_validation_when_cpuacct_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"))
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"))
         self.assertFalse(self.cgroup.validate_comp_dirs())
 
     def test_comp_dirs_validation_when_cpuset_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"), 0o100)
         if gpver.version >= [6, 0, 0]:
             self.assertFalse(self.cgroup.validate_comp_dirs())
         else:
             self.assertTrue(self.cgroup.validate_comp_dirs())
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"), 0o700)
 
     def test_comp_dirs_validation_when_cpuset_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"))
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"))
         if gpver.version >= [6, 0, 0]:
             self.assertFalse(self.cgroup.validate_comp_dirs())
         else:
@@ -136,161 +136,161 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"))
-        with self.assertRaisesRegex(AssertionError, "directory '.*/cpu/gpdb/' does not exist"):
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"))
+        with self.assertRaisesRegex(AssertionError, "directory '.*/cpu/gpdb.slice/' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"), 0o500)
-        with self.assertRaisesRegex(AssertionError, "directory '.*/cpu/gpdb/' permission denied: require permission 'rwx'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"), 0o500)
+        with self.assertRaisesRegex(AssertionError, "directory '.*/cpu/gpdb.slice/' permission denied: require permission 'rwx'"):
             self.cgroup.validate_all()
         # restore permission for the dir to be removed in tearDown()
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice"), 0o700)
 
     def test_when_cpu_gpdb_cgroup_procs_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cgroup.procs"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cgroup.procs' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cgroup.procs"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cgroup.procs' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cgroup_procs_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cgroup.procs"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cgroup.procs' permission denied: require permission 'rw'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cgroup.procs"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cgroup.procs' permission denied: require permission 'rw'"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_cfs_period_us_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_period_us"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.cfs_period_us' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_period_us"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.cfs_period_us' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_cfs_period_us_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_period_us"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.cfs_period_us' permission denied: require permission 'rw'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_period_us"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.cfs_period_us' permission denied: require permission 'rw'"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_cfs_quota_us_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_quota_us"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.cfs_quota_us' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_quota_us"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.cfs_quota_us' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_cfs_quota_us_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.cfs_quota_us"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.cfs_quota_us' permission denied: require permission 'rw'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.cfs_quota_us"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.cfs_quota_us' permission denied: require permission 'rw'"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_shares_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.shares"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.shares' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.shares"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.shares' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpu_gpdb_cpu_shares_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb", "cpu.shares"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb/cpu.shares' permission denied: require permission 'rw'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpu", "gpdb.slice", "cpu.shares"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpu/gpdb.slice/cpu.shares' permission denied: require permission 'rw'"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"))
-        with self.assertRaisesRegex(AssertionError, "directory '.*/cpuacct/gpdb/' does not exist"):
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"))
+        with self.assertRaisesRegex(AssertionError, "directory '.*/cpuacct/gpdb.slice/' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"), 0o500)
-        with self.assertRaisesRegex(AssertionError, "directory '.*/cpuacct/gpdb/' permission denied: require permission 'rwx'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"), 0o500)
+        with self.assertRaisesRegex(AssertionError, "directory '.*/cpuacct/gpdb.slice/' permission denied: require permission 'rwx'"):
             self.cgroup.validate_all()
         # restore permission for the dir to be removed in tearDown()
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice"), 0o700)
 
     def test_when_cpuacct_gpdb_cgroup_procs_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cgroup.procs"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cgroup.procs' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cgroup.procs"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cgroup.procs' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_cgroup_procs_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cgroup.procs"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cgroup.procs' permission denied: require permission 'rw'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cgroup.procs"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cgroup.procs' permission denied: require permission 'rw'"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_cpuacct_usage_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.usage"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cpuacct.usage' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.usage"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cpuacct.usage' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_cpuacct_usage_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.usage"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cpuacct.usage' permission denied: require permission 'r'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.usage"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cpuacct.usage' permission denied: require permission 'r'"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_cpuacct_stat_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.stat"))
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cpuacct.stat' does not exist"):
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.stat"))
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cpuacct.stat' does not exist"):
             self.cgroup.validate_all()
 
     def test_when_cpuacct_gpdb_cpuacct_stat_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb", "cpuacct.stat"), 0o100)
-        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb/cpuacct.stat' permission denied: require permission 'r'"):
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuacct", "gpdb.slice", "cpuacct.stat"), 0o100)
+        with self.assertRaisesRegex(AssertionError, "file '.*/cpuacct/gpdb.slice/cpuacct.stat' permission denied: require permission 'r'"):
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_dir_missing(self):
-        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"))
+        shutil.rmtree(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"))
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "directory '.*/cpuset/gpdb/' does not exist"):
+            with self.assertRaisesRegex(AssertionError, "directory '.*/cpuset/gpdb.slice/' does not exist"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_dir_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"), 0o500)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"), 0o500)
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "directory '.*/cpuset/gpdb/' permission denied: require permission 'rwx'"):
+            with self.assertRaisesRegex(AssertionError, "directory '.*/cpuset/gpdb.slice/' permission denied: require permission 'rwx'"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
         # restore permission for the dir to be removed in tearDown()
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb"), 0o700)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice"), 0o700)
 
     def test_when_cpuset_gpdb_cgroup_procs_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cgroup.procs"))
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cgroup.procs"))
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cgroup.procs' does not exist"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cgroup.procs' does not exist"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_cgroup_procs_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cgroup.procs"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cgroup.procs"), 0o100)
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cgroup.procs' permission denied: require permission 'rw'"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cgroup.procs' permission denied: require permission 'rw'"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_cpuset_cpus_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.cpus"))
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.cpus"))
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cpuset.cpus' does not exist"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cpuset.cpus' does not exist"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_cpuset_cpus_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.cpus"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.cpus"), 0o100)
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cpuset.cpus' permission denied: require permission 'rw'"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cpuset.cpus' permission denied: require permission 'rw'"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_cpuset_mems_missing(self):
-        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.mems"))
+        os.unlink(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.mems"))
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cpuset.mems' does not exist"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cpuset.mems' does not exist"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()
 
     def test_when_cpuset_gpdb_cpuset_mems_bad_permission(self):
-        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb", "cpuset.mems"), 0o100)
+        os.chmod(os.path.join(self.cgroup_mntpnt, "cpuset", "gpdb.slice", "cpuset.mems"), 0o100)
         if gpver.version >= [6, 0, 0]:
-            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb/cpuset.mems' permission denied: require permission 'rw'"):
+            with self.assertRaisesRegex(AssertionError, "file '.*/cpuset/gpdb.slice/cpuset.mems' permission denied: require permission 'rw'"):
                 self.cgroup.validate_all()
         else:
             self.cgroup.validate_all()

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -720,7 +720,7 @@ getcpuusage_v2(Oid group)
 	int status = regexec(&reg, buffer, 1, &pmatch, 0);
 
 	if (status == REG_NOMATCH)
-		CGROUP_ERROR("can't read the value of usage_usec from /sys/fs/cgroup/gpdb/cpu.stat");
+		CGROUP_ERROR("can't read the value of usage_usec from /sys/fs/cgroup/gpdb.slice/cpu.stat");
 	else if (pmatch.rm_so != -1)
 		memcpy(result, buffer + pmatch.rm_so + strlen("usage_usec "), pmatch.rm_eo - pmatch.rm_so);
 

--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -97,14 +97,14 @@ setComponentDir(CGroupComponentType component, const char *dir)
  *
  * - buildPath(ROOT, PARENT, CPU, ""     ): /sys/fs/cgroup/cpu
  * - buildPath(ROOT, PARENT, CPU, "tasks"): /sys/fs/cgroup/cpu/tasks
- * - buildPath(ROOT, GPDB  , CPU, "tasks"): /sys/fs/cgroup/cpu/gpdb/tasks
+ * - buildPath(ROOT, GPDB  , CPU, "tasks"): /sys/fs/cgroup/cpu/gpdb.slice/tasks
  *
  * - buildPath(ROOT, PARENT, ALL, "     "): /sys/fs/cgroup/
  * - buildPath(ROOT, PARENT, ALL, "tasks"): /sys/fs/cgroup/tasks
- * - buildPath(ROOT, GPDB  , ALL, "tasks"): /sys/fs/cgroup/gpdb/tasks
+ * - buildPath(ROOT, GPDB  , ALL, "tasks"): /sys/fs/cgroup/gpdb.slice/tasks
  *
- * - buildPath(6437, GPDB  , CPU, "tasks"): /sys/fs/cgroup/cpu/gpdb/6437/tasks
- * - buildPath(6437, GPDB  , ALL, "tasks"): /sys/fs/cgroup/gpdb/6437/tasks
+ * - buildPath(6437, GPDB  , CPU, "tasks"): /sys/fs/cgroup/cpu/gpdb.slice/6437/tasks
+ * - buildPath(6437, GPDB  , ALL, "tasks"): /sys/fs/cgroup/gpdb.slice/6437/tasks
  */
 void
 buildPath(Oid group,
@@ -147,7 +147,7 @@ buildPathSafe(Oid group,
 	Assert(base == BASEDIR_GPDB || base == BASEDIR_PARENT);
 
 	if (base == BASEDIR_GPDB)
-		base_dir = "/gpdb";
+		base_dir = "/gpdb.slice";
 	else
 		base_dir = "";
 
@@ -174,7 +174,7 @@ buildPathSafe(Oid group,
 		 * for cgroup v2, we just have the top level and child level,
 		 * don't need to care about the component.
 		 */
-		base_dir = base == BASEDIR_GPDB ? "gpdb" : "";
+		base_dir = base == BASEDIR_GPDB ? "gpdb.slice" : "";
 		len = snprintf(path, path_size, "%s/%s%s/%s",
 					   cgroupSystemInfo->cgroup_dir, base_dir, group_dir, filename);
 	}

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
@@ -4,12 +4,12 @@
 -- CPUSET, and the Cgroup file is exist or not.
 --
 -- In Cgroup v1 (Alpha), we will check the directory of
---  /sys/fs/cgroup/cpu/gpdb
---  /sys/fs/cgroup/cpuacct/gpdb
--- /sys/fs/cgroup/cpuset/gpdb
+--  /sys/fs/cgroup/cpu/gpdb.slice
+--  /sys/fs/cgroup/cpuacct/gpdb.slice
+-- /sys/fs/cgroup/cpuset/gpdb.slice
 --
 -- In Cgroup v2 (Beta), we will check the directory of
--- /sys/fs/cgroup/gpdb/*
+-- /sys/fs/cgroup/gpdb.slice/*
 --
 -- When we run different tests, we should include different auxiliary tool files
 -- to schedule file.
@@ -66,12 +66,12 @@ ERROR:  language "plpython3u" already exists
 root = '/sys/fs/cgroup/' 
 def get_cgroup_prop(prop): fullpath = os.path.join(root, prop) return int(open(fullpath).readline()) 
 def show_guc(guc): return plpy.execute('SHOW {}'.format(guc))[0][guc] 
-# get top-level cgroup props cfs_quota_us = get_cgroup_prop('cpu/gpdb/cpu.cfs_quota_us') cfs_period_us = get_cgroup_prop('cpu/gpdb/cpu.cfs_period_us') shares = get_cgroup_prop('cpu/gpdb/cpu.shares') 
+# get top-level cgroup props cfs_quota_us = get_cgroup_prop('cpu/gpdb.slice/cpu.cfs_quota_us') cfs_period_us = get_cgroup_prop('cpu/gpdb.slice/cpu.cfs_period_us') shares = get_cgroup_prop('cpu/gpdb.slice/cpu.shares') 
 # get system props ncores = os.cpu_count() 
 # get global gucs gp_resource_group_cpu_limit = float(show_guc('gp_resource_group_cpu_limit')) gp_resource_group_cpu_priority = int(show_guc('gp_resource_group_cpu_priority')) 
 # cfs_quota_us := cfs_period_us * ncores * gp_resource_group_cpu_limit assert cfs_quota_us == cfs_period_us * ncores * gp_resource_group_cpu_limit 
 # shares := 1024 * gp_resource_group_cpu_priority assert shares == 1024 * gp_resource_group_cpu_priority 
-def check_group_shares(name): cpu_weight = int(plpy.execute(''' SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=3 AND g.rsgname='{}' '''.format(name))[0]['value']) oid = int(plpy.execute(''' SELECT oid FROM pg_resgroup WHERE rsgname='{}' '''.format(name))[0]['oid']) sub_shares = get_cgroup_prop('cpu/gpdb/{}/cpu.shares'.format(oid)) assert sub_shares == int(cpu_weight * 1024 / 100) 
+def check_group_shares(name): cpu_weight = int(plpy.execute(''' SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=3 AND g.rsgname='{}' '''.format(name))[0]['value']) oid = int(plpy.execute(''' SELECT oid FROM pg_resgroup WHERE rsgname='{}' '''.format(name))[0]['oid']) sub_shares = get_cgroup_prop('cpu/gpdb.slice/{}/cpu.shares'.format(oid)) assert sub_shares == int(cpu_weight * 1024 / 100) 
 # check default groups check_group_shares('default_group') check_group_shares('admin_group') check_group_shares('system_group') 
 # check user groups check_group_shares('rg1_cpu_test') check_group_shares('rg2_cpu_test') 
 return True $$ LANGUAGE plpython3u;
@@ -86,7 +86,7 @@ CREATE FUNCTION
 pt = re.compile(r'con(\d+)') 
 def check(expect_cpus, sess_ids): # use ps -eF to find all processes which belongs to postgres and in the given sessions procs = subprocess.check_output(['ps', '-eF']).decode().split('\n') head, proc_stats = procs[0], procs[1:] PSR = [id for id, attr in enumerate(head.split()) if attr.strip() == 'PSR'][0] cpus = [proc_stat.split()[PSR].strip() for proc_stat in proc_stats if 'postgres' in proc_stat and pt.findall(proc_stat) and sess_ids.issubset(set(pt.findall(proc_stat)))] return set(cpus).issubset(set(expect_cpus)) 
 def get_all_sess_ids_in_group(group_name): sql = "select sess_id from pg_stat_activity where rsgname = '%s'" % group_name result = plpy.execute(sql) return set([str(r['sess_id']) for r in result]) 
-conf = cpuset if conf == '': fd = open("/sys/fs/cgroup/cpuset/gpdb/cpuset.cpus") line = fd.readline() fd.close() conf = line.strip('\n') 
+conf = cpuset if conf == '': fd = open("/sys/fs/cgroup/cpuset/gpdb.slice/cpuset.cpus") line = fd.readline() fd.close() conf = line.strip('\n') 
 tokens = conf.split(",") 
 expect_cpu = [] 
 for token in tokens: if token.find('-') != -1: interval = token.split("-") num1 = interval[0] num2 = interval[1] for num in range(int(num1), int(num2) + 1): expect_cpu.append(str(num)) else: expect_cpu.append(token) sess_ids = get_all_sess_ids_in_group(grp) 
@@ -96,16 +96,16 @@ CREATE FUNCTION
 
 -- create a resource group that contains all the cpu cores
 0: CREATE OR REPLACE FUNCTION create_allcores_group(grp TEXT) RETURNS BOOL AS $$ import subprocess 
-file = "/sys/fs/cgroup/cpuset/gpdb/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
+file = "/sys/fs/cgroup/cpuset/gpdb.slice/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
 # plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
-file = "/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
+file = "/sys/fs/cgroup/cpuset/gpdb.slice/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
 return True $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
 -- check whether the cpuset value in cgroup is valid according to the rule
 0: CREATE OR REPLACE FUNCTION check_cpuset_rules() RETURNS BOOL AS $$ def get_all_group_which_cpuset_is_set(): sql = "select groupid,cpuset from gp_toolkit.gp_resgroup_config where cpuset != '-1'" result = plpy.execute(sql) return result 
 def parse_cpuset(line): line = line.strip('\n') if len(line) == 0: return set([]) tokens = line.split(",") cpuset = [] for token in tokens: if token.find('-') != -1: interval = token.split("-") num1 = interval[0] num2 = interval[1] for num in range(int(num1), int(num2) + 1): cpuset.append(str(num)) else: cpuset.append(token) return set(cpuset) 
-def get_cgroup_cpuset(group): group = str(group) if group == '0': file = "/sys/fs/cgroup/cpuset/gpdb/cpuset.cpus" else: file = "/sys/fs/cgroup/cpuset/gpdb/" + group + "/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() return parse_cpuset(line) 
+def get_cgroup_cpuset(group): group = str(group) if group == '0': file = "/sys/fs/cgroup/cpuset/gpdb.slice/cpuset.cpus" else: file = "/sys/fs/cgroup/cpuset/gpdb.slice/" + group + "/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() return parse_cpuset(line) 
 config_groups = get_all_group_which_cpuset_is_set() groups_cpuset = set([]) 
 # check whether cpuset in config and cgroup are same, and have no overlap for config_group in config_groups: groupid = config_group['groupid'] cpuset_value = config_group['cpuset'] config_cpuset = parse_cpuset(cpuset_value) cgroup_cpuset = get_cgroup_cpuset(groupid) if len(groups_cpuset & cgroup_cpuset) > 0: return False groups_cpuset |= cgroup_cpuset 
 if not (config_cpuset.issubset(cgroup_cpuset) and cgroup_cpuset.issubset(config_cpuset)): return False 
@@ -119,7 +119,7 @@ sql = "select sess_id from pg_stat_activity where pid = '%d'" % pid result = plp
 sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 sql = "select hostname from gp_segment_configuration group by hostname" result = plpy.execute(sql) hosts = [_['hostname'] for _ in result] 
 def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], capture_output=True, check=True).stdout session_pids = stdout.splitlines() 
-path = "/sys/fs/cgroup/cpu/gpdb/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
+path = "/sys/fs/cgroup/cpu/gpdb.slice/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
 return set(session_pids).issubset(set(cgroups_pids)) 
 for host in hosts: if not get_result(host): return False return True 
 $$ LANGUAGE plpython3u;

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -4,12 +4,12 @@
 -- CPUSET, and the Cgroup file is exist or not.
 --
 -- In Cgroup v1 (Alpha), we will check the directory of
---  /sys/fs/cgroup/cpu/gpdb
---  /sys/fs/cgroup/cpuacct/gpdb
--- /sys/fs/cgroup/cpuset/gpdb
+--  /sys/fs/cgroup/cpu/gpdb.slice
+--  /sys/fs/cgroup/cpuacct/gpdb.slice
+-- /sys/fs/cgroup/cpuset/gpdb.slice
 --
 -- In Cgroup v2 (Beta), we will check the directory of
--- /sys/fs/cgroup/gpdb/*
+-- /sys/fs/cgroup/gpdb.slice/*
 --
 -- When we run different tests, we should include different auxiliary tool files
 -- to schedule file.
@@ -66,11 +66,11 @@ ERROR:  language "plpython3u" already exists
 root = '/sys/fs/cgroup/' 
 def get_cgroup_prop(prop): fullpath = os.path.join(root, prop) return int(open(fullpath).readline()) 
 def show_guc(guc): return plpy.execute('SHOW {}'.format(guc))[0][guc] 
-# get top-level cgroup props shares = get_cgroup_prop('gpdb/cpu.weight') 
+# get top-level cgroup props shares = get_cgroup_prop('gpdb.slice/cpu.weight') 
 # get system props ncores = os.cpu_count() 
 # get global gucs gp_resource_group_cpu_limit = float(show_guc('gp_resource_group_cpu_limit')) gp_resource_group_cpu_priority = int(show_guc('gp_resource_group_cpu_priority')) 
 # shares := 100 * gp_resource_group_cpu_priority assert shares == 100 * gp_resource_group_cpu_priority 
-def check_group_shares(name): cpu_weight = int(plpy.execute(''' SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=3 AND g.rsgname='{}' '''.format(name))[0]['value']) oid = int(plpy.execute(''' SELECT oid FROM pg_resgroup WHERE rsgname='{}' '''.format(name))[0]['oid']) sub_shares = get_cgroup_prop('gpdb/{}/cpu.weight'.format(oid)) assert sub_shares == int(cpu_weight * 1024 / 100) 
+def check_group_shares(name): cpu_weight = int(plpy.execute(''' SELECT value FROM pg_resgroupcapability c, pg_resgroup g WHERE c.resgroupid=g.oid AND reslimittype=3 AND g.rsgname='{}' '''.format(name))[0]['value']) oid = int(plpy.execute(''' SELECT oid FROM pg_resgroup WHERE rsgname='{}' '''.format(name))[0]['oid']) sub_shares = get_cgroup_prop('gpdb.slice/{}/cpu.weight'.format(oid)) assert sub_shares == int(cpu_weight * 1024 / 100) 
 # check default groups check_group_shares('default_group') check_group_shares('admin_group') check_group_shares('system_group') 
 # check user groups check_group_shares('rg1_cpu_test') check_group_shares('rg2_cpu_test') 
 return True $$ LANGUAGE plpython3u;
@@ -85,7 +85,7 @@ CREATE FUNCTION
 pt = re.compile(r'con(\d+)') 
 def check(expect_cpus, sess_ids): # use ps -eF to find all processes which belongs to postgres and in the given sessions procs = subprocess.check_output(['ps', '-eF']).decode().split('\n') head, proc_stats = procs[0], procs[1:] PSR = [id for id, attr in enumerate(head.split()) if attr.strip() == 'PSR'][0] cpus = [proc_stat.split()[PSR].strip() for proc_stat in proc_stats if 'postgres' in proc_stat and pt.findall(proc_stat) and sess_ids.issubset(set(pt.findall(proc_stat)))] return set(cpus).issubset(set(expect_cpus)) 
 def get_all_sess_ids_in_group(group_name): sql = "select sess_id from pg_stat_activity where rsgname = '%s'" % group_name result = plpy.execute(sql) return set([str(r['sess_id']) for r in result]) 
-conf = cpuset if conf == '': fd = open("/sys/fs/cgroup/gpdb/cpuset.cpus") line = fd.readline() fd.close() conf = line.strip('\n') 
+conf = cpuset if conf == '': fd = open("/sys/fs/cgroup/gpdb.slice/cpuset.cpus") line = fd.readline() fd.close() conf = line.strip('\n') 
 tokens = conf.split(",") 
 expect_cpu = [] 
 for token in tokens: if token.find('-') != -1: interval = token.split("-") num1 = interval[0] num2 = interval[1] for num in range(int(num1), int(num2) + 1): expect_cpu.append(str(num)) else: expect_cpu.append(token) sess_ids = get_all_sess_ids_in_group(grp) 
@@ -95,16 +95,16 @@ CREATE FUNCTION
 
 -- create a resource group that contains all the cpu cores
 0: CREATE OR REPLACE FUNCTION create_allcores_group(grp TEXT) RETURNS BOOL AS $$ import subprocess 
-file = "/sys/fs/cgroup/gpdb/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
+file = "/sys/fs/cgroup/gpdb.slice/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
 # plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
-file = "/sys/fs/cgroup/gpdb/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
+file = "/sys/fs/cgroup/gpdb.slice/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
 return True $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
 -- check whether the cpuset value in cgroup is valid according to the rule
 0: CREATE OR REPLACE FUNCTION check_cpuset_rules() RETURNS BOOL AS $$ def get_all_group_which_cpuset_is_set(): sql = "select groupid,cpuset from gp_toolkit.gp_resgroup_config where cpuset != '-1'" result = plpy.execute(sql) return result 
 def parse_cpuset(line): line = line.strip('\n') if len(line) == 0: return set([]) tokens = line.split(",") cpuset = [] for token in tokens: if token.find('-') != -1: interval = token.split("-") num1 = interval[0] num2 = interval[1] for num in range(int(num1), int(num2) + 1): cpuset.append(str(num)) else: cpuset.append(token) return set(cpuset) 
-def get_cgroup_cpuset(group): group = str(group) if group == '0': file = "/sys/fs/cgroup/gpdb/cpuset.cpus" else: file = "/sys/fs/cgroup/gpdb/" + group + "/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() return parse_cpuset(line) 
+def get_cgroup_cpuset(group): group = str(group) if group == '0': file = "/sys/fs/cgroup/gpdb.slice/cpuset.cpus" else: file = "/sys/fs/cgroup/gpdb.slice/" + group + "/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() return parse_cpuset(line) 
 config_groups = get_all_group_which_cpuset_is_set() groups_cpuset = set([]) 
 # check whether cpuset in config and cgroup are same, and have no overlap for config_group in config_groups: groupid = config_group['groupid'] cpuset_value = config_group['cpuset'] config_cpuset = parse_cpuset(cpuset_value) cgroup_cpuset = get_cgroup_cpuset(groupid) if len(groups_cpuset & cgroup_cpuset) > 0: return False groups_cpuset |= cgroup_cpuset 
 if not (config_cpuset.issubset(cgroup_cpuset) and cgroup_cpuset.issubset(config_cpuset)): return False 
@@ -118,7 +118,7 @@ sql = "select sess_id from pg_stat_activity where pid = '%d'" % pid result = plp
 sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 sql = "select hostname from gp_segment_configuration group by hostname" result = plpy.execute(sql) hosts = [_['hostname'] for _ in result] 
 def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], capture_output=True, check=True).stdout session_pids = stdout.splitlines() 
-path = "/sys/fs/cgroup/gpdb/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
+path = "/sys/fs/cgroup/gpdb.slice/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
 return set(session_pids).issubset(set(cgroups_pids)) 
 for host in hosts: if not get_result(host): return False return True 
 $$ LANGUAGE plpython3u;
@@ -127,7 +127,7 @@ CREATE FUNCTION
 0: CREATE OR REPLACE FUNCTION check_cgroup_io_max(groupname text, tablespace_name text, parameters text) RETURNS BOOL AS $$ import ctypes import os 
 postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_oid = postgres['get_tablespace_oid'] 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
-cgroup_path = "/sys/fs/cgroup/gpdb/%d" % groupid 
+cgroup_path = "/sys/fs/cgroup/gpdb.slice/%d" % groupid 
 # get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = ctypes.cast(get_tablespace_path(spcoid), ctypes.c_char_p).value 
 if location == "": return False 
 bdi = get_bdi_of_path(location) major = os.major(bdi) minor = os.minor(bdi) 
@@ -152,6 +152,6 @@ CREATE FUNCTION
 postgres = ctypes.CDLL(None) clear_io_max = postgres['clear_io_max'] 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 clear_io_max(groupid) 
-cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid 
+cgroup_path = "/sys/fs/cgroup/gpdb.slice/%d/io.max" % groupid 
 return os.stat(cgroup_path).st_size == 0 $$ LANGUAGE plpython3u;
 CREATE FUNCTION

--- a/src/test/isolation2/expected/resgroup/resgroup_cpuset_empty_default.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cpuset_empty_default.out
@@ -5,7 +5,7 @@
 -- CREATE / ALTER RESOURCE GROUP, but missing in startup logic, an empty cpu
 -- core list "" is set to cgroup and cause a runtime error:
 --
---     can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus':
+--     can't write data to file '/sys/fs/cgroup/cpuset/gpdb.slice/1/cpuset.cpus':
 --       No space left on device (resgroup-ops-linux.c:916)
 --
 -- To trigger the issue we create a resource group, allocate all the cpu cores

--- a/src/test/isolation2/sql/resgroup/resgroup_cpuset_empty_default.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cpuset_empty_default.sql
@@ -5,7 +5,7 @@
 -- CREATE / ALTER RESOURCE GROUP, but missing in startup logic, an empty cpu
 -- core list "" is set to cgroup and cause a runtime error:
 --
---     can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus':
+--     can't write data to file '/sys/fs/cgroup/cpuset/gpdb.slice/1/cpuset.cpus':
 --       No space left on device (resgroup-ops-linux.c:916)
 --
 -- To trigger the issue we create a resource group, allocate all the cpu cores


### PR DESCRIPTION
[slice](https://www.freedesktop.org/software/systemd/man/systemd.slice.html) is a systemd standard for cgroup naming. Docker's cgroup-parent parameter need the cgroup name end with `.slice` when use cgroup v2.

PLContainer support use cgroup of gpdb as the cgroup-parent of container, in cgroup v1, it works well. And now some customers want to use this function in cgroup v2,so gpdb's cgroup name should end with '.slice':
```
> docker run -it --rm  --cgroup-parent=/gpdb alpine                                                        
docker: Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice".
See 'docker run --help'.
```

This pr only contains renames.