### PR TITLE
[6X] Remove `getaddrinfo` in `SendDummyPacket()` to address malloc deadlock

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -635,6 +635,9 @@ typedef struct ICStatistics
 /* Statistics for UDP interconnect. */
 static ICStatistics ic_statistics;
 
+/* Cached sockaddr of the listening udp socket */
+static struct sockaddr_storage udp_dummy_packet_sockaddr;
+
 /*=========================================================================
  * STATIC FUNCTIONS declarations
  */
@@ -656,10 +659,16 @@ static void setRxThreadError(int eno);
 static void resetRxThreadError(void);
 static void SendDummyPacket(void);
 
+static void ConvertToIPv4MappedAddr(struct sockaddr_storage *sockaddr, socklen_t *o_len);
+#if defined(__darwin__)
+#define	s6_addr32 __u6_addr.__u6_addr32
+static void ConvertIPv6WildcardToLoopback(struct sockaddr_storage* dest);
+#endif
 static void getSockAddr(struct sockaddr_storage *peer, socklen_t *peer_len, const char *listenerAddr, int listenerPort);
 static void setXmitSocketOptions(int txfd);
 static uint32 setSocketBufferSize(int fd, int type, int expectedSize, int leastSize);
-static void setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFamily);
+static void setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort,
+							int *txFamily, struct sockaddr_storage *listenerSockaddr);
 static ChunkTransportStateEntry *startOutgoingUDPConnections(ChunkTransportState *transportStates,
 							Slice *sendSlice,
 							int *pOutgoingCount);
@@ -1155,7 +1164,7 @@ resetRxThreadError()
  * 		Setup udp listening socket.
  */
 static void
-setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFamily)
+setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFamily, struct sockaddr_storage *listenerSockaddr)
 {
 	int			errnoSave;
 	int			fd = -1;
@@ -1322,6 +1331,13 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	else
 		*listenerPort = ntohs(((struct sockaddr_in *) &our_addr)->sin_port);
 
+	/*
+	 * cache the successful sockaddr of the listening socket, so
+	 * we can use this information to connect to the listening socket.
+	 */
+	if (listenerSockaddr != NULL)
+		memcpy(listenerSockaddr, &our_addr, sizeof(struct sockaddr_storage));
+
 	setXmitSocketOptions(fd);
 
 	return;
@@ -1438,8 +1454,8 @@ InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort)
 	/*
 	 * setup listening socket and sending socket for Interconnect.
 	 */
