### PR TITLE
docs - clarify fillfactor valid for heap tables only (7x)

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
@@ -599,6 +599,8 @@ compresstype
 fillfactor
 :   The fillfactor for a table is a percentage between 10 and 100. 100 (complete packing) is the default. When a smaller fillfactor is specified, `INSERT` operations pack table pages only to the indicated percentage; the remaining space on each page is reserved for updating rows on that page. This gives `UPDATE` a chance to place the updated copy of a row on the same page as the original, which is more efficient than placing it on a different page. For a table whose entries are never updated, complete packing is the best choice, but in heavily updated tables smaller fillfactors are appropriate. This parameter cannot be set for TOAST tables.
 
+:   The fillfactor option is valid only for heap tables (tables that specify the `heap` access method or the `appendoptimized=FALSE` storage parameter).
+
 orientation
 :   Set to `column` for column-oriented storage, or `row` (the default) for row-oriented storage. This option is only valid if the table is append-optimized. Heap-storage tables can only be row-oriented.
 


### PR DESCRIPTION
the ALTER TABLE page defers to CREATE TABLE storage parameters section, so only one update required.
