### PR TITLE
ao/co: Support TABLESAMPLE

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1088,8 +1088,16 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
 
 				if (startrow + rowcount - 1 >= targrow)
 				{
+					int64 blocksRead;
+
 					/* read a new buffer to consume */
 					datumstreamread_block_content(ds);
+
+					AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
+					blocksRead =
+						RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+					pgstat_count_buffer_read_ao(scan->rs_base.rs_rd,
+												blocksRead);
 
 					if (!aocs_gettuple_column(scan, attno, startrow, targrow, chkvisimap, slot))
 						ret = false;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -651,7 +651,7 @@ aocs_beginscan_internal(Relation relation,
 		 */
 		if ((flags & SO_TYPE_ANALYZE) != 0 || (flags & SO_TYPE_SAMPLESCAN) != 0)
 		{
-			if (OidIsValid(blkdirrelid))
+			if (OidIsValid(blkdirrelid) && gp_enable_blkdir_sampling)
 				aocs_blkdirscan_init(scan);
 		}
 	}

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1156,6 +1156,9 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
  * the corresponding tuple in 'slot'.
  *
  * If the tuple is visible, return true. Otherwise, return false.
+ *
+ * Note: for the duration of the scan, we expect targrow to be monotonically
+ * increasing in between successive calls.
  */
 bool
 aocs_get_target_tuple(AOCSScanDesc aoscan, int64 targrow, TupleTableSlot *slot)

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1055,11 +1055,7 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
 			if (startrow + rowcount - 1 >= targrow)
 			{
 				if (!aocs_gettuple_column(scan, attno, startrow, targrow, chkvisimap, slot))
-				{
 					ret = false;
-					/* must update tracking vars before return */
-					goto out;
-				}
 
 				chkvisimap = false;
 				/* haven't finished scanning on current block */
@@ -1096,11 +1092,7 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
 					datumstreamread_block_content(ds);
 
 					if (!aocs_gettuple_column(scan, attno, startrow, targrow, chkvisimap, slot))
-					{
 						ret = false;
-						/* must update tracking vars before return */
-						goto out;
-					}
 
 					chkvisimap = false;
 					/* done this column */
@@ -1116,13 +1108,13 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
 		}
 	}
 