-	setupUDPListeningSocket(listenerSocketFd, listenerPort, &txFamily);
-	setupUDPListeningSocket(&ICSenderSocket, &ICSenderPort, &ICSenderFamily);
+	setupUDPListeningSocket(listenerSocketFd, listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+	setupUDPListeningSocket(&ICSenderSocket, &ICSenderPort, &ICSenderFamily, NULL);
 
 	/* Initialize receive control data. */
 	resetMainThreadWaiting(&rx_control_info.mainWaitingState);
@@ -1539,6 +1555,8 @@ CleanupMotionUDPIFC(void)
 	ICSenderSocket = -1;
 	ICSenderPort = 0;
 	ICSenderFamily = 0;
+
+	memset(&udp_dummy_packet_sockaddr, 0, sizeof(udp_dummy_packet_sockaddr));
 
 #ifdef USE_ASSERT_CHECKING
 
@@ -2849,30 +2867,8 @@ setupOutgoingUDPConnection(ChunkTransportState *transportStates, ChunkTransportS
 			 */
 			if (pEntry->txfd_family == AF_INET6)
 			{
-				struct sockaddr_storage temp;
-				const struct sockaddr_in *in = (const struct sockaddr_in *) &conn->peer;
-				struct sockaddr_in6 *in6_new = (struct sockaddr_in6 *) &temp;
-
-				memset(&temp, 0, sizeof(temp));
-
 				elog(DEBUG1, "We are inet6, remote is inet.  Converting to v4 mapped address.");
-
-				/* Construct a V4-to-6 mapped address.  */
-				temp.ss_family = AF_INET6;
-				in6_new->sin6_family = AF_INET6;
-				in6_new->sin6_port = in->sin_port;
-				in6_new->sin6_flowinfo = 0;
-
-				memset(&in6_new->sin6_addr, '\0', sizeof(in6_new->sin6_addr));
-				/* in6_new->sin6_addr.s6_addr16[5] = 0xffff; */
-				((uint16 *) &in6_new->sin6_addr)[5] = 0xffff;
-				/* in6_new->sin6_addr.s6_addr32[3] = in->sin_addr.s_addr; */
-				memcpy(((char *) &in6_new->sin6_addr) + 12, &(in->sin_addr), 4);
-				in6_new->sin6_scope_id = 0;
-
-				/* copy it back */
-				memcpy(&conn->peer, &temp, sizeof(struct sockaddr_in6));
-				conn->peer_len = sizeof(struct sockaddr_in6);
+				ConvertToIPv4MappedAddr(&conn->peer, &conn->peer_len);
 			}
 			else
 			{
@@ -6870,109 +6866,122 @@ WaitInterconnectQuitUDPIFC(void)
 }
 
 /*
+ * If the socket was created AF_INET6, but the address we want to
+ * send to is IPv4 (AF_INET), we need to change the address
+ * format. On Linux, this is not necessary: glibc automatically
+ * handles this. But on MAC OSX and Solaris, we need to convert
+ * the IPv4 address to IPv4-mapped IPv6 address in AF_INET6 format.
+ *
+ * The comment above relies on getaddrinfo() via function getSockAddr to get
+ * the correct V4-mapped address. We need to be careful here as we need to
+ * ensure that the platform we are using is POSIX 1003-2001 compliant.
+ * Just to be on the safeside, we'll be keeping this function for
+ * now to be used for all platforms and not rely on POSIX.
+ *
+ * Since this can be called in a signal handler, we avoid the use of
+ * async-signal unsafe functions such as memset/memcpy
+ */
+static void
+ConvertToIPv4MappedAddr(struct sockaddr_storage *sockaddr, socklen_t *o_len)
+{
+	const struct sockaddr_in *in = (const struct sockaddr_in *) sockaddr;
+	struct sockaddr_storage temp = {0};
+	struct sockaddr_in6 *in6_new = (struct sockaddr_in6 *) &temp;
+
+	/* Construct a IPv4-to-IPv6 mapped address.  */
+	temp.ss_family = AF_INET6;
+	in6_new->sin6_family = AF_INET6;
+	in6_new->sin6_port = in->sin_port;
+	in6_new->sin6_flowinfo = 0;
+
+	((uint16 *) &in6_new->sin6_addr)[5] = 0xffff;
+
+	in6_new->sin6_addr.s6_addr32[3] = in->sin_addr.s_addr;
+	in6_new->sin6_scope_id = 0;
+
+	/* copy it back */
+	*sockaddr = temp;
+	*o_len = sizeof(struct sockaddr_in6);
+}
+
+#if defined(__darwin__)
+/* macos does not accept :: as the destination, we will need to covert this to the IPv6 loopback */
+static void
+ConvertIPv6WildcardToLoopback(struct sockaddr_storage* dest)
+{
+	char address[INET6_ADDRSTRLEN];
+	/* we want to terminate our own process, so this should be local */
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	inet_ntop(AF_INET6, &in6->sin6_addr, address, sizeof(address));
+	if (strcmp("::", address) == 0)
+		((struct sockaddr_in6 *)dest)->sin6_addr = in6addr_loopback;
+}
+#endif
+
+/*
  * Send a dummy packet to interconnect thread to exit poll() immediately
  */
 static void
 SendDummyPacket(void)
 {
-	int			sockfd = -1;
-	int			ret;
-	struct addrinfo *addrs = NULL;
-	struct addrinfo *rp;
-	struct addrinfo hint;
-	uint16		udp_listener;
-	char		port_str[32] = {0};
-	char	   *dummy_pkt = "stop it";
-	int			counter;
+	int					ret;
+	char				*dummy_pkt = "stop it";
+	int					counter;
+	struct sockaddr_storage dest;
+	socklen_t	dest_len;
 
-	/*
-	 * Get address info from interconnect udp listener port
-	 */
-	udp_listener = (Gp_listener_port >> 16) & 0x0ffff;
-	snprintf(port_str, sizeof(port_str), "%d", udp_listener);
+	Assert(udp_dummy_packet_sockaddr.ss_family == AF_INET || udp_dummy_packet_sockaddr.ss_family == AF_INET6);
+	Assert(ICSenderFamily == AF_INET || ICSenderFamily == AF_INET6);
 
-	MemSet(&hint, 0, sizeof(hint));
-	hint.ai_socktype = SOCK_DGRAM;
-	hint.ai_family = AF_UNSPEC; /* Allow for IPv4 or IPv6  */
+	dest = udp_dummy_packet_sockaddr;
+	dest_len = (ICSenderFamily == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
 
-	/* Never do name resolution */
-#ifdef AI_NUMERICSERV
-	hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
-#else
-	hint.ai_flags = AI_NUMERICHOST;
+#if defined(__darwin__)
+	if (ICSenderFamily == AF_INET6)
+	{
+#if defined(__darwin__)
+		if (udp_dummy_packet_sockaddr.ss_family == AF_INET6)
+			ConvertIPv6WildcardToLoopback(&dest);
+#endif
+		if (udp_dummy_packet_sockaddr.ss_family == AF_INET)
+			ConvertToIPv4MappedAddr(&dest, &dest_len);
+	}
 #endif
 
-	ret = pg_getaddrinfo_all(interconnect_address, port_str, &hint, &addrs);
-	if (ret || !addrs)
+	if (ICSenderFamily == AF_INET && udp_dummy_packet_sockaddr.ss_family == AF_INET6)
 	{
-		elog(LOG, "send dummy packet failed, pg_getaddrinfo_all(): %m");
-		goto send_error;
-	}
-
-	for (rp = addrs; rp != NULL; rp = rp->ai_next)
-	{
-		/* Create socket according to pg_getaddrinfo_all() */
-		sockfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-		if (sockfd < 0)
-			continue;
-
-		if (!pg_set_noblock(sockfd))
-		{
-			if (sockfd >= 0)
-			{
-				closesocket(sockfd);
-				sockfd = -1;
-			}
-			continue;
-		}
-		break;
-	}
-
-	if (rp == NULL)
-	{
-		elog(LOG, "send dummy packet failed, create socket failed: %m");
-		goto send_error;
+		/* the size of AF_INET6 is bigger than the side of IPv4, so
+		 * converting from IPv6 to IPv4 may potentially not work. */
+		ereport(LOG, (errmsg("sending dummy packet failed: cannot send from AF_INET to receiving on AF_INET6")));
+		return;
 	}
 
 	/*
-	 * Send a dummy package to the interconnect listener, try 10 times
+	 * Send a dummy package to the interconnect listener, try 10 times.
+	 * We don't want to close the socket at the end of this function, since
+	 * the socket will eventually close during the motion layer cleanup.
 	 */
-
 	counter = 0;
 	while (counter < 10)
 	{
 		counter++;
-		ret = sendto(sockfd, dummy_pkt, strlen(dummy_pkt), 0, rp->ai_addr, rp->ai_addrlen);
+		ret = sendto(ICSenderSocket, dummy_pkt, strlen(dummy_pkt), 0, (struct sockaddr *) &dest, dest_len);
 		if (ret < 0)
 		{
 			if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 				continue;
 			else
 			{
-				elog(LOG, "send dummy packet failed, sendto failed: %m");
-				goto send_error;
+				ereport(LOG, (errmsg("send dummy packet failed, sendto failed: %m")));
+				return;
 			}
 		}
 		break;
 	}
 
 	if (counter >= 10)
-	{
-		elog(LOG, "send dummy packet failed, sendto failed: %m");
-		goto send_error;
-	}
+		ereport(LOG, (errmsg("send dummy packet failed, sendto failed with 10 times: %m")));
 
-	pg_freeaddrinfo_all(hint.ai_family, addrs);
-	closesocket(sockfd);
-	return;
-
-send_error:
-
-	if (addrs)
-		pg_freeaddrinfo_all(hint.ai_family, addrs);
-	if (sockfd != -1)
-		closesocket(sockfd);
-	return;
 }
 
 uint32

--- a/src/backend/cdb/motion/test/Makefile
+++ b/src/backend/cdb/motion/test/Makefile
@@ -1,0 +1,9 @@
+subdir=src/backend/cdb/motion
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=cdbsenddummypacket
+
+include $(top_builddir)/src/backend/mock.mk
+
+cdbsenddummypacket.t: EXCL_OBJS += src/backend/cdb/motion/ic_udpifc.o

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -1,0 +1,331 @@
+#include <unistd.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../../motion/ic_udpifc.c"
+
+bool break_loop = false;
+
+/*
+ * PROTOTYPES
+ */
+
+extern ssize_t __real_sendto(int sockfd, const void *buf, size_t len, int flags,
+							 const struct sockaddr *dest_addr, socklen_t addrlen);
+int __wrap_errcode(int sqlerrcode);
+int __wrap_errdetail(const char *fmt,...);
+int __wrap_errmsg(const char *fmt,...);
+ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags,
+					  const struct sockaddr *dest_addr, socklen_t addrlen);
+void __wrap_elog_finish(int elevel, const char *fmt,...);
+void __wrap_elog_start(const char *filename, int lineno, const char *funcname);
+void __wrap_errfinish(int dummy __attribute__((unused)),...);
+void __wrap_errstart(int elevel, const char *filename, int lineno, const char *funcname, const char *domain);
+void __wrap_write_log(const char *fmt,...);
+
+/*
+ * WRAPPERS
+ */
+
+int __wrap_errcode(int sqlerrcode)  {return 0;}
+int __wrap_errdetail(const char *fmt,...) { return 0; }
+int __wrap_errmsg(const char *fmt,...) { return 0; }
+void __wrap_elog_start(const char *filename, int lineno, const char *funcname) {}
+void __wrap_errfinish(int dummy __attribute__((unused)),...) {}
+void __wrap_errstart(int elevel, const char *filename, int lineno, const char *funcname, const char *domain){}
+
+void __wrap_write_log(const char *fmt,...)
+{
+	/* check if we actually receive the message that sends the error */
+	if (strcmp("Interconnect error: short conn receive (\%d)", fmt) == 0)
+		break_loop = true;
+}
+
+void __wrap_elog_finish(int elevel, const char *fmt,...)
+{
+	assert_true(elevel <= LOG);
+}
+
+ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+	assert_true(sockfd != PGINVALID_SOCKET);
+#if defined(__darwin__)
+	/* check to see if we converted the wildcard value to something routeable */
+	if (udp_dummy_packet_sockaddr.ss_family == AF_INET6)
+	{
+		const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) dest_addr;
+		char address[INET6_ADDRSTRLEN];
+		inet_ntop(AF_INET6, &in6->sin6_addr, address, sizeof(address));
+		/* '::' and '::1' should always be '::1' */
+		assert_true(strcmp("::1", address) == 0);
+	}
+#endif
+
+	return	__real_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+/*
+ * HELPER FUNCTIONS
+ */
+
+static void wait_for_receiver(bool should_fail)
+{
+	int counter = 0;
+	/* break_loop should be reset at the beginning of each test
+	 * The while loop will end early once __wrap_write_log is called;
+	 * this should happen when the receiver polls the message that
+	 * SendDummyPacket sends.
+	 */
+	while(!break_loop)
+	{
+		/* we are sleeping for a generous amount of time; we should never
+		 * need this much time. There is something wrong if it takes this long.
+		 *
+		 * expect to fail if the communication is invalid, i.e,. IPv4 to IPv6
+		 */
+		if (counter > 2)
+			break;
+		sleep(1);
+		counter++;
+	}
+
+	if (should_fail)
+		assert_true(counter > 2);
+	else
+		assert_true(counter < 2);
+}
+
+static void
+start_receiver()
+{
+	pthread_attr_t	t_atts;
+	sigset_t		pthread_sigs;
+	int				pthread_err;
+
+	pthread_attr_init(&t_atts);
+	pthread_attr_setstacksize(&t_atts, Max(PTHREAD_STACK_MIN, (128 * 1024)));
+	ic_set_pthread_sigmasks(&pthread_sigs);
+	pthread_err = pthread_create(&ic_control_info.threadHandle, &t_atts, rxThreadFunc, NULL);
+	ic_reset_pthread_sigmasks(&pthread_sigs);
+
+	pthread_attr_destroy(&t_atts);
+	if (pthread_err != 0)
+	{
+		ic_control_info.threadCreated = false;
+		printf("failed to create thread");
+		fail();
+	}
+
+	ic_control_info.threadCreated = true;
+}
+
+static sa_family_t
+create_sender_socket(sa_family_t af)
+{
+	int sockfd = socket(af,
+						SOCK_DGRAM,
+						0);
+	if (sockfd < 0)
+	{
+		printf("send dummy packet failed, create socket failed: %m\n");
+		fail();
+		return PGINVALID_SOCKET;
+	}
+
+	if (!pg_set_noblock(sockfd))
+	{
+		if (sockfd >= 0)
+		{
+			closesocket(sockfd);
+		}
+		printf("send dummy packet failed, setting socket with noblock failed: %m\n");
+		fail();
+		return PGINVALID_SOCKET;
+	}
+
+	return sockfd;
+}
+
+/*
+ * START UNIT TEST
+ */
+
+static void
+test_send_dummy_packet_ipv4_to_ipv4(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "0.0.0.0";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET);
+	ICSenderFamily = AF_INET;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in *in = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET);
+	assert_true(in->sin_family == AF_INET);
+	assert_true(listenerPort == ntohs(in->sin_port));
+	assert_true(strcmp("0.0.0.0", inet_ntoa(in->sin_addr)) == 0);
+
+	wait_for_receiver(false);
+}
+
+/* Sending from IPv4 to receiving on IPv6 is currently not supported.
+ * The size of AF_INET6 is bigger than the side of IPv4, so converting from
+ * IPv6 to IPv4 may potentially not work.
+ */
+static void
+test_send_dummy_packet_ipv4_to_ipv6_should_fail(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET);
+	ICSenderFamily = AF_INET;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(true);
+}
+
+static void
+test_send_dummy_packet_ipv6_to_ipv6(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::1";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(false);
+}
+
+static void
+test_send_dummy_packet_ipv6_to_ipv4(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "0.0.0.0";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in *in = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET);
+	assert_true(in->sin_family == AF_INET);
+	assert_true(listenerPort == ntohs(in->sin_port));
+	assert_true(strcmp("0.0.0.0", inet_ntoa(in->sin_addr)) == 0);
+
+	wait_for_receiver(false);
+}
+
+
+static void
+test_send_dummy_packet_ipv6_to_ipv6_wildcard(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(false);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	int is_ipv6_supported = true;
+	int sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (sockfd < 0 && errno == EAFNOSUPPORT)
+		is_ipv6_supported = false;
+
+	log_min_messages = DEBUG1;
+
+	start_receiver();
+
+	if (is_ipv6_supported)
+	{
+		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
+			unit_test(test_send_dummy_packet_ipv4_to_ipv6_should_fail),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv6),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv4),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv6_wildcard),
+		};
+		return run_tests(tests);
+	}
+	else
+	{
+		printf("WARNING: IPv6 is not supported, skipping unittest\n");
+		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
+		};
+		return run_tests(tests);
+	}
+	return 0;
+}


