### PR TITLE
ao/co: Support System table sampling

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -19,6 +19,7 @@
 #include "access/heapam.h"
 #include "access/multixact.h"
 #include "access/tableam.h"
+#include "access/tsmapi.h"
 #include "access/xact.h"
 #include "catalog/aoseg.h"
 #include "catalog/catalog.h"
@@ -667,8 +668,7 @@ aoco_endscan(TableScanDesc scan)
  * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: When doing an initial rescan with `table_rescan`,
  * the values for the new flags (introduced by Table AM API) are
  * set to false. This means that whichever ScanOptions flags that were initially set will be
- * used for the rescan. However with TABLESAMPLE, which is currently not
- * supported for AO/CO, the new flags may be modified.
+ * used for the rescan. However with TABLESAMPLE, the new flags may be modified.
  * Additionally, allow_sync, allow_strat, and allow_pagemode may
  * need to be implemented for AO/CO in order to properly use them.
  * You may view `syncscan.c` as an example to see how heap added scan
@@ -2483,26 +2483,158 @@ aoco_scan_bitmap_next_tuple(TableScanDesc scan,
 static bool
 aoco_scan_sample_next_block(TableScanDesc scan, SampleScanState *scanstate)
 {
+	TsmRoutine *tsm = scanstate->tsmroutine;
 	/*
-	 * GPDB_95_MERGE_FIXME: Add support for AO_COLUMN tables
+	 * GPDB_95_MERGE_FIXME: Add support for AO tables
 	 */
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("invalid relation type"),
-			 errhint("Sampling is only supported in heap tables.")));
+	if (tsm->NextSampleBlock)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("invalid relation type"),
+				 errhint("SYSTEM sampling is only supported in heap tables.")));
+	else
+	{
+		/* scanning table sequentially */
+		AOCSScanDesc aoscan = (AOCSScanDesc) scan;
+		ItemPointer  currtid = &aoscan->sampleSlot->tts_tid;
+
+		if (aoscan->cur_seg == -1)
+		{
+			/* no more items in relation, exit */
+			ExecClearTuple(aoscan->sampleSlot);
+			return false;
+		}
+
+		/* First time in this function */
+		if (!ItemPointerIsValid(currtid))
+		{
+			/*
+			 * We must scan the first tuple into the sample slot, so that the
+			 * entry criteria for appendonly_scan_sample_next_tuple() is met.
+			 */
+			if (!aoco_getnextslot(scan, ForwardScanDirection, aoscan->sampleSlot))
+			{
+				ExecClearTuple(aoscan->sampleSlot);
+				return false;
+			}
+		}
+	}
+
+	return true;
 }
 
 static bool
 aoco_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
                                   TupleTableSlot *slot)
 {
+	TsmRoutine 			*tsm = scanstate->tsmroutine;
+	AOCSScanDesc 		aoscan = (AOCSScanDesc) scan;
+	TupleTableSlot      *sampleslot = aoscan->sampleSlot;
+	BlockNumber  		targetblk;
+	OffsetNumber 		currrownum;
+
 	/*
-	 * GPDB_95_MERGE_FIXME: Add support for AO_COLUMN tables
+	 * Entry criteria:
+	 *
+	 * (1) If we are switching to a new "next" logical block:
+	 * We currently expect that the 1st tuple in the "next" logical block has
+	 * already been read and has been stored in the scan's sample slot. This
+	 * will be the next tuple considered for sampling.
+	 *
+	 * (2) If we are in the  "next" tuple in the current logical block:
+	 * We currently expect that the previously sampled tuple (from the same
+	 * block) is present in the scan's sample slot. The tuple after this one
+	 * will be the next tuple considered for sampling.
 	 */
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("invalid relation type"),
-			 errhint("Sampling is only supported in heap tables.")));
+	Assert(!TTS_EMPTY(sampleslot));
+	Assert(ItemPointerIsValid(&sampleslot->tts_tid));
+	targetblk  = ItemPointerGetBlockNumber(&sampleslot->tts_tid);
+	currrownum = ItemPointerGetOffsetNumber(&sampleslot->tts_tid);
+
+	for (;;)
+	{
+		OffsetNumber targetrownum;
+		BlockNumber  currblk;
+
+		CHECK_FOR_INTERRUPTS();
+
+		/* Ask the tablesample method which rows to scan on this logical page. */
+		targetrownum = tsm->NextSampleTuple(scanstate,
+											targetblk,
+											AO_MAX_TUPLES_PER_HEAP_BLOCK);
+		if (targetrownum != InvalidOffsetNumber)
+		{
+			/* Seek to the targetrownum in the targetblk by scanning sequentially */
+			while (currrownum < targetrownum)
+			{
+				if (!aoco_getnextslot(scan, ForwardScanDirection, sampleslot))
+					goto end_of_rel;
+
+				currblk = ItemPointerGetBlockNumber(&sampleslot->tts_tid);
+				currrownum = ItemPointerGetOffsetNumber(&sampleslot->tts_tid);
+
+				if (currblk > targetblk)
+				{
+					/*
+					 * The target row number fell into a hole at the end of the
+					 * target logical heap block, and we have scanned our way to
+					 * the next one.
+					 *
+					 * We should move on to sampling from this next one (in the
+					 * current aoseg or a subsequent one). We invoke
+					 * NextSampleTuple() with the current tuple offset, to mimic
+					 * an end-of-block sampler reset.
+					 */
+					targetrownum = tsm->NextSampleTuple(scanstate,
+														targetblk,
+														targetrownum);
+					Assert(targetrownum == InvalidOffsetNumber);
+					ExecClearTuple(slot);
+					return false;
+				}
+			}
+
+			if (currrownum == targetrownum)
+			{
+				/*
+				 * We "seeked" our way to the target row number. Copy the tuple
+				 * from the sample slot into the output slot, and move on to
+				 * the next tuple.
+				 */
+				ExecCopySlot(slot, sampleslot);
+				ItemPointerCopy(&sampleslot->tts_tid, &slot->tts_tid);
+				/* Count successfully-fetched tuples as heap fetches */
+				pgstat_count_heap_getnext(scan->rs_rd);
+
+				return true;
+			}
+		}
+		else
+		{
+			/*
+			 * If we get here, it means that we have considered all tuples in
+			 * the current logical heap block, and it's time to move to the
+			 * next. We do so by scanning until we hit the next block (in the
+			 * current aoseg or a subsequent one).
+			 */
+			do
+			{
+				if (!aoco_getnextslot(scan, ForwardScanDirection, sampleslot))
+					goto end_of_rel;
+				currblk = ItemPointerGetBlockNumber(&sampleslot->tts_tid);
+			} while (currblk <= targetblk);
+
+			ExecClearTuple(slot);
+			return false;
+		}
+	}
+
+	end_of_rel:
+	/* no more items in relation, exit */
+	Assert(aoscan->cur_seg == -1);
+	ExecClearTuple(slot);
+	ExecClearTuple(sampleslot);
+	return false;
 }
 
 /* ------------------------------------------------------------------------

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -418,6 +418,10 @@ extern bool aocs_positionscan(AOCSScanDesc aoscan,
 							  AppendOnlyBlockDirectoryEntry *dirEntry,
 							  int colIdx,
 							  int fsInfoIdx);
+extern bool aocs_positionscan_wo_blkdir(AOCSScanDesc aoscan,
+										BlockNumber targetblk,
+										int columnGroupNo);
+
 
 extern bool switch_to_next_scan_seg(AOCSScanDesc scan);
 

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -260,6 +260,9 @@ typedef struct AOCSScanDescData
 
 	/* sampleSlot: Holds tuple last read as part of a sample scan */
 	TupleTableSlot *sampleSlot;
