### PR TITLE
Fix bug in per-segment rows calculation when a child is replicated

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-random-distributed-from-replicated-distributed-table.mdp
@@ -227,7 +227,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1" VarTypeModList="-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.020932" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.020974" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
@@ -245,7 +245,7 @@
         </dxl:ProjList>
         <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -262,7 +262,7 @@
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -279,7 +279,7 @@
             <dxl:OneTimeFilter/>
             <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
@@ -12,35 +12,35 @@
     ), h AS (
         SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
     ) SELECT * FROM r JOIN h USING (a);
-                                           QUERY PLAN
-    ----------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)
-       ->  Sequence
-             ->  Shared Scan (share slice:id 1:0)
-                   ->  HashAggregate
-                         Group Key: d.b
-                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                               Hash Key: d.b
-                               ->  Seq Scan on d
-             ->  Hash Join
-                   Hash Cond: (r.a = d_1.a)
-                   ->  Result
-                         ->  Seq Scan on r
-                   ->  Hash
-                         ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                               Hash Key: d_1.a
-                               ->  Hash Join
-                                     Hash Cond: (d_1.b = share0_ref3.b)
-                                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                           Hash Key: d_1.b
-                                           ->  Seq Scan on d d_1
-                                     ->  Hash
-                                           ->  Hash Join
-                                                 Hash Cond: (share0_ref3.b = share0_ref2.b)
-                                                 ->  Shared Scan (share slice:id 3:0)
-                                                 ->  Hash
-                                                       ->  Shared Scan (share slice:id 3:0)
-     Optimizer: Pivotal Optimizer (GPORCA)
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  HashAggregate
+                     Group Key: d.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d.b
+                           ->  Seq Scan on d
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 2)
+               ->  Hash Join
+                     Hash Cond: (r.a = d_1.a)
+                     ->  Seq Scan on r
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: (d_1.b = share0_ref3.b)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Hash Key: d_1.b
+                                             ->  Seq Scan on d d_1
+                                       ->  Hash
+                                             ->  Hash Join
+                                                   Hash Cond: (share0_ref3.b = share0_ref2.b)
+                                                   ->  Shared Scan (share slice:id 3:0)
+                                                   ->  Hash
+                                                         ->  Shared Scan (share slice:id 3:0)
+ Optimizer: GPORCA
     (27 rows)
   ]]>
   </dxl:Comment>
@@ -352,7 +352,7 @@
     <dxl:Plan Id="0" SpaceSize="24318">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.004218" Rows="1.000000" Width="263"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.004757" Rows="1.000000" Width="263"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="40" Alias="a">
@@ -369,7 +369,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.003238" Rows="1.000000" Width="263"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.003777" Rows="1.000000" Width="263"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="40" Alias="a">
@@ -447,9 +447,9 @@
               </dxl:RedistributeMotion>
             </dxl:Aggregate>
           </dxl:CTEProducer>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003012" Rows="1.000000" Width="263"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003551" Rows="1.000000" Width="263"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="40" Alias="a">
@@ -463,16 +463,10 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.002868" Rows="3.000000" Width="263"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="a">
@@ -486,12 +480,13 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1977.1.0">
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
+                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="3.000000" Width="263"/>
@@ -523,26 +518,9 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:RedistributeMotion>
-            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000707" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="50" Alias="a">
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1977.1.0">
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:HashJoin JoinType="Inner">
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000701" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000773" Rows="3.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="50" Alias="a">
@@ -550,35 +528,27 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:SortingColumnList/>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000701" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="50" Alias="a">
                       <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="b">
-                      <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:TableScan>
+                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="50" Alias="a">
@@ -589,62 +559,82 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.16396.1.0" TableName="d" LockMode="1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:RedistributeMotion>
-                <dxl:HashJoin JoinType="Inner">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="60" Alias="b">
-                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:CTEConsumer CTEId="0" Columns="60">
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1977.1.0">
+                        <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="50" Alias="a">
+                          <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="51" Alias="b">
+                          <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.16396.1.0" TableName="d" LockMode="1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                  <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="b">
                         <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:CTEConsumer CTEId="0" Columns="70">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="70" Alias="b">
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                         <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:CTEConsumer CTEId="0" Columns="60">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="60" Alias="b">
+                          <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:CTEConsumer CTEId="0" Columns="70">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="70" Alias="b">
+                          <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:HashJoin>
                 </dxl:HashJoin>
-              </dxl:HashJoin>
-            </dxl:RedistributeMotion>
-          </dxl:HashJoin>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
+          </dxl:RandomMotion>
         </dxl:Sequence>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
@@ -11,37 +11,37 @@
     ), h AS (
         SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
     ) SELECT * FROM r JOIN h USING (a);
