### PR TITLE
    Correct locus type for subquery

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -320,6 +320,7 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 				List	   *distkeys = NIL;
 				ListCell   *expr_cell;
 				ListCell   *opf_cell;
+				bool		succeeded = false;
 
 				forboth(expr_cell, flow->hashExprs, opf_cell, flow->hashOpfamilies)
 				{
@@ -348,7 +349,12 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 					distkeys = lappend(distkeys, distkey);
 				}
 				if (distkeys && !expr_cell)
+					succeeded = true;
+
+				if (succeeded && flow->locustype == CdbLocusType_Hashed)
 					CdbPathLocus_MakeHashed(&locus, distkeys, numsegments);
+				else if (succeeded && flow->locustype == CdbLocusType_HashedOJ)
+					CdbPathLocus_MakeHashedOJ(&locus, distkeys, numsegments);
 				else
 					CdbPathLocus_MakeStrewn(&locus, numsegments);
 				break;

--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -1792,6 +1792,37 @@ select * from sales_par where region='asia' and id in (select b from m where a =
 ----+------+-------+-----+--------
 (0 rows)
 
+------------------------------------------------------------
+-- Inserts with motion:
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION nvl(p1 in text, p2 in text) RETURNS text AS $$
+DECLARE
+BEGIN
+	return COALESCE(p1, p2);
+END;
+$$ LANGUAGE plpgsql;
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists tr;
+NOTICE:  table "tr" does not exist, skipping
+create table t1(a varchar(2), b varchar(2)) distributed by (a);
+create table t2(a varchar(2), b varchar(2)) distributed by (a);
+create table tr(a varchar(2), b varchar(2)) distributed by (a);
+explain (costs off) insert into tr select t1.a, nvl(t1.b, '') from t1 full join t2 on t1.a = t2.a;
+                          QUERY PLAN
+--------------------------------------------------------------
+ Insert on tr
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: "*SELECT*".a
+         ->  Subquery Scan on "*SELECT*"
+               ->  Hash Full Join
+                     Hash Cond: ((t1.a)::text = (t2.a)::text)
+                     ->  Seq Scan on t1
+                     ->  Hash
+                           ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(10 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1799,6 +1799,37 @@ select * from sales_par where region='asia' and id in (select b from m where a =
 ----+------+-------+-----+--------
 (0 rows)
 
+------------------------------------------------------------
+-- Inserts with motion:
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION nvl(p1 in text, p2 in text) RETURNS text AS $$
+DECLARE
+BEGIN
+	return COALESCE(p1, p2);
+END;
+$$ LANGUAGE plpgsql;
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists tr;
+NOTICE:  table "tr" does not exist, skipping
+create table t1(a varchar(2), b varchar(2)) distributed by (a);
+create table t2(a varchar(2), b varchar(2)) distributed by (a);
+create table tr(a varchar(2), b varchar(2)) distributed by (a);
+explain (costs off) insert into tr select t1.a, nvl(t1.b, '') from t1 full join t2 on t1.a = t2.a;
+                          QUERY PLAN
+--------------------------------------------------------------
+ Insert on tr
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: "*SELECT*".a
+         ->  Subquery Scan on "*SELECT*"
+               ->  Hash Full Join
+                     Hash Cond: ((t1.a)::text = (t2.a)::text)
+                     ->  Seq Scan on t1
+                     ->  Hash
+                           ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(10 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -1440,6 +1440,26 @@ EXECUTE plan5;
 select * from sales_par where region='asia' and id in (select b from m where a = 2);
 
 
+------------------------------------------------------------
+-- Inserts with motion:
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION nvl(p1 in text, p2 in text) RETURNS text AS $$
+DECLARE
+BEGIN
+	return COALESCE(p1, p2);
+END;
+$$ LANGUAGE plpgsql;
+
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists tr;
+
+create table t1(a varchar(2), b varchar(2)) distributed by (a);
+create table t2(a varchar(2), b varchar(2)) distributed by (a);
+create table tr(a varchar(2), b varchar(2)) distributed by (a);
+
+explain (costs off) insert into tr select t1.a, nvl(t1.b, '') from t1 full join t2 on t1.a = t2.a;
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
    =====================================================================

    When the subplan's locusType is CdbLocusType_HashedOJ, cdbpathlocus_from_subquery
    will create an incorrect locus with locusType of CdbLocusType_Hashed. This will
    cause distributed motion node not to be added on top of the subquery node during
    insert operation, resulting in incorrect data distribution.

    This issue doesn't occur on the main branch, but there's no separate commit in
    the main branch that fixes this issue, so I fixed the issue on 6X_STABLE with
    this commit.

    Setup:
    ======
    ```
    CREATE OR REPLACE FUNCTION nvl(p1 in text, p2 in text) RETURNS text AS $$
    DECLARE
    BEGIN
        return COALESCE(p1, p2);
    END;
    $$ LANGUAGE plpgsql;

    create table t1(a varchar(2), b varchar(2)) distributed by (a);
    create table t2(a varchar(2), b varchar(2)) distributed by (a);
    create table tr(a varchar(2), b varchar(2)) distributed by (a);
    ```

    Current Behaviour:
    ==================
    ```
    explain (costs off) insert into tr select t1.a, nvl(t1.b, '') from t1 full join t2 on t1.a = t2.a;
                           QUERY PLAN
    --------------------------------------------------------
    Insert on tr
    ->  Subquery Scan on "*SELECT*"
         ->  Hash Full Join
               Hash Cond: ((t1.a)::text = (t2.a)::text)
               ->  Seq Scan on t1
               ->  Hash
                     ->  Seq Scan on t2
    Optimizer: Postgres query optimizer
    (8 rows)

    After Fix:
    ==========
    ```
    explain (costs off) insert into tr select t1.a, nvl(t1.b, '') from t1 full join t2 on t1.a = t2.a;
                              QUERY PLAN
    --------------------------------------------------------------
    Insert on tr
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
          Hash Key: "*SELECT*".a
          ->  Subquery Scan on "*SELECT*"
                ->  Hash Full Join
                      Hash Cond: ((t1.a)::text = (t2.a)::text)
                      ->  Seq Scan on t1
                      ->  Hash
                            ->  Seq Scan on t2
   Optimizer: Postgres query optimizer
   (10 rows)
   ```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
