### PR TITLE
Implementation of network throttling in gprecoverseg

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1013,12 +1013,12 @@ class GpSegRecovery(Command):
     """
     Format gpsegrecovery call for running pg_basebackup/pg_rewind on remoteHost for the segments passed in confinfo
     """
-    def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite, era):
-        cmdStr = _get_cmd_for_recovery_wrapper('gpsegrecovery', confinfo, logdir, batchSize, verbose, forceoverwrite, era)
+    def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite, era, maxRate):
+        cmdStr = _get_cmd_for_recovery_wrapper('gpsegrecovery', confinfo, logdir, batchSize, verbose, forceoverwrite, era, maxRate)
         Command.__init__(self, name, cmdStr, REMOTE, remoteHost, start_new_session=True)
 
 
-def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite, era=None):
+def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite, era=None, maxRate=None):
     cmdStr = '$GPHOME/sbin/{}.py -c {} -l {}'.format(wrapper_filename, pipes.quote(confinfo), pipes.quote(logdir))
 
     if verbose:
@@ -1029,6 +1029,9 @@ def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize,
         cmdStr += " --force-overwrite"
     if era:
         cmdStr += " --era={}".format(era)
+    if maxRate:
+        cmdStr += " --max-rate {}".format(maxRate)
+
 
     return cmdStr
 

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -338,7 +338,7 @@ class PgRewind(Command):
 class PgBaseBackup(Command):
     def __init__(self, target_datadir, source_host, source_port, create_slot=False, replication_slot_name=None,
                  excludePaths=[], ctxt=LOCAL, remoteHost=None, writeconffilesonly=False, forceoverwrite=False,
-                 target_gp_dbid=0, progress_file=None, recovery_mode=True):
+                 target_gp_dbid=0, progress_file=None, recovery_mode=True, max_rate=None):
         cmd_tokens = ['pg_basebackup', '-c', 'fast']
         cmd_tokens.append('-D')
         cmd_tokens.append(target_datadir)
@@ -397,6 +397,9 @@ class PgBaseBackup(Command):
                     cmd_tokens.append('-E')
                     cmd_tokens.append(path)
 