-                                            QUERY PLAN
-    ------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)
-       ->  Sequence
-             ->  Shared Scan (share slice:id 1:0)
-                   ->  GroupAggregate
-                         Group Key: d.b
-                         ->  Sort
-                               Sort Key: d.b
-                               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                     Hash Key: d.b
-                                     ->  Seq Scan on d
-             ->  Hash Join
-                   Hash Cond: (r.a = d_1.a)
-                   ->  Result
-                         ->  Seq Scan on r
-                   ->  Hash
-                         ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                               Hash Key: d_1.a
-                               ->  Hash Join
-                                     Hash Cond: (d_1.b = share0_ref3.b)
-                                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                           Hash Key: d_1.b
-                                           ->  Seq Scan on d d_1
-                                     ->  Hash
-                                           ->  Hash Join
-                                                 Hash Cond: (share0_ref3.b = share0_ref2.b)
-                                                 ->  Shared Scan (share slice:id 3:0)
-                                                 ->  Hash
-                                                       ->  Shared Scan (share slice:id 3:0)
-     Optimizer: Pivotal Optimizer (GPORCA)
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  GroupAggregate
+                     Group Key: d.b
+                     ->  Sort
+                           Sort Key: d.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: d.b
+                                 ->  Seq Scan on d
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 1)
+               ->  Hash Join
+                     Hash Cond: (r.a = d_1.a)
+                     ->  Seq Scan on r
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: (d_1.b = share0_ref3.b)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Hash Key: d_1.b
+                                             ->  Seq Scan on d d_1
+                                       ->  Hash
+                                             ->  Hash Join
+                                                   Hash Cond: (share0_ref3.b = share0_ref2.b)
+                                                   ->  Shared Scan (share slice:id 3:0)
+                                                   ->  Hash
+                                                         ->  Shared Scan (share slice:id 3:0)
+ Optimizer: GPORCA
     (29 rows)
   ]]>
   </dxl:Comment>
@@ -366,7 +366,7 @@
     <dxl:Plan Id="0" SpaceSize="81060">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.004147" Rows="1.000000" Width="263"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.004686" Rows="1.000000" Width="263"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="40" Alias="a">
@@ -383,7 +383,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.003167" Rows="1.000000" Width="263"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.003706" Rows="1.000000" Width="263"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="40" Alias="a">
@@ -477,9 +477,9 @@
               </dxl:Sort>
             </dxl:Aggregate>
           </dxl:CTEProducer>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003012" Rows="1.000000" Width="263"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003551" Rows="1.000000" Width="263"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="40" Alias="a">
@@ -493,16 +493,10 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.002868" Rows="3.000000" Width="263"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="a">
@@ -516,12 +510,13 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1977.1.0">
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
+                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="3.000000" Width="263"/>
@@ -553,26 +548,9 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:RedistributeMotion>
-            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000707" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="50" Alias="a">
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1977.1.0">
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:HashJoin JoinType="Inner">
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000701" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000773" Rows="3.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="50" Alias="a">
@@ -580,35 +558,27 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:SortingColumnList/>
+                <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000701" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="50" Alias="a">
                       <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="b">
-                      <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:TableScan>
+                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="50" Alias="a">
@@ -619,62 +589,82 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.49176.1.0" TableName="d" LockMode="1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:RedistributeMotion>
-                <dxl:HashJoin JoinType="Inner">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="60" Alias="b">
-                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:CTEConsumer CTEId="0" Columns="60">
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1977.1.0">
+                        <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="50" Alias="a">
+                          <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="51" Alias="b">
+                          <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.49176.1.0" TableName="d" LockMode="1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                  <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="b">
                         <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:CTEConsumer CTEId="0" Columns="70">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="70" Alias="b">
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
                         <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:CTEConsumer CTEId="0" Columns="60">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="60" Alias="b">
+                          <dxl:Ident ColId="60" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:CTEConsumer CTEId="0" Columns="70">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="70" Alias="b">
+                          <dxl:Ident ColId="70" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:HashJoin>
                 </dxl:HashJoin>
-              </dxl:HashJoin>
-            </dxl:RedistributeMotion>
-          </dxl:HashJoin>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
+          </dxl:RandomMotion>
         </dxl:Sequence>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/CTE2HAReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE2HAReplicated.mdp
@@ -12,42 +12,43 @@
     ), h AS (
         SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
     ) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