-out:
 	/* update rows processed */
 	scan->segrowsprocessed = rowstoprocess;
 
 	if (ret)
 	{
 		ExecStoreVirtualTuple(slot);
+
 		pgstat_count_heap_getnext(scan->rs_base.rs_rd);
 	}
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -2494,8 +2494,24 @@ aoco_scan_sample_next_block(TableScanDesc scan, SampleScanState *scanstate)
 	if (tsm->NextSampleBlock)
 	{
 		int64 nblocks = (totalrows + (AO_MAX_TUPLES_PER_HEAP_BLOCK - 1)) / AO_MAX_TUPLES_PER_HEAP_BLOCK;
+		int64 nextblk;
 
-		aoscan->sampleTargetBlk = tsm->NextSampleBlock(scanstate, nblocks);
+		nextblk = tsm->NextSampleBlock(scanstate, nblocks);
+
+		if (nextblk <= aoscan->sampleTargetBlk)
+		{
+			/*
+			 * Some tsm methods may wrap around and return a block prior to our
+			 * current scan position, like tsm_system_time.
+			 *
+			 * Since our sample scan infrastructure expects monotonically
+			 * increasing block numbers between successive calls, simply rewind
+			 * the scan here.
+			 */
+			aoco_rescan(&aoscan->rs_base, NULL, false, false, false, false);
+		}
+
+		aoscan->sampleTargetBlk = nextblk;
 
 		/* ran out of blocks, scan is done */
 		if (aoscan->sampleTargetBlk == InvalidBlockNumber)

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1839,7 +1839,7 @@ appendonly_beginrangescan_internal(Relation relation,
 		 */
 		if ((flags & SO_TYPE_ANALYZE) != 0 || (flags & SO_TYPE_SAMPLESCAN) != 0)
 		{
-			if (OidIsValid(blkdirrelid))
+			if (OidIsValid(blkdirrelid) && gp_enable_blkdir_sampling)
 				appendonly_blkdirscan_init(scan);
 		}
 	}

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1422,6 +1422,9 @@ appendonly_blkdirscan_get_target_tuple(AppendOnlyScanDesc scan, int64 targrow, T
  * the corresponding tuple in 'slot'.
  *
  * If the tuple is visible, return true. Otherwise, return false.
+ *
+ * Note: for the duration of the scan, we expect targrow to be monotonically
+ * increasing in between successive calls.
  */
 bool
 appendonly_get_target_tuple(AppendOnlyScanDesc aoscan, int64 targrow, TupleTableSlot *slot)

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1299,7 +1299,15 @@ appendonly_getblock(AppendOnlyScanDesc scan, int64 targrow, int64 *startrow)
 			Assert(rowcount > 0);
 			if (*startrow + rowcount - 1 >= targrow)
 			{
+				int64 blocksRead;
+
 				AppendOnlyExecutorReadBlock_GetContents(varblock);
+
+				AppendOnlyScanDesc_UpdateTotalBytesRead(scan);
+				blocksRead = RelationGuessNumberOfBlocksFromSize(scan->totalBytesRead);
+				pgstat_count_buffer_read_ao(scan->aos_rd,
+											blocksRead);
+
 				/* got a new buffer to consume */
 				scan->needNextBuffer = false;
 				return;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -441,6 +441,9 @@ double		optimizer_jit_above_cost;
 double		optimizer_jit_inline_above_cost;
 double		optimizer_jit_optimize_above_cost;
 
+/* Switch to toggle block-directory based sampling for AO/CO tables */
+bool		gp_enable_blkdir_sampling;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -636,6 +639,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&enable_groupagg,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"gp_enable_blkdir_sampling", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Enables the use of an append-optimized table's block "
+					  "directory for sampling (if one is present)."),
+		 NULL,
+		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_blkdir_sampling,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -170,6 +170,8 @@ typedef struct AOCSScanDescData
 	 * which starts from 0.
 	 * In other words, if we have seg0 rownums: [1, 100], seg1 rownums: [1, 200]
 	 * If targrow = 150, then we are referring to seg1's rownum=51.
+	 *
+	 * In the context of TABLESAMPLE, this is the next row to be sampled.
 	 */
 	int64			targrow;
 
@@ -257,6 +259,20 @@ typedef struct AOCSScanDescData
 	 * across all columns projected, so far. It is used for scan progress reporting.
 	 */
 	int64		totalBytesRead;
+
+	/*
+	 * The next block of AO_MAX_TUPLES_PER_HEAP_BLOCK tuples to be considered
+	 * for TABLESAMPLE. This only corresponds to tuples that are physically
+	 * present in segfiles (excludes aborted tuples). This "block" is purely a
+	 * logical grouping of tuples (in the flat row number space spanning segs).
+	 * It does NOT correspond to the concept of a "logical heap block" (block
+	 * number in a ctid).
+	 *
+	 * The choice of AO_MAX_TUPLES_PER_HEAP_BLOCK is somewhat arbitrary. It
+	 * could have been anything (that can be represented with an OffsetNumber,
+	 * to comply with the TSM API).
+	 */
+	int64 		sampleTargetBlk;
 } AOCSScanDescData;
 
 typedef AOCSScanDescData *AOCSScanDesc;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -613,6 +613,8 @@ extern bool gp_log_endpoints;
 
 extern bool gp_allow_date_field_width_5digits;
 
+extern bool gp_enable_blkdir_sampling;
+
 typedef enum
 {
 	INDEX_CHECK_NONE,

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -45,6 +45,7 @@
 		"gp_default_storage_options",
 		"gp_detect_data_correctness",
 		"gp_disable_tuple_hints",
+		"gp_enable_blkdir_sampling",
 		"gp_enable_interconnect_aggressive_retry",
 		"gp_enable_segment_copy_checking",
 		"gp_external_enable_filter_pushdown",

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -60,7 +60,11 @@ clean distclean:
 	rm -f data
 	rm -rf $(pg_regress_clean_files)
 
-install: all gpdiff.pl gpstringsubs.pl
+# GPDB: tsm_system_rows module is needed by some tests.
+install-tests:
+	$(MAKE) -C $(top_builddir)/contrib/tsm_system_rows install
+
+install: all gpdiff.pl gpstringsubs.pl install-tests
 
 installcheck: install installcheck-resource-queue installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/isolation2_schedule

--- a/src/test/isolation2/input/uao/tablesample.source
+++ b/src/test/isolation2/input/uao/tablesample.source
@@ -1,5 +1,5 @@
--- Test Bernoulli and System sampling. For System sampling both blkdir and
--- without blkdir cases are considered.
+-- Test block-level and row-level sampling. For block-level sampling both blkdir
+-- and without blkdir cases are considered.
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
 
@@ -270,3 +270,26 @@ RESET enable_mergejoin;
 RESET enable_nestloop;
 DROP TABLE ttr1;
 DROP TABLE ttr2;
+
+-- Case 8: Test tsm_system_rows on distributed tables
+CREATE EXTENSION IF NOT EXISTS tsm_system_rows;
+
+CREATE TABLE tsample8_@amname@(i int, j int) USING @amname@ DISTRIBUTED BY (i);
+
+INSERT INTO tsample8_@amname@ SELECT 1, j FROM generate_series(1, 32768) j;
+INSERT INTO tsample8_@amname@ SELECT 2, j + 32768 FROM generate_series(1, 32768) j;
+INSERT INTO tsample8_@amname@ SELECT 5, j + 32768 * 2 FROM generate_series(1, 32768) j;
+
+SELECT gp_segment_id, count(DISTINCT j) FROM tsample8_@amname@
+  TABLESAMPLE SYSTEM_ROWS(1000) GROUP BY gp_segment_id;
+SELECT count(DISTINCT j) FROM tsample8_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 * 3);
+SELECT count(DISTINCT j) FROM tsample8_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 * 3 + 1);
+
+-- Case 9: Test tsm_system_rows on replicated tables
+CREATE TABLE tsample9_@amname@(i int) USING @amname@ DISTRIBUTED REPLICATED;
+
+INSERT INTO tsample9_@amname@ SELECT * FROM generate_series(1, 32768);
+
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(1000);
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(32768);
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 + 1);

