### PR TITLE
Update the statistic info of hash join temporary files

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -2528,12 +2528,11 @@ ExecHashTableExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 
 		appendStringInfo(buf,
 						 "Work file set: %u files (%u compressed), "
-						 "max file size %lu, min file size %lu, "
+						 "avg file size %lu, "
 						 "compression buffer size %lu bytes \n",
 						 hashtable->workset_num_files,
 						 hashtable->workset_num_files_compressed,
-						 hashtable->workset_max_file_size,
-						 hashtable->workset_min_file_size,
+						 hashtable->workset_avg_file_size,
 						 hashtable->workset_compression_buf_total);
 		ResetWorkFileSetStatsInfo(hashtable);
     }
@@ -3938,7 +3937,6 @@ static inline void ResetWorkFileSetStatsInfo(HashJoinTable hashtable)
 {
 	hashtable->workset_num_files = 0;
 	hashtable->workset_num_files_compressed = 0;
-	hashtable->workset_max_file_size = 0;
-	hashtable->workset_min_file_size = 0;
+	hashtable->workset_avg_file_size = 0;
 	hashtable->workset_compression_buf_total = 0;
 }

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -420,12 +420,6 @@ UpdateWorkFileSize(File file, uint64 newsize)
 	perquery->total_bytes += diff;
 	workfile_shared->total_bytes += diff;
 
-	if (newsize > work_set->max_file_size)
-		work_set->max_file_size = newsize;
-	if (work_set->min_file_size == 0 ||
-		newsize < work_set->min_file_size)
-		work_set->min_file_size = newsize;
-
 	/* also update the local entry */
 	localEntry->size = newsize;
 
@@ -643,8 +637,6 @@ workfile_mgr_create_set_internal(const char *operator_name, const char *prefix)
 	work_set->total_bytes = 0;
 	work_set->active = true;
 	work_set->pinned = false;
-	work_set->max_file_size = 0;
-	work_set->min_file_size = 0;
 	work_set->compression_buf_total = 0;
 	work_set->num_files_compressed = 0;
 

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -409,8 +409,7 @@ typedef struct HashJoinTableData
 	/* Statistic info of work file set, copied from work_set */
 	uint32		workset_num_files;
 	uint32		workset_num_files_compressed;
-	uint64		workset_max_file_size;
-	uint64		workset_min_file_size;
+	uint64		workset_avg_file_size;
 	uint64		workset_compression_buf_total;
 }			HashJoinTableData;
 

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -411,7 +411,7 @@ typedef struct HashJoinTableData
 	uint32		workset_num_files_compressed;
 	uint64		workset_avg_file_size;
 	/* Not used, just to for ABI compatibility */
-	uint64		workset_min_file_size;
+	uint64		workset_abi_reserved;
 	uint64		workset_compression_buf_total;
 }			HashJoinTableData;
 

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -410,6 +410,8 @@ typedef struct HashJoinTableData
 	uint32		workset_num_files;
 	uint32		workset_num_files_compressed;
 	uint64		workset_avg_file_size;
+	/* Not used, just to for ABI compatibility */
+	uint64		workset_min_file_size;
 	uint64		workset_compression_buf_total;
 }			HashJoinTableData;
 

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -91,6 +91,9 @@ typedef struct workfile_set
 	/* Average work file size */
 	uint64		avg_file_size;
 
+	/* Not used, just to for ABI compatibility */
+	uint64		min_file_size;
+
 	/* Total memory usage by compression buffer */
 	uint64		compression_buf_total;
 

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -92,7 +92,7 @@ typedef struct workfile_set
 	uint64		avg_file_size;
 
 	/* Not used, just to for ABI compatibility */
-	uint64		min_file_size;
+	uint64		abi_reserved;
 
 	/* Total memory usage by compression buffer */
 	uint64		compression_buf_total;

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -88,11 +88,8 @@ typedef struct workfile_set
 	/* Used to track workfile_set created in current process */
 	dlist_node	local_node;
 
-	/* Max work file size */
-	uint64		max_file_size;
-
-	/* Min work file size */
-	uint64		min_file_size;
+	/* Average work file size */
+	uint64		avg_file_size;
 
 	/* Total memory usage by compression buffer */
 	uint64		compression_buf_total;

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -21,13 +21,12 @@ INSERT INTO test_zlib_hashjoin SELECT i,i,i,i,i,i,i,i FROM
 create language plpython3u;
 -- end_ignore
 -- Check if compressed work file count is limited to file_count_limit
