### PR TITLE
[6x]: Added support for gpstate tracking for differential recovery

### DIFF
--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
@@ -65,5 +65,21 @@ class UnixCommandTestCase(GpTestCase):
         self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
         self.subject.logger.error.assert_called_once_with('Failed to kill process 789 for segment /data/primary/gpseg0: Kill Error')
 
+
+    @patch('gppylib.commands.unix.get_rsync_version', return_value='rsync version 3.2.7')
+    @patch('gppylib.commands.unix.LooseVersion', side_effect=['3.2.7', '3.1.0'])
+    def test_compare_rsync_version(self, mock_parse_version, mock_get_cmd_version):
+
+        result = self.subject.validate_rsync_version("3.2.7")
+        self.assertTrue(result)
+
+
+    @patch('gppylib.commands.unix.get_rsync_version', return_value='rsync version 2.6.9')
+    @patch('gppylib.commands.unix.LooseVersion', side_effect=['2.6.9', '3.1.0'])
+    def test_validate_rsync_version_false(self, mock_parse_version, mock_get_cmd_version):
+
+        result =self.subject.validate_rsync_version("2.6.9")
+        self.assertFalse(result)
+
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -13,6 +13,8 @@ import socket
 import signal
 import uuid
 import pipes
+import re
+from distutils.version import LooseVersion
 
 from gppylib.gplog import get_default_logger
 from gppylib.commands.base import *
@@ -534,8 +536,10 @@ class Rsync(Command):
         if checksum:
             cmd_tokens.append('-c')
 
+        # Shows the progress of the whole transfer,
+        # Note : It is only supported with rsync 3.1.0 or above
         if progress:
-            cmd_tokens.append('--progress')
+            cmd_tokens.append('--info=progress2,name0')
 
         # To show file transfer stats
         if stats:
@@ -568,11 +572,14 @@ class Rsync(Command):
 
         cmd_tokens.extend(exclude_str)
 
+        # Combines output streams, uses 'sed' to find lines with 'kB/s' or 'MB/s' and appends ':%s' as suffix to the end
+        # of each line and redirects it to progress_file
         if progress_file:
-            cmd_tokens.append('> %s 2>&1' % pipes.quote(progress_file))
+            cmd_tokens.append(
+                '2>&1 | tr "\\r" "\\n" |sed -E "/[0-9]+%/ s/$/ :{0}/" > {1}'.format(name, pipes.quote(progress_file)))
 
         cmdStr = ' '.join(cmd_tokens)
-
+        cmdStr = "set -o pipefail; {}".format(cmdStr)
         self.command_tokens = cmd_tokens
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
@@ -812,3 +819,25 @@ def isScpEnabled(hostlist):
             return False
 
     return True