+
+	/* Block directory used for block sample scans */
+	AppendOnlyBlockDirectory *sampleBlkdir;
 } AOCSScanDescData;
 
 typedef AOCSScanDescData *AOCSScanDesc;
@@ -415,6 +418,8 @@ extern bool aocs_positionscan(AOCSScanDesc aoscan,
 							  AppendOnlyBlockDirectoryEntry *dirEntry,
 							  int colIdx,
 							  int fsInfoIdx);
+
+extern bool switch_to_next_scan_seg(AOCSScanDesc scan);
 
 /*
  * Update total bytes read for the entire scan. If the block was compressed,

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -257,6 +257,9 @@ typedef struct AOCSScanDescData
 	 * across all columns projected, so far. It is used for scan progress reporting.
 	 */
 	int64		totalBytesRead;
+
+	/* sampleSlot: Holds tuple last read as part of a sample scan */
+	TupleTableSlot *sampleSlot;
 } AOCSScanDescData;
 
 typedef AOCSScanDescData *AOCSScanDesc;

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -500,6 +500,8 @@ extern void appendonly_delete_finish(AppendOnlyDeleteDesc aoDeleteDesc);
 extern bool appendonly_positionscan(AppendOnlyScanDesc aoscan,
 									AppendOnlyBlockDirectoryEntry *dirEntry,
 									int fsInfoIdx);
+extern bool appendonly_positionscan_wo_blkdir(AppendOnlyScanDesc aoscan,
+											  BlockNumber targetblk);
 
 extern bool SwitchToNextFileSegForRead(AppendOnlyScanDesc aoscan);
 /*

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -270,6 +270,9 @@ typedef struct AppendOnlyScanDescData
 
 	/* sampleSlot: Holds tuple last read as part of a sample scan */
 	TupleTableSlot *sampleSlot;
+
+	/* Block directory used for block sample scans */
+	AppendOnlyBlockDirectory *sampleBlkdir;
 }	AppendOnlyScanDescData;
 
 typedef AppendOnlyScanDescData *AppendOnlyScanDesc;