--- If the parameter upper_or_lower is true, it means the comp_workfile_created
--- must be equal or smaller than file_count_limit;
--- If the parameter upper_or_lower is false, it means the comp_workfile_created
--- must be equal or larger than file_count_limit.
+-- If the parameter is_comp_buff_limit is true, it means the comp_workfile_created
+-- must be smaller than file_count_limit because some work files are not compressed;
+-- If the parameter is_comp_buff_limit is false, it means the comp_workfile_created
+-- must be equal to file_count_limit because all work files are compressed.
 create or replace function check_workfile_compressed(explain_query text,
-    file_count_limit int,
-    upper_or_lower bool)
+    is_comp_buff_limit bool)
 returns setof int as
 $$
 import re
@@ -35,16 +34,16 @@ rv = plpy.execute(explain_query)
 search_text = 'Work file set'
 result = []
 for i in range(len(rv)):
-    #cur_line = rv[i]['QUERY PLAN']
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('(\d+) compressed')
+        p = re.compile('(\d+) files \((\d+) compressed\)')
         m = p.search(cur_line)
-        comp_workfile_created = int(m.group(1))
-        if upper_or_lower:
-            result.append(int(comp_workfile_created <= file_count_limit))
+        workfile_created = int(m.group(1))
+        comp_workfile_created = int(m.group(2))
+        if is_comp_buff_limit:
+            result.append(int(comp_workfile_created < workfile_created))
         else:
-            result.append(int(comp_workfile_created >= file_count_limit))
+            result.append(int(comp_workfile_created == workfile_created))
 return result
 $$
 language plpython3u;
@@ -207,8 +206,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1
@@ -235,7 +233,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-4, true) limit 6;
+true) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1
@@ -263,8 +261,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -191,7 +191,7 @@ set statement_mem='2MB';
 set gp_workfile_compression=on;
 set gp_workfile_limit_files_per_query=0;
 -- Run the query with a large value of gp_workfile_compression_overhead_limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 set gp_workfile_compression_overhead_limit=2048000;
 select * from check_workfile_compressed('
 explain (analyze)
@@ -218,7 +218,7 @@ false) limit 6;
 (6 rows)
 
 -- Run the query with a smaller value of gp_workfile_compression_overhead_limit
--- The compressed file number should be no more than 4
+-- The compressed file number should be less than total work file number
 set gp_workfile_compression_overhead_limit=5000;
 select * from check_workfile_compressed('
 explain (analyze)
@@ -246,7 +246,7 @@ true) limit 6;
 
 -- Run the query with gp_workfile_compression_overhead_limit=0, which means
 -- no limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 set gp_workfile_compression_overhead_limit=0;
 select * from check_workfile_compressed('
 explain (analyze)

--- a/src/test/regress/expected/zlib_optimizer.out
+++ b/src/test/regress/expected/zlib_optimizer.out
@@ -21,13 +21,12 @@ INSERT INTO test_zlib_hashjoin SELECT i,i,i,i,i,i,i,i FROM
 create language plpython3u;
 -- end_ignore
 -- Check if compressed work file count is limited to file_count_limit
--- If the parameter upper_or_lower is true, it means the comp_workfile_created
--- must be equal or smaller than file_count_limit;
--- If the parameter upper_or_lower is false, it means the comp_workfile_created
--- must be equal or larger than file_count_limit.
+-- If the parameter is_comp_buff_limit is true, it means the comp_workfile_created
+-- must be smaller than file_count_limit because some work files are not compressed;
+-- If the parameter is_comp_buff_limit is false, it means the comp_workfile_created
+-- must be equal to file_count_limit because all work files are compressed.
 create or replace function check_workfile_compressed(explain_query text,
-    file_count_limit int,
-    upper_or_lower bool)
+    is_comp_buff_limit bool)
 returns setof int as
 $$
 import re
@@ -35,16 +34,16 @@ rv = plpy.execute(explain_query)
 search_text = 'Work file set'
 result = []
 for i in range(len(rv)):
-    #cur_line = rv[i]['QUERY PLAN']
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('(\d+) compressed')
+        p = re.compile('(\d+) files \((\d+) compressed\)')
         m = p.search(cur_line)
-        comp_workfile_created = int(m.group(1))
-        if upper_or_lower:
-            result.append(int(comp_workfile_created <= file_count_limit))
+        workfile_created = int(m.group(1))
+        comp_workfile_created = int(m.group(2))
+        if is_comp_buff_limit:
+            result.append(int(comp_workfile_created < workfile_created))
         else:
-            result.append(int(comp_workfile_created >= file_count_limit))
+            result.append(int(comp_workfile_created == workfile_created))
 return result
 $$
 language plpython3u;
@@ -207,8 +206,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1
@@ -235,7 +233,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-4, true) limit 6;
+true) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1
@@ -263,8 +261,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
  check_workfile_compressed 
 ---------------------------
                          1

