### PR TITLE
Fix segmentation fault caused by concurrent INSERT ON CONFLICT and DROP TABLE

### DIFF
--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -222,7 +222,9 @@ CdbTryOpenTable(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 		{
 			lockmode = RowExclusiveLock;
 			rel = try_table_open(relid, lockmode, false);
-			if (RelationIsAppendOptimized(rel))
+
+			if (RelationIsValid(rel) &&
+				RelationIsAppendOptimized(rel))
 			{
 				/*
 				 * AO|AOCO table does not support concurrently

--- a/src/test/isolation2/expected/gdd/concurrent_insert_on_conflict.out
+++ b/src/test/isolation2/expected/gdd/concurrent_insert_on_conflict.out
@@ -1,0 +1,21 @@
+--
+-- Test case for concurrent insert on conflict and drop a table
+--
+CREATE TABLE t_concurrent_insert(a int primary key, b int);
+CREATE TABLE
+
+1: BEGIN;
+BEGIN
+1: DROP TABLE t_concurrent_insert;
+DROP TABLE
+2&: INSERT INTO t_concurrent_insert VALUES(1, 1) ON CONFLICT(a) DO UPDATE SET b = excluded.b;  <waiting ...>
+1: COMMIT;
+COMMIT
+
+-- insert failed, rather than segment fault
+2<:  <... completed>
+ERROR:  relation "t_concurrent_insert" does not exist
+LINE 1: INSERT INTO t_concurrent_insert VALUES(1, 1) ON CONFLICT(a) ...
+                    ^
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/concurrent_insert_on_conflict_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_insert_on_conflict_optimizer.out
@@ -1,0 +1,21 @@
+--
+-- Test case for concurrent insert on conflict and drop a table
+--
+CREATE TABLE t_concurrent_insert(a int primary key, b int);
+CREATE TABLE
+
+1: BEGIN;
+BEGIN
+1: DROP TABLE t_concurrent_insert;
+DROP TABLE
+2&: INSERT INTO t_concurrent_insert VALUES(1, 1) ON CONFLICT(a) DO UPDATE SET b = excluded.b;  <waiting ...>
+1: COMMIT;
+COMMIT
+
+-- insert failed, rather than segment fault
+2<:  <... completed>
+ERROR:  relation "t_concurrent_insert" does not exist
+LINE 1: INSERT INTO t_concurrent_insert VALUES(1, 1) ON CONFLICT(a) ...
+                    ^
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -40,6 +40,7 @@ test: insert_root_partition_truncate_deadlock_without_gdd
 test: gdd/prepare
 test: gdd/insert_root_partition_truncate_deadlock
 test: gdd/concurrent_update
+test: gdd/concurrent_insert_on_conflict
 test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
 test: gdd/dist-deadlock-upsert
 # until we can improve below flaky case please keep it disabled

--- a/src/test/isolation2/sql/gdd/concurrent_insert_on_conflict.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_insert_on_conflict.sql
@@ -1,0 +1,14 @@
+-- 
+-- Test case for concurrent insert on conflict and drop a table
+-- 
+CREATE TABLE t_concurrent_insert(a int primary key, b int);
+
+1: BEGIN;
+1: DROP TABLE t_concurrent_insert;
+2&: INSERT INTO t_concurrent_insert VALUES(1, 1) ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+1: COMMIT;
+
+-- insert failed, rather than segment fault
+2<:
+1q:
+2q:


### PR DESCRIPTION
This bug is introduced by #[13440](https://github.com/greenplum-db/gpdb/pull/13440)

When performing an INSERT ON CONFLICT operation, the target table is parsed with a RowExclusiveLock, which will call CdbTryOpenTable() with the same lock. If another transaction deletes the same table concurrently, try_table_open() returns nullptr. When GDD(Global Deadlock Detector) is enabled, this nullptr is fetched by RelationIsAppendOptimized, resulting in a segmentation fault.

This commit fixes this bug by adding a check with RelationIsValid(rel) to prevent fetching nullptr.