### PR TITLE
Enable tablefunc extension in gpdb7

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -31,6 +31,7 @@ all:
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo all
 endif
+	$(MAKE) -C contrib/tablefunc all
 ifneq ($(with_uuid),no)
 	$(MAKE) -C contrib/uuid-ossp all
 endif
@@ -77,6 +78,7 @@ install:
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo $@
 endif
+	$(MAKE) -C contrib/tablefunc $@
 ifneq ($(with_uuid),no)
 	$(MAKE) -C contrib/uuid-ossp $@
 endif
@@ -181,6 +183,7 @@ ICW_TARGETS += contrib/indexscan contrib/hstore contrib/ltree contrib/pgcrypto c
 ifeq ($(with_openssl), yes)
 ICW_TARGETS += contrib/sslinfo
 endif
+ICW_TARGETS += contrib/tablefunc
 ifneq ($(with_uuid),no)
 ICW_TARGETS += contrib/uuid-ossp
 endif


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Migrate changes https://github.com/greenplum-db/gpdb/pull/14150 to gpdb7.

The test for tablefunc extension is enabled: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-lxy-rhel8/jobs/icw_planner_rhel8/builds/1#L647c1c1b:3915
