### PR TITLE
Avoid motion for lateral join contains function scan

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1591,3 +1591,40 @@ drop table random_dis_char;
 set optimizer_enable_hashjoin to on;
 reset enable_hashjoin;
 reset enable_nestloop;
+-- Test lateral join a subquery where the subquery contains a function can node
+-- that refs outer query's parameter.
+create table t1_funcscan (id int, c_jsonb jsonb);
+create table t2_funcscan (id int not null,  c1_var varchar(50) not null, c2_var varchar(50) not null);
+insert into t1_funcscan values (1, '[{"c1":"abc", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (2, '[{"c1":"abcd", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (3, '[{"c1":"abcde", "c2":"m", "c3":"s"}]');
+insert into t2_funcscan values(1, 'abc', 'abcd');
+explain (costs off)
+select * from t1_funcscan as a
+left join lateral (
+    select string_agg(distinct (case when a.c1='abc' then d.c2_var when a.c1='abcd' then a.c2 else a.c1 end), '||') from
+      jsonb_to_recordset(c_jsonb) as a (
+        c1 varchar,
+        c2 varchar,
+        c3 varchar
+        )
+        left join t2_funcscan d on lower(a.c1)=lower(d.c1_var)
+    ) c on 1 = 1;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1_funcscan a
+   ->  Materialize
+         ->  Aggregate
+               ->  Hash Left Join
+                     Hash Cond: (lower((a_1.c1)::text) = lower((d.c1_var)::text))
+                     ->  Function Scan on jsonb_to_recordset a_1
+                     ->  Hash
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on t2_funcscan d
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+drop table t1_funcscan;
+drop table t2_funcscan;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1601,3 +1601,40 @@ drop table random_dis_char;
 set optimizer_enable_hashjoin to on;
 reset enable_hashjoin;
 reset enable_nestloop;
+-- Test lateral join a subquery where the subquery contains a function can node
+-- that refs outer query's parameter.
+create table t1_funcscan (id int, c_jsonb jsonb);
+create table t2_funcscan (id int not null,  c1_var varchar(50) not null, c2_var varchar(50) not null);
+insert into t1_funcscan values (1, '[{"c1":"abc", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (2, '[{"c1":"abcd", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (3, '[{"c1":"abcde", "c2":"m", "c3":"s"}]');
+insert into t2_funcscan values(1, 'abc', 'abcd');
+explain (costs off)
+select * from t1_funcscan as a
+left join lateral (
+    select string_agg(distinct (case when a.c1='abc' then d.c2_var when a.c1='abcd' then a.c2 else a.c1 end), '||') from
+      jsonb_to_recordset(c_jsonb) as a (
+        c1 varchar,
+        c2 varchar,
+        c3 varchar
+        )
+        left join t2_funcscan d on lower(a.c1)=lower(d.c1_var)
+    ) c on 1 = 1;
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1_funcscan a
+   ->  Materialize
+         ->  Aggregate
+               ->  Hash Left Join
+                     Hash Cond: (lower((a_1.c1)::text) = lower((d.c1_var)::text))
+                     ->  Function Scan on jsonb_to_recordset a_1
+                     ->  Hash
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on t2_funcscan d
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+drop table t1_funcscan;
+drop table t2_funcscan;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -737,3 +737,28 @@ drop table random_dis_char;
 set optimizer_enable_hashjoin to on;
 reset enable_hashjoin;
 reset enable_nestloop;
+
+-- Test lateral join a subquery where the subquery contains a function can node
+-- that refs outer query's parameter.
+create table t1_funcscan (id int, c_jsonb jsonb);
+create table t2_funcscan (id int not null,  c1_var varchar(50) not null, c2_var varchar(50) not null);
+
+insert into t1_funcscan values (1, '[{"c1":"abc", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (2, '[{"c1":"abcd", "c2":"m", "c3":"s"}]');
+insert into t1_funcscan values (3, '[{"c1":"abcde", "c2":"m", "c3":"s"}]');
+insert into t2_funcscan values(1, 'abc', 'abcd');
+
+explain (costs off)
+select * from t1_funcscan as a
+left join lateral (
+    select string_agg(distinct (case when a.c1='abc' then d.c2_var when a.c1='abcd' then a.c2 else a.c1 end), '||') from
+      jsonb_to_recordset(c_jsonb) as a (
+        c1 varchar,
+        c2 varchar,
+        c3 varchar
+        )
+        left join t2_funcscan d on lower(a.c1)=lower(d.c1_var)
+    ) c on 1 = 1;
+
+drop table t1_funcscan;
+drop table t2_funcscan;


### PR DESCRIPTION
If a lateral join that joins a subquery, and the subquery contains a join and a function scan that refs the outer join. Then we should avoid motion on top of the function scan.

A typical case is:
      ```
create table t1_funcscan (id int, c_jsonb jsonb);
create table t2_funcscan (id int not null,  c1_var varchar(50) not null, c2_var varchar(50) not null);
select * from t1_funcscan as a
    left join lateral (
        select string_agg(distinct (case when a.c1='abc' then d.c2_var when
    a.c1='abcd' then a.c2 else a.c1 end), '||') from
          jsonb_to_recordset(c_jsonb) as a (
            c1 varchar,
            c2 varchar,
            c3 varchar
            )
            left join t2_funcscan d on lower(a.c1)=lower(d.c1_var)
        ) c on 1 = 1;
```

Without the fix, the plan is:

     Nested Loop Left Join
       ->  Gather Motion 3:1  (slice1; segments: 3)
             ->  Seq Scan on t1_funcscan a
       ->  Materialize
             ->  Aggregate
                   ->  Gather Motion 3:1  (slice4; segments: 3)
                         ->  Hash Left Join
                               Hash Cond: (lower((a_1.c1)::text) = lower((d.c1_var)::text))
                               ->  Redistribute Motion 1:3  (slice2)
                                     Hash Key: lower((a_1.c1)::text)
                                     ->  Function Scan on jsonb_to_recordset a_1
                               ->  Hash
                                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                           Hash Key: lower((d.c1_var)::text)
                                           ->  Seq Scan on t2_funcscan d

    After the commit, the plan looks like:

     Nested Loop Left Join
       ->  Gather Motion 3:1  (slice1; segments: 3)
             ->  Seq Scan on t1_funcscan a
       ->  Materialize
             ->  Aggregate
                   ->  Hash Left Join
                         Hash Cond: (lower((a_1.c1)::text) = lower((d.c1_var)::text))
                         ->  Function Scan on jsonb_to_recordset a_1
                         ->  Hash
                               ->  Gather Motion 3:1  (slice2; segments: 3)
                                     ->  Seq Scan on t2_funcscan d


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheckAvoid motion for lateral join contains function scan`
- [ ] Review a PR in return to support the community