--- a/src/test/regress/expected/zlib_optimizer.out
+++ b/src/test/regress/expected/zlib_optimizer.out
@@ -191,7 +191,7 @@ set statement_mem='2MB';
 set gp_workfile_compression=on;
 set gp_workfile_limit_files_per_query=0;
 -- Run the query with a large value of gp_workfile_compression_overhead_limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 set gp_workfile_compression_overhead_limit=2048000;
 select * from check_workfile_compressed('
 explain (analyze)
@@ -218,7 +218,7 @@ false) limit 6;
 (6 rows)
 
 -- Run the query with a smaller value of gp_workfile_compression_overhead_limit
--- The compressed file number should be no more than 4
+-- The compressed file number should be less than total work file number
 set gp_workfile_compression_overhead_limit=5000;
 select * from check_workfile_compressed('
 explain (analyze)
@@ -246,7 +246,7 @@ true) limit 6;
 
 -- Run the query with gp_workfile_compression_overhead_limit=0, which means
 -- no limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 set gp_workfile_compression_overhead_limit=0;
 select * from check_workfile_compressed('
 explain (analyze)

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -137,7 +137,7 @@ set gp_workfile_compression=on;
 set gp_workfile_limit_files_per_query=0;
 
 -- Run the query with a large value of gp_workfile_compression_overhead_limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 
 set gp_workfile_compression_overhead_limit=2048000;
 
@@ -157,7 +157,7 @@ inner join  F on A.a::text = F.a ;',
 false) limit 6;
 
 -- Run the query with a smaller value of gp_workfile_compression_overhead_limit
--- The compressed file number should be no more than 4
+-- The compressed file number should be less than total work file number
 
 set gp_workfile_compression_overhead_limit=5000;
 
@@ -178,7 +178,7 @@ true) limit 6;
 
 -- Run the query with gp_workfile_compression_overhead_limit=0, which means
 -- no limit
--- The compressed file number should be at least 7
+-- The compressed file number should be equal to total work file number
 
 set gp_workfile_compression_overhead_limit=0;
 

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -24,13 +24,12 @@ create language plpython3u;
 -- end_ignore
 
 -- Check if compressed work file count is limited to file_count_limit
--- If the parameter upper_or_lower is true, it means the comp_workfile_created
--- must be equal or smaller than file_count_limit;
--- If the parameter upper_or_lower is false, it means the comp_workfile_created
--- must be equal or larger than file_count_limit.
+-- If the parameter is_comp_buff_limit is true, it means the comp_workfile_created
+-- must be smaller than file_count_limit because some work files are not compressed;
+-- If the parameter is_comp_buff_limit is false, it means the comp_workfile_created
+-- must be equal to file_count_limit because all work files are compressed.
 create or replace function check_workfile_compressed(explain_query text,
-    file_count_limit int,
-    upper_or_lower bool)
+    is_comp_buff_limit bool)
 returns setof int as
 $$
 import re
@@ -38,16 +37,16 @@ rv = plpy.execute(explain_query)
 search_text = 'Work file set'
 result = []
 for i in range(len(rv)):
-    #cur_line = rv[i]['QUERY PLAN']
     cur_line = rv[i]['QUERY PLAN']
     if search_text.lower() in cur_line.lower():
-        p = re.compile('(\d+) compressed')
+        p = re.compile('(\d+) files \((\d+) compressed\)')
         m = p.search(cur_line)
-        comp_workfile_created = int(m.group(1))
-        if upper_or_lower:
-            result.append(int(comp_workfile_created <= file_count_limit))
+        workfile_created = int(m.group(1))
+        comp_workfile_created = int(m.group(2))
+        if is_comp_buff_limit:
+            result.append(int(comp_workfile_created < workfile_created))
         else:
-            result.append(int(comp_workfile_created >= file_count_limit))
+            result.append(int(comp_workfile_created == workfile_created))
 return result
 $$
 language plpython3u;
@@ -155,8 +154,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
 
 -- Run the query with a smaller value of gp_workfile_compression_overhead_limit
 -- The compressed file number should be no more than 4
@@ -176,7 +174,7 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-4, true) limit 6;
+true) limit 6;
 
 -- Run the query with gp_workfile_compression_overhead_limit=0, which means
 -- no limit
@@ -197,7 +195,6 @@ inner join  C on A.a = C.a
 inner join  D on A.a = D.a
 inner join  E on A.a = E.a
 inner join  F on A.a::text = F.a ;',
-7,
-false);
+false) limit 6;
 
 DROP TABLE test_zlib_memlimit;


### PR DESCRIPTION
1. Remove the max/min file size in the statistic info of temporary files, and add the average file size.
2. Include the statistic info of temporary files of the hash table and the outer table.
