### PR TITLE
[6X] fix memory allocation in abort transaction

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -65,6 +65,11 @@ typedef struct CdbDispatchCmdAsync
 	 */
 	struct CdbDispatchResult **dispatchResultPtrArray;
 
+	/*
+	 * pollfd array, we will check dispatch status and dispatch results after
+	 * dispatch command to QE, each pollfd object store socket info which need
+	 * to check from.
+	 */
 	struct pollfd *fds;
 
 	/* Number of segment DBs dispatched */


### PR DESCRIPTION
During transaction abort, before cleanup dispatcher state, need to receive and process results from all running QEs, it will allocate a pollfd array to store QES' connect info. More segments request more memory.

Add an attribute pollfd array to CdbDispatchCmdAsync, and pre-allocate memory when make makeDispatchParams. Memory will be freed when destroy DispatcherState by deleting the memory context, it happens after finish query or during transaction abort.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