-                                           QUERY PLAN
-    ----------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)
-       ->  Sequence
-             ->  Shared Scan (share slice:id 1:0)
-                   ->  HashAggregate
-                         Group Key: d.b
-                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                               Hash Key: d.b
-                               ->  Seq Scan on d
-             ->  Sequence
-                   ->  Shared Scan (share slice:id 1:1)
-                         ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                               Hash Key: d_1.a
-                               ->  Hash Join
-                                     Hash Cond: (d_1.b = share0_ref3.b)
-                                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                           Hash Key: d_1.b
-                                           ->  Seq Scan on d d_1
-                                     ->  Hash
-                                           ->  Hash Join
-                                                 Hash Cond: (share0_ref3.b = share0_ref2.b)
-                                                 ->  Shared Scan (share slice:id 3:0)
-                                                 ->  Hash
-                                                       ->  Shared Scan (share slice:id 3:0)
-                   ->  Hash Join
-                         Hash Cond: (r.a = share1_ref3.a)
-                         ->  Result
-                               ->  Seq Scan on r
-                         ->  Hash
-                               ->  Hash Join
-                                     Hash Cond: (share1_ref3.a = share1_ref2.a)
-                                     ->  Shared Scan (share slice:id 1:1)
-                                     ->  Hash
-                                           ->  Shared Scan (share slice:id 1:1)
-     Optimizer: Pivotal Optimizer (GPORCA)
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  HashAggregate
+                     Group Key: d.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d.b
+                           ->  Seq Scan on d
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash Join
+                           Hash Cond: (d_1.b = share0_ref3.b)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: d_1.b
+                                 ->  Seq Scan on d d_1
+                           ->  Hash
+                                 ->  Hash Join
+                                       Hash Cond: (share0_ref3.b = share0_ref2.b)
+                                       ->  Shared Scan (share slice:id 1:0)
+                                       ->  Hash
+                                             ->  Shared Scan (share slice:id 1:0)
+               ->  Result
+                     One-Time Filter: (gp_execution_segment() = 2)
+                     ->  Hash Join
+                           Hash Cond: (r.a = share1_ref3.a)
+                           ->  Seq Scan on r
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Hash Join
+                                             Hash Cond: (share1_ref3.a = share1_ref2.a)
+                                             ->  Shared Scan (share slice:id 4:1)
+                                             ->  Hash
+                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                         ->  Shared Scan (share slice:id 5:1)
+ Optimizer: GPORCA
     (34 rows)
   ]]>
   </dxl:Comment>
@@ -363,10 +364,10 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1782738">
+    <dxl:Plan Id="0" SpaceSize="2537892">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.004530" Rows="1.000000" Width="263"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.005139" Rows="1.000000" Width="263"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="40" Alias="a">
@@ -383,7 +384,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.003550" Rows="1.000000" Width="263"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.004159" Rows="1.000000" Width="263"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="40" Alias="a">
@@ -463,7 +464,7 @@
           </dxl:CTEProducer>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2586.003324" Rows="1.000000" Width="263"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.003934" Rows="1.000000" Width="263"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="40" Alias="a">
@@ -478,16 +479,16 @@
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="1" Columns="10">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000668" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000664" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
                   <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000667" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000663" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -495,32 +496,35 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:HashJoin JoinType="Inner">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.000663" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="a">
                       <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
                       <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -531,84 +535,64 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="10" Alias="a">
-                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="b">
-                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16402.1.0" TableName="d" LockMode="1">
-                        <dxl:Columns>
-                          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:TableDescriptor Mdid="6.16402.1.0" TableName="d" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="b">
+                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:CTEConsumer CTEId="0" Columns="20">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="b">
                         <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:CTEConsumer>
+                  <dxl:CTEConsumer CTEId="0" Columns="30">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="30" Alias="b">
                         <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:CTEConsumer CTEId="0" Columns="20">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="b">
-                          <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                    <dxl:CTEConsumer CTEId="0" Columns="30">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="30" Alias="b">
-                          <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                  </dxl:HashJoin>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
                 </dxl:HashJoin>
-              </dxl:RedistributeMotion>
+              </dxl:HashJoin>
             </dxl:CTEProducer>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.002569" Rows="1.000000" Width="263"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.003182" Rows="1.000000" Width="263"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="a">
@@ -622,16 +606,10 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:SortingColumnList/>
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.002499" Rows="3.000000" Width="263"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="40" Alias="a">
@@ -645,12 +623,13 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
+                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
                 <dxl:TableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="3.000000" Width="263"/>
@@ -682,46 +661,70 @@
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
-              </dxl:RedistributeMotion>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="50" Alias="a">
-                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:CTEConsumer CTEId="1" Columns="50">
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000404" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="50" Alias="a">
                       <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                </dxl:CTEConsumer>
-                <dxl:CTEConsumer CTEId="1" Columns="80">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="80" Alias="a">
-                      <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                </dxl:CTEConsumer>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000332" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="50" Alias="a">
+                        <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:CTEConsumer CTEId="1" Columns="50">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="50" Alias="a">
+                          <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="3.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="80" Alias="a">
+                          <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:CTEConsumer CTEId="1" Columns="80">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="80" Alias="a">
+                            <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:BroadcastMotion>
+                  </dxl:HashJoin>
+                </dxl:BroadcastMotion>
               </dxl:HashJoin>
-            </dxl:HashJoin>
+            </dxl:RandomMotion>
           </dxl:Sequence>
         </dxl:Sequence>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/CTE2Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE2Replicated.mdp
