### PR TITLE
Fix missing check return value of pg_strcasecmp.

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -614,12 +614,14 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts, bool hasStorage)
 
 				if (opts->compresstype[0])
 				{
-					if (gp_quicklz_fallback && pg_strcasecmp(opts->compresstype, "quicklz"))				
+					if (gp_quicklz_fallback && pg_strcasecmp(opts->compresstype, "quicklz") == 0)
+					{						
 #ifdef USE_ZSTD
 						compresstype = "zstd";
 #else
 						compresstype = AO_DEFAULT_USABLE_COMPRESSTYPE;
-#endif				
+#endif
+					}
 					else
 						compresstype = opts->compresstype;
 				}

--- a/src/test/regress/expected/quicklz_fallback.out
+++ b/src/test/regress/expected/quicklz_fallback.out
@@ -36,6 +36,16 @@ DROP TABLE quicklz_err;
 -- Ensure statements correctly fall back to a different compresstype when gp_quicklz_fallback=true.
 SET gp_quicklz_fallback = true;
 SET gp_default_storage_options='';
+-- with gp_quicklz_fallback set to true, create table using other compress type
+-- should not be impacted
+CREATE TABLE zlib_with(a int) USING ao_column WITH (compresstype=zlib) DISTRIBUTED BY (a);
+select reloptions::text like '%compresstype=zlib%' as ok from pg_class where oid = 'zlib_with'::regclass::oid;
+ ok 
+----
+ t
+(1 row)
+
+DROP TABLE zlib_with;
 -- Fill in column encoding from WITH clause
 CREATE TABLE quicklz_with(c1 int, c2 int) USING ao_column WITH (compresstype=quicklz) DISTRIBUTED BY (c1);
 \d+ quicklz_with

--- a/src/test/regress/sql/quicklz_fallback.sql
+++ b/src/test/regress/sql/quicklz_fallback.sql
@@ -35,6 +35,12 @@ DROP TABLE quicklz_err;
 SET gp_quicklz_fallback = true;
 SET gp_default_storage_options='';
 
+-- with gp_quicklz_fallback set to true, create table using other compress type
+-- should not be impacted
+CREATE TABLE zlib_with(a int) USING ao_column WITH (compresstype=zlib) DISTRIBUTED BY (a);
+select reloptions::text like '%compresstype=zlib%' as ok from pg_class where oid = 'zlib_with'::regclass::oid;
+DROP TABLE zlib_with;
+
 -- Fill in column encoding from WITH clause
 CREATE TABLE quicklz_with(c1 int, c2 int) USING ao_column WITH (compresstype=quicklz) DISTRIBUTED BY (c1);
 \d+ quicklz_with


### PR DESCRIPTION
We should not directly use the return value of pg_strcasecmp.