--- a/src/test/isolation2/input/uao/tablesample.source
+++ b/src/test/isolation2/input/uao/tablesample.source
@@ -1,0 +1,272 @@
+-- Test Bernoulli and System sampling. For System sampling both blkdir and
+-- without blkdir cases are considered.
+
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
+
+-- Case 0: Empty table
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+
+-- Case 1: Single partially populated logical heap block on each QE
+CREATE TABLE tsample1_@amname@(i int) USING @amname@;
+INSERT INTO tsample1_@amname@ SELECT generate_series(1, 100);
+
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample1_@amname@(i) WHERE i != i;
+
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(100);
+
+-- Case 2: Multiple full logical heap blocks on a single QE
+CREATE TABLE tsample2_@amname@(i int) USING @amname@;
+INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32768 * 3);
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@;
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+
+-- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
+CREATE TABLE tsample3_@amname@(i int) USING @amname@;
+INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32768 * 2 + 100);
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@;
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample3_@amname@ GROUP BY 1 ORDER BY 1;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum,
+  count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum,
+  count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum,
+  count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum,
+  count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+
+-- Case 4: Logical heap blocks with holes on a single QE
+CREATE TABLE tsample4_@amname@(i int) USING @amname@;
+BEGIN;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 16384);
+ABORT;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 16384);
+BEGIN;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+ABORT;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+BEGIN;
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+ABORT;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+
+-- Case 5: Multiple full logical heap blocks across 2 aosegs on a single QE
+CREATE TABLE tsample5_@amname@(i int) USING @amname@;
+1: BEGIN;
+2: BEGIN;
+1: INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32768 * 3);
+2: INSERT INTO tsample5_@amname@ SELECT 20 FROM generate_series(1, 32768 * 3);
+1: COMMIT;
+2: COMMIT;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*)
+  FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+
+-- Case 6: 1 partially full logical block on a single QE with deleted rows
+CREATE TABLE tsample6_@amname@(i int, j int) USING @amname@;
+INSERT INTO tsample6_@amname@ SELECT 1, j FROM generate_series(1, 10) j;
+DELETE FROM tsample6_@amname@ WHERE j % 2 = 0;
+SELECT j FROM tsample6_@amname@;
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100) ORDER BY j;
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100) ORDER BY j;
+
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100) ORDER BY j;
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100) ORDER BY j;
+
+-- Case 7: Test rescans (similar to upstream test in regress/tablesample.sql)
+
+CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+
+INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
+INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
+ANALYZE ttr1;
+ANALYZE ttr2;
+SET optimizer TO OFF;
+SET enable_hashjoin TO OFF;
+SET enable_mergejoin TO OFF;
+SET enable_nestloop TO ON;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100),
+  ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+
+CREATE INDEX ON ttr1(a);
+CREATE INDEX ON ttr2(a);
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100),
+  ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100) REPEATABLE (2),
+  ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2),
+  ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100),
+  ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+
+RESET optimizer;
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_nestloop;
+DROP TABLE ttr1;
+DROP TABLE ttr2;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -146,6 +146,7 @@ test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
 test: uao/snapshot_index_corruption_row
