### PR TITLE
[ORCA] Add GUC optimizer_locale_for_query_to_dxl_translation 

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -517,6 +517,10 @@ CConfigParamMapping::PackConfigParamInBitset(
 	// enable using opfamilies in distribution specs for GPDB 6
 	traceflag_bitset->ExchangeSet(EopttraceConsiderOpfamiliesForDistribution);
 
+	// set optimizer locale for vswprintf() used in query to DXL translation
+	ITask::Self()->SetLocaleForQueryToDXLTranslation(
+		optimizer_locale_for_query_to_dxl_translation);
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/gporca/libgpos/include/gpos/task/CTask.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CTask.h
@@ -11,6 +11,8 @@
 #ifndef GPOS_CTask_H
 #define GPOS_CTask_H
 
+#include <string>
+
 #include "gpos/base.h"
 #include "gpos/common/CList.h"
 #include "gpos/error/CErrorContext.h"
@@ -124,6 +126,10 @@ private:
 		m_reported = true;
 	}
 
+	// locale setting used while calling vswprintf/wcstombs for query to DXL
+	// translation
+	std::string m_localeForQueryToDXLTranslation;
+
 public:
 	CTask(const CTask &) = delete;
 
@@ -189,6 +195,18 @@ public:
 	Locale() const override
 	{
 		return m_task_ctxt->Locale();
+	}
+
+	const char *
+	LocaleForQueryToDXLTranslation() const override
+	{
+		return m_localeForQueryToDXLTranslation.c_str();
+	}
+
+	void
+	SetLocaleForQueryToDXLTranslation(char *locale) override
+	{
+		m_localeForQueryToDXLTranslation = locale;
 	}
 
 	// check if task is canceled

--- a/src/backend/gporca/libgpos/include/gpos/task/ITask.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/ITask.h
@@ -72,6 +72,8 @@ public:
 
 	// current locale
 	virtual ELocale Locale() const = 0;
+	virtual const char *LocaleForQueryToDXLTranslation() const = 0;
+	virtual void SetLocaleForQueryToDXLTranslation(char *locale) = 0;
 
 	// error context
 	virtual IErrorContext *GetErrCtxt() const = 0;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -276,6 +276,7 @@ int			optimizer_cost_model;
 bool		optimizer_metadata_caching;
 int			optimizer_mdcache_size;
 bool		optimizer_use_gpdb_allocators;
+char	   *optimizer_locale_for_query_to_dxl_translation;
 
 /* Optimizer debugging GUCs */
 bool		optimizer_print_query;
@@ -4494,6 +4495,17 @@ struct config_string ConfigureNamesString_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
 		&qdHostname,
+		"",
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_locale_for_query_to_dxl_translation", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Set backend locale for multibyte to wide string conversion."),
+			gettext_noop("Valid values align with setlocale() 'locale' argument (e.g. 'en_US.UTF-8')"),
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_locale_for_query_to_dxl_translation,
 		"",
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -447,6 +447,7 @@ extern int optimizer_minidump;
 extern int  optimizer_cost_model;
 extern bool optimizer_metadata_caching;
 extern int	optimizer_mdcache_size;
+extern char *optimizer_locale_for_query_to_dxl_translation;
 
 /* Optimizer debugging GUCs */
 extern bool optimizer_print_query;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -399,6 +399,7 @@
 		"optimizer_force_three_stage_scalar_dqa",
 		"optimizer_join_arity_for_associativity_commutativity",
 		"optimizer_join_order",
+		"optimizer_locale_for_query_to_dxl_translation",
 		"optimizer_join_order_threshold",
 		"optimizer_log",
 		"optimizer_log_failure",

--- a/src/test/regress/expected/gp_locale.out
+++ b/src/test/regress/expected/gp_locale.out
@@ -1,0 +1,58 @@
+DROP DATABASE IF EXISTS testdb3;
+CREATE DATABASE testdb3 WITH LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+\c testdb3
+CREATE TABLE hi_안녕세계 (a int, 안녕세계 text) DISTRIBUTED BY (a);
+INSERT INTO hi_안녕세계 VALUES(1, '안녕세계 1');
+INSERT INTO hi_안녕세계 VALUES(42, '안녕세계 42');
+SET optimizer_trace_fallback=on;
+-- without setting optimizer_locale_for_query_to_dxl_translation the following queries should fall back.
+SHOW optimizer_locale_for_query_to_dxl_translation;
+ optimizer_locale_for_query_to_dxl_translation 
+-----------------------------------------------
+ 
+(1 row)
+
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Delete on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+         Filter: (a = 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+EXPLAIN SELECT * FROM hi_안녕세계;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..860.67 rows=49600 width=36)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..199.33 rows=16533 width=36)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+-- with valid optimizer_locale_for_query_to_dxl_translation setting the following queries shouldn't fall back.
+SET optimizer_locale_for_query_to_dxl_translation='en_US.UTF-8';
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Delete on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+         Filter: (a = 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+DELETE FROM hi_안녕세계 WHERE a=42;
+EXPLAIN SELECT * FROM hi_안녕세계;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..860.67 rows=49600 width=36)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..199.33 rows=16533 width=36)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+SELECT * FROM hi_안녕세계;
+ a |  안녕세계  
+---+------------
+ 1 | 안녕세계 1
+(1 row)
+
+RESET optimizer_locale_for_query_to_dxl_translation;