+            if max_rate:
+                cmd_tokens.append('--max-rate')
+                cmd_tokens.append(max_rate)
         # This is needed to handle Greenplum tablespaces
         cmd_tokens.append('--target-gp-dbid')
         cmd_tokens.append(str(target_gp_dbid))

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
@@ -185,6 +185,40 @@ class TestUnitPgBaseBackup(unittest.TestCase):
         self.assertNotIn("-x", base_backup.command_tokens)
         self.assertNotIn("--xlog", base_backup.command_tokens)
 
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=True)
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=True)
+    def test_max_rate_not_passed_when_not_given_max_rate(self, mock1, mock2):
+        base_backup = pg.PgBaseBackup(
+            create_slot=True,
+            replication_slot_name='some-replication-slot-name',
+            target_datadir="foo",
+            source_host="bar",
+            source_port="baz",
+            max_rate=None,
+            )
+        self.assertNotIn("--max-rate", base_backup.command_tokens)
+        self.assertIn("--create-slot", base_backup.command_tokens)
+        self.assertIn("--slot", base_backup.command_tokens)
+        self.assertIn("some-replication-slot-name", base_backup.command_tokens)
+        self.assertIn("--wal-method", base_backup.command_tokens)
+
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=True)
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=True)
+    def test_max_rate_passed_when_given_max_rate(self, mock1, mock2):
+        base_backup = pg.PgBaseBackup(
+            create_slot=True,
+            replication_slot_name='some-replication-slot-name',
+            target_datadir="foo",
+            source_host="bar",
+            source_port="baz",
+            max_rate="123k",
+            )
+        self.assertIn("--max-rate", base_backup.command_tokens)
+        self.assertIn("--create-slot", base_backup.command_tokens)
+        self.assertIn("--slot", base_backup.command_tokens)
+        self.assertIn("some-replication-slot-name", base_backup.command_tokens)
+        self.assertIn("--wal-method", base_backup.command_tokens)
+
 class PgTests(GpTestCase):
     def setUp(self):
         self.apply_patches([

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -171,7 +171,7 @@ class GpMirrorListToBuild:
         ADDMIRRORS='add'
         RECOVERMIRRORS='recover'
 
-    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False, progressMode=Progress.INPLACE, parallelPerHost=gp.DEFAULT_SEGHOST_NUM_WORKERS):
+    def __init__(self, toBuild, pool, quiet, parallelDegree, additionalWarnings=None, logger=logger, forceoverwrite=False, progressMode=Progress.INPLACE, parallelPerHost=gp.DEFAULT_SEGHOST_NUM_WORKERS, maxRate=None):
         self.__mirrorsToBuild = toBuild
         self.__pool = pool
         self.__quiet = quiet
@@ -181,6 +181,7 @@ class GpMirrorListToBuild:
         self.__forceoverwrite = forceoverwrite
         self.__parallelPerHost = parallelPerHost
         self.__additionalWarnings = additionalWarnings or []
+        self.__maxRate = maxRate
         self.segments_to_mark_down = []
         if not logger:
             raise Exception('logger argument cannot be None')
@@ -209,6 +210,12 @@ class GpMirrorListToBuild:
         Returns any additional warnings generated during building of list
         """
         return self.__additionalWarnings
+
+    def getMaxTransferRate(self):
+        """
+        returns the maximum transfer rate of data directory during Full recovery of failed segments
+        """
+        return self.__maxRate
 
     def _cleanup_before_recovery(self, gpArray, gpEnv):
         self.checkForPortAndDirectoryConflicts(gpArray)
@@ -602,6 +609,7 @@ class GpMirrorListToBuild:
                                          batchSize=self.__parallelPerHost,
                                          remoteHost=hostName,
                                          era=era,
+                                         maxRate=self.__maxRate,
                                          forceoverwrite=self.__forceoverwrite))
         completed_recovery_results = self.__runWaitAndCheckWorkerPoolForErrorsAndClear(cmds, suppressErrorCheck=True,
                                                                                        progressCmds=progress_cmds)

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -3,6 +3,7 @@ from mock import Mock, patch, call
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands.base import CommandResult, ExecutionError
 from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
+from gppylib.test.unit.test_unit_gprecoverseg import Options
 
 class RecoverSegmentsTestCase(GpTestCase):
     def setUp(self):
@@ -73,6 +74,39 @@ class RecoverSegmentsTestCase(GpTestCase):
         self.mock_logger.error.assert_has_calls([call("Not able to terminate recovery process on host sdw1: Error getting recovery PID"),
                                                  call("Not able to terminate recovery process on host sdw3: Error getting recovery PID")])
 
+    def test_is_max_rate_valid_exception(self):
+        options = Options()
+        options.showProgressInplace = True
+
+        options.maxRate = 'k32'
+        object = GpRecoverSegmentProgram(options)
+        with self.assertRaises(Exception) as ex:
+            object.validateMaxRate()
+        self.assertEqual("transfer rate k32 is not a valid value", str(ex.exception))
+
+        options.maxRate = '0'
+        object = GpRecoverSegmentProgram(options)
+        with self.assertRaises(Exception) as ex:
+            object.validateMaxRate()
+        self.assertEqual("Transfer rate must be greater than zero", str(ex.exception))
+
+        options.maxRate = '1046M'
+        object = GpRecoverSegmentProgram(options)
+        with self.assertRaises(Exception) as ex:
+            object.validateMaxRate()
+        self.assertEqual("transfer rate 1046M is out of range", str(ex.exception))
+
+        options.maxRate = '1024G'
+        object = GpRecoverSegmentProgram(options)
+        with self.assertRaises(Exception) as ex:
+            object.validateMaxRate()
+        self.assertEqual("Invalid --max-rate unit: G", str(ex.exception))
+
+        options.maxRate = '3k2k'
+        object = GpRecoverSegmentProgram(options)
+        with self.assertRaises(Exception) as ex:
+            object.validateMaxRate()
+        self.assertEqual("transfer rate 3k2k is not a valid value", str(ex.exception))
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -35,6 +35,7 @@ class Options:
         self.quiet = None
         self.interactive = False
         self.hba_hostnames = False
+        self.maxRate = None
 
 
 class GpRecoversegTestCase(GpTestCase):
@@ -91,6 +92,7 @@ class GpRecoversegTestCase(GpTestCase):
             patch.object(GpMirrorListToBuild, "recover_mirrors"),
             patch.object(GpMirrorListToBuild, "getAdditionalWarnings"),
             patch.object(GpMirrorListToBuild, "getMirrorsToBuild"),
+            patch.object(GpMirrorListToBuild, "getMaxTransferRate"),
             patch.object(HeapChecksum, "check_segment_consistency"),
             patch.object(HeapChecksum, "get_segments_checksum_settings"),
         ])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
@@ -188,7 +188,7 @@ class RecoveryBaseTestCase(GpTestCase):
         mock_workerpool.return_value.getCompletedItems = Mock(return_value=[cmd1, cmd1])
         sys.argv = ['recovery_base', '-l', '/tmp/logdir',
                     '-c {}'.format(self.confinfo),
-                    '-b 10', '-f', '-v', '--era', '1234_2021']
+                    '-b 10', '-f', '-v', '--era', '1234_2021', '--max-rate', '1024M']
         stderr_buf, ex = self.run_recovery_base_get_stderr()
         self._asserts_for_passing_tests(stderr_buf, ex, enable_verbose_count=1)
         self.assertEqual([call('test_file.py', ANY, ANY, logdir='/tmp/logdir')],
@@ -325,7 +325,7 @@ class SetCmdResultsTestCase(GpTestCase):
             raise Exception('running the cmd failed')
 
         recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
-        test_cmd = FullRecovery('original name', recovery_info, True,None,None)
+        test_cmd = FullRecovery('original name', recovery_info, True,None,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)
 
@@ -340,7 +340,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.error_type = None
             raise Exception('running the cmd failed')
         recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
-        test_cmd = FullRecovery('original name', recovery_info, True,None,None)
+        test_cmd = FullRecovery('original name', recovery_info, True,None,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -491,8 +491,8 @@ class RecoveryResultTestCase(GpTestCase):
                 else:
                     host2_result = CommandResult(1, 'failed 2'.encode(), test["host2_error"].encode(), True, False)
 
-                host1_recovery_output = gp.GpSegRecovery(None, None, None, False, 1, 'host1', None, True)
-                host2_recovery_output = gp.GpSegRecovery(None, None, None, False, 1, 'host2', None, True)
+                host1_recovery_output = gp.GpSegRecovery(None, None, None, False, 1, 'host1', None, True, None)
+                host2_recovery_output = gp.GpSegRecovery(None, None, None, False, 1, 'host2', None, True, None)
                 host1_recovery_output.get_results = Mock(return_value=host1_result)
                 host2_recovery_output.get_results = Mock(return_value=host2_result)
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -12,6 +12,7 @@ gprecoverseg [-p <new_recover_host>[,...]]
              [-d <coordinator_data_directory>]
              [-B <batch_size>] [-b <segment_batch_size>] [--differential]
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
+             [--max-rate <max_rate>]
 
 
 gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
@@ -151,6 +152,12 @@ Optional. Perform a differential copy of the active segment instance
 in order to recover the failed segment. The default is to only copy
 over the incremental changes that occurred while the segment was down.
 
+--max-rate <max_rate>
+
+Optional. Specifies the max-rate for full recovery of failed segments.
+Rate is in kB/s, suffix `k` or `M` can be used to signify kB/s or MB/s.
+Valid rate ranges from 32kB/s to 1048576kB/s(1024MB/s). The default is to use the
+entire available network bandwidth to perform full recovery of failed segment.
 
 -i <recover_config_file>
 

--- a/gpMgmt/sbin/recovery_base.py
+++ b/gpMgmt/sbin/recovery_base.py
@@ -40,6 +40,7 @@ class RecoveryBase(object):
         parser.add_option('-f', '--force-overwrite', dest='forceoverwrite', action='store_true', default=False)
         parser.add_option('-l', '--log-dir', dest="logfileDirectory", type="string")
         parser.add_option('', '--era', dest="era", help="coordinator era", )
+        parser.add_option('--max-rate', type='string', dest='maxRate', metavar='<maxRate>')
 
         # Parse the command line arguments
         self.options, _ = parser.parse_args()

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -9,7 +9,7 @@ Recovers a primary or mirror segment instance that has been marked as down \(if 
 gprecoverseg [[-p <new_recover_host>[,...]] | -i <recover_config_file>] [-d <coordinator_data_directory>] 
              [-b <segment_batch_size>] [-B <batch_size>] [-F [-s]] [-a] [-q] [--differential]
 	           [--hba-hostnames <boolean>] 
-             [--no-progress] [-l <logfile_directory>]
+             [--no-progress] [-l <logfile_directory>] [--max-rate <max_rate>]
 
 gprecoverseg -r [--replay-lag <replay_lag>] [--disable-replay-lag]
 
@@ -186,6 +186,9 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 
     >**Note**
     >The `--differential` option cannot be combined with any of the following `gprecoverseg` options: `-i`, `-o`, `-F`, or `-p`.
+
+--max-rate max\_rate
+:    Optional. Maximum transfer rate for Full recovery of failed segments. Rate is in kB/s, suffix `k` or `M` can be used to signify kB/s or MB/s. Valid options are from 32kB/s to 1048576kB/s(1024MB/s).
 
 -v \| --verbose
 :   Sets logging output to verbose.


### PR DESCRIPTION
As part of this PR, an option is introduced to throttle network speed during full recovery of a segment.
`--max-rate` option is added in gprecoverseg utility to tune the speed at which recovery should happen.
Its value can range from `32KB/s to 1048576KB/s(1024MB/s).`
This is an optional argument and if not passed then it takes entire available network bandwidth for Full recovery of failed segments.

gprecoverseg uses pg_basebackup as an underlying utility for transfer of data-directories in case of Full recovery.
`pg_basebackup` has a existing 'max-rate' option provided as an option to the user to control the rate at which data-directory can be transferred. This utility is now introduced in gprecoverseg also, using which the user can tune the rate of full recovery and thereby preventing recovery from using up entire network bandwidth.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
