### PR TITLE
Fix ERROR:  function brin_metapage_info(bytea) does not exist 

### DIFF
--- a/contrib/pageinspect/pageinspect--1.8--1.9.sql
+++ b/contrib/pageinspect/pageinspect--1.8--1.9.sql
@@ -6,7 +6,7 @@
 --
 -- brin_metapage_info()
 --
-DROP FUNCTION brin_metapage_info(IN page bytea, OUT magic text,
+DROP FUNCTION IF EXISTS brin_metapage_info(IN page bytea, OUT magic text,
                                  OUT version integer, OUT pagesperrange integer, OUT lastrevmappage bigint);
 CREATE FUNCTION brin_metapage_info(IN page bytea, OUT magic text,
                                    OUT version integer, OUT pagesperrange integer, OUT lastrevmappage bigint,
@@ -29,7 +29,7 @@ AS 'MODULE_PATHNAME', 'brin_revmap_chain'
 --
 -- add information about BRIN empty ranges
 --
-DROP FUNCTION brin_page_items(IN page bytea, IN index_oid regclass);
+DROP FUNCTION If EXISTS brin_page_items(IN page bytea, IN index_oid regclass);
 CREATE FUNCTION brin_page_items(IN page bytea, IN index_oid regclass,
                                 OUT itemoffset int,
                                 OUT blknum int8,


### PR DESCRIPTION
Long log:

We encountered some errors when we `make installcheck-small`:
```
============== installing gp_toolkit                  ==============
CREATE EXTENSION
============== installing pageinspect                 ==============
ERROR:  function brin_metapage_info(bytea) does not exist
command failed: "/usr/local/gpdb/bin/psql" -X -c "CREATE EXTENSION IF NOT EXISTS \"pageinspect\"" "regression"
make: *** [installcheck-good] Error 2
```

The solution is simple, just add `IF EXISTS` in these SQL.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>