@@ -11,44 +11,43 @@
     ), h AS (
         SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
     ) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
-                                             QUERY PLAN
-    ---------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)
-       ->  Sequence
-             ->  Shared Scan (share slice:id 1:0)
-                   ->  GroupAggregate
-                         Group Key: d.b
-                         ->  Sort
-                               Sort Key: d.b
-                               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                     Hash Key: d.b
-                                     ->  Seq Scan on d
-             ->  Sequence
-                   ->  Shared Scan (share slice:id 1:1)
-                         ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                               Hash Key: d_1.a
-                               ->  Hash Join
-                                     Hash Cond: (d_1.b = share0_ref3.b)
-                                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                           Hash Key: d_1.b
-                                           ->  Seq Scan on d d_1
-                                     ->  Hash
-                                           ->  Hash Join
-                                                 Hash Cond: (share0_ref3.b = share0_ref2.b)
-                                                 ->  Shared Scan (share slice:id 3:0)
-                                                 ->  Hash
-                                                       ->  Shared Scan (share slice:id 3:0)
-                   ->  Hash Join
-                         Hash Cond: (r.a = share1_ref3.a)
-                         ->  Result
-                               ->  Seq Scan on r
-                         ->  Hash
-                               ->  Hash Join
-                                     Hash Cond: (share1_ref3.a = share1_ref2.a)
-                                     ->  Shared Scan (share slice:id 1:1)
-                                     ->  Hash
-                                           ->  Shared Scan (share slice:id 1:1)
-     Optimizer: Pivotal Optimizer (GPORCA)
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  HashAggregate
+                     Group Key: d.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: d.b
+                           ->  Seq Scan on d
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash Join
+                           Hash Cond: (d_1.b = share0_ref3.b)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: d_1.b
+                                 ->  Seq Scan on d d_1
+                           ->  Hash
+                                 ->  Hash Join
+                                       Hash Cond: (share0_ref3.b = share0_ref2.b)
+                                       ->  Shared Scan (share slice:id 1:0)
+                                       ->  Hash
+                                             ->  Shared Scan (share slice:id 1:0)
+               ->  Result
+                     One-Time Filter: (gp_execution_segment() = 0)
+                     ->  Hash Join
+                           Hash Cond: (r.a = share1_ref3.a)
+                           ->  Seq Scan on r
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Hash Join
+                                             Hash Cond: (share1_ref3.a = share1_ref2.a)
+                                             ->  Shared Scan (share slice:id 4:1)
+                                             ->  Hash
+                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                         ->  Shared Scan (share slice:id 5:1)
+ Optimizer: GPORCA
     (36 rows)
   ]]>
   </dxl:Comment>
@@ -377,10 +376,10 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5942460">
+    <dxl:Plan Id="0" SpaceSize="8459640">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.004459" Rows="1.000000" Width="263"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.005068" Rows="1.000000" Width="263"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="40" Alias="a">
@@ -397,7 +396,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.003479" Rows="1.000000" Width="263"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.004088" Rows="1.000000" Width="263"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="40" Alias="a">
@@ -493,7 +492,7 @@
           </dxl:CTEProducer>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2586.003324" Rows="1.000000" Width="263"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.003934" Rows="1.000000" Width="263"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="40" Alias="a">
@@ -508,16 +507,16 @@
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="1" Columns="10">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000668" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000664" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
                   <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000667" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000663" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -525,32 +524,35 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:HashJoin JoinType="Inner">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.000663" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="a">
                       <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
                       <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -561,84 +563,64 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="10" Alias="a">
-                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="b">
-                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.49182.1.0" TableName="d" LockMode="1">
-                        <dxl:Columns>
-                          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:TableDescriptor Mdid="6.49182.1.0" TableName="d" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="b">
+                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:CTEConsumer CTEId="0" Columns="20">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="b">
                         <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:CTEConsumer>
+                  <dxl:CTEConsumer CTEId="0" Columns="30">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="30" Alias="b">
                         <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:CTEConsumer CTEId="0" Columns="20">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="b">
-                          <dxl:Ident ColId="20" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                    <dxl:CTEConsumer CTEId="0" Columns="30">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="30" Alias="b">
-                          <dxl:Ident ColId="30" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                  </dxl:HashJoin>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
                 </dxl:HashJoin>
-              </dxl:RedistributeMotion>
+              </dxl:HashJoin>
             </dxl:CTEProducer>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.002569" Rows="1.000000" Width="263"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.003182" Rows="1.000000" Width="263"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="a">
@@ -652,16 +634,10 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:SortingColumnList/>
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.001474" Rows="1.000000" Width="263"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.002499" Rows="3.000000" Width="263"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="40" Alias="a">
@@ -675,12 +651,13 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
+                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
                 <dxl:TableScan>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="3.000000" Width="263"/>
