### PR TITLE
[6X] gprecoverseg: Fix behaviour of -o flag

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -78,12 +78,24 @@ class GpRecoverSegmentProgram:
     def outputToFile(self, mirrorBuilder, gpArray, fileName):
         lines = []
 
+        # Entry for a failed segment will be commented if failed segment host is unreachable to inform the user about
+        # those unreachable hosts. As we know gprecoverseg skips the recovery of a segment if host is unreachable so if
+        # the user wants to recover it to another host, they can do so by uncommenting the line and adding the
+        # failover details.
+        lines.append("# If any entry is commented, please know that it belongs to failed segment which is unreachable."
+                     "\n# If you need to recover them, please modify the segment entry and add failover details "
+                     "\n# (failed_addresss|failed_port|failed_dataDirectory<space>failover_addresss|failover_port|failover_dataDirectory) "
+                     "to recover it to another host.\n")
+
         # one entry for each failure
         for mirror in mirrorBuilder.getMirrorsToBuild():
             output_str = ""
             seg = mirror.getFailedSegment()
             addr = canonicalize_address(seg.getSegmentAddress())
             output_str += ('%s|%d|%s' % (addr, seg.getSegmentPort(), seg.getSegmentDataDirectory()))
+            if seg.unreachable:
+                # Entry is commented if failed segment host is unreachable
+                output_str = "#{}".format(output_str)
 
             seg = mirror.getFailoverSegment()
             if seg is not None:
@@ -99,16 +111,15 @@ class GpRecoverSegmentProgram:
     def getRecoveryActionsBasedOnOptions(self, gpEnv, gpArray):
         if self.__options.rebalanceSegments:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.replayLag)
-        else:
-            instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
-            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
-                    for t in instance.getTriplets()]
-            return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
-                                       self.__options.parallelDegree,
-                                       instance.getInterfaceHostnameWarnings(),
-                                       forceoverwrite=True,
-                                       progressMode=self.getProgressMode(),
-                                       parallelPerHost=self.__options.parallelPerHost)
+        instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.outputSampleConfigFile, self.__options.parallelDegree)
+        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
+                for t in instance.getTriplets()]
+        return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
+                                   self.__options.parallelDegree,
+                                   instance.getInterfaceHostnameWarnings(),
+                                   forceoverwrite=True,
+                                   progressMode=self.getProgressMode(),
+                                   parallelPerHost=self.__options.parallelPerHost)
 
     def syncPackages(self, new_hosts):
         # The design decision here is to squash any exceptions resulting from the

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -30,14 +30,14 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
         with tempfile.NamedTemporaryFile() as f:
             f.write(test["config"].encode("utf-8"))
             f.flush()
-            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, test.get("unreachable_hosts"),
+            return self._run_single_FromGpArray_test(test["gparray"], f.name, test.get("output_config_file", None), None, test.get("unreachable_hosts"),
                                                      test.get("is_pgrewind_running", itertools.repeat(False)),
                                                      test.get("is_seg_in_backup_mode", itertools.repeat(False)),
                                                      test.get("segments_with_running_basebackup", set()),
                                                      test.get("unreachable_existing_hosts"))
 
     def run_single_GpArray_test(self, test):
