### PR TITLE
Init ICProxy's SHM variable in CreateSharedMemoryAndSemaphores()

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -519,25 +519,6 @@ ic_proxy_backend_init_context(ChunkTransportState *state)
 }
 
 /*
- * Check if current Segment's IC_PROXY listener failed
- */
-bool
-ic_proxy_backend_check_listener_failed(void)
-{
-	bool found;
-	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
-											sizeof(*ic_proxy_peer_listener_failed),
-											&found);
-
-	Assert(ic_proxy_peer_listener_failed != NULL);
-	/* init it to 0 when the backend accesses it firstly */
-	if (!found)
-		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
-
-	return pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0;
-}
-
-/*
  * Close the icproxy backend context
  */
 void

--- a/src/backend/cdb/motion/ic_proxy_backend.h
+++ b/src/backend/cdb/motion/ic_proxy_backend.h
@@ -13,7 +13,6 @@
 #define IC_PROXY_BACKEND_H
 
 #include "postgres.h"
-#include "port/atomics.h"
 
 #include "cdb/cdbinterconnect.h"
 
@@ -48,6 +47,5 @@ extern void ic_proxy_backend_connect(ICProxyBackendContext *context,
 extern void ic_proxy_backend_init_context(ChunkTransportState *state);
 extern void ic_proxy_backend_close_context(ChunkTransportState *state);
 extern void ic_proxy_backend_run_loop(ICProxyBackendContext *context);
-extern bool ic_proxy_backend_check_listener_failed(void);
 
 #endif   /* IC_PROXY_BACKEND_H */

--- a/src/backend/cdb/motion/ic_proxy_bgworker.c
+++ b/src/backend/cdb/motion/ic_proxy_bgworker.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "storage/ipc.h"
+#include "storage/shmem.h"
 
 #include "cdb/ic_proxy_bgworker.h"
 #include "ic_proxy_server.h"
@@ -34,4 +35,23 @@ ICProxyMain(Datum main_arg)
 {
 	/* main loop */
 	proc_exit(ic_proxy_server_main());
+}
+
+Size
+ICProxyShmemSize(void)
+{
+	Size		size = 0;
+	size = add_size(size, sizeof(*ic_proxy_peer_listener_failed));
+	return size;
+}
+
+void
+ICProxyShmemInit(void)
+{
+	bool		found;
+	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
+													sizeof(*ic_proxy_peer_listener_failed),
+													&found);
+	if (!found)
+		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
 }

--- a/src/backend/cdb/motion/ic_proxy_bgworker.c
+++ b/src/backend/cdb/motion/ic_proxy_bgworker.c
@@ -37,6 +37,9 @@ ICProxyMain(Datum main_arg)
 	proc_exit(ic_proxy_server_main());
 }
 
+/*
+ * the size of ICProxy SHM structure
+ */
 Size
 ICProxyShmemSize(void)
 {
@@ -45,6 +48,9 @@ ICProxyShmemSize(void)
 	return size;
 }
 