@@ -712,46 +689,70 @@
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
-              </dxl:RedistributeMotion>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000391" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="50" Alias="a">
-                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:CTEConsumer CTEId="1" Columns="50">
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000404" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="50" Alias="a">
                       <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                </dxl:CTEConsumer>
-                <dxl:CTEConsumer CTEId="1" Columns="80">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="80" Alias="a">
-                      <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                </dxl:CTEConsumer>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000332" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="50" Alias="a">
+                        <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:CTEConsumer CTEId="1" Columns="50">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="50" Alias="a">
+                          <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="3.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="80" Alias="a">
+                          <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:CTEConsumer CTEId="1" Columns="80">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="80" Alias="a">
+                            <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:BroadcastMotion>
+                  </dxl:HashJoin>
+                </dxl:BroadcastMotion>
               </dxl:HashJoin>
-            </dxl:HashJoin>
+            </dxl:RandomMotion>
           </dxl:Sequence>
         </dxl:Sequence>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Replicated.mdp
@@ -5,6 +5,20 @@
 	CREATE TABLE repl2 (c int, d int) DISTRIBUTED REPLICATED;
 
 	EXPLAIN SELECT * FROM repl1 FULL JOIN repl2 ON (a = c);
+	                                        QUERY PLAN
+    ------------------------------------------------------------------------------------------
+     Merge Full Join  (cost=0.00..862.00 rows=3 width=16)
+       Merge Cond: (repl1.a = repl2.c)
+       ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+             Merge Key: repl1.a
+             ->  Sort  (cost=0.00..431.00 rows=3 width=8)
+                   Sort Key: repl1.a
+                   ->  Seq Scan on repl1  (cost=0.00..431.00 rows=3 width=8)
+       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+             Sort Key: repl2.c
+             ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+                   ->  Seq Scan on repl2  (cost=0.00..431.00 rows=3 width=8)
+     Optimizer: GPORCA
 	]]>
 	</dxl:Comment>
   <dxl:Thread Id="0">
@@ -237,9 +251,9 @@
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="14">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+      <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000981" Rows="3.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001039" Rows="3.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -256,10 +270,16 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
+        <dxl:JoinFilter/>
+        <dxl:MergeCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:MergeCondList>
+        <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000712" Rows="3.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000216" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -268,24 +288,14 @@
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="c">
-              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="d">
-              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:MergeCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:MergeCondList>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000152" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000126" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -301,9 +311,9 @@
             </dxl:SortingColumnList>
             <dxl:LimitCount/>
             <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -314,44 +324,43 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="3.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.112884.1.0" TableName="repl1">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:RedistributeMotion>
+              <dxl:TableDescriptor Mdid="6.112884.1.0" TableName="repl1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
           </dxl:Sort>
-          <dxl:Sort SortDiscardDuplicates="false">
+        </dxl:GatherMotion>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000216" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="d">
+              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000152" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">
@@ -362,14 +371,10 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="c">
@@ -380,43 +385,23 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="3.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="c">
-                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="d">
-                    <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.112887.1.0" TableName="repl2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
-        </dxl:MergeJoin>
-      </dxl:GatherMotion>
+              <dxl:TableDescriptor Mdid="6.112887.1.0" TableName="repl2">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Sort>
+      </dxl:MergeJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonSingleton.mdp
@@ -5,18 +5,18 @@ CREATE TABLE snackbox (a int) DISTRIBUTED REPLICATED;
 CREATE TABLE hottoast (c int) DISTRIBUTED REPLICATED;
 
 EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON a = c;
-                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: (hottoast.c = snackbox.a)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-               ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 1:1  (slice3; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on hottoast  (cost=0.00..431.00 rows=3 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  Seq Scan on snackbox  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..862.00 rows=1 width=4)
+   Hash Cond: (snackbox.a = hottoast.c)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on snackbox  (cost=0.00..431.00 rows=3 width=4)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+               ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on hottoast  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: GPORCA
+(9 rows)
   ]]></dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
@@ -265,9 +265,9 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
       </dxl:LogicalJoin>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="22">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+      <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000381" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000527" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -275,10 +275,16 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="Inner">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000366" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -286,76 +292,7 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
-          <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="8" Alias="c">
-                <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Limit>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="8" Alias="c">
-                  <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="c">
-                    <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="c">
-                      <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.34247.1.0" TableName="hottoast">
-                    <dxl:Columns>
-                      <dxl:Column ColId="8" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="3"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:RandomMotion>
+          <dxl:SortingColumnList/>
           <dxl:TableScan>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
@@ -379,8 +316,59 @@ EXPLAIN SELECT a FROM snackbox JOIN (SELECT c FROM hottoast LIMIT 3) hottoast ON
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
+        </dxl:GatherMotion>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="8" Alias="c">
+              <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="c">
+                <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="c">
+                  <dxl:Ident ColId="8" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.34247.1.0" TableName="hottoast">
+                <dxl:Columns>
+                  <dxl:Column ColId="8" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="3"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
@@ -6,6 +6,16 @@
      insert into r1 SELECT i, i from generate_series(1, 100) i;
      insert into t1 SELECT i, i from generate_series(1, 100) i;
      select * FROM r1 inner join t1 on r1.a = t1.b;