+
+
+
+def validate_rsync_version(min_ver):
+    """
+    checks the version of the 'rsync' command and compares it with a required version.
+    If the current version is lower than the required version, it raises an exception
+    """
+    rsync_version_info = get_rsync_version()
+    pattern = r"version (\d+\.\d+\.\d+)"
+    match = re.search(pattern, rsync_version_info)
+    current_rsync_version = match.group(1)
+    if LooseVersion(current_rsync_version) < LooseVersion(min_ver):
+        return False
+    return True
+
+def get_rsync_version():
+    """ get the rsync current version """
+    cmdStr = findCmdInPath("rsync") + " --version"
+    cmd = Command("get rsync version", cmdStr=cmdStr)
+    cmd.run(validateAfter=True)
+    return cmd.get_stdout()

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -70,7 +70,7 @@ def get_recovery_progress_pattern(recovery_type='incremental'):
         progress of rsync looks like: "1,036,923,510  99%   39.90MB/s    0:00:24"
     """
     if recovery_type == 'differential':
-        return r" +\d+%\ +\d+.\d+(kB|mB)\/s"
+        return r" +\d+%\ +\d+.\d+(kB|MB)\/s"
     return r"\d+\/\d+ (kB|mB) \(\d+\%\)"
 
 
@@ -459,18 +459,66 @@ class GpMirrorListToBuild:
                 os.remove(combined_progress_filepath)
 
 
-    def _get_progress_cmd(self, progressFile, targetSegmentDbId, targetHostname):
+    def _get_progress_cmd(self, progressFile, targetSegmentDbId, targetHostname, isDifferentialRecovery):
         """
         # There is race between when the recovery process creates the progressFile
         # when this progress cmd is run. Thus, the progress command touches
         # the file to ensure its presence before tailing.
         """
         if self.__progressMode != GpMirrorListToBuild.Progress.NONE:
-            return GpMirrorListToBuild.ProgressCommand("tail the last line of the file",
-                                                       "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' |"
-                                                       " tail -1".format(pipes.quote(progressFile)),
-                                                       targetSegmentDbId, progressFile, ctxt=base.REMOTE,
-                                                       remoteHost=targetHostname)
+            cmd_desc = "tail the last line of the file"
+            if isDifferentialRecovery:
+                # For differential recovery, use sed to filter lines with specific patterns to avoid race condition.
+
+                # Set the option to make the pipeline fail if any command within it fails;
+                # Example: set -o pipefail;
+
+                # Create or update a file with the name specified in {0};
+                # Example: touch -a 'rsync.20230926_145006.dbid2.out';
+
+                # Display the last 3 lines of the file specified in {0} and pass them to the next command;
+                # Example: If {0} contains:
+                # receiving incremental file list
+                #
+                #               0   0%    0.00kB/s    0:00:00   :Syncing pg_control file of dbid 5
+                #           8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control file of dbid 5
+                #           8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control file of dbid 5
+                #
+                # This command will pass the above lines (excluding the first) to the next command.
+
+                # Process the output using sed (stream editor), printing lines that match certain patterns;
+                # Example: If the output is "          8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control file of dbid 5",
+                # this command will print:
+                # 8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control file of dbid 5
+                #
+                # It will print lines that contain ":Syncing.*dbid", "error:", or "total".
+
+                # Translate carriage return characters to newline characters;
+                # Example: If the output contains '\r' characters, they will be replaced with '\n'.
+
+                # Display only the last line of the processed output.
+                # Example: If the output after the previous command is:
+                # 8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing pg_control file of dbid 5
+                # This command will output the same line.
+
+                cmd_str = (
+                    "set -o pipefail; touch -a {0}; tail -3 {0} | sed -n -e '/:Syncing.*dbid/p; /error:/p; /total/p' | tr '\\r' '\\n' | tail -1"
+                    .format(pipes.quote(progressFile))
+                )
+            else:
+                # For full and incremental recovery, simply tail the last line.
+                cmd_str = (
+                    "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1"
+                    .format(pipes.quote(progressFile))
+                )
+
+            progress_command = GpMirrorListToBuild.ProgressCommand(
+                cmd_desc, cmd_str,
+                targetSegmentDbId, progressFile, ctxt=base.REMOTE,
+                remoteHost=targetHostname
+            )
+
+            return progress_command
         return None
 
     def _get_remove_cmd(self, remove_file, target_host):
@@ -533,7 +581,7 @@ class GpMirrorListToBuild:
         era = read_era(gpEnv.getMasterDataDir(), logger=self.__logger)
         for hostName, recovery_info_list in recovery_info_by_host.items():
             for ri in recovery_info_list:
-                progressCmd = self._get_progress_cmd(ri.progress_file, ri.target_segment_dbid, hostName)
+                progressCmd = self._get_progress_cmd(ri.progress_file, ri.target_segment_dbid, hostName, ri.is_differential_recovery)
                 if progressCmd:
                     progress_cmds.append(progressCmd)
 

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -256,6 +256,14 @@ class GpRecoverSegmentProgram:
         if self.__options.replayLag and not self.__options.rebalanceSegments:
             raise ProgramArgumentValidationException("--replay-lag should be used only with -r")
 
+        # Checking rsync version before performing a differential recovery operation.
+        # the --info=progress2 option, which provides whole file transfer progress, requires rsync 3.1.0 or above
+        min_rsync_ver = "3.1.0"
+        if self.__options.differentialResynchronization and not unix.validate_rsync_version(min_rsync_ver):
+            raise ProgramArgumentValidationException("To perform a differential recovery, a minimum rsync version "
+                                                         "of {0} is required. Please ensure that rsync is updated to "
+                                                         "version {0} or higher.".format(min_rsync_ver))
+
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getMasterPort())
 
         confProvider = configInterface.getConfigurationProvider().initializeProvider(gpEnv.getMasterPort())

--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -77,6 +77,7 @@ VALUE_RECOVERY_COMPLETED_BYTES = FieldDefinition("Completed bytes (kB)", "recove
 VALUE_RECOVERY_TOTAL_BYTES = FieldDefinition("Total bytes (kB)", "recovery_total_bytes", "int")
 VALUE_RECOVERY_PERCENTAGE = FieldDefinition("Percentage completed", "recovery_percentage", "int")
 VALUE_RECOVERY_TYPE = FieldDefinition("Recovery type", "recovery_type", "int")
+VALUE_RECOVERY_STAGE = FieldDefinition("Stage", "recovery_stage", "text")
 
 CATEGORY__STATUS = "Status"
 VALUE__MASTER_REPORTS_STATUS = FieldDefinition("Configuration reports status as", "status_in_config", "text", "Config status")
@@ -165,7 +166,7 @@ class GpStateData:
                     VALUE__ACTIVE_PID_INT, VALUE__POSTMASTER_PID_VALUE_INT,
                     VALUE__POSTMASTER_PID_FILE, VALUE__POSTMASTER_PID_VALUE, VALUE__LOCK_FILES,
                     VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES, VALUE_RECOVERY_PERCENTAGE,
-                    VALUE_RECOVERY_TYPE
+                    VALUE_RECOVERY_TYPE, VALUE_RECOVERY_STAGE
                     ]:
             self.__allValues[k] = True
 
@@ -692,8 +693,14 @@ class GpSystemStateProgram:
             if segments_under_recovery:
                 logger.info("----------------------------------------------------")
                 logger.info("Segments in recovery")
-                logSegments(segments_under_recovery, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
-                                                            VALUE_RECOVERY_PERCENTAGE])
+                if data.getStrValue(segments_under_recovery[0], VALUE_RECOVERY_TYPE) == "differential":
+                    logSegments(segments_under_recovery, False,
+                                [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_STAGE, VALUE_RECOVERY_COMPLETED_BYTES,
+                                 VALUE_RECOVERY_PERCENTAGE])
+                else:
+                    logSegments(segments_under_recovery, False,
+                                [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
+                                 VALUE_RECOVERY_PERCENTAGE])
                 exitCode = 1
 
         # final output -- no errors, then log this message
@@ -975,12 +982,26 @@ class GpSystemStateProgram:
         with open(recovery_progress_file, 'r') as fp:
             for line in fp:
                 recovery_type, dbid, progress = line.strip().split(':',2)
-                pattern = re.compile(get_recovery_progress_pattern())
-                if re.search(pattern, progress):
-                    bytes, units, precentage_str = progress.strip().split(' ',2)
-                    completed_bytes, total_bytes = bytes.split('/')
-                    percentage = re.search(r'(\d+\%)', precentage_str).group()
-                    recovery_progress_by_dbid[int(dbid)] = [recovery_type, completed_bytes, total_bytes, percentage]
+                # Define patterns for identifying different recovery types
+                rewind_bb_pattern = re.compile(get_recovery_progress_pattern())
+                diff_pattern = re.compile(get_recovery_progress_pattern('differential'))
+
+                # Check if the progress matches full,incremental or differential recovery patterns
+                if re.search(rewind_bb_pattern, progress) or re.search(diff_pattern, progress):
+                    stage, total_bytes = "", ""
+                    if recovery_type == "differential":
+                        # Process differential recovery progress.
+                        progress_parts = progress.strip().split(':')
+                        stage = progress_parts[-1]
+                        completed_bytes, percentage = progress_parts[0].split()[:2]
+                    else:
+                        # Process full or incremental recovery progress.
+                        bytes, units, precentage_str = progress.strip().split(' ', 2)
+                        completed_bytes, total_bytes = bytes.split('/')
+                        percentage = re.search(r'(\d+\%)', precentage_str).group()
+
+                    recovery_progress_by_dbid[int(dbid)] = [recovery_type, completed_bytes, total_bytes, percentage,
+                                                            stage]
 
         # Now the catalog update happens before we run recovery,
         # so now when we query gpArray here, it will have new address/port for the recovering segments
@@ -990,11 +1011,19 @@ class GpSystemStateProgram:
             if dbid in recovery_progress_by_dbid.keys():
                 data.switchSegment(seg)
                 recovery_progress_segs.append(seg)
-                recovery_type, completed_bytes, total_bytes, percentage = recovery_progress_by_dbid[dbid]
+                recovery_type, completed_bytes, total_bytes, percentage, stage = recovery_progress_by_dbid[dbid]
+
+                # Add recovery progress values to GpstateData
                 data.addValue(VALUE_RECOVERY_TYPE, recovery_type)
                 data.addValue(VALUE_RECOVERY_COMPLETED_BYTES, completed_bytes)
-                data.addValue(VALUE_RECOVERY_TOTAL_BYTES, total_bytes)
                 data.addValue(VALUE_RECOVERY_PERCENTAGE, percentage)
+
+                if recovery_type == "differential":
+                    # If differential recovery, add stage information.
+                    data.addValue(VALUE_RECOVERY_STAGE, stage)
+                else:
+                    # If full or incremental, add total bytes' information.
+                    data.addValue(VALUE_RECOVERY_TOTAL_BYTES, total_bytes)
 
         return recovery_progress_segs
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
@@ -61,11 +61,14 @@ class RecoveryProgressTestCase(unittest.TestCase):
         self.gpArrayMock = mock.MagicMock(spec=gparray.GpArray)
         self.gpArrayMock.getSegDbList.return_value = [self.primary1, self.primary2, self.primary3]
 
-    def check_recovery_fields(self, segment, type, completed, total, percentage):
+    def check_recovery_fields(self, segment, type, completed, total, percentage, stage=None):
         self.assertEqual(type, self.data.getStrValue(segment, VALUE_RECOVERY_TYPE))
         self.assertEqual(completed, self.data.getStrValue(segment, VALUE_RECOVERY_COMPLETED_BYTES))
-        self.assertEqual(total, self.data.getStrValue(segment, VALUE_RECOVERY_TOTAL_BYTES))
         self.assertEqual(percentage, self.data.getStrValue(segment, VALUE_RECOVERY_PERCENTAGE))
+        if type == "differential":
+            self.assertEqual(stage, self.data.getStrValue(segment, VALUE_RECOVERY_STAGE))
+        else:
+            self.assertEqual(total, self.data.getStrValue(segment, VALUE_RECOVERY_TOTAL_BYTES))
 
     def test_parse_recovery_progress_data_returns_empty_when_file_does_not_exist(self):
         self.assertEqual([], GpSystemStateProgram._parse_recovery_progress_data(self.data, '/file/does/not/exist', self.gpArrayMock))
@@ -88,12 +91,16 @@ class RecoveryProgressTestCase(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as f:
             f.write("full:1: 1164848/1371715 kB (0%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
             f.write("incremental:2: 1171384/1371875 kB (85%)anything can appear here".encode('utf-8'))
+            f.write("incremental:2: 1171384/1371875 kB (85%)anything can appear here\n".encode('utf-8'))
+            f.write(
+                "differential:3:    122,017,543  74%   74.02MB/s    0:00:01 (xfr#1994, to-chk=963/2979) :Syncing pg_data of dbid 1\n".encode(
+                    "utf-8"))
             f.flush()
-            self.assertEqual([self.primary1, self.primary2], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+            self.assertEqual([self.primary1, self.primary2, self.primary3], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
 
             self.check_recovery_fields(self.primary1,'full', '1164848', '1371715', '0%')
             self.check_recovery_fields(self.primary2, 'incremental', '1171384', '1371875', '85%')
-            self.check_recovery_fields(self.primary3, '', '', '', '')
+            self.check_recovery_fields(self.primary3, 'differential', '122,017,543', '', '74%', 'Syncing pg_data of dbid 1')
 
     def test_parse_recovery_progress_data_doesnt_adds_recovery_progress_data_only_for_completed_recoveries(self):
         with tempfile.NamedTemporaryFile() as f:
@@ -123,6 +130,30 @@ class RecoveryProgressTestCase(unittest.TestCase):
 
             self.check_recovery_fields(self.primary1,'full', '1164848', '1371715', '84%')
             self.check_recovery_fields(self.primary2,'full', '1164848', '1371715', '100%')
+            self.check_recovery_fields(self.primary3, '', '', '', '')
+
+
+    def test_parse_recovery_progress_data_adds_differential_recovery_progress_data_during_single_recovery(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write("differential:1:     38,861,653   7%   43.45MB/s    0:00:00 (xfr#635, ir-chk=9262/9919) :Syncing pg_data of dbid 1\n".encode("utf-8"))
+            f.flush()
+            self.assertEqual([self.primary1], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+
+            self.check_recovery_fields(self.primary1, 'differential', '38,861,653', '', '7%', "Syncing pg_data of dbid 1")
+            self.check_recovery_fields(self.primary2, '', '', '', '')
+            self.check_recovery_fields(self.primary3, '', '', '', '')
+
+
+    def test_parse_recovery_progress_data_adds_differential_recovery_progress_data_during_multiple_recovery(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write("differential:1:     38,861,653   7%   43.45MB/s    0:00:00 (xfr#635, ir-chk=9262/9919) :Syncing pg_data of dbid 1\n".encode("utf-8"))
+            f.write("differential:2:    122,017,543  74%   74.02MB/s    0:00:01 (xfr#1994, to-chk=963/2979) :Syncing tablespace of dbid 2 for oid 17934\n".encode("utf-8"))
+            f.write("differential:3:    122,017,543  (74%)   74.02MB/s    0:00:01 (xfr#1994, to-chk=963/2979) :Invalid format\n".encode("utf-8"))
+            f.flush()
+            self.assertEqual([self.primary1, self.primary2], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+
+            self.check_recovery_fields(self.primary1, 'differential', '38,861,653', '', '7%', "Syncing pg_data of dbid 1")
+            self.check_recovery_fields(self.primary2, 'differential', '122,017,543', '', '74%', "Syncing tablespace of dbid 2 for oid 17934")
             self.check_recovery_fields(self.primary3, '', '', '', '')
 
 

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -210,7 +210,8 @@ class DifferentialRecovery(Command):
         # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
         # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
         # will copy the last directory and the content of the directory.
-        cmd = Rsync(name="Sync pg data_dir", srcFile=os.path.join(self.recovery_info.source_datadir, ""),
+        cmd = Rsync(name='Syncing pg_data of dbid {}'.format(self.recovery_info.target_segment_dbid),
+                    srcFile=os.path.join(self.recovery_info.source_datadir, ""),
                     dstFile=self.recovery_info.target_datadir,
                     srcHost=self.recovery_info.source_hostname, exclude_list=rsync_exclude_list,
                     delete=True, checksum=True, progress=True, progress_file=self.recovery_info.progress_file)
@@ -259,7 +260,7 @@ class DifferentialRecovery(Command):
         # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
         # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
         # will copy the last directory and the content of the directory.
-        cmd = Rsync(name="Sync pg_xlog files", srcFile=os.path.join(self.recovery_info.source_datadir, "pg_xlog", ""),
+        cmd = Rsync(name="Syncing pg_xlog files of dbid {}".format(self.recovery_info.target_segment_dbid), srcFile=os.path.join(self.recovery_info.source_datadir, "pg_xlog", ""),
                     dstFile=os.path.join(self.recovery_info.target_datadir, "pg_xlog", ""), progress=True, checksum=True,
                     srcHost=self.recovery_info.source_hostname,
                     progress_file=self.recovery_info.progress_file)
@@ -307,7 +308,7 @@ class DifferentialRecovery(Command):
                 # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
                 # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
                 # will copy the last directory and the content of the directory.
-                cmd = Rsync(name="Sync tablespace",
+                cmd = Rsync(name="Syncing tablespace of dbid {0} for oid {1}" .format(self.recovery_info.target_segment_dbid, str(oid)),
                             srcFile=os.path.join(srcPath, ""),
                             dstFile=targetPath,
                             srcHost=self.recovery_info.source_hostname,

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -110,6 +110,51 @@ Feature: gprecoverseg tests
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the cluster is rebalanced
 
+    @concourse_cluster
+    Scenario: gpstate track of differential recovery for single host
+      Given the database is running
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And user immediately stops all mirror processes for content 0
+      And the user waits until mirror on content 0 is down
+      And user can start transactions
+      And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+      And sql "DROP TABLE IF EXISTS test_recoverseg_1; CREATE TABLE test_recoverseg_1 AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+      When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+      Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies that all dbids progress with pg_data are present
+      When the user runs "gpstate -e"
+      Then gpstate should print "Segments in recovery" to stdout
+      And gpstate output contains "differential" entries for mirrors of content 0
+          And gpstate output looks like
+              | Segment | Port   | Recovery type  | Stage                                      | Completed bytes \(kB\) | Percentage completed |
+              | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 6                  | ([\d,]+)[ \t]          | \d+%                 |
+      And the user waits until saved async process is completed
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And sql "DROP TABLE IF EXISTS test_recoverseg;" is executed in "postgres" db
+      And sql "DROP TABLE IF EXISTS test_recoverseg_1;" is executed in "postgres" db
+      And the cluster is rebalanced
+
+
+    @concourse_cluster
+    Scenario: check Tablespace Recovery Progress with gpstate
+       Given the database is running
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And user immediately stops all mirror processes for content 0
+      And user can start transactions
+      And a tablespace is created with data
+      And insert additional data into the tablespace
+      When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+      Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies that all dbids progress with tablespace are present
+      When the user runs "gpstate -e"
+      Then gpstate should print "Segments in recovery" to stdout
+      And gpstate output contains "differential" entries for mirrors of content 0
+          And gpstate output looks like
+              | Segment | Port   | Recovery type  | Stage                                      | Completed bytes \(kB\) | Percentage completed |
+              | \S+     | [0-9]+ | differential   | Syncing tablespace of dbid 6 for oid \d+   | ([\d,]+)[ \t]          | \d+%                 |
+      And the user waits until saved async process is completed
+      And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+      And the cluster is rebalanced
+
+
     Scenario: full recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -656,3 +656,21 @@ Feature: gpstate tests
         And the user runs command "unset PGDATABASE && $GPHOME/bin/gpstate -e -v"
         Then command should print "pg_isready -q -h .* -p .* -d postgres" to stdout
         And command should print "All segments are running normally" to stdout
+
+
+    Scenario: gpstate -e shows information about segments with ongoing differential recovery
+        Given a standard local demo cluster is running
+        Given all files in gpAdminLogs directory are deleted
+        And a sample recovery_progress.file is created with ongoing differential recoveries in gpAdminLogs
+        And we run a sample background script to generate a pid on "master" segment
+        And a sample gprecoverseg.lock directory is created using the background pid in master_data_directory
+        When the user runs "gpstate -e"
+        Then gpstate should print "Segments in recovery" to stdout
+        And gpstate output contains "differential,differential" entries for mirrors of content 0,1
+        And gpstate output looks like
+            | Segment | Port   | Recovery type  | Stage                                       | Completed bytes \(kB\) | Percentage completed |
+            | \S+     | [0-9]+ | differential   | Syncing pg_data of dbid 5                   | 16,454,866             | 4%                   |
+            | \S+     | [0-9]+ | differential   | Syncing tablespace of dbid 6 for oid 20516  | 8,192                  | 100%                 |
+        And all files in gpAdminLogs directory are deleted
+        And the background pid is killed on "master" segment
+        And the gprecoverseg lock directory is removed

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -66,8 +66,12 @@ def impl(context, recovery_types, contents):
     for index, seg_to_display in enumerate(segments_to_display):
         hostname = seg_to_display.getSegmentHostName()
         port = seg_to_display.getSegmentPort()
-        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
-                                                                                         recovery_types[index])
+        if recovery_types[index] == "differential":
+            expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+(.+?)[ \t]+([\d,]+)[ \t]+[0-9]+\%".format(hostname, port,
+                                                                                              recovery_types[index])
+        else:
+            expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
+                                                                                             recovery_types[index])
         check_stdout_msg(context, expected_msg)
 
     #TODO assert that only segments_to_display are printed to the console
@@ -124,4 +128,15 @@ def check_stdout_msg_in_order(context, msg):
         raise Exception(err_str)
 
     context.stdout_position = match.end()
+
+
+@given('a sample recovery_progress.file is created with ongoing differential recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write(
+            "differential:5:     16,454,866   4%   16.52MB/s    0:00:00 (xfr#216, ir-chk=9669/9907) :Syncing pg_data "
+            "of dbid 5\n")
+        fp.write("differential:6:          8,192 100%    7.81MB/s    0:00:00 (xfr#1, to-chk=0/1) :Syncing tablespace of "
+                 "dbid 6 for oid 20516")
+
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -459,7 +459,7 @@ def impl(context, logdir):
             with open(recovery_progress_file, 'r') as fp:
                 context.recovery_lines = fp.readlines()
             for line in context.recovery_lines:
-                recovery_type, dbid, progress = line.strip().split(':', 2)
+                recovery_type, dbid, progress = line.strip().split(':')[:3]
                 progress_pattern = re.compile(get_recovery_progress_pattern(recovery_type))
                 # TODO: assert progress line in the actual hosts bb/rewind progress file
                 if re.search(progress_pattern, progress) and dbid.isdigit() and recovery_type in ['full', 'differential', 'incremental']:
@@ -4337,4 +4337,44 @@ def impl(context, dbname):
         datname, oid = dbconn.execSQLForSingletonRow(conn, query)
         context.db_name = datname
         context.db_oid = oid
+
+
+
+
+@then('the user waits until recovery_progress.file is created in {logdir} and verifies that all dbids progress with {stage} are present')
+def impl(context, logdir, stage):
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    failed_segments = filter(lambda seg: seg.getSegmentStatus() == 'd', all_segments)
+    stage_patterns = []
+    for seg in failed_segments:
+        dbid = seg.getSegmentDbId()
+        if stage == "tablespace":
+            pat = "Syncing tablespace of dbid {} for oid".format(dbid)
+        else:
+            pat = "differential:{}" .format(dbid)
+        stage_patterns.append(pat)
+    if len(stage_patterns) == 0:
+        raise Exception('Failed to get the details of down segment')
+    attempt = 0
+    num_retries = 9000
+    log_dir = _get_gpAdminLogs_directory() if logdir == 'gpAdminLogs' else logdir
+    recovery_progress_file = '{}/recovery_progress.file'.format(log_dir)
+    while attempt < num_retries:
+        attempt += 1
+        if os.path.exists(recovery_progress_file):
+            if verify_elements_in_file(recovery_progress_file, stage_patterns):
+                return
+        time.sleep(0.1)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))
+
+
+def verify_elements_in_file(filename, elements):
+    with open(filename, 'r') as file:
+        content = file.read()
+        for element in elements:
+            if element not in content:
+                return False
+
+        return True
 


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/16460/

Issue : The "gpstate -e" command allows us to track full and incremental recovery progress. However, this functionality is not available for differential recovery.

Approach :  Show the progress stage-wise with rsync version 3.1.0 or above. We are synchronizing data for several components of the segment data directory, including pg_data, tablespace, pg_wal, and pg_control. Multiple rsync sessions will run sequentially for these components, and we want to track the progress of each stage. In rsync version 3.1.0 and above, the --info=progress2 option is available, which allows us to display cumulative progress information for a running rsync session. As each rsync session progresses, the cumulative progress information will be displayed on the terminal. The --info=progress2 option details the bytes transferred and the percentage completed for each session. Using --info=progress2 we can monitor the progress stage-wise of rsync session. The displayed information includes the remote segment, port, recovery type, stage name, completed bytes, and percentage completed.

Implementation:  The approach now includes a validation check for rsync version 3.1.0 or above. If the current version is below this threshold, an exception will be raised. Added a suffix of the stage name to each line with a 'kB/s' or 'MB/s' pattern in it of rsync.*.dbid5.out file. Implemented filtering of relevant lines using grep while tailing data from rsync..dbid5.out and writing to the recovery_progress file to prevent race conditions. In gpsate utility parse the recovery_progress data and process differential recovery progress.

So the stage-wise progress  looks like :

```
gpstate:pkumar144Q6L7:-[INFO]:-   Segment                    Port   Recovery type   Stage                       Completed bytes (kB)   Percentage completed
gpstate:pkumar144Q6L7:-[INFO]:-   pkumar144Q6L7.vmware.com   7005   differential    Syncing pg_data of dbid 5   298,338,995            32%
gpstate:pkumar144Q6L7:-[INFO]:-   pkumar144Q6L7.vmware.com   7007   differential    Syncing pg_data of dbid 7   157,475,653            18%
```

Test : Added unit and beahve test cases

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
