### PR TITLE
Don't lose query ids in Orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -162,7 +162,8 @@ CTranslatorDXLToPlStmt::~CTranslatorDXLToPlStmt()
 PlannedStmt *
 CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 											  const Query *orig_query,
-											  bool can_set_tag)
+											  bool can_set_tag,
+											  uint32_t query_id)
 {
 	GPOS_ASSERT(nullptr != dxlnode);
 
@@ -245,6 +246,7 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 	planned_stmt->planTree = plan;
 
 	planned_stmt->canSetTag = can_set_tag;
+	planned_stmt->queryId = query_id;
 	planned_stmt->relationOids = oids_list;
 
 	planned_stmt->commandType = m_cmd_type;

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -266,7 +266,7 @@ COptTasks::LogExceptionMessageAndDelete(CHAR *err_buf)
 PlannedStmt *
 COptTasks::ConvertToPlanStmtFromDXL(
 	CMemoryPool *mp, CMDAccessor *md_accessor, const Query *orig_query,
-	const CDXLNode *dxlnode, bool can_set_tag,
+	const CDXLNode *dxlnode, Query *query,
 	DistributionHashOpsKind distribution_hashops)
 {
 	GPOS_ASSERT(nullptr != md_accessor);
@@ -288,7 +288,7 @@ COptTasks::ConvertToPlanStmtFromDXL(
 	CTranslatorDXLToPlStmt dxl_to_plan_stmt_translator(
 		mp, md_accessor, &dxl_to_plan_stmt_ctxt, gpdb::GetGPSegmentCount());
 	return dxl_to_plan_stmt_translator.GetPlannedStmtFromDXL(
-		dxlnode, orig_query, can_set_tag);
+		dxlnode, orig_query, query->canSetTag, query->queryId);
 }
 
 
@@ -585,8 +585,7 @@ COptTasks::OptimizeTask(void *ptr)
 				// that may not have the correct can_set_tag
 				opt_ctxt->m_plan_stmt =
 					(PlannedStmt *) gpdb::CopyObject(ConvertToPlanStmtFromDXL(
-						mp, &mda, opt_ctxt->m_query, plan_dxl,
-						opt_ctxt->m_query->canSetTag,
+						mp, &mda, opt_ctxt->m_query, plan_dxl, opt_ctxt->m_query,
 						query_to_dxl_translator->GetDistributionHashOpsKind()));
 			}
 

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -161,7 +161,8 @@ public:
 	// main translation routine for DXL tree -> PlannedStmt
 	PlannedStmt *GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 									   const Query *orig_query,
-									   bool can_set_tag);
+									   bool can_set_tag,
+									   uint32_t query_id);
 
 	// translate the join types from its DXL representation to the GPDB one
 	static JoinType GetGPDBJoinTypeFromDXLJoinType(EdxlJoinType join_type);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -128,7 +128,7 @@ private:
 	// translate a DXL tree into a planned statement
 	static PlannedStmt *ConvertToPlanStmtFromDXL(
 		CMemoryPool *mp, CMDAccessor *md_accessor, const Query *orig_query,
-		const CDXLNode *dxlnode, bool can_set_tag,
+		const CDXLNode *dxlnode, Query *query,
 		DistributionHashOpsKind distribution_hashops);
 
 	// load search strategy from given path


### PR DESCRIPTION
@Simon-Wong initially proposed a similar fix for 6X here: https://github.com/greenplum-db/gpdb/pull/15385
Query id is required for some extensions and also will be needed for pg_stat_statements if GP ever tries to support it. I didn't come up with any regressions tests though to make sure we don't lose query id again.