+                                   QUERY PLAN
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.05 rows=100 width=16)
+   ->  Hash Join  (cost=0.00..862.04 rows=34 width=16)
+         Hash Cond: (t1.b = r1.a)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=34 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=100 width=8)
+               ->  Seq Scan on r1  (cost=0.00..431.00 rows=100 width=8)
+ Optimizer: GPORCA
+(7 rows)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -1420,7 +1430,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.046716" Rows="100.000001" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1440,7 +1450,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.024892" Rows="100.000001" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.040753" Rows="100.000001" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1460,60 +1470,13 @@
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
-          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.002027" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -1524,40 +1487,47 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="b">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16412.1.0" TableName="t1">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
+            <dxl:TableDescriptor Mdid="6.16412.1.0" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
@@ -6,6 +6,15 @@
      insert into r1 SELECT i, i from generate_series(1, 100) i;
      insert into t2 SELECT i, i from generate_series(1, 100) i;
      select * from r1 inner join t2 on r1.a = t2.b;
+                                       QUERY PLAN
+     -------------------------------------------------------------------------------
+      Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+        ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+              Hash Cond: (t2.b = r1.a)
+              ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=8)
+              ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                    ->  Seq Scan on r1  (cost=0.00..431.00 rows=1 width=8)
+      Optimizer: GPORCA
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -1022,7 +1031,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.046716" Rows="100.000001" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1042,7 +1051,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.024892" Rows="100.000001" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.040753" Rows="100.000001" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1062,60 +1071,13 @@
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
-          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.002027" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -1126,40 +1088,47 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="b">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16415.1.0" TableName="t2">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
+            <dxl:TableDescriptor Mdid="6.16415.1.0" TableName="t2">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
@@ -1420,7 +1420,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.058851" Rows="100.000001" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1440,7 +1440,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.024892" Rows="100.000001" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.040963" Rows="100.000001" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1466,7 +1466,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.006082" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
@@ -1022,7 +1022,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.058851" Rows="100.000001" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1042,7 +1042,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.024892" Rows="100.000001" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.040963" Rows="100.000001" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1068,7 +1068,7 @@
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.006082" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableCTE.mdp
@@ -6,6 +6,15 @@
      insert into r1 SELECT i, i from generate_series(1, 100) i;
      insert into t1 SELECT i, i from generate_series(1, 100) i;
      explain with cte as (select * from t1) select * from cte, r1 where r1.a = cte.b;
+                                        QUERY PLAN
+     ---------------------------------------------------------------------------------
+      Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.05 rows=100 width=16)
+        ->  Hash Join  (cost=0.00..862.04 rows=34 width=16)
+              Hash Cond: (t1.b = r1.a)
+              ->  Seq Scan on t1  (cost=0.00..431.00 rows=34 width=8)
+              ->  Hash  (cost=431.00..431.00 rows=100 width=8)
+                    ->  Seq Scan on r1  (cost=0.00..431.00 rows=100 width=8)
+      Optimizer: GPORCA
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -1426,7 +1435,7 @@
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.030854" Rows="100.000001" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.046716" Rows="100.000001" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="a">
@@ -1446,7 +1455,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.024892" Rows="100.000001" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.040753" Rows="100.000001" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="a">
@@ -1466,60 +1475,13 @@
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005655" Rows="100.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="18" Alias="a">
-                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="b">
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="a">
-                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="b">
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
-                <dxl:Columns>
-                  <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
-          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.002027" Rows="100.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -1530,40 +1492,47 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="b">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16412.1.0" TableName="t1">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RedistributeMotion>
+            <dxl:TableDescriptor Mdid="6.16412.1.0" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.002090" Rows="300.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="a">
+                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="b">
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r1">
+              <dxl:Columns>
+                <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -267,6 +267,9 @@ public:
 	// is this cost context of a single stage agg
 	static BOOL IsSingleStageAggCostCtxt(const CCostContext *pcc);
 
+	// is the child replicated
+	static BOOL IsChildReplicated(COptimizationContextArray *pdrgpoc);
+
 	// equality function
 	static BOOL
 	Equals(const CCostContext &ccLeft, const CCostContext &ccRight)

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalScan.h
@@ -87,6 +87,13 @@ public:
 		return m_pdrgpcrOutput;
 	}
 
