### PR TITLE
fix missing cgroup v2 controllers caused by systemd management

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup.bash
+++ b/concourse/scripts/ic_gpdb_resgroup.bash
@@ -25,7 +25,7 @@ mount_cgroups() {
     fi
 
     if [ "$TEST_OS" = rhel8 ]; then
-      ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+      ssh $gpdb_host_alias sudo -n bash -ex <<EOF
         mkdir -p $basedir
         mount -t tmpfs tmpfs $basedir
         for group in $rhel8_groups; do
@@ -42,7 +42,7 @@ make_cgroups_dir() {
     local gpdb_host_alias=$1
     local basedir=$CGROUP_BASEDIR
 
-    ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+    ssh $gpdb_host_alias sudo -n bash -ex <<EOF
         for comp in cpuset cpu cpuacct memory; do
             chmod -R 777 $basedir/\$comp
             mkdir -p $basedir/\$comp/gpdb
@@ -97,7 +97,7 @@ keep_minimal_cgroup_dirs() {
     local gpdb_master_alias=$1
     local basedir=$CGROUP_BASEDIR
 
-    ssh -t $gpdb_master_alias sudo bash -ex <<EOF
+    ssh $gpdb_master_alias sudo -n bash -ex <<EOF
         rmdir $basedir/memory/gpdb/*/ || :
         rmdir $basedir/memory/gpdb
         rmdir $basedir/cpuset/gpdb/*/ || :

--- a/concourse/scripts/ic_resgroup.bash
+++ b/concourse/scripts/ic_resgroup.bash
@@ -28,7 +28,7 @@ mount_cgroups() {
     fi
 
     if [ "$TEST_OS" = rhel8 ]; then
-      ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+      ssh $gpdb_host_alias sudo -n bash -ex <<EOF
         mkdir -p $basedir
         mount -t tmpfs tmpfs $basedir
         for group in $rhel8_groups; do
@@ -45,7 +45,7 @@ make_cgroups_dir() {
     local gpdb_host_alias=$1
     local basedir=$CGROUP_BASEDIR
 
-    ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+    ssh $gpdb_host_alias sudo -n bash -ex <<EOF
         for comp in cpuset cpu cpuacct memory; do
             chmod -R 777 $basedir/\$comp
             mkdir -p $basedir/\$comp/gpdb
@@ -105,7 +105,7 @@ keep_minimal_cgroup_dirs() {
     local gpdb_master_alias=$1
     local basedir=$CGROUP_BASEDIR
 
-    ssh -t $gpdb_master_alias sudo bash -ex <<EOF
+    ssh $gpdb_master_alias sudo -n bash -ex <<EOF
         rmdir $basedir/memory/gpdb/*/ || :
         rmdir $basedir/memory/gpdb
         rmdir $basedir/cpuset/gpdb/*/ || :


### PR DESCRIPTION
Systemd would try to remove unused controllers. Those controllers activated
by gpdb scripts are not realized by systemd and is likely to be cleaned.
We tell systemd all controllers are required via `Delegate=yes` option
in some service, so the controllers get survived during the maintenance:
1) For pipelines, a transient service is applied to get there.
2) For normal runtimes, the greenplum-cgroup-v2-config service is
   recommended in gpdb-doc.

Other minor fixes in this commit:
1) reduntant command `sudo su` removed in `enable_cgroup_subtree_control()`,
which benifits tracing of following remote commands.
2) option `-t` removed for `ssh` with shell heredoc, so avoid the warning
"Pseudo-terminal will not be allocated because stdin is not a terminal."
3) option `-n` added for `sudo` so we can get explicit error message if
password asked unexpectly in non-interactive context of pipelines.

This PR is expected to solve https://github.com/greenplum-db/gpdb/issues/16536 .

Cgroup v2 tests in CI pipeline also turn green (https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_cgroup_v2_systemd/jobs/resource_group_v2_rocky8/builds/1)