+test: uao/tablesample_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -213,6 +214,7 @@ test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
 test: uao/snapshot_index_corruption_column
+test: uao/tablesample_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/tablesample.source
+++ b/src/test/isolation2/output/uao/tablesample.source
@@ -1,5 +1,5 @@
--- Test Bernoulli and System sampling. For System sampling both blkdir and
--- without blkdir cases are considered.
+-- Test block-level and row-level sampling. For block-level sampling both blkdir
+-- and without blkdir cases are considered.
 
 CREATE TABLE tsample_@amname@(i int) USING @amname@;
 CREATE TABLE
@@ -927,3 +927,58 @@ DROP TABLE ttr1;
 DROP TABLE
 DROP TABLE ttr2;
 DROP TABLE
+
+-- Case 8: Test tsm_system_rows on distributed tables
+CREATE EXTENSION IF NOT EXISTS tsm_system_rows;
+CREATE EXTENSION
+
+CREATE TABLE tsample8_@amname@(i int, j int) USING @amname@ DISTRIBUTED BY (i);
+CREATE TABLE
+
+INSERT INTO tsample8_@amname@ SELECT 1, j FROM generate_series(1, 32768) j;
+INSERT 0 32768
+INSERT INTO tsample8_@amname@ SELECT 2, j + 32768 FROM generate_series(1, 32768) j;
+INSERT 0 32768
+INSERT INTO tsample8_@amname@ SELECT 5, j + 32768 * 2 FROM generate_series(1, 32768) j;
+INSERT 0 32768
+
+SELECT gp_segment_id, count(DISTINCT j) FROM tsample8_@amname@ TABLESAMPLE SYSTEM_ROWS(1000) GROUP BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 333   
+ 1             | 333   
+ 2             | 334   
+(3 rows)
+SELECT count(DISTINCT j) FROM tsample8_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 * 3);
+ count 
+-------
+ 98304 
+(1 row)
+SELECT count(DISTINCT j) FROM tsample8_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 * 3 + 1);
+ count 
+-------
+ 98304 
+(1 row)
+
+-- Case 9: Test tsm_system_rows on replicated tables
+CREATE TABLE tsample9_@amname@(i int) USING @amname@ DISTRIBUTED REPLICATED;
+CREATE TABLE
+
+INSERT INTO tsample9_@amname@ SELECT * FROM generate_series(1, 32768);
+INSERT 0 32768
+
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(1000);
+ count 
+-------
+ 1000  
+(1 row)
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(32768);
+ count 
+-------
+ 32768 
+(1 row)
+SELECT count(DISTINCT i) FROM tsample9_@amname@ TABLESAMPLE SYSTEM_ROWS(32768 + 1);
+ count 
+-------
+ 32768 
+(1 row)