+	// return derived distribution
+	CDistributionSpec *
+	Pds() const
+	{
+		return m_pds;
+	}
+
 	// sensitivity to order of inputs
 	BOOL FInputOrderSensitive() const override;
 

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3993,6 +3993,99 @@ INSERT INTO ext_stats_tbl VALUES('tC', true);
 ANALYZE ext_stats_tbl;
 explain SELECT 1 FROM ext_stats_tbl t11 FULL JOIN ext_stats_tbl t12 ON t12.c2;
 ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+-- Tests for verifying that HashJoin should not choose the [hash, hash] alternative
+-- start_ignore
+drop table if exists rep;
+NOTICE:  table "rep" does not exist, skipping
+drop table if exists rand;
+NOTICE:  table "rand" does not exist, skipping
+-- end_ignore
+create table rep(a int, b int) distributed replicated;
+create table rand(a int, b int) distributed randomly;
+insert into rep select i, i from generate_series(1, 300)i;
+insert into rand select i, i from generate_series(1, 10)i;
+analyze rep, rand;
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t2.a = t1.a)
+         ->  Seq Scan on rep t2
+         ->  Hash
+               ->  Seq Scan on rand t1
+ Optimizer: Postgres-based planner
+(7 rows)
+
+-- Verify the plan by adding more tuples to rand table
+insert into rand select i, i from generate_series(1, 1000)i;
+analyze rand;
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.a = t2.a)
+         ->  Seq Scan on rand t1
+         ->  Hash
+               ->  Seq Scan on rep t2
+ Optimizer: Postgres-based planner
+(7 rows)
+
+-- Filter over replicated table
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a and t2.a<100;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t2.a = t1.a)
+         ->  Seq Scan on rep t2
+               Filter: (a < 100)
+         ->  Hash
+               ->  Seq Scan on rand t1
+                     Filter: (a < 100)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+-- GroupAgg over replicated table
+delete from rep;
+delete from rand;
+insert into rep select i%10, i%10 from generate_series(1, 10)i;
+insert into rand select i%10, i%10 from generate_series(1, 10)i;
+analyze rep, rand;
+explain (costs off) select x.a from rand x join (select distinct(a) from rep) as agg on x.a=agg.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rep.a = x.a)
+         ->  HashAggregate
+               Group Key: rep.a
+               ->  Seq Scan on rep
+         ->  Hash
+               ->  Seq Scan on rand x
+ Optimizer: Postgres-based planner
+(9 rows)
+
+-- HashAgg over replicated table
+insert into rand select i%10, i%10 from generate_series(1, 100)i;
+insert into rep select i, i from generate_series(1, 100)i;
+analyze rep, rand ;
+explain (costs off) select x.a from rand x join (select distinct(a) from rep) as agg on x.a=agg.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rep.a = x.a)
+         ->  HashAggregate
+               Group Key: rep.a
+               ->  Seq Scan on rep
+         ->  Hash
+               ->  Seq Scan on rand x
+ Optimizer: Postgres-based planner
+(9 rows)
+
+drop table rep, rand;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4006,6 +4006,102 @@ INSERT INTO ext_stats_tbl VALUES('tC', true);
 ANALYZE ext_stats_tbl;
 explain SELECT 1 FROM ext_stats_tbl t11 FULL JOIN ext_stats_tbl t12 ON t12.c2;
 ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