@@ -498,6 +501,7 @@ extern bool appendonly_positionscan(AppendOnlyScanDesc aoscan,
 									AppendOnlyBlockDirectoryEntry *dirEntry,
 									int fsInfoIdx);
 
+extern bool SwitchToNextFileSegForRead(AppendOnlyScanDesc aoscan);
 /*
  * Update total bytes read for the entire scan. If the block was compressed,
  * update it with the compressed length. If the block was not compressed, update

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -268,6 +268,8 @@ typedef struct AppendOnlyScanDescData
 	 */
 	int64		totalBytesRead;
 
+	/* sampleSlot: Holds tuple last read as part of a sample scan */
+	TupleTableSlot *sampleSlot;
 }	AppendOnlyScanDescData;
 
 typedef AppendOnlyScanDescData *AppendOnlyScanDesc;

--- a/src/test/isolation2/input/uao/tablesample.source
+++ b/src/test/isolation2/input/uao/tablesample.source
@@ -1,13 +1,22 @@
--- Test Bernoulli and System sampling
+-- Test Bernoulli and System sampling. For System sampling both blkdir and
+-- without blkdir cases are considered.
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
 
 -- Case 0: Empty table
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
 SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
 
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+
+DROP TABLE tsample_@amname@;
+
 -- Case 1: Single partially populated logical heap block on each QE
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
 INSERT INTO tsample_@amname@ SELECT generate_series(1, 100);
 
 SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0);
@@ -22,9 +31,15 @@ SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE
 
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 2: Multiple full logical heap blocks on a single QE
 CREATE TABLE tsample2_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
 INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
   count(*) FROM tsample2_@amname@ GROUP BY 1;
@@ -40,9 +55,15 @@ SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEAT
 
 SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
 CREATE TABLE tsample3_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
 INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
   count(*) FROM tsample3_@amname@ GROUP BY 1;
@@ -53,9 +74,20 @@ SELECT ctid FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
 
 SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 4: Logical heap block with hole in the beginning on a single QE
 CREATE TABLE tsample4_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
 BEGIN;
 INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
 ABORT;
@@ -74,9 +106,15 @@ SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEAT
 
 SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
+
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 5: Logical heap block with hole in the middle on a single QE
 CREATE TABLE tsample5_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
@@ -93,11 +131,20 @@ SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEAT
 
 SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 6: Logical heap block with hole at the end on a single QE
 CREATE TABLE tsample6_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
+BEGIN;
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
+ABORT;
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 300);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
   count(*) FROM tsample6_@amname@ GROUP BY 1;
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@;
@@ -107,14 +154,20 @@ SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
 
-SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
-SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
 
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
 
 -- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
 CREATE TABLE tsample7_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
 1: BEGIN;
 2: BEGIN;
 1: INSERT INTO tsample7_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768);
@@ -136,9 +189,15 @@ SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
 
 SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
+
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
 CREATE TABLE tsample8_@amname@(i int) USING @amname@;
-CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
 1: BEGIN;
 2: BEGIN;
 1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 5);
@@ -162,12 +221,19 @@ SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(100);
 
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
 
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
 
 -- Case 9: Logical heap blocks with deleted tuples on each QE
 CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
-CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
 INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
 DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
 DELETE FROM tsample9_@amname@ WHERE j > 65535;
@@ -185,12 +251,17 @@ SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEAT
 
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
 
+CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
 
 CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
-CREATE INDEX ON ttr1(a);
-CREATE INDEX ON ttr2(a);
 
 INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
 INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
@@ -204,6 +275,14 @@ EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2)
   ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
 SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
   ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+
+CREATE INDEX ON ttr1(a);
+CREATE INDEX ON ttr2(a);
 
 EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
   ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;

--- a/src/test/isolation2/input/uao/tablesample.source
+++ b/src/test/isolation2/input/uao/tablesample.source
@@ -1,6 +1,7 @@
--- Test Bernoulli sampling
+-- Test Bernoulli and System sampling
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
 
 -- Case 0: Empty table
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
@@ -16,8 +17,14 @@ SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(5);
 
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 2: Multiple full logical heap blocks on a single QE
 CREATE TABLE tsample2_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
 INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
   count(*) FROM tsample2_@amname@ GROUP BY 1;
@@ -28,8 +35,14 @@ SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.0005) REPEATABLE(5);
 
 SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
 CREATE TABLE tsample3_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
 INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
   count(*) FROM tsample3_@amname@ GROUP BY 1;
@@ -42,6 +55,7 @@ SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
 
 -- Case 4: Logical heap block with hole in the beginning on a single QE
 CREATE TABLE tsample4_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
 BEGIN;
 INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
 ABORT;
@@ -55,8 +69,14 @@ SELECT ctid FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
 
 SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 5: Logical heap block with hole in the middle on a single QE
 CREATE TABLE tsample5_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
