### PR TITLE
docs - clarify ALTER SERVER option actions

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SERVER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SERVER.html.md
@@ -34,7 +34,8 @@ new\_version
 :   The new server version.
 
 OPTIONS \( \[ ADD \| SET \| DROP \] option \['value'\] \[, ... \] \)
-:   Change the server's options. `ADD`, `SET`, and `DROP` specify the action to perform. If no operation is explicitly specified, the default operation is `ADD`. Option names must be unique. Greenplum Database validates names and values using the server's foreign-data wrapper library.
+:   Change the server's options. `ADD`, `SET`, and `DROP` specify the action to perform. Option names must be unique. Greenplum Database validates names and values using the server's foreign-data wrapper library.
+:   Use `ADD` to define an option that is not currently set. Use `SET` to change the value of an option that you previously defined. If you do not explicitly specify an action, the default operation is `ADD`.
 
 new\_owner
 :   Specifies the new owner of the foreign server.


### PR DESCRIPTION
see https://greenplum.slack.com/archives/C04JJQ5AHJ4/p1691999617535799.

greenplum behaves the same as postgresql.  the default action for an ALTER SERVER on an option is ADD.  if you specified an option when you created the server (or if you previously altered the server and specified that option), the option is considered to be already defined.  an ALTER SERVER command with no action for that option is attempting to add that option again.  to change/replace an option, the user should specify the SET action.

the error "provided more than once" is slightly misleading, as is noted in this message from the postgresql message board:  https://www.postgresql.org/message-id/10352.1374877685%40sss.pgh.pa.us.  (i don't think the postgresql community acted on the recommendation in that message.)

i updated the description of the OPTIONS keyword on the ALTER SERVER sql reference page to better identify the behaviour.