+-- Tests for verifying that HashJoin should not choose the [hash, hash] alternative
+-- start_ignore
+drop table if exists rep;
+NOTICE:  table "rep" does not exist, skipping
+drop table if exists rand;
+NOTICE:  table "rand" does not exist, skipping
+-- end_ignore
+create table rep(a int, b int) distributed replicated;
+create table rand(a int, b int) distributed randomly;
+insert into rep select i, i from generate_series(1, 300)i;
+insert into rand select i, i from generate_series(1, 10)i;
+analyze rep, rand;
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Hash Join
+         Hash Cond: (rep.a = rand.a)
+         ->  Seq Scan on rep
+         ->  Hash
+               ->  Broadcast Motion 3:1  (slice2; segments: 3)
+                     ->  Seq Scan on rand
+ Optimizer: GPORCA
+(8 rows)
+
+-- Verify the plan by adding more tuples to rand table
+insert into rand select i, i from generate_series(1, 1000)i;
+analyze rand;
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rand.a = rep.a)
+         ->  Seq Scan on rand
+         ->  Hash
+               ->  Seq Scan on rep
+ Optimizer: GPORCA
+(7 rows)
+
+-- Filter over replicated table
+explain (costs off) select * from rand t1 join rep t2 on t1.a = t2.a and t2.a<100;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rand.a = rep.a)
+         ->  Seq Scan on rand
+               Filter: (a < 100)
+         ->  Hash
+               ->  Seq Scan on rep
+                     Filter: (a < 100)
+ Optimizer: GPORCA
+(9 rows)
+
+-- GroupAgg over replicated table
+delete from rep;
+delete from rand;
+insert into rep select i%10, i%10 from generate_series(1, 10)i;
+insert into rand select i%10, i%10 from generate_series(1, 10)i;
+analyze rep, rand;
+explain (costs off) select x.a from rand x join (select distinct(a) from rep) as agg on x.a=agg.a;
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rand.a = rep.a)
+         ->  Seq Scan on rand
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: rep.a
+                     ->  Sort
+                           Sort Key: rep.a
+                           ->  Seq Scan on rep
+ Optimizer: GPORCA
+(11 rows)
+
+-- HashAgg over replicated table
+insert into rand select i%10, i%10 from generate_series(1, 100)i;
+insert into rep select i, i from generate_series(1, 100)i;
+analyze rep, rand ;
+explain (costs off) select x.a from rand x join (select distinct(a) from rep) as agg on x.a=agg.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (rand.a = rep.a)
+         ->  Seq Scan on rand
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: rep.a
+                     ->  Seq Scan on rep
+ Optimizer: GPORCA
+(9 rows)
+
+drop table rep, rand;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1227,16 +1227,19 @@ explain select c from rep_tab where c in (select distinct d from rand_tab);
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: (rep_tab.c = rand_tab.d)
-         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+               Group Key: rand_tab.d
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: rand_tab.d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: rand_tab.d
+                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                     Hash Key: rand_tab.d
-                     ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+ Optimizer: GPORCA
+(13 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 


### PR DESCRIPTION
Orca's behavior in setting the operator's per-segment rows is incorrect when the child is replicated. As a result, the hash join often chooses the [hash, hash]alternative, even when better alternatives are available.

Example:
create table rep as select generate_series(1,10000) a distributed replicated;
create table rand as select generate_series(1,100) a distributed randomly;
analyze rep, rand;
explain select * from rand t1 join rep t2 on t1.a = t2.a; PhysicalPlan:
```
+--CPhysicalMotionGather(coordinator)
   +--CPhysicalInnerHashJoin
      |--CPhysicalMotionHashDistribute HASHED
      |  +--CPhysicalTableScan "rep" ("rep")
      |--CPhysicalMotionHashDistribute HASHED
      |  +--CPhysicalTableScan "rand" ("rand")
      +--CScalarCmp (=)
         |--CScalarIdent "a" (0)
         +--CScalarIdent "a" (8)
```
Note: Number of segments=3
In the above example, with regards to the operator CPhysicalMotionHashDistribute over the 'rep' table, we are incorrectly setting  the per-segment number of rows to 3333 instead of 10000. This incorrect setting is the reason for the lower cost of the hash join alternative (redistribute, redistribute). This PR addresses the issue of adjusting per-segment row calculations when the operator's child is replicated. After applying the fix, it was noticed that the query's execution time decreased compared to the previous run without fix.

Before fix:

explain analyze select * from rand t1 join rep t2 on t1.a = t2.a;
```

                                                                    QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.96 rows=100 width=8) (actual time=18.842..19.111 rows=100 loops=1)
   ->  Hash Join  (cost=0.00..862.96 rows=34 width=8) (actual time=9.693..14.288 rows=38 loops=1)
         Hash Cond: (rep.a = rand.a)
         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 38 of 524288 buckets.
         ->  Result  (cost=0.00..431.37 rows=3334 width=4) (actual time=0.180..2.964 rows=3385 loops=1)
               ->  Seq Scan on rep  (cost=0.00..431.19 rows=10000 width=4) (actual time=0.168..1.077 rows=10000 loops=1)
         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=2.770..2.770 rows=38 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.950..2.744 rows=38 loops=1)
                     Hash Key: rand.a
                     ->  Seq Scan on rand  (cost=0.00..431.00 rows=34 width=4) (actual time=0.157..0.161 rows=37 loops=1)
 Optimizer: GPORCA
 Planning Time: 11.404 ms
 Execution Time: 95.326 ms
```

 After Fix:
explain analyze select * from rand t1 join rep t2 on t1.a = t2.a;
```

                                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..864.06 rows=100 width=8) (actual time=9.607..9.627 rows=100 loops=1)
   ->  Hash Join  (cost=0.00..864.05 rows=300 width=8) (actual time=3.345..9.015 rows=100 loops=1)
         Hash Cond: (rep.a = rand.a)
         Extra Text: Hash chain length 1.0 avg, 1 max, using 100 of 524288 buckets.
         ->  Seq Scan on rep  (cost=0.00..431.19 rows=30000 width=4) (actual time=0.226..1.846 rows=10000 loops=1)
         ->  Hash  (cost=431.01..431.01 rows=300 width=4) (actual time=0.271..0.272 rows=100 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 4100kB
               ->  Broadcast Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=300 width=4) (actual time=0.023..0.227 rows=100 loops=1)
                     ->  Seq Scan on rand  (cost=0.00..431.00 rows=34 width=4) (actual time=0.884..0.891 rows=40 loops=1)
 Optimizer: GPORCA
 Planning Time: 16.417 ms
 Execution Time: 31.988 ms
```