@@ -68,8 +88,14 @@ SELECT ctid FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 
 SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 6: Logical heap block with hole at the end on a single QE
 CREATE TABLE tsample6_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
@@ -81,8 +107,14 @@ SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
 CREATE TABLE tsample7_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
 1: BEGIN;
 2: BEGIN;
 1: INSERT INTO tsample7_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768);
@@ -99,8 +131,14 @@ SELECT ctid FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 
 SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
 CREATE TABLE tsample8_@amname@(i int) USING @amname@;
+CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
 1: BEGIN;
 2: BEGIN;
 1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 5);
@@ -123,8 +161,13 @@ SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
 
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 9: Logical heap blocks with deleted tuples on each QE
 CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
+CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
 INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
 DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
 DELETE FROM tsample9_@amname@ WHERE j > 65535;
@@ -137,10 +180,18 @@ SELECT ctid FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 
 SELECT count(*) FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(100);
 
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+
 -- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
 
 CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE INDEX ON ttr1(a);
+CREATE INDEX ON ttr2(a);
+
 INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
 INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
 ANALYZE ttr1;
@@ -153,6 +204,11 @@ EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2)
   ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
 SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
   ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
 
 RESET enable_hashjoin;
 RESET enable_mergejoin;

--- a/src/test/isolation2/input/uao/tablesample.source
+++ b/src/test/isolation2/input/uao/tablesample.source
@@ -1,0 +1,161 @@
+-- Test Bernoulli sampling
+
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
+
+-- Case 0: Empty table
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+
+-- Case 1: Single partially populated logical heap block on each QE
+INSERT INTO tsample_@amname@ SELECT generate_series(1, 100);
+
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(5);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(5);
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 2: Multiple full logical heap blocks on a single QE
+CREATE TABLE tsample2_@amname@(i int) USING @amname@;
+INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample2_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@;
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.0005) REPEATABLE(5);
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.0005) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
+CREATE TABLE tsample3_@amname@(i int) USING @amname@;
+INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample3_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@;
+
+SELECT ctid FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+SELECT ctid FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 4: Logical heap block with hole in the beginning on a single QE
+CREATE TABLE tsample4_@amname@(i int) USING @amname@;
+BEGIN;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
+ABORT;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32800);
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample4_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@;
+
+SELECT ctid FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+SELECT ctid FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 5: Logical heap block with hole in the middle on a single QE
+CREATE TABLE tsample5_@amname@(i int) USING @amname@;
+INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
+INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample5_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@;
+
+SELECT ctid FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+SELECT ctid FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 6: Logical heap block with hole at the end on a single QE
+CREATE TABLE tsample6_@amname@(i int) USING @amname@;
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample6_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@;
+
+SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
+CREATE TABLE tsample7_@amname@(i int) USING @amname@;
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO tsample7_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768);
+2: INSERT INTO tsample7_@amname@ SELECT 20 FROM generate_series(1, 32767 + 32768);
+1: COMMIT;
+2: COMMIT;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample7_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@;
+
+SELECT ctid FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+SELECT ctid FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
+CREATE TABLE tsample8_@amname@(i int) USING @amname@;
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 5);
+2: INSERT INTO tsample8_@amname@ SELECT 20 FROM generate_series(1, 10);
+1: COMMIT;
+2: ABORT;
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 15);
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 20);
+2: INSERT INTO tsample8_@amname@ SELECT 20 FROM generate_series(1, 25);
+1: ABORT;
+2: COMMIT;
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample8_@amname@ GROUP BY 1;
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@;
+
+SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
+SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 9: Logical heap blocks with deleted tuples on each QE
+CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
+INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
+DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
+DELETE FROM tsample9_@amname@ WHERE j > 65535;
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum,
+  count(*) FROM tsample9_@amname@ GROUP BY 1;
+SELECT count(*) FROM tsample9_@amname@;
+
+SELECT ctid FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+SELECT ctid FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+
+SELECT count(*) FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(100);
+
+-- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
+
+CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
+INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
+ANALYZE ttr1;
+ANALYZE ttr2;
+SET enable_hashjoin TO OFF;
+SET enable_mergejoin TO OFF;
+SET enable_nestloop TO ON;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_nestloop;
+DROP TABLE ttr1;
+DROP TABLE ttr2;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -145,6 +145,7 @@ test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
 test: uao/snapshot_index_corruption_row
+test: uao/tablesample_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -212,6 +213,7 @@ test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
 test: uao/snapshot_index_corruption_column
+test: uao/tablesample_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/tablesample.source
+++ b/src/test/isolation2/output/uao/tablesample.source
@@ -1,9 +1,8 @@
--- Test Bernoulli and System sampling
+-- Test Bernoulli and System sampling. For System sampling both blkdir and
+-- without blkdir cases are considered.
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
-CREATE INDEX
 
 -- Case 0: Empty table
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
@@ -16,7 +15,35 @@ SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
 ---
 (0 rows)
 
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+ count 
+-------
+ 0     
+(1 row)
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+CREATE INDEX
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+ count 
+-------
+ 0     
+(1 row)
+
+DROP TABLE tsample_@amname@;
+DROP TABLE
+
 -- Case 1: Single partially populated logical heap block on each QE
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
+CREATE TABLE
 INSERT INTO tsample_@amname@ SELECT generate_series(1, 100);
 INSERT 0 100
 