### PR DESCRIPTION
`SendDummyPacket` eventually calls `getaddrinfo` (which is a reentrant), however, `getaddrinfo` is not an async-signal-safe function. `getaddrinfo` internally calls `malloc`, which is strongly advised to not do within a signal handler as it may cause deadlocks. Cache the accepted socket information for the listener, so that it can be reused in `SendDummyPacket()`.

The purpose of `SendDummyPacket` is to exit more quickly; it circumvents the polling that happens, which eventually times out after 250ms.

Without `SendDummyPacket()`, there will be multiple test failures since some tests expects the backend connection to terminate almost immediately.

To view all the async-signal-safe functions, please view the signal-safety(7) — Linux manual page.

====================

Accommodate for AF_INET6 and AF_INET when doing a motion layer IPC teardown

Previously on commit 70306db18e2, we removed pg_getaddrinfo_all for signal handlers. However, in doing so, the capability of supporting both AF_INET6 and AF_INET was lost; this responsibility must now be handled by us. The commit mentioned above fixed the issue for AF_INET (IPv4), but not for AF_INET6 (IPv6).

This commit also addresses the situation for both AF_INET and AF_INET6.

====================

This commit backports: https://github.com/greenplum-db/gpdb/commit/70306db18e2bfac4969bf327f5ada45bf33f57a1 and
https://github.com/greenplum-db/gpdb/commit/1ee34a424548e759e82c93cf9b4fe1411465e0e9.
Conflicts resolved:
- setupUDPListeningSocket is not one to one with 7X, so resolve conflict
  on the location where `listenerSockaddr` is `memcpy`ed.
- resolve conflicts due to difference of from the modernized version and
  refactor from https://github.com/greenplum-db/gpdb/commit/50748b756758db19229c47911e4c29cbe5ba937b

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
