### PR TITLE
[6X] gprecoverseg rebalance: revert 10 GB default value for replay lag

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -52,11 +52,6 @@ DEFAULT_MASTER_NUM_WORKERS=16
 #max batch size of thread pool on master
 MAX_MASTER_NUM_WORKERS=64
 
-# Maximum replay lag (in GBs) allowed on mirror when rebalancing the segments
-# The default value for ALLOWED_REPLAY_LAG has been decided to be 10 GBs as mirror
-# took 5 mins to replay 10 GB lag on a local demo cluster.
-ALLOWED_REPLAY_LAG = 10
-
 # Application name used by the pg_rewind instance that gprecoverseg starts
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -98,7 +98,7 @@ class GpRecoverSegmentProgram:
 
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
-            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.disableReplayLag, self.__options.replayLag)
+            return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.replayLag)
         else:
             instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
             segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
@@ -253,8 +253,8 @@ class GpRecoverSegmentProgram:
         if self.__options.differentialResynchronization and self.__options.outputSampleConfigFile:
             raise ProgramArgumentValidationException("Invalid -o provided with --differential argument")
 
-        if self.__options.disableReplayLag and not self.__options.rebalanceSegments:
-            raise ProgramArgumentValidationException("--disable-replay-lag should be used only with -r")
+        if self.__options.replayLag and not self.__options.rebalanceSegments:
+            raise ProgramArgumentValidationException("--replay-lag should be used only with -r")
 
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getMasterPort())
 
@@ -464,11 +464,9 @@ class GpRecoverSegmentProgram:
 
         addTo.add_option("-r", None, default=False, action='store_true',
                          dest='rebalanceSegments', help='Rebalance synchronized segments.')
-        addTo.add_option("--replay-lag", None, type="float", default=gp.ALLOWED_REPLAY_LAG,
+        addTo.add_option("--replay-lag", None, type="float",
                          dest="replayLag",
                          metavar="<replayLag>", help='Allowed replay lag on mirror, lag should be provided in GBs')
-        addTo.add_option("--disable-replay-lag", None, default=False, action='store_true',
-                         dest='disableReplayLag', help='Disable replay lag check when rebalancing segments')
         addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',
                          help='use hostnames instead of CIDR in pg_hba.conf')
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -24,7 +24,6 @@ class Options:
         self.recoveryConfigFile = None
         self.outputSpareDataDirectoryFile = None
         self.rebalanceSegments = None
-        self.disableReplayLag = None
         self.replayLag = None
 
         self.outputSampleConfigFile = None

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -14,7 +14,7 @@ gprecoverseg [-p <new_recover_host>[,...]]
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
 
-gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
+gprecoverseg -r [--replay-lag <replay_lag>]
 
 
 gprecoverseg -o <output_recover_config_file> 
@@ -244,13 +244,9 @@ running gprecoverseg -r. If there are any in progress queries, they will
 be cancelled and rolled back.
 
 --replay-lag
-Replay lag(in GBs) allowed on mirror when rebalancing the segments. Default is 10 GB. If
-the replay_lag (flush_lsn-replay_lsn) is more than the value provided with this option
-then rebalance will be aborted.
-
-
---disable-replay-lag
-Disable replay lag check when rebalancing segments
+Replay lag(in GBs) allowed on mirror when rebalancing the segments. If the replay_lag
+(flush_lsn-replay_lsn) is more than the value provided with this option then rebalance
+will be aborted.
 
 
 -s

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1913,36 +1913,19 @@ Feature: gprecoverseg tests
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And user immediately stops all primary processes for content 0
         And user can start transactions
+       When the user runs "gprecoverseg -av --replay-lag 10"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "--replay-lag should be used only with -r" to stdout
         When the user runs "gprecoverseg -av"
         Then gprecoverseg should return a return code of 0
         When the user runs "gprecoverseg -ar --replay-lag 0"
         Then gprecoverseg should return a return code of 2
+         And gprecoverseg should print "Allowed replay lag during rebalance is 0.0 GB" to stdout
          And gprecoverseg should print ".* bytes of xlog is still to be replayed on mirror with dbid.*, let mirror catchup on replay then trigger rebalance" regex to logfile
-        When the user runs "gprecoverseg -ar --disable-replay-lag"
+        When the user runs "gprecoverseg -ar"
         Then gprecoverseg should return a return code of 0
          And all the segments are running
          And user can start transactions
-
-  @demo_cluster
-  @concourse_cluster
-  Scenario: gprecoverseg errors out if invalid options are used with --disable-replay-lag
-      Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
-        And user immediately stops all primary processes for content 0,1,2
-        And user can start transactions
-       When the user runs "gprecoverseg -av"
-       Then gprecoverseg should return a return code of 0
-        And verify that mirror on content 0,1,2 is up
-       When the user runs "gprecoverseg -aF --disable-replay-lag"
-       Then gprecoverseg should return a return code of 2
-        And gprecoverseg should print "--disable-replay-lag should be used only with -r" to stdout
-        When the user runs "gprecoverseg -ar"
-        Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Allowed replay lag during rebalance is 10 GB" to stdout
-        And all the segments are running
-        And user can start transactions
 
 
     @remove_rsync_bash

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -10,7 +10,7 @@ gprecoverseg [[-p <new_recover_host>[,...]] | -i <recover_config_file>] [-d <coo
 	           [--hba-hostnames <boolean>] 
              [--no-progress] [-l <logfile_directory>]
 
-gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
+gprecoverseg -r [--replay-lag <replay_lag>]
 
 gprecoverseg -o <output_recover_config_file> 
              [-p <new_recover_host>[,...]]
@@ -169,10 +169,7 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 :   After a segment recovery, segment instances may not be returned to the preferred role that they were given at system initialization time. This can leave the system in a potentially unbalanced state, as some segment hosts may have more active segments than is optimal for top system performance. This option rebalances primary and mirror segments by returning them to their preferred roles. All segments must be valid and resynchronized before running `gprecoverseg -r`. If there are any in progress queries, they will be cancelled and rolled back.
 
 --replay-lag
-:   Replay lag(in GBs) allowed on mirror when rebalancing the segments. Default is 10 GB. If the replay_lag (flush_lsn-replay_lsn) is more than the value provided with this option then rebalance will be aborted.
-
---disable-replay-lag
-:   Disable replay lag check when rebalancing segments
+:   Replay lag(in GBs) allowed on mirror when rebalancing the segments. If the replay_lag (flush_lsn-replay_lsn) is more than the value provided with this option then rebalance will be aborted.
 
 -s \(sequential progress\)
 :   Show `pg_basebackup` or `pg_rewind` progress sequentially instead of in-place. Useful when writing to a file, or if a tty does not support escape sequences. The default is to show progress in-place.


### PR DESCRIPTION
Check for replay lag during rebalance was introduced in commit d5f26a703a91735b4798630d0894326e9961513d. The default value of replay lag is set to 10 GB which can be configured through --replay-lag flag. Reverting the default value of replay lag as the user can configure to any required value. --disable-replay-lag flag is not required now as there will be no replay lag check by default.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