@@ -126,11 +153,29 @@ SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
  100   
 (1 row)
 
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 100   
+(1 row)
+
 -- Case 2: Multiple full logical heap blocks on a single QE
 CREATE TABLE tsample2_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
-CREATE INDEX
 INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
 INSERT 0 98303
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample2_@amname@ GROUP BY 1;
@@ -182,11 +227,29 @@ SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
  98303 
 (1 row)
 
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 98303 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 98303 
+(1 row)
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 98303 
+(1 row)
+
 -- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
 CREATE TABLE tsample3_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
-CREATE INDEX
 INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
 INSERT 0 65635
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample3_@amname@ GROUP BY 1;
@@ -217,11 +280,46 @@ SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
  65635 
 (1 row)
 
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 32868 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 32868 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 65635 
+(1 row)
+
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 32868 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 32868 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 65635 
+(1 row)
+
 -- Case 4: Logical heap block with hole in the beginning on a single QE
 CREATE TABLE tsample4_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
-CREATE INDEX
 BEGIN;
 BEGIN
 INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
@@ -274,11 +372,29 @@ SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
  32800 
 (1 row)
 
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+ count 
+-------
+ 32800 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+ count 
+-------
+ 32800 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 32800 
+(1 row)
+
 -- Case 5: Logical heap block with hole in the middle on a single QE
 CREATE TABLE tsample5_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
-CREATE INDEX
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
 INSERT 0 50
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
@@ -331,25 +447,49 @@ SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
  32850 
 (1 row)
 
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 32850 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 32850 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 32850 
+(1 row)
+
 -- Case 6: Logical heap block with hole at the end on a single QE
 CREATE TABLE tsample6_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
-CREATE INDEX
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
 INSERT 0 32700
+BEGIN;
+BEGIN
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
 INSERT 0 200
+ABORT;
+ROLLBACK
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 300);
+INSERT 0 300
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample6_@amname@ GROUP BY 1;
  blknum   | count 
 ----------+-------
- 33554433 | 200   
  33554432 | 32700 
+ 33554433 | 300   
 (2 rows)
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@;
  count 
 -------
- 32900 
+ 33000 
 (1 row)
 
 SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
@@ -368,31 +508,49 @@ SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
  count 
 -------
- 32900 
+ 33000 
 (1 row)
 
-SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
  count 
 -------
- 32700 
+ 300   
 (1 row)
-SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
  count 
 -------
- 32700 
+ 300   
 (1 row)
 
 SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
  count 
 -------
- 32900 
+ 33000 
+(1 row)
+
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
+ count 
+-------
+ 300   
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(2);
+ count 
+-------
+ 300   
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 33000 
 (1 row)
 
 -- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
 CREATE TABLE tsample7_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
-CREATE INDEX
 1: BEGIN;
 BEGIN
 2: BEGIN;
@@ -480,11 +638,29 @@ SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
  131070 
 (1 row)
 
+CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 65534 
+(1 row)
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 65534 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
+ count  
+--------
+ 131070 
+(1 row)
+
 -- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
 CREATE TABLE tsample8_@amname@(i int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
-CREATE INDEX
 1: BEGIN;
 BEGIN
 2: BEGIN;
@@ -559,6 +735,31 @@ SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEAT
 -------
  0     
 (1 row)
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 0     
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 45    
+(1 row)
+
+CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 0     
+(1 row)
 
 SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
  count 
@@ -569,8 +770,6 @@ SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
 -- Case 9: Logical heap blocks with deleted tuples on each QE
 CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
 CREATE TABLE
-CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
-CREATE INDEX
 INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
 INSERT 0 65635
 DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
@@ -631,16 +830,32 @@ SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
  45    
 (1 row)
 
+CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 45    
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 45    
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 45    
+(1 row)
+
 -- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
 
 CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE
 CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE
-CREATE INDEX ON ttr1(a);
-CREATE INDEX
-CREATE INDEX ON ttr2(a);
-CREATE INDEX
 
 INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
 INSERT 0 4
@@ -674,6 +889,32 @@ SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE B
 ----+---+----+---
  31 | 1 | 31 | 2 
 (1 row)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                         
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)           
+   ->  Nested Loop                                  
+         Join Filter: (ttr1.a = ttr2.a)             
+         ->  Sample Scan on ttr1                    
+               Sampling: system ('100'::real)       
+         ->  Materialize                            
+               ->  Sample Scan on ttr2              
+                     Sampling: system ('100'::real) 
+ Optimizer: Postgres-based planner                  
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
+
+CREATE INDEX ON ttr1(a);
+CREATE INDEX
+CREATE INDEX ON ttr2(a);
+CREATE INDEX
 
 EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
  QUERY PLAN                                         

