### PR TITLE
Fix missing " in subpartition template name

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -9236,9 +9236,9 @@ get_rule_expr(Node *node, deparse_context *context,
 					if (elem->partName)
 					{
 						if (elem->isDefault)
-							appendStringInfo(buf, "DEFAULT SUBPARTITION %s", elem->partName);
+							appendStringInfo(buf, "DEFAULT SUBPARTITION %s", quote_identifier(elem->partName));
 						else
-							appendStringInfo(buf, "SUBPARTITION %s", elem->partName);
+							appendStringInfo(buf, "SUBPARTITION %s", quote_identifier(elem->partName));
 					}
 
 					if (elem->boundSpec)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6533,7 +6533,7 @@ select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -
 (2 rows)
 
 drop table test_listPartition;
--- Test case witt missing " for special-char for subpartition template name
+-- Test case witt missing " for special-char in subpartition template name
 -- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
 CREATE TABLE public.logs_issue_16558
 (

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6561,4 +6561,14 @@ SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHER
      1 | SUBPARTITION TEMPLATE(SUBPARTITION "1 2" VALUES ('1', '2', '3'))
 (1 row)
 
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    DEFAULT SUBPARTITION "1 2"
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+ level |                    pg_get_expr                    
+-------+---------------------------------------------------
+     1 | SUBPARTITION TEMPLATE(DEFAULT SUBPARTITION "1 2")
+(1 row)
+
 DROP TABLE public.logs_issue_16558;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6533,3 +6533,32 @@ select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -
 (2 rows)
 
 drop table test_listPartition;
+-- Test case witt missing " for special-char for subpartition template name
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
+CREATE TABLE public.logs_issue_16558
+(
+  log_id integer,
+  log_date date,
+  log_type text
+)
+WITH (APPENDONLY=FALSE)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(log_date)
+    SUBPARTITION BY LIST(log_type)
+(
+    PARTITION p1 START ('2023-01-01') END ('2023-03-31') WITH (APPENDONLY=FALSE)
+    (
+        SUBPARTITION s1 VALUES ('1', '2', '3') WITH (APPENDONLY=FALSE)
+    )
+);
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    SUBPARTITION "1 2" VALUES ('1', '2', '3')
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+ level |                           pg_get_expr                            
+-------+------------------------------------------------------------------
+     1 | SUBPARTITION TEMPLATE(SUBPARTITION "1 2" VALUES ('1', '2', '3'))
+(1 row)
+
+DROP TABLE public.logs_issue_16558;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6532,4 +6532,14 @@ SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHER
      1 | SUBPARTITION TEMPLATE(SUBPARTITION "1 2" VALUES ('1', '2', '3'))
 (1 row)
 
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    DEFAULT SUBPARTITION "1 2"
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+ level |                    pg_get_expr                    
+-------+---------------------------------------------------
+     1 | SUBPARTITION TEMPLATE(DEFAULT SUBPARTITION "1 2")
+(1 row)
+
 DROP TABLE public.logs_issue_16558;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6504,3 +6504,32 @@ select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -
 (2 rows)
 
 drop table test_listPartition;
+-- Test case witt missing " for special-char for subpartition template name
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
+CREATE TABLE public.logs_issue_16558
+(
+  log_id integer,
+  log_date date,
+  log_type text
+)
+WITH (APPENDONLY=FALSE)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(log_date)
+    SUBPARTITION BY LIST(log_type)
+(
+    PARTITION p1 START ('2023-01-01') END ('2023-03-31') WITH (APPENDONLY=FALSE)
+    (
+        SUBPARTITION s1 VALUES ('1', '2', '3') WITH (APPENDONLY=FALSE)
+    )
+);
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    SUBPARTITION "1 2" VALUES ('1', '2', '3')
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+ level |                           pg_get_expr                            
+-------+------------------------------------------------------------------
+     1 | SUBPARTITION TEMPLATE(SUBPARTITION "1 2" VALUES ('1', '2', '3'))
+(1 row)
+
+DROP TABLE public.logs_issue_16558;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6504,7 +6504,7 @@ select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -
 (2 rows)
 
 drop table test_listPartition;
--- Test case witt missing " for special-char for subpartition template name
+-- Test case witt missing " for special-char in subpartition template name
 -- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
 CREATE TABLE public.logs_issue_16558
 (

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4167,4 +4167,9 @@ ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
     SUBPARTITION "1 2" VALUES ('1', '2', '3')
 );
 SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    DEFAULT SUBPARTITION "1 2"
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
 DROP TABLE public.logs_issue_16558;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4144,7 +4144,7 @@ select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -
 
 drop table test_listPartition;
 
--- Test case witt missing " for special-char for subpartition template name
+-- Test case witt missing " for special-char in subpartition template name
 -- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
 CREATE TABLE public.logs_issue_16558
 (

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4143,3 +4143,28 @@ explain (costs off) select d from test_listPartition where d='2022-10-23' or d=(
 select d from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -interval '1 day');
 
 drop table test_listPartition;
+
+-- Test case witt missing " for special-char for subpartition template name
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/16558
+CREATE TABLE public.logs_issue_16558
+(
+  log_id integer,
+  log_date date,
+  log_type text
+)
+WITH (APPENDONLY=FALSE)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(log_date)
+    SUBPARTITION BY LIST(log_type)
+(
+    PARTITION p1 START ('2023-01-01') END ('2023-03-31') WITH (APPENDONLY=FALSE)
+    (
+        SUBPARTITION s1 VALUES ('1', '2', '3') WITH (APPENDONLY=FALSE)
+    )
+);
+ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
+(
+    SUBPARTITION "1 2" VALUES ('1', '2', '3')
+);
+SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
+DROP TABLE public.logs_issue_16558;


### PR DESCRIPTION
Long log:

This commit can fix the bug reported in https://github.com/greenplum-db/gpdb/issues/16558
Solution is simple, use `quote_identifier` to add quotes if needed.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
Co-authored-by: Hovhannes Tsakanyan <thovhannes@vmware.com>