### PR TITLE
Update platform-requirements-overview.html.md

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -37,7 +37,7 @@ Greenplum Database 7 requires the following software packages on RHEL systems. T
 -   libzstd
 -   openldap
 -   openssh
--   openssh-client
+-   openssh-clients
 -   openssh-server
 -   openssl
 -   openssl-libs


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Document changes

The platform requirements indicates that one of the package name is openssh-client, however, it should be openssh-clients. This could bother if try to run in scripts.

Could you please fix this?

Thanks!

```
[root@mdw /]# yum install openssh-client
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
epel/aarch64/metalink                                                                                                                                      | 8.4 kB  00:00:00
 * base: mirror.nju.edu.cn
 * centos-sclo-rh: mirror.nju.edu.cn
 * centos-sclo-sclo: mirror.nju.edu.cn
 * epel: mirror.nju.edu.cn
 * extras: mirror.nju.edu.cn
 * updates: mirror.nju.edu.cn
base                                                                                                                                                       | 3.6 kB  00:00:00
centos-sclo-rh                                                                                                                                             | 3.0 kB  00:00:00
centos-sclo-sclo                                                                                                                                           | 3.0 kB  00:00:00
epel                                                                                                                                                       | 5.4 kB  00:00:00
extras                                                                                                                                                     | 2.9 kB  00:00:00
updates                                                                                                                                                    | 2.9 kB  00:00:00
(1/9): base/7/aarch64/group_gz                                                                                                                             | 153 kB  00:00:00
(2/9): centos-sclo-sclo/aarch64/primary_db                                                                                                                 | 189 kB  00:00:00
(3/9): centos-sclo-rh/aarch64/primary_db                                                                                                                   | 2.5 MB  00:00:00
(4/9): base/7/aarch64/primary_db                                                                                                                           | 4.9 MB  00:00:00
(5/9): epel/aarch64/group_gz                                                                                                                               |  88 kB  00:00:00
(6/9): epel/aarch64/updateinfo                                                                                                                             | 1.0 MB  00:00:00
(7/9): epel/aarch64/primary_db                                                                                                                             | 6.6 MB  00:00:00
(8/9): extras/7/aarch64/primary_db                                                                                                                         | 253 kB  00:00:00
(9/9): updates/7/aarch64/primary_db                                                                                                                        | 3.8 MB  00:00:00
No package openssh-client available.
Error: Nothing to do
[root@mdw /]# yum install openssh-clients
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: mirror.nju.edu.cn
 * centos-sclo-rh: mirror.nju.edu.cn
 * centos-sclo-sclo: mirror.nju.edu.cn
 * epel: mirror.nju.edu.cn
 * extras: mirror.nju.edu.cn
 * updates: mirror.nju.edu.cn
Package openssh-clients-7.4p1-23.el7_9.aarch64 already installed and latest version
Nothing to do
[root@mdw /]#
```