### PR TITLE
Remove yum install from verify_gpdb_versions task

### DIFF
--- a/concourse/scripts/verify_gpdb_versions.bash
+++ b/concourse/scripts/verify_gpdb_versions.bash
@@ -20,8 +20,6 @@ assert_postgres_version_matches() {
   fi
 }
 
-yum -d0 -y install git
-
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel
 GPDB_SRC_SHA=$(cd gpdb_src && git rev-parse HEAD)
 


### PR DESCRIPTION
we have found several times the concourse task failed with `no URLs in mirrorlist` on this task, in order to reduce error, install the package in the docker image.

[GPR-1562]

Authored-by: Ning Wu <ningw@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
