### PR TITLE
Add missing dep pyscopg2 for ubuntu readme

### DIFF
--- a/README.Ubuntu.bash
+++ b/README.Ubuntu.bash
@@ -35,6 +35,7 @@ sudo apt-get install -y \
 	pkg-config \
 	python3-dev \
 	python3-pip \
+	python3-psycopg2 \
 	python3-psutil \
 	python3-yaml \
 	zlib1g-dev


### PR DESCRIPTION
Fix #16571
