### PR TITLE
[ORCA] Fix bug checking index_can_return()

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1039,27 +1039,27 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 
 	for (int i = 0; i < form_pg_index->indnatts; i++)
 	{
-		INT attno = form_pg_index->indkey.values[i];
-		GPOS_ASSERT(0 != attno && "Index expressions not supported");
+		INT colno = form_pg_index->indkey.values[i];
+		GPOS_ASSERT(0 != colno && "Index expressions not supported");
 
 		// key columns are indexed [0, indnkeyatts)
 		if (i < form_pg_index->indnkeyatts)
 		{
 			index_key_cols_array->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
 		}
 		// include columns are indexed [indnkeyatts, indnatts)
 		else
 		{
 			included_cols->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
 		}
 
 		// check if index can return column for index-only scans
-		if (gpdb::IndexCanReturn(index_rel.get(), attno))
+		if (gpdb::IndexCanReturn(index_rel.get(), i + 1))
 		{
 			returnable_cols->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
 		}
 	}
 

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1039,27 +1039,27 @@ CTranslatorRelcacheToDXL::RetrieveIndex(CMemoryPool *mp,
 
 	for (int i = 0; i < form_pg_index->indnatts; i++)
 	{
-		INT colno = form_pg_index->indkey.values[i];
-		GPOS_ASSERT(0 != colno && "Index expressions not supported");
+		INT attno = form_pg_index->indkey.values[i];
+		GPOS_ASSERT(0 != attno && "Index expressions not supported");
 
 		// key columns are indexed [0, indnkeyatts)
 		if (i < form_pg_index->indnkeyatts)
 		{
 			index_key_cols_array->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 		}
 		// include columns are indexed [indnkeyatts, indnatts)
 		else
 		{
 			included_cols->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 		}
 
 		// check if index can return column for index-only scans
 		if (gpdb::IndexCanReturn(index_rel.get(), i + 1))
 		{
 			returnable_cols->Append(
-				GPOS_NEW(mp) ULONG(GetAttributePosition(colno, attno_mapping)));
+				GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
 		}
 	}
 

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -706,6 +706,38 @@ SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+CREATE TABLE tsvector_table(t text, a tsvector) DISTRIBUTED BY (t);
+INSERT INTO tsvector_table values('\n', '');
+CREATE INDEX a_gist_index ON tsvector_table USING GIST (a);
+-- Check index-only-scan is not used when index can not return column
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+-- expect fallback
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT count(*) FROM tsvector_table WHERE a @@ 'w:*|q:*';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+         ->  Partial Aggregate (actual rows=1 loops=1)
+               ->  Bitmap Heap Scan on tsvector_table (actual rows=0 loops=1)
+                     Recheck Cond: (a @@ '''w'':* | ''q'':*'::tsquery)
+                     ->  Bitmap Index Scan on a_gist_index (actual rows=1 loops=1)
+                           Index Cond: (a @@ '''w'':* | ''q'':*'::tsquery)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+SELECT count(*) FROM tsvector_table WHERE a @@ 'w:*|q:*';
+ count 
+-------
+     0
+(1 row)
+
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_bitmapscan;
+RESET optimizer_enable_tablescan;
 -- KEYS: [a]    INCLUDED: [b]
 -- Check support dynamic-index-only-scan on GIST indexes
 CREATE TABLE test_partition_table_with_gist_index(a int, b_box box)

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -680,6 +680,42 @@ SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+CREATE TABLE tsvector_table(t text, a tsvector) DISTRIBUTED BY (t);
+INSERT INTO tsvector_table values('\n', '');
+CREATE INDEX a_gist_index ON tsvector_table USING GIST (a);
+-- Check index-only-scan is not used when index can not return column
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+-- expect fallback
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT count(*) FROM tsvector_table WHERE a @@ 'w:*|q:*';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+         ->  Partial Aggregate (actual rows=1 loops=1)
+               ->  Bitmap Heap Scan on tsvector_table (actual rows=0 loops=1)
+                     Recheck Cond: (a @@ '''w'':* | ''q'':*'::tsquery)
+                     ->  Bitmap Index Scan on a_gist_index (actual rows=1 loops=1)
+                           Index Cond: (a @@ '''w'':* | ''q'':*'::tsquery)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+SELECT count(*) FROM tsvector_table WHERE a @@ 'w:*|q:*';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
+ count 
+-------
+     0
+(1 row)
+
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_bitmapscan;
+RESET optimizer_enable_tablescan;
 -- KEYS: [a]    INCLUDED: [b]
 -- Check support dynamic-index-only-scan on GIST indexes
 CREATE TABLE test_partition_table_with_gist_index(a int, b_box box)


### PR DESCRIPTION
ORCA uses index_can_return() to check whether an index can return a
given column's data. The result determines whether an index-only-scan
plan is allowed. The function uses attno, however ORCA erroneously
passed the column number instead. This caused ORCA to incorrectly allow
an index-only-scan plan.

See get_relation_info() usage of index_can_return() attno for PLANNER.