### PR TITLE
Docs: new guc gp_interconnect_cursor_ic_table_size

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1085,6 +1085,14 @@ communication. In these cases, you must configure this parameter to use a wildca
 |-----------|-------|-------------------|
 |wildcard,unicast|wildcard|local, system, reload|
 
+## <a id="gp_interconnect_cursor_ic_table_size"></a>gp_interconnect_cursor_ic_table_size
+
+Specifies the size of the Cursor History Table for UDP interconnect. You may increase it if running a user-defined function which contains many concurrent cursor queries hangs. The default value is 128.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|128-102400|128|master, session, reload|
+
 ## <a id="gp_interconnect_debug_retry_interval"></a>gp_interconnect_debug_retry_interval 
 
 Specifies the interval, in seconds, to log Greenplum Database interconnect debugging messages when the server configuration parameter [gp\_log\_interconnect](#gp_log_interconnect) is set to `DEBUG`. The default is 10 seconds.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1087,7 +1087,7 @@ communication. In these cases, you must configure this parameter to use a wildca
 
 ## <a id="gp_interconnect_cursor_ic_table_size"></a>gp_interconnect_cursor_ic_table_size
 
-Specifies the size of the Cursor History Table for UDP interconnect. You may increase it if running a user-defined function which contains many concurrent cursor queries hangs. The default value is 128.
+Specifies the size of the Cursor History Table for UDP interconnect. Although it is not usually necessary, you may increase it if running a user-defined function which contains many concurrent cursor queries hangs. The default value is 128.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -475,6 +475,7 @@ The parameters in this topic control the configuration of the Greenplum Database
 ### <a id="topic50"></a>Interconnect Configuration Parameters 
 
 - [gp_interconnect_address_type](guc-list.html#gp_interconnect_address_type)
+- [gp_interconnect_cursor_ic_table_size](guc-list.html#gp_interconnect_cursor_ic_table_size)
 - [gp_interconnect_fc_method](guc-list.html#gp_interconnect_fc_method)
 - [gp_interconnect_proxy_addresses](guc-list.html#gp_interconnect_proxy_addresses)
 - [gp_interconnect_queue_depth](guc-list.html#gp_interconnect_queue_depth)


### PR DESCRIPTION
This PR documents the new guc gp_interconnect_cursor_ic_table_size for Greenplum 6.26