--- a/src/test/isolation2/output/uao/tablesample.source
+++ b/src/test/isolation2/output/uao/tablesample.source
@@ -1,0 +1,929 @@
+-- Test Bernoulli and System sampling. For System sampling both blkdir and
+-- without blkdir cases are considered.
+
+CREATE TABLE tsample_@amname@(i int) USING @amname@;
+CREATE TABLE
+
+-- Case 0: Empty table
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+ i 
+---
+(0 rows)
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+ count 
+-------
+ 0     
+(1 row)
+
+CREATE INDEX ON tsample_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT * FROM tsample_@amname@ TABLESAMPLE BERNOULLI(10);
+ i 
+---
+(0 rows)
+
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(DISTINCT i) FROM tsample_@amname@ TABLESAMPLE SYSTEM(10);
+ count 
+-------
+ 0     
+(1 row)
+
+-- Case 1: Single partially populated logical heap block on each QE
+CREATE TABLE tsample1_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample1_@amname@ SELECT generate_series(1, 100);
+INSERT 0 100
+
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+ i   
+-----
+ 3   
+ 6   
+ 7   
+ 10  
+ 12  
+ 20  
+ 65  
+ 72  
+ 75  
+ 78  
+ 100 
+(11 rows)
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+ i   
+-----
+ 3   
+ 6   
+ 7   
+ 10  
+ 12  
+ 20  
+ 65  
+ 72  
+ 75  
+ 78  
+ 100 
+(11 rows)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 100   
+(1 row)
+
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 100   
+(1 row)
+
+CREATE INDEX ON tsample1_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+ i   
+-----
+ 3   
+ 6   
+ 7   
+ 10  
+ 12  
+ 20  
+ 65  
+ 72  
+ 75  
+ 78  
+ 100 
+(11 rows)
+SELECT * FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(1) ORDER BY i;
+ i   
+-----
+ 3   
+ 6   
+ 7   
+ 10  
+ 12  
+ 20  
+ 65  
+ 72  
+ 75  
+ 78  
+ 100 
+(11 rows)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 100   
+(1 row)
+
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1);
+ count 
+-------
+ 100   
+(1 row)
+SELECT count(DISTINCT i) FROM tsample1_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 100   
+(1 row)
+
+-- Case 2: Multiple full logical heap blocks on a single QE
+CREATE TABLE tsample2_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample2_@amname@ SELECT 1 FROM generate_series(1, 32768 * 3);
+INSERT 0 98304
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@;
+ count 
+-------
+ 98304 
+(1 row)
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+ ctid             
+------------------
+ (33554432,22587) 
+ (33554432,28096) 
+ (33554433,15970) 
+ (33554434,26278) 
+(4 rows)
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+ ctid             
+------------------
+ (33554432,22587) 
+ (33554432,28096) 
+ (33554433,15970) 
+ (33554434,26278) 
+(4 rows)
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 98304 
+(1 row)
+
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 65536 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 65536 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 98304 
+(1 row)
+
+CREATE INDEX ON tsample2_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+ ctid             
+------------------
+ (33554432,22587) 
+ (33554432,28096) 
+ (33554433,15970) 
+ (33554434,26278) 
+(4 rows)
+SELECT ctid FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(0.001) REPEATABLE(15);
+ ctid             
+------------------
+ (33554432,22587) 
+ (33554432,28096) 
+ (33554433,15970) 
+ (33554434,26278) 
+(4 rows)
+SELECT count(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 98304 
+(1 row)
+
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 65536 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0);
+ count 
+-------
+ 65536 
+(1 row)
+SELECT COUNT(DISTINCT ctid) FROM tsample2_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 98304 
+(1 row)
+
+-- Case 3: Multiple full logical heap blocks + a final partial block on a single QE
+CREATE TABLE tsample3_@amname@(i int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample3_@amname@ SELECT 1 FROM generate_series(1, 32768 * 2 + 100);
+INSERT 0 65636
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@;
+ count 
+-------
+ 65636 
+(1 row)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 65636 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 32767 
+ 33554433 | 32768 
+ 33554434 | 101   
+(3 rows)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3335  
+ 33554433 | 3221  
+ 33554434 | 13    
+(3 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3335  
+ 33554433 | 3221  
+ 33554434 | 13    
+(3 rows)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 101   
+(2 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 101   
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 65636 
+(1 row)
+
+CREATE INDEX ON tsample3_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 65636 
+(1 row)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3335  
+ 33554433 | 3221  
+ 33554434 | 13    
+(3 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3335  
+ 33554433 | 3221  
+ 33554434 | 13    
+(3 rows)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 101   
+(2 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(7) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 101   
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample3_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 65636 
+(1 row)
+
+-- Case 4: Logical heap blocks with holes on a single QE
+CREATE TABLE tsample4_@amname@(i int) USING @amname@;
+CREATE TABLE
+BEGIN;
+BEGIN
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 16384);
+INSERT 0 16384
+ABORT;
+ROLLBACK
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 16384);
+INSERT 0 16384
+BEGIN;
+BEGIN
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+INSERT 0 32768
+ABORT;
+ROLLBACK
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+INSERT 0 32768
+BEGIN;
+BEGIN
+INSERT INTO tsample4_@amname@ SELECT 1 FROM generate_series(1, 32768);
+INSERT 0 32768
+ABORT;
+ROLLBACK
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 16367 
+ 33554433 | 17    
+ 33554434 | 32703 
+ 33554435 | 65    
+(4 rows)
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@;
+ count 
+-------
+ 49152 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 1604  
+ 33554433 | 2     
+ 33554434 | 3307  
+ 33554435 | 5     
+(4 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 1604  
+ 33554433 | 2     
+ 33554434 | 3307  
+ 33554435 | 5     
+(4 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 49152 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554434 | 16319 
+ 33554435 | 65    
+(2 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554434 | 16319 
+ 33554435 | 65    
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 49152 
+(1 row)
+
+CREATE INDEX ON tsample4_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 1604  
+ 33554433 | 2     
+ 33554434 | 3307  
+ 33554435 | 5     
+(4 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 1604  
+ 33554433 | 2     
+ 33554434 | 3307  
+ 33554435 | 5     
+(4 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE BERNOULLI(100);
+ count 
+-------
+ 49152 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554434 | 16319 
+ 33554435 | 65    
+(2 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(66) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554434 | 16319 
+ 33554435 | 65    
+(2 rows)
+SELECT count(DISTINCT ctid) FROM tsample4_@amname@ TABLESAMPLE SYSTEM(100);
+ count 
+-------
+ 49152 
+(1 row)
+
+-- Case 5: Multiple full logical heap blocks across 2 aosegs on a single QE
+CREATE TABLE tsample5_@amname@(i int) USING @amname@;
+CREATE TABLE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+1: INSERT INTO tsample5_@amname@ SELECT 1 FROM generate_series(1, 32768 * 3);
+INSERT 0 98304
+2: INSERT INTO tsample5_@amname@ SELECT 20 FROM generate_series(1, 32768 * 3);
+INSERT 0 98304
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 32767 
+ 33554433 | 32768 
+ 33554434 | 32768 
+ 33554435 | 1     
+ 67108864 | 32767 
+ 67108865 | 32768 
+ 67108866 | 32768 
+ 67108867 | 1     
+(8 rows)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@;
+ count  
+--------
+ 196608 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3289  
+ 33554433 | 3304  
+ 33554434 | 3348  
+ 67108864 | 3228  
+ 67108865 | 3393  
+ 67108866 | 3254  
+(6 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3289  
+ 33554433 | 3304  
+ 33554434 | 3348  
+ 67108864 | 3228  
+ 67108865 | 3393  
+ 67108866 | 3254  
+(6 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+ count  
+--------
+ 196608 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 32768 
+ 33554435 | 1     
+ 67108865 | 32767 
+ 67108866 | 1     
+(5 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 32768 
+ 33554435 | 1     
+ 67108865 | 32767 
+ 67108866 | 1     
+(5 rows)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+ count  
+--------
+ 196608 
+(1 row)
+
+CREATE INDEX ON tsample5_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3289  
+ 33554433 | 3304  
+ 33554434 | 3348  
+ 67108864 | 3228  
+ 67108865 | 3393  
+ 67108866 | 3254  
+(6 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(10) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554432 | 3289  
+ 33554433 | 3304  
+ 33554434 | 3348  
+ 67108864 | 3228  
+ 67108865 | 3393  
+ 67108866 | 3254  
+(6 rows)
+
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE BERNOULLI(100);
+ count  
+--------
+ 196608 
+(1 row)
+
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 32768 
+ 33554435 | 1     
+ 67108865 | 32767 
+ 67108866 | 1     
+(5 rows)
+SELECT right(split_part(ctid::text, ',', 1), -1) AS blknum, count(*) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(0) GROUP BY 1 ORDER BY 1;
+ blknum   | count 
+----------+-------
+ 33554433 | 32767 
+ 33554434 | 32768 
+ 33554435 | 1     
+ 67108865 | 32767 
+ 67108866 | 1     
+(5 rows)
+SELECT count(DISTINCT ctid) FROM tsample5_@amname@ TABLESAMPLE SYSTEM(100);
+ count  
+--------
+ 196608 
+(1 row)
+
+-- Case 6: 1 partially full logical block on a single QE with deleted rows
+CREATE TABLE tsample6_@amname@(i int, j int) USING @amname@;
+CREATE TABLE
+INSERT INTO tsample6_@amname@ SELECT 1, j FROM generate_series(1, 10) j;
+INSERT 0 10
+DELETE FROM tsample6_@amname@ WHERE j % 2 = 0;
+DELETE 5
+SELECT j FROM tsample6_@amname@;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 9 
+(1 row)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 9 
+(1 row)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+
+CREATE INDEX ON tsample6_@amname@(i) WHERE i != i;
+CREATE INDEX
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 9 
+(1 row)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(20) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 9 
+(1 row)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE BERNOULLI(100) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(50) REPEATABLE(1) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+SELECT j FROM tsample6_@amname@ TABLESAMPLE SYSTEM(100) ORDER BY j;
+ j 
+---
+ 1 
+ 3 
+ 5 
+ 7 
+ 9 
+(5 rows)
+
+-- Case 7: Test rescans (similar to upstream test in regress/tablesample.sql)
+
+CREATE TABLE ttr1 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE
+CREATE TABLE ttr2 (a int, b int) USING @amname@ DISTRIBUTED BY (a);
+CREATE TABLE
+
+INSERT INTO ttr1 VALUES (1, 1), (12, 1), (31, 1), (NULL, NULL);
+INSERT 0 4
+INSERT INTO ttr2 VALUES (1, 2), (12, 2), (31, 2), (NULL, 6);
+INSERT 0 4
+ANALYZE ttr1;
+ANALYZE
+ANALYZE ttr2;
+ANALYZE
+SET optimizer TO OFF;
+SET
+SET enable_hashjoin TO OFF;
+SET
+SET enable_mergejoin TO OFF;
+SET
+SET enable_nestloop TO ON;
+SET
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                                                        
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)                                          
+   ->  Nested Loop                                                                 
+         Join Filter: (ttr1.a = ttr2.a)                                            
+         ->  Sample Scan on ttr1                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+         ->  Sample Scan on ttr2                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+ Optimizer: Postgres-based planner                                                 
+(8 rows)
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 31 | 1 | 31 | 2 
+(2 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100), ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                            
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)              
+   ->  Nested Loop                                     
+         Join Filter: (ttr1.a = ttr2.a)                
+         ->  Sample Scan on ttr1                       
+               Sampling: bernoulli ('100'::real)       
+         ->  Materialize                               
+               ->  Sample Scan on ttr2                 
+                     Sampling: bernoulli ('100'::real) 
+ Optimizer: Postgres-based planner                     
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2), ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                                                     
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)                                       
+   ->  Nested Loop                                                              
+         Join Filter: (ttr1.a = ttr2.a)                                         
+         ->  Sample Scan on ttr1                                                
+               Sampling: system ('50'::real) REPEATABLE ('2'::double precision) 
+         ->  Sample Scan on ttr2                                                
+               Sampling: system ('50'::real) REPEATABLE ('2'::double precision) 
+ Optimizer: Postgres-based planner                                              
+(8 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2), ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ a | b | a | b 
+---+---+---+---
+(0 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                         
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)           
+   ->  Nested Loop                                  
+         Join Filter: (ttr1.a = ttr2.a)             
+         ->  Sample Scan on ttr1                    
+               Sampling: system ('100'::real)       
+         ->  Materialize                            
+               ->  Sample Scan on ttr2              
+                     Sampling: system ('100'::real) 
+ Optimizer: Postgres-based planner                  
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
+
+CREATE INDEX ON ttr1(a);
+CREATE INDEX
+CREATE INDEX ON ttr2(a);
+CREATE INDEX
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                                                        
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)                                          
+   ->  Nested Loop                                                                 
+         Join Filter: (ttr1.a = ttr2.a)                                            
+         ->  Sample Scan on ttr1                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+         ->  Sample Scan on ttr2                                                   
+               Sampling: bernoulli ('50'::real) REPEATABLE ('2'::double precision) 
+ Optimizer: Postgres-based planner                                                 
+(8 rows)
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (50) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 31 | 1 | 31 | 2 
+(2 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100), ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                            
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)              
+   ->  Nested Loop                                     
+         Join Filter: (ttr1.a = ttr2.a)                
+         ->  Sample Scan on ttr1                       
+               Sampling: bernoulli ('100'::real)       
+         ->  Materialize                               
+               ->  Sample Scan on ttr2                 
+                     Sampling: bernoulli ('100'::real) 
+ Optimizer: Postgres-based planner                     
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE BERNOULLI (100) REPEATABLE (2), ttr2 TABLESAMPLE BERNOULLI (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2), ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                                                     
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)                                       
+   ->  Nested Loop                                                              
+         Join Filter: (ttr1.a = ttr2.a)                                         
+         ->  Sample Scan on ttr1                                                
+               Sampling: system ('50'::real) REPEATABLE ('2'::double precision) 
+         ->  Sample Scan on ttr2                                                
+               Sampling: system ('50'::real) REPEATABLE ('2'::double precision) 
+ Optimizer: Postgres-based planner                                              
+(8 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (50) REPEATABLE (2), ttr2 TABLESAMPLE SYSTEM (50) REPEATABLE (2) WHERE ttr1.a = ttr2.a;
+ a | b | a | b 
+---+---+---+---
+(0 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ QUERY PLAN                                         
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)           
+   ->  Nested Loop                                  
+         Join Filter: (ttr1.a = ttr2.a)             
+         ->  Sample Scan on ttr1                    
+               Sampling: system ('100'::real)       
+         ->  Materialize                            
+               ->  Sample Scan on ttr2              
+                     Sampling: system ('100'::real) 
+ Optimizer: Postgres-based planner                  
+(9 rows)
+SELECT * FROM ttr1 TABLESAMPLE SYSTEM (100), ttr2 TABLESAMPLE SYSTEM (100) WHERE ttr1.a = ttr2.a;
+ a  | b | a  | b 
+----+---+----+---
+ 1  | 1 | 1  | 2 
+ 12 | 1 | 12 | 2 
+ 31 | 1 | 31 | 2 
+(3 rows)
+
+RESET optimizer;
+RESET
+RESET enable_hashjoin;
+RESET
+RESET enable_mergejoin;
+RESET
+RESET enable_nestloop;
+RESET
+DROP TABLE ttr1;
+DROP TABLE
+DROP TABLE ttr2;
+DROP TABLE


### PR DESCRIPTION
This PR contains a couple of bug fixes for CO analyze infrastructure, a commit to update pg_statio.blks_read for sampling, and then the commit to support BERNOULLI/SYSTEM TABLESAMPLE for AO/CO tables. The main tablesample commit also adds implicit coverage for the 2 bug fixes.

Supporting commits for tsm_system_rows and tsm_system_time have also been added.

Finally, a dev GUC has been added for devs to toggle between blkdir and non-blkdir based analyze for ease of testing.

Please refer to individual commit messages for details.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/tsamplev2?group=all