### PR TITLE
Update the verify_gpdb_versions task image

### DIFF
--- a/concourse/tasks/verify_gpdb_versions.yml
+++ b/concourse/tasks/verify_gpdb_versions.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: centos
-    tag: 7
+    repository: gcr.io/data-gpdb-public-images/gpdb6-rocky8-build
+    tag: latest
 
 inputs:
   - name: gpdb_src


### PR DESCRIPTION
change to gcr.io/data-gpdb-public-images/gpdb6-rocky8-build image which includes git.

[GPR-1562]

Authored-by: Ning Wu <ningw@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