--- a/src/test/isolation2/output/uao/tablesample.source
+++ b/src/test/isolation2/output/uao/tablesample.source
@@ -1,0 +1,533 @@
+-- Test Bernoulli sampling
+
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
+CREATE TABLE
+
+-- Case 0: Empty table
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+ i 
+---
+(0 rows)
+
+-- Case 1: Single partially populated logical heap block on each QE
+INSERT INTO tsample_@amname@ SELECT generate_series(1, 100);
+INSERT 0 100
+
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0);
+ i  
+----
+ 15 
+ 26 
+ 57 
+ 69 
+ 78 
+ 87 
+ 98 
+ 9  
+ 13 
+ 63 
+ 85 
+ 4  
+ 16 
+ 51 
+ 59 
+ 75 
+ 84 
+ 97 
+(18 rows)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0);
+ i  
+----
+ 4  
+ 16 
+ 51 
+ 59 
+ 75 
+ 84 
+ 97 
+ 15 
+ 26 
+ 57 
+ 69 
+ 78 
+ 87 
+ 98 
+ 9  
+ 13 
+ 63 
+ 85 
+(18 rows)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(5);
+ i   
+-----
+ 6   
+ 14  
+ 56  
+ 67  
+ 100 
+ 3   
+ 18  
+ 41  
+ 53  
+ 65  
+ 12  
+ 30  
+ 48  
+ 61  
+ 72  
+(15 rows)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(5);
+ i   
+-----
+ 6   
+ 14  
+ 56  
+ 67  
+ 100 
+ 3   
+ 18  
+ 41  
+ 53  
+ 65  
+ 12  
+ 30  
+ 48  
+ 61  
+ 72  
+(15 rows)
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 100   
+(1 row)
+
+-- Case 2: Multiple full logical heap blocks on a single QE
+CREATE TABLE tsample2_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
+INSERT 0 98303
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample2_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 32767 
+ 33554433 | 32768 
+ 33554434 | 32768 
+(3 rows)
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@;
+ count 
+-------
+ 98303 
+(1 row)
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.0005) REPEATABLE(5);
+ ctid             
+------------------
+ (33554432,8375)  
+ (33554434,26251) 
+(2 rows)
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.0005) REPEATABLE(5);
+ ctid             
+------------------
+ (33554432,8375)  
+ (33554434,26251) 
+(2 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 98303 
+(1 row)
+
+-- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
+CREATE TABLE tsample3_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
+INSERT 0 65635
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample3_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 32767 
+ 33554433 | 32768 
+ 33554434 | 100   
+(3 rows)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@;
+ count 
+-------
+ 65635 
+(1 row)
+
+SELECT ctid FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+ ctid 
+------
+(0 rows)
+SELECT ctid FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+ ctid 
+------
+(0 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 65635 
+(1 row)
+
+-- Case 4: Logical heap block with hole in the beginning on a single QE
+CREATE TABLE tsample4_@amname@(i int) USING @amname@;
+CREATE TABLE
+BEGIN;
+BEGIN
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
+INSERT 0 50
+ABORT;
+ROLLBACK
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32800);
+INSERT 0 32800
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample4_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 133   
+ 33554432 | 32667 
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@;
+ count 
+-------
+ 32800 
+(1 row)
+
+SELECT ctid FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+ ctid 
+------
+(0 rows)
+SELECT ctid FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(0.0001) REPEATABLE(5);
+ ctid 
+------
+(0 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 32800 
+(1 row)
+
+-- Case 5: Logical heap block with hole in the middle on a single QE
+CREATE TABLE tsample5_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
+INSERT 0 50
+INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
+INSERT 0 32800
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample5_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 133   
+ 33554432 | 32717 
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@;
+ count 
+-------
+ 32850 
+(1 row)
+
+SELECT ctid FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+(2 rows)
+SELECT ctid FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+(2 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 32850 
+(1 row)
+
+-- Case 6: Logical heap block with hole at the end on a single QE
+CREATE TABLE tsample6_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
+INSERT 0 32700
+INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
+INSERT 0 200
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample6_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 200   
+ 33554432 | 32700 
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@;
+ count 
+-------
+ 32900 
+(1 row)
+
+SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+(2 rows)
+SELECT ctid FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+(2 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 32900 
+(1 row)
+
+-- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
+CREATE TABLE tsample7_@amname@(i int) USING @amname@;
+CREATE TABLE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO tsample7_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768);
+INSERT 0 65535
+2: INSERT INTO tsample7_@amname@ SELECT 20 FROM generate_series(1, 32767 + 32768);
+INSERT 0 65535
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample7_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 32767 
+ 33554433 | 32768 
+ 67108864 | 32767 
+ 67108865 | 32768 
+(4 rows)
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@;
+ count  
+--------
+ 131070 
+(1 row)
+
+SELECT ctid FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+ (33554433,2096)  
+ (33554433,5866)  
+ (33554433,15922) 
+ (33554433,28588) 
+ (33554433,30496) 
+ (67108864,22419) 
+ (67108864,24501) 
+ (67108864,30450) 
+ (67108865,10043) 
+ (67108865,12536) 
+ (67108865,15619) 
+ (67108865,25530) 
+(14 rows)
+SELECT ctid FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554432,13824) 
+ (33554432,14962) 
+ (33554433,2096)  
+ (33554433,5866)  
+ (33554433,15922) 
+ (33554433,28588) 
+ (33554433,30496) 
+ (67108864,22419) 
+ (67108864,24501) 
+ (67108864,30450) 
+ (67108865,10043) 
+ (67108865,12536) 
+ (67108865,15619) 
+ (67108865,25530) 
+(14 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(100);
+ count  
+--------
+ 131070 
+(1 row)
+
+-- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
+CREATE TABLE tsample8_@amname@(i int) USING @amname@;
+CREATE TABLE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 5);
+INSERT 0 5
+2: INSERT INTO tsample8_@amname@ SELECT 20 FROM generate_series(1, 10);
+INSERT 0 10
+1: COMMIT;
+COMMIT
+2: ABORT;
+ROLLBACK
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 15);
+INSERT 0 15
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO tsample8_@amname@ SELECT 1 FROM generate_series(1, 20);
+INSERT 0 20
+2: INSERT INTO tsample8_@amname@ SELECT 20 FROM generate_series(1, 25);
+INSERT 0 25
+1: ABORT;
+ROLLBACK
+2: COMMIT;
+COMMIT
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample8_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 5     
+ 67108864 | 40    
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@;
+ count 
+-------
+ 45    
+(1 row)
+
+SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
+ ctid           
+----------------
+ (33554432,6)   
+ (67108864,103) 
+ (67108864,107) 
+ (67108864,203) 
+ (67108864,209) 
+ (67108864,215) 
+ (67108864,216) 
+ (67108864,223) 
+(8 rows)
+SELECT ctid FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1);
+ ctid           
+----------------
+ (33554432,6)   
+ (67108864,103) 
+ (67108864,107) 
+ (67108864,203) 
+ (67108864,209) 
+ (67108864,215) 
+ (67108864,216) 
+ (67108864,223) 
+(8 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 45    
+(1 row)
+
+-- Case 9: Logical heap blocks with deleted tuples on each QE
+CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
+INSERT 0 65635
+DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
+DELETE 16382
+DELETE FROM tsample9_@amname@ WHERE j > 65535;
+DELETE 100
+SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample9_@amname@ GROUP BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 16385 
+ 33554433 | 32768 
+(2 rows)
+SELECT count(*) FROM tsample9_@amname@;
+ count 
+-------
+ 49153 
+(1 row)
+
+SELECT ctid FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554433,2096)  
+ (33554433,5866)  
+ (33554433,15922) 
+ (33554433,28588) 
+ (33554433,30496) 
+(5 rows)
+SELECT ctid FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(0.01) REPEATABLE(1);
+ ctid             
+------------------
+ (33554433,2096)  
+ (33554433,5866)  
+ (33554433,15922) 
+ (33554433,28588) 
+ (33554433,30496) 
+(5 rows)
+
+SELECT count(*) FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 49153 
+(1 row)
+
+-- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
+
+CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE
+CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE
+INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
+INSERT 0 4
+INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
+INSERT 0 4
+ANALYZE ttr1;
+ANALYZE
+ANALYZE ttr2;
+ANALYZE
+SET enable_hashjoin TO OFF;
+SET
+SET enable_mergejoin TO OFF;
+SET
+SET enable_nestloop TO ON;
+SET
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                                                        
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)                                          
+   ->  Nested Loop                                                                 
+         Join Filter: (ttr1.a = ttr2.a)                                            
+         ->  Sample Scan on ttr1                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+         ->  Sample Scan on ttr2                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+ Optimizer: Postgres-based planner                                                 
+(8 rows)
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 31 | 1 | 31 | 2 
+(1 row)
+
+RESET enable_hashjoin;
+RESET
+RESET enable_mergejoin;
+RESET
+RESET enable_nestloop;
+RESET
+DROP TABLE ttr1;
+DROP TABLE
+DROP TABLE ttr2;
+DROP TABLE