+/*
+ * initialize ICProxy's SHM structure: only one flag variable
+ */
 void
 ICProxyShmemInit(void)
 {

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -537,19 +537,10 @@ int
 ic_proxy_server_main(void)
 {
 	char		path[MAXPGPATH];
-	bool		found;
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_TERSE,
 		   LOG, "ic-proxy: server setting up");
 
-	/* get and init failure flag */
-	ic_proxy_peer_listener_failed = ShmemInitStruct("IC_PROXY Listener Failure Flag",
-													sizeof(*ic_proxy_peer_listener_failed),
-													&found);
-	if (!found)
-		pg_atomic_init_u32(ic_proxy_peer_listener_failed, 0);
-	else
-		pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
-
+	pg_atomic_exchange_u32(ic_proxy_peer_listener_failed, 0);
 	ic_proxy_pkt_cache_init(IC_PROXY_MAX_PKT_SIZE);
 
 	uv_loop_init(&ic_proxy_server_loop);

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1292,7 +1292,8 @@ SetupTCPInterconnect(EState *estate)
 	interconnect_context->doSendStopMessage = doSendStopMessageTCP;
 
 #ifdef ENABLE_IC_PROXY
-	if (ic_proxy_backend_check_listener_failed())
+	/* Check if current Segment's IC_PROXY listener failed */
+	if (pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0)
 		elog(ERROR, "SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check.");
 	ic_proxy_backend_init_context(interconnect_context);
 #endif /* ENABLE_IC_PROXY */

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1292,7 +1292,7 @@ SetupTCPInterconnect(EState *estate)
 	interconnect_context->doSendStopMessage = doSendStopMessageTCP;
 
 #ifdef ENABLE_IC_PROXY
-	/* Check if current Segment's IC_PROXY listener failed */
+	/* check if current Segment's ICProxy listener failed */
 	if (pg_atomic_read_u32(ic_proxy_peer_listener_failed) > 0)
 		elog(ERROR, "SetupInterconnect: We are in IC_PROXY mode, but IC-Proxy Listener failed, please check.");
 	ic_proxy_backend_init_context(interconnect_context);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -428,11 +428,7 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 
 #ifdef ENABLE_IC_PROXY
 	{"ic proxy process", "ic proxy process",
-#ifdef FAULT_INJECTOR
 	 BGWORKER_SHMEM_ACCESS,
-#else
-	 0,
-#endif
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if ic proxy process exits with non-zero code */
 	 "postgres", "ICProxyMain", 0, {0}, 0,

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -70,6 +70,7 @@
 #include "utils/session_state.h"
 #include "cdb/cdbendpoint.h"
 #include "replication/gp_replication.h"
+#include "cdb/ic_proxy_bgworker.h"
 
 /* GUCs */
 int			shared_memory_type = DEFAULT_SHARED_MEMORY_TYPE;
@@ -200,6 +201,10 @@ CreateSharedMemoryAndSemaphores(int port)
 #ifdef FAULT_INJECTOR
 		size = add_size(size, FaultInjector_ShmemSize());
 #endif			
+
+#ifdef ENABLE_IC_PROXY
+		size = add_size(size, ICProxyShmemSize());
+#endif
 
 		/* This elog happens before we know the name of the log file we are supposed to use */
 		elog(DEBUG1, "Size not including the buffer pool %lu",
@@ -353,6 +358,10 @@ CreateSharedMemoryAndSemaphores(int port)
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_ShmemInit();
+#endif
+
+#ifdef ENABLE_IC_PROXY
+	ICProxyShmemInit();
 #endif
 
 	/*

--- a/src/include/cdb/ic_proxy_bgworker.h
+++ b/src/include/cdb/ic_proxy_bgworker.h
@@ -15,6 +15,7 @@
 
 #include "port/atomics.h"
 
+/* flag (in SHM) for incidaing if peer listener bind/listen failed */
 extern pg_atomic_uint32 *ic_proxy_peer_listener_failed;
 
 extern bool ICProxyStartRule(Datum main_arg);

--- a/src/include/cdb/ic_proxy_bgworker.h
+++ b/src/include/cdb/ic_proxy_bgworker.h
@@ -13,7 +13,13 @@
 #ifndef IC_PROXY_BGWORKER_H
 #define IC_PROXY_BGWORKER_H
 
+#include "port/atomics.h"
+
+extern pg_atomic_uint32 *ic_proxy_peer_listener_failed;
+
 extern bool ICProxyStartRule(Datum main_arg);
 extern void ICProxyMain(Datum main_arg);
+extern Size ICProxyShmemSize(void);
+extern void ICProxyShmemInit(void);
 
 #endif   /* IC_PROXY_BGWORKER_H */


### PR DESCRIPTION
My previous commit 8915cd09333961e203baf0255ca1a0f2c4d8607e caused coredump in some pipeline jobs.
Example stack:
```
Core was generated by `postgres:  7000, ic proxy process                                             '.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000000000b46ec3 in pg_atomic_read_u32_impl (ptr=0x7f05a8c51104) at ../../../../src/include/port/atomics/generic.h:48
(gdb) bt
#0  0x0000000000b46ec3 in pg_atomic_read_u32_impl (ptr=0x7f05a8c51104) at ../../../../src/include/port/atomics/generic.h:48
#1  pg_atomic_read_u32 (ptr=0x7f05a8c51104) at ../../../../src/include/port/atomics.h:247
#2  LWLockAttemptLock (mode=LW_EXCLUSIVE, lock=0x7f05a8c51100) at lwlock.c:751
#3  LWLockAcquire (lock=0x7f05a8c51100, mode=mode@entry=LW_EXCLUSIVE) at lwlock.c:1188
#4  0x0000000000b32fff in ShmemInitStruct (name=name@entry=0x130e160 "", size=size@entry=4, foundPtr=foundPtr@entry=0x7ffcf94513bf) at shmem.c:412
#5  0x0000000000d6d18e in ic_proxy_server_main () at ic_proxy_main.c:545
#6  0x0000000000d6c219 in ICProxyMain (main_arg=<optimized out>) at ic_proxy_bgworker.c:36
#7  0x0000000000aa9caa in StartBackgroundWorker () at bgworker.c:955
#8  0x0000000000ab9407 in do_start_bgworker (rw=<optimized out>) at postmaster.c:6450
#9  maybe_start_bgworkers () at postmaster.c:6706
#10 0x0000000000abbc59 in ServerLoop () at postmaster.c:2095
#11 0x0000000000abd777 in PostmasterMain (argc=argc@entry=5, argv=argv@entry=0x36e3650) at postmaster.c:1633
#12 0x00000000006e4764 in main (argc=5, argv=0x36e3650) at main.c:240
(gdb) p *ptr
Cannot access memory at address 0x7f05a8c51104
```

The root cause is I forgot to init SHM structure at `CreateSharedMemoryAndSemaphores()`.
Fix it in this PR.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