--- a/src/test/regress/expected/gp_locale_optimizer.out
+++ b/src/test/regress/expected/gp_locale_optimizer.out
@@ -1,0 +1,62 @@
+DROP DATABASE IF EXISTS testdb3;
+CREATE DATABASE testdb3 WITH LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+\c testdb3
+CREATE TABLE hi_안녕세계 (a int, 안녕세계 text) DISTRIBUTED BY (a);
+INSERT INTO hi_안녕세계 VALUES(1, '안녕세계 1');
+INSERT INTO hi_안녕세계 VALUES(42, '안녕세계 42');
+SET optimizer_trace_fallback=on;
+-- without setting optimizer_locale_for_query_to_dxl_translation the following queries should fall back.
+SHOW optimizer_locale_for_query_to_dxl_translation;
+ optimizer_locale_for_query_to_dxl_translation 
+-----------------------------------------------
+ 
+(1 row)
+
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Invalid multibyte character for locale encountered in metadata name
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Delete on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..240.67 rows=17 width=10)
+         Filter: (a = 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+EXPLAIN SELECT * FROM hi_안녕세계;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Invalid multibyte character for locale encountered in metadata name
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..860.67 rows=49600 width=36)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..199.33 rows=16533 width=36)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+-- with valid optimizer_locale_for_query_to_dxl_translation setting the following queries shouldn't fall back.
+SET optimizer_locale_for_query_to_dxl_translation='en_US.UTF-8';
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Delete on "hi_안녕세계"  (cost=0.00..431.03 rows=1 width=1)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..431.00 rows=1 width=22)
+         Filter: (a = 42)
+ Optimizer: GPORCA
+(4 rows)
+
+DELETE FROM hi_안녕세계 WHERE a=42;
+EXPLAIN SELECT * FROM hi_안녕세계;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Seq Scan on "hi_안녕세계"  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: GPORCA
+(3 rows)
+
+SELECT * FROM hi_안녕세계;
+ a |  안녕세계  
+---+------------
+ 1 | 안녕세계 1
+(1 row)
+
+RESET optimizer_locale_for_query_to_dxl_translation;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -51,7 +51,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types combocid_gp gp_sort gp_prepared_xacts gp_backend_info
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types combocid_gp gp_sort gp_prepared_xacts gp_backend_info gp_locale
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults

--- a/src/test/regress/sql/gp_locale.sql
+++ b/src/test/regress/sql/gp_locale.sql
@@ -1,0 +1,23 @@
+DROP DATABASE IF EXISTS testdb3;
+CREATE DATABASE testdb3 WITH LC_COLLATE='C' LC_CTYPE='C' TEMPLATE=template0;
+\c testdb3
+
+CREATE TABLE hi_안녕세계 (a int, 안녕세계 text) DISTRIBUTED BY (a);
+INSERT INTO hi_안녕세계 VALUES(1, '안녕세계 1');
+INSERT INTO hi_안녕세계 VALUES(42, '안녕세계 42');
+SET optimizer_trace_fallback=on;
+
+-- without setting optimizer_locale_for_query_to_dxl_translation the following queries should fall back.
+SHOW optimizer_locale_for_query_to_dxl_translation;
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+EXPLAIN SELECT * FROM hi_안녕세계;
+
+-- with valid optimizer_locale_for_query_to_dxl_translation setting the following queries shouldn't fall back.
+SET optimizer_locale_for_query_to_dxl_translation='en_US.UTF-8';
+EXPLAIN DELETE FROM hi_안녕세계 WHERE a=42;
+DELETE FROM hi_안녕세계 WHERE a=42;
+
+EXPLAIN SELECT * FROM hi_안녕세계;
+SELECT * FROM hi_안녕세계;
+
+RESET optimizer_locale_for_query_to_dxl_translation;


### PR DESCRIPTION
ORCA represents strings using wide characters. That requires converting
to wide format using `vswprintf()`. However, that API may fail if the
string to covert is incompatible with the set LC_CTYPE character set.
That can happen if the database defined LC_CTYPE character set doesn't
support the client character set.

For example, if the database has LC_CTYPE set to 'C', but the client has
'ko_KR.UTF-8'. In that case, ORCA currently falls back to PLANNER
because converting to wide format fails.

A few possible solutions were considered:
  1) Remove wide characters from ORCA
  2) Return a generic wide character string on failure
  3) Use a 'good' LC_CTYPE while calling `vswprintf()`

Solution 1 is very invasive. Solution 2 doesn't work for select queries
that project the problematic column (see testcases in this commit).
Solution 3 is tricky to pick a LC_CTYPE, so instead we push that choice
to the user through GUC optimizer_locale_for_query_to_dxl_translation.

---

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-orca-locale-vswprintf-guc-rocky8