-        return self._run_single_FromGpArray_test(test["gparray"], None, test["new_hosts"],
+        return self._run_single_FromGpArray_test(test["gparray"], None, test.get("output_config_file", None), test["new_hosts"],
                                                  test.get("unreachable_hosts"),
                                                  test.get("is_pgrewind_running", itertools.repeat(False)),
                                                  test.get("is_seg_in_backup_mode", itertools.repeat(False)),
@@ -117,7 +117,9 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "gparray": self.all_up_gparray_str,
                 "config": "sdw2|21000|/mirror/gpseg0",
                 "unreachable_existing_hosts": ['sdw2'],
-                "expected": []
+                "expected": [self._triplet('10|0|m|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|p|p|s|u|sdw1|sdw1|20000|/primary/gpseg0',
+                                           None, True)]
             },
             {
                 "name": "one_mirror_inconfig_has_running_basebackup",
@@ -354,6 +356,55 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "expected": [self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
                                            '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
                                            None)]
+            },
+            {
+                "name": "output_config_file_when_one_existing_host_down",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": [],
+                "unreachable_existing_hosts": ['sdw1'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           None, True),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           None, True),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "output_config_file_when_one_existing_host_down_and_new_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": ['new_1', 'new_2'],
+                "unreachable_existing_hosts": ['sdw1'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0',
+                                           True),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1',
+                                           True),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
+            },
+            {
+                "name": "output_config_file_when_new_hosts",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "output_config_file": "recovery_sample_config.out",
+                "new_hosts": ['new_1', 'new_2'],
+                "expected": [self._triplet('2|0|m|p|s|d|sdw1|sdw1|20000|/primary/gpseg0',
+                                           '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
+                                           '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0'),
+                             self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           '3|1|m|p|s|d|new_1|new_1|20001|/primary/gpseg1'),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           '4|2|m|p|s|d|new_2|new_2|20000|/primary/gpseg2')]
             },
             {
                 "name": "all_relevant_existing_hosts_down",
@@ -789,7 +840,7 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                   4|2|p|p|s|u|sdw2|sdw2|20000|/primary/gpseg2
                                   5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
 
-    def _run_single_FromGpArray_test(self, gparray_str, config_file, new_hosts, unreachable_hosts, is_pgrewind_running,
+    def _run_single_FromGpArray_test(self, gparray_str, config_file, output_config_file, new_hosts, unreachable_hosts, is_pgrewind_running,
                                      is_seg_in_backup_mode, segments_with_running_basebackup, unreachable_existing_hosts=None):
         unreachable_hosts = unreachable_hosts if unreachable_hosts else []
         gppylib.programs.clsRecoverSegment_triples.get_unreachable_segment_hosts = Mock(return_value=unreachable_hosts)
@@ -800,7 +851,8 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
 
         initial_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
         mutated_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
-        i = RecoveryTripletsFactory.instance(mutated_gparray, config_file=config_file, new_hosts=new_hosts)
+        i = RecoveryTripletsFactory.instance(mutated_gparray, config_file=config_file,
+                                             outputConfigFile=output_config_file, new_hosts=new_hosts)
         triples = i.getTriplets()
 
         warnings = i.getInterfaceHostnameWarnings()

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -729,6 +729,26 @@ Feature: gprecoverseg tests
         | differential | -a --differential  |
         | full         | -aF                |
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg creates output sample config file correctly when failed segment hosts are unreachable
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And the primary on content 1 is stopped
+    And user can start transactions
+    And the primary on content 2 is stopped
+    And user can start transactions
+    And the status of the primary on content 1 should be "d"
+    And the status of the primary on content 2 should be "d"
+    And the host for the primary on content 1 is made unreachable
+    When the user runs "gprecoverseg -o /tmp/output_config"
+    Then gprecoverseg should return a return code of 0
+    And gprecoverseg should print "One or more hosts are not reachable via SSH." to stdout
+    And gprecoverseg should print "Host invalid_host is unreachable" to stdout
+    And the created config file /tmp/output_config contains the commented row for unreachable failed segment
+    And the cluster is returned to a good state
+
   @concourse_cluster
   Scenario Outline: <scenario> incremental recovery works with tablespaces on a multi-host environment
     Given the database is running


### PR DESCRIPTION
Backport of f03f27e8ebadf2cb3859aff7b63ea2e9bc6277fa

**Current behaviour:** gprecoverseg -o outputs a config file containing the rows for each failed segment. But skips to add row for segment if failed segment is unreachable as it can't be recovered during the recovery process.

**Requested behaviour:** gprecoverseg -o should generate config file which contains row for each failed segment from gp_segment_configuration even if the failed segment host is unreachable. As the genarted config file can be modified according to usecase and need.

**Fix:** While creating the list of triplets (which will considered for recovery) a triplet is not added to list if failed host is unreachable. This triplet should not skipped if we just want to generate an output config file. So added check for -o option with the reachability check of failed segment host. This way the triplet will be added to final list even if failed host is unreachable.

**Testing:** Have added unit tests and a behave test

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
