### PR TITLE
gpexpand: skip expanded/broken tables when redistributing

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -10,6 +10,7 @@ import copy
 import datetime
 import os
 import random
+import re
 import sys
 import json
 import shutil
@@ -1381,7 +1382,7 @@ class gpexpand:
         dbconn.execSQL(self.conn, "CHECKPOINT")
         self.conn.close()
 
-        # increase expand version 
+        # increase expand version
         self.conn = dbconn.connect(self.dburl, utility=True, encoding='UTF8')
         dbconn.execSQL(self.conn, "select gp_expand_bump_version()")
         self.conn.close()
@@ -1760,7 +1761,7 @@ class gpexpand:
             FROM
                 pg_inherits a,
                 pg_partitioned_table b,
-                pg_class c, 
+                pg_class c,
                 pg_class d,
                 pg_namespace n
             WHERE
@@ -2072,8 +2073,17 @@ class ExpandTable():
 
         # check is atomic in python
         if not cancel_flag:
-            dbconn.execSQL(table_conn, sql)
-            # the ALTER TABLE command requires a commit to execute
+            try:
+                dbconn.execSQL(table_conn, sql)
+            except DatabaseError as e:
+                if re.search('DETAIL:\s*table has already been expanded', str(e)):
+                    logger.info('Table %s.%s seems to be already expanded, marking as done' % (self.dbname, self.fq_name))
+                elif re.search('\s*could not open relation with (OID \d+ )?', str(e)):
+                    logger.warning('Encountered unexpected issue when expanding table %s.%s, skipping' % (self.dbname, self.fq_name))
+                    table_conn.rollback()
+                    return False
+                else:
+                    raise
             table_conn.commit()
             if self.options.analyze:
                 sql = 'ANALYZE %s' % (self.fq_name)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2927,6 +2927,7 @@ def _gpexpand_redistribute(context, duration=False, endtime=False):
     gpexpand = Gpexpand(context, working_directory=context.working_directory)
     context.command = gpexpand
     ret_code, std_err, std_out = gpexpand.redistribute(duration, endtime)
+    context.stdout_message = std_out
     if duration or endtime:
         if ret_code != 0:
             # gpexpand exited on time, it's expected
@@ -3257,6 +3258,23 @@ def impl(context):
             raise Exception("table %s has not finished expanding" % row[0])
     finally:
         conn.close()
+
+
+@then('table "{table_name}" {expansion_state} be marked as expanded')
+def impl(context, table_name, expansion_state):
+    dbname = 'postgres'
+    conn = dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)
+    try:
+        query = """select status from gpexpand.status_detail where fq_name='public.{0}'""".format(table_name)
+        result = dbconn.querySingleton(conn, query)
+
+        if result == 'NOT STARTED' and expansion_state == "should":
+            raise Exception("table {0} is not marked as expanded".format(table_name))
+        if result == "COMPLETED" and expansion_state == "should not":
+            raise Exception("table {0} is marked as expanded".format(table_name))
+    finally:
+        conn.close()
+
 
 @given('an FTS probe is triggered')
 @when('an FTS probe is triggered')


### PR DESCRIPTION
This commit is a cherry-pick of the community PR #15961. In summary `gpexpand redistribution` earlier used to error out when the table would have been already expanded manually by the user or the table would have been damaged. This commit changes this behaviour so that any expanded/broken tables are skipped without affecting the redistribution for other tables.