--- a/src/test/isolation2/output/uao/tablesample.source
+++ b/src/test/isolation2/output/uao/tablesample.source
@@ -1,7 +1,9 @@
--- Test Bernoulli sampling
+-- Test Bernoulli and System sampling
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+CREATE INDEX
 
 -- Case 0: Empty table
 SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
@@ -107,9 +109,28 @@ SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
  100   
 (1 row)
 
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT COUNT(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 100   
+(1 row)
+
 -- Case 2: Multiple full logical heap blocks on a single QE
 CREATE TABLE tsample2_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
+CREATE INDEX
 INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 32768);
 INSERT 0 98303
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample2_@amname@ GROUP BY 1;
@@ -144,9 +165,28 @@ SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
  98303 
 (1 row)
 
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 98303 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 98303 
+(1 row)
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 98303 
+(1 row)
+
 -- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
 CREATE TABLE tsample3_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
+CREATE INDEX
 INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32767 + 32768 + 100);
 INSERT 0 65635
 SELECT right(split_part(ctid::text, ',', 1), -1) as blknum, count(*) FROM tsample3_@amname@ GROUP BY 1;
@@ -180,6 +220,8 @@ SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
 -- Case 4: Logical heap block with hole in the beginning on a single QE
 CREATE TABLE tsample4_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
+CREATE INDEX
 BEGIN;
 BEGIN
 INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 50);
@@ -215,9 +257,28 @@ SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
  32800 
 (1 row)
 
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+ count 
+-------
+ 32800 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(1);
+ count 
+-------
+ 32800 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 32800 
+(1 row)
+
 -- Case 5: Logical heap block with hole in the middle on a single QE
 CREATE TABLE tsample5_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
+CREATE INDEX
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 50);
 INSERT 0 50
 INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32800);
@@ -253,9 +314,28 @@ SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
  32850 
 (1 row)
 
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 32850 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 32850 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 32850 
+(1 row)
+
 -- Case 6: Logical heap block with hole at the end on a single QE
 CREATE TABLE tsample6_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
+CREATE INDEX
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 32700);
 INSERT 0 32700
 INSERT INTO tsample6_@amname@ SELECT 1 FROM generate_series(1, 200);
@@ -291,9 +371,28 @@ SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100);
  32900 
 (1 row)
 
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+ count 
+-------
+ 32700 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(3);
+ count 
+-------
+ 32700 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 32900 
+(1 row)
+
 -- Case 7: Multiple full logical heap blocks across 2 aosegs on a single QE
 CREATE TABLE tsample7_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample7_@amname@(i) WHERE i != i;
+CREATE INDEX
 1: BEGIN;
 BEGIN
 2: BEGIN;
@@ -364,9 +463,28 @@ SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE BERNOULLI(100);
  131070 
 (1 row)
 
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 65534 
+(1 row)
+SELECT count(*) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 65534 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample7_@amname@ TABLESAMPLE SYSTEM(100);
+ count  
+--------
+ 131070 
+(1 row)
+
 -- Case 8: Logical heap blocks with holes across 2 aosegs on a single QE
 CREATE TABLE tsample8_@amname@(i int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample8_@amname@(i) WHERE i != i;
+CREATE INDEX
 1: BEGIN;
 BEGIN
 2: BEGIN;
@@ -436,9 +554,23 @@ SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE BERNOULLI(100);
  45    
 (1 row)
 
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 0     
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 45    
+(1 row)
+
 -- Case 9: Logical heap blocks with deleted tuples on each QE
 CREATE TABLE tsample9_@amname@(i int, j int) USING @amname@;
 CREATE TABLE
+CREATE INDEX ON tsample9_@amname@(i) WHERE i != i;
+CREATE INDEX
 INSERT INTO tsample9_@amname@ SELECT 1, j FROM generate_series(1, 32767 + 32768 + 100) j;
 INSERT 0 65635
 DELETE FROM tsample9_@amname@ WHERE j < 32767/2;
@@ -482,12 +614,34 @@ SELECT count(*) FROM tsample9_@amname@ TABLESAMPLE BERNOULLI(100);
  49153 
 (1 row)
 
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 45    
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(5);
+ count 
+-------
+ 45    
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample8_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 45    
+(1 row)
+
 -- Case 10: Test rescans (similar to upstream test in regress/tablesample.sql)
 
 CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE
 CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
 CREATE TABLE
+CREATE INDEX ON ttr1(a);
+CREATE INDEX
+CREATE INDEX ON ttr2(a);
+CREATE INDEX
+
 INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
 INSERT 0 4
 INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
@@ -520,6 +674,27 @@ SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE B
 ----+---+----+---
  31 | 1 | 31 | 2 
 (1 row)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                         
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)           
+   ->  Nested Loop                                  
+         Join Filter: (ttr1.a = ttr2.a)             
+         ->  Sample Scan on ttr1                    
+               Sampling: system ('100'::real)       
+         ->  Materialize                            
+               ->  Sample Scan on ttr2              
+                     Sampling: system ('100'::real) 
+ Optimizer: Postgres-based planner                  
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
 
 RESET enable_hashjoin;
 RESET


### PR DESCRIPTION
This implements the SYSTEM sampling method for append-optimized tables.

TODO: CO tables and possibly without-blkdir-support.

This is meant to go in after #16556.
Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/system_ts