### PR TITLE
[6X] UDF to move orphaned files

### DIFF
--- a/gpcontrib/gp_check_functions/Makefile
+++ b/gpcontrib/gp_check_functions/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = gp_check_functions
-DATA = gp_check_functions--1.0.0.sql
+DATA = gp_check_functions--1.1.sql gp_check_functions--1.0.0--1.1.sql
 MODULES = gp_check_functions
 # REGRESS testing is covered by the main suite test 'gp_check_files' as we need the custom tablespace directory support
 

--- a/gpcontrib/gp_check_functions/gp_check_functions--1.0.0--1.1.sql
+++ b/gpcontrib/gp_check_functions/gp_check_functions--1.0.0--1.1.sql
@@ -1,0 +1,179 @@
+/* gpcontrib/gp_check_functions/gp_check_functions--1.0.0--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_check_functions UPDATE TO '1.1'" to load this file. \quit
+
+-- Check orphaned data files on default and user tablespaces.
+-- Compared to the previous version, add gp_segment_id to show which segment it is being executed.
+CREATE OR REPLACE VIEW __check_orphaned_files AS
+SELECT f1.tablespace, f1.filename, f1.filepath, pg_catalog.gp_execution_segment() AS gp_segment_id
+from __get_exist_files f1
+LEFT JOIN __get_expect_files f2
+ON f1.tablespace = f2.tablespace AND substring(f1.filename from '[0-9]+') = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+(\.)?(\_)?%';
+
+-- Function to check orphaned files.
+-- Compared to the previous version, adjust the SELECT ... FROM __check_orphaned_files since we added new column to it.
+-- NOTE: this function does the same lock and checks as gp_check_functions.gp_move_orphaned_files(), and it needs to be that way. 
+CREATE OR REPLACE FUNCTION __gp_check_orphaned_files_func()
+RETURNS TABLE (
+    gp_segment_id int,
+    tablespace oid,
+    filename text,
+    filepath text
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        -- lock pg_class so that no one will be adding/altering relfilenodes
+        LOCK TABLE pg_class IN SHARE MODE NOWAIT;
+
+        -- make sure no other active/idle transaction is running
+        IF EXISTS (
+            SELECT 1
+            FROM (SELECT * from pg_stat_activity UNION ALL SELECT * FROM gp_dist_random('pg_stat_activity'))q
+            WHERE
+            sess_id <> -1
+            AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        ) THEN
+            RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+        END IF;
+
+        -- force checkpoint to make sure we do not include files that are normally pending delete
+        CHECKPOINT;
+
+        RETURN QUERY 
+        SELECT v.gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM gp_dist_random('__check_orphaned_files') v
+        UNION ALL
+        SELECT -1 AS gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM __check_orphaned_files v;
+    EXCEPTION
+        WHEN lock_not_available THEN
+            RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
+        WHEN OTHERS THEN
+            RAISE;
+    END;
+
+    RETURN;
+END;
+$$;
+
+-- Function to move orphaned files to a designated location.
+-- NOTE: this function does the same lock and checks as gp_move_orphaned_files(),
+-- and it needs to be that way. 
+CREATE OR REPLACE FUNCTION __gp_check_orphaned_files_func()
+RETURNS TABLE (
+    gp_segment_id int,
+    tablespace oid,
+    filename text,
+    filepath text
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        -- lock pg_class so that no one will be adding/altering relfilenodes
+        LOCK TABLE pg_class IN SHARE MODE NOWAIT;
+
+        -- make sure no other active/idle transaction is running
+        IF EXISTS (
+            SELECT 1
+            FROM (SELECT * from pg_stat_activity UNION ALL SELECT * FROM gp_dist_random('pg_stat_activity'))q
+            WHERE
+            sess_id <> -1
+            AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        ) THEN
+            RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+        END IF;
+
+        -- force checkpoint to make sure we do not include files that are normally pending delete
+        CHECKPOINT;
+
+        RETURN QUERY 
+        SELECT v.gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM gp_dist_random('__check_orphaned_files') v
+        UNION ALL
+        SELECT -1 AS gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM __check_orphaned_files v;
+    EXCEPTION
+        WHEN lock_not_available THEN
+            RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
+        WHEN OTHERS THEN
+            RAISE;
+    END;
+
+    RETURN;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION __gp_check_orphaned_files_func() TO public;
+
+-- UDF to move orphaned files to a designated location
+-- NOTE: this function does the same lock and checks as __gp_check_orphaned_files_func(),
+-- and it needs to be that way. 
+CREATE FUNCTION gp_move_orphaned_files(target_location TEXT) RETURNS TABLE (
+    gp_segment_id INT,
+    move_success BOOL,
+    oldpath TEXT,
+    newpath TEXT
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- lock pg_class so that no one will be adding/altering relfilenodes
+    LOCK TABLE pg_class IN SHARE MODE NOWAIT;
+
+    -- make sure no other active/idle transaction is running
+    IF EXISTS (
+        SELECT 1
+        FROM (SELECT * from pg_stat_activity UNION ALL SELECT * FROM gp_dist_random('pg_stat_activity'))q
+        WHERE
+        sess_id <> -1
+        AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+    ) THEN
+        RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+    END IF;
+
+    -- force checkpoint to make sure we do not include files that are normally pending delete
+    CHECKPOINT;
+
+    RETURN QUERY
+    SELECT 
+        q.gp_segment_id,
+        q.move_success,
+        q.oldpath,
+        q.newpath
+    FROM (
+        WITH OrphanedFiles AS (
+            -- Coordinator
+            SELECT 
+                o.gp_segment_id,
+                s.setting || '/' || o.filepath as oldpath,
+                target_location || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') as newpath
+            FROM __check_orphaned_files o, pg_settings s
+            WHERE s.name = 'data_directory'
+            UNION ALL
+            -- Segments
+            SELECT
+                 o.gp_segment_id,
+                 s.setting || '/' || o.filepath as oldpath,
+                 target_location || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') as newpath
+            FROM gp_dist_random('__check_orphaned_files') o 
+            JOIN (SELECT gp_execution_segment() as gp_segment_id, * FROM gp_dist_random('pg_settings')) s on o.gp_segment_id = s.gp_segment_id
+            WHERE s.name = 'data_directory'
+        )
+        SELECT 
+            OrphanedFiles.gp_segment_id,
+            OrphanedFiles.oldpath,
+            OrphanedFiles.newpath,
+            pg_file_rename(OrphanedFiles.oldpath, OrphanedFiles.newpath, NULL) AS move_success
+        FROM OrphanedFiles
+    ) q ORDER BY q.gp_segment_id, q.oldpath;
+EXCEPTION
+    WHEN lock_not_available THEN
+        RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
+    WHEN OTHERS THEN
+        RAISE;
+END;
+$$;
+

--- a/gpcontrib/gp_check_functions/gp_check_functions--1.1.sql
+++ b/gpcontrib/gp_check_functions/gp_check_functions--1.1.sql
@@ -234,12 +234,13 @@ GRANT SELECT ON __get_expect_files_ext TO public;
 --
 --------------------------------------------------------------------------------
 CREATE OR REPLACE VIEW __check_orphaned_files AS
-SELECT f1.tablespace, f1.filename, f1.filepath
+SELECT f1.tablespace, f1.filename, f1.filepath, pg_catalog.gp_execution_segment() AS gp_segment_id
 from __get_exist_files f1
 LEFT JOIN __get_expect_files f2
 ON f1.tablespace = f2.tablespace AND substring(f1.filename from '[0-9]+') = f2.filename
 WHERE f2.tablespace IS NULL
   AND f1.filename SIMILAR TO '[0-9]+(\.)?(\_)?%';
+
 
 GRANT SELECT ON __check_orphaned_files TO public;
 
@@ -261,6 +262,8 @@ GRANT SELECT ON __check_orphaned_files TO public;
 --
 --------------------------------------------------------------------------------
 
+-- NOTE: this function does the same lock and checks as gp_move_orphaned_files(),
+-- and it needs to be that way. 
 CREATE OR REPLACE FUNCTION __gp_check_orphaned_files_func()
 RETURNS TABLE (
     gp_segment_id int,
@@ -289,11 +292,11 @@ BEGIN
         CHECKPOINT;
 
         RETURN QUERY 
-        SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
-        FROM gp_dist_random('__check_orphaned_files')
+        SELECT v.gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM gp_dist_random('__check_orphaned_files') v
         UNION ALL
-        SELECT -1 AS gp_segment_id, *
-        FROM __check_orphaned_files;
+        SELECT -1 AS gp_segment_id, v.tablespace, v.filename, v.filepath
+        FROM __check_orphaned_files v;
     EXCEPTION
         WHEN lock_not_available THEN
             RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
@@ -304,7 +307,93 @@ BEGIN
     RETURN;
 END;
 $$;
+
 GRANT EXECUTE ON FUNCTION __gp_check_orphaned_files_func() TO public;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_move_orphaned_files
+--
+-- @in:
+--        target_location text - directory where we move the orphaned files to
+--
+-- @out:
+--        gp_segment_id int - segment content ID
+--        move_success bool - whether the move attempt succeeded
+--        oldpath text - filepath (name included) of the orphaned file before moving
+--        newpath text - filepath (name included) of the orphaned file after moving
+--
+-- @doc:
+--        UDF to move orphaned files to a designated location
+--
+--------------------------------------------------------------------------------
+
+-- NOTE: this function does the same lock and checks as __gp_check_orphaned_files_func(),
+-- and it needs to be that way. 
+CREATE FUNCTION gp_move_orphaned_files(target_location TEXT) RETURNS TABLE (
+    gp_segment_id INT,
+    move_success BOOL,
+    oldpath TEXT,
+    newpath TEXT
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- lock pg_class so that no one will be adding/altering relfilenodes
+    LOCK TABLE pg_class IN SHARE MODE NOWAIT;
+
+    -- make sure no other active/idle transaction is running
+    IF EXISTS (
+        SELECT 1
+        FROM (SELECT * from pg_stat_activity UNION ALL SELECT * FROM gp_dist_random('pg_stat_activity'))q
+        WHERE
+        sess_id <> -1
+        AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+    ) THEN
+        RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
+    END IF;
+
+    -- force checkpoint to make sure we do not include files that are normally pending delete
+    CHECKPOINT;
+
+    RETURN QUERY
+    SELECT 
+        q.gp_segment_id,
+        q.move_success,
+        q.oldpath,
+        q.newpath
+    FROM (
+        WITH OrphanedFiles AS (
+            -- Coordinator
+            SELECT 
+                o.gp_segment_id,
+                s.setting || '/' || o.filepath as oldpath,
+                target_location || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') as newpath
+            FROM __check_orphaned_files o, pg_settings s
+            WHERE s.name = 'data_directory'
+            UNION ALL
+            -- Segments
+            SELECT
+                 o.gp_segment_id,
+                 s.setting || '/' || o.filepath as oldpath,
+                 target_location || '/seg' || o.gp_segment_id::text || '_' || REPLACE(o.filepath, '/', '_') as newpath
+            FROM gp_dist_random('__check_orphaned_files') o 
+            JOIN (SELECT gp_execution_segment() as gp_segment_id, * FROM gp_dist_random('pg_settings')) s on o.gp_segment_id = s.gp_segment_id
+            WHERE s.name = 'data_directory'
+        )
+        SELECT 
+            OrphanedFiles.gp_segment_id,
+            OrphanedFiles.oldpath,
+            OrphanedFiles.newpath,
+            pg_file_rename(OrphanedFiles.oldpath, OrphanedFiles.newpath, NULL) AS move_success
+        FROM OrphanedFiles
+    ) q ORDER BY q.gp_segment_id, q.oldpath;
+EXCEPTION
+    WHEN lock_not_available THEN
+        RAISE EXCEPTION 'cannot obtain SHARE lock on pg_class';
+    WHEN OTHERS THEN
+        RAISE;
+END;
+$$;
 
 --------------------------------------------------------------------------------
 -- @view:
@@ -393,3 +482,4 @@ SELECT -1 AS gp_segment_id, *
 FROM __check_missing_files; -- not checking ext on coordinator
 
 GRANT SELECT ON gp_check_missing_files_ext TO public;
+

--- a/gpcontrib/gp_check_functions/gp_check_functions.control
+++ b/gpcontrib/gp_check_functions/gp_check_functions.control
@@ -1,5 +1,5 @@
 # gp_check_functions extension
 
 comment = 'various GPDB helper views/functions'
-default_version = '1.0.0'
+default_version = '1.1'
 relocatable = true

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -7,6 +7,12 @@
 -- s/aocsseg_\d+/aocsseg_xxx/g
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
+-- m/seg1_pg_tblspc_.*/
+-- s/seg1_pg_tblspc_.*/seg1_pg_tblspc_XXX/g
+-- m/ERROR\:  could not rename .*/
+-- s/ERROR\:  could not rename .*/ERROR\:  could not rename XXX/g
+-- m/ERROR\:  cannot rename .*/
+-- s/ERROR\:  cannot rename .*/ERROR\:  cannot rename XXX/g
 -- end_matchsubs
 
 create extension gp_check_functions;
@@ -40,9 +46,14 @@ $$ LANGUAGE plpgsql;
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;
 
--- create a table that we'll delete the files 
+-- create a table that we'll delete the files to test missing files.
+-- this have to be created beforehand in order for the tablespace directories to be created.
 CREATE TABLE checkmissing_heap(a int, b int, c int);
 insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+
+--
+-- Tests for orphaned files
+--
 
 -- go to seg1's data directory for the tablespace we just created
 \cd @testtablespace@
@@ -62,9 +73,57 @@ set client_min_messages = ERROR;
 select gp_segment_id, filename from run_orphaned_files_view();
 reset client_min_messages;
 
--- remove the orphaned files so not affect subsequent tests
-\! rm 987654
-\! rm 987654.3
+-- test moving the orphaned files
+
+-- firstly, should not move anything if the target directory doesn't exist
+select * from gp_move_orphaned_files('@testtablespace@/non_exist_dir');
+select gp_segment_id, filename from run_orphaned_files_view();
+
+-- should also fail to move if no proper permission to the target directory
+\! mkdir @testtablespace@/moving_orphaned_file_test
+\! chmod 000 @testtablespace@/moving_orphaned_file_test
+select * from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+select gp_segment_id, filename from run_orphaned_files_view();
+
+-- should not allow non-superuser to run,
+-- though it would complain as soon as non-superuser tries to lock pg_class in gp_move_orphaned_files
+create role check_file_test_role nosuperuser;
+set role = check_file_test_role;
+select * from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+reset role;
+drop role check_file_test_role;
+
+\! chmod 700 @testtablespace@/moving_orphaned_file_test
+-- should correctly move the orphaned files,
+-- filter out exact paths as that could vary
+\a
+select gp_segment_id, move_success, regexp_replace(oldpath, '^.*/(.+)$', '\1') as oldpath, regexp_replace(newpath, '^.*/(.+)$', '\1') as newpath
+from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+\a
+
+-- The moved orphaned files are in the target directory tree with a name that indicates its original location in data directory
+\cd @testtablespace@/moving_orphaned_file_test/
+
+-- should see the orphaned files being moved
+\! ls
+-- no orphaned files can be found now
+select gp_segment_id, filename from run_orphaned_files_view();
+
+-- should not affect existing tables
+select count(*) from checkmissing_heap;
+
+-- go back to the valid data directory
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+
+--
+-- Tests for missing files
+--
 
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -6,6 +6,12 @@
 -- s/aocsseg_\d+/aocsseg_xxx/g
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
+-- m/seg1_pg_tblspc_.*/
+-- s/seg1_pg_tblspc_.*/seg1_pg_tblspc_XXX/g
+-- m/ERROR\:  could not rename .*/
+-- s/ERROR\:  could not rename .*/ERROR\:  could not rename XXX/g
+-- m/ERROR\:  cannot rename .*/
+-- s/ERROR\:  cannot rename .*/ERROR\:  cannot rename XXX/g
 -- end_matchsubs
 create extension gp_check_functions;
 -- helper function to repeatedly run gp_check_orphaned_files for up to 10 minutes,
@@ -35,9 +41,13 @@ $$ LANGUAGE plpgsql;
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;
--- create a table that we'll delete the files 
+-- create a table that we'll delete the files to test missing files.
+-- this have to be created beforehand in order for the tablespace directories to be created.
 CREATE TABLE checkmissing_heap(a int, b int, c int);
 insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+--
+-- Tests for orphaned files
+--
 -- go to seg1's data directory for the tablespace we just created
 \cd @testtablespace@
 select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
@@ -59,9 +69,81 @@ select gp_segment_id, filename from run_orphaned_files_view();
 (2 rows)
 
 reset client_min_messages;
--- remove the orphaned files so not affect subsequent tests
-\! rm 987654
-\! rm 987654.3
+-- test moving the orphaned files
+-- firstly, should not move anything if the target directory doesn't exist
+select * from gp_move_orphaned_files('@testtablespace@/non_exist_dir');
+ERROR:  could not rename XXX
+select gp_segment_id, filename from run_orphaned_files_view();
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654.3
+             1 | 987654
+(2 rows)
+
+-- should also fail to move if no proper permission to the target directory
+\! mkdir @testtablespace@/moving_orphaned_file_test
+\! chmod 000 @testtablespace@/moving_orphaned_file_test
+select * from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+ERROR:  cannot rename XXX
+CONTEXT:  PL/pgSQL function gp_move_orphaned_files(text) line 20 at RETURN QUERY
+select gp_segment_id, filename from run_orphaned_files_view();
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654.3
+             1 | 987654
+(2 rows)
+
+-- should not allow non-superuser to run,
+-- though it would complain as soon as non-superuser tries to lock pg_class in gp_move_orphaned_files
+create role check_file_test_role nosuperuser;
+set role = check_file_test_role;
+select * from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+ERROR:  permission denied for relation pg_class
+CONTEXT:  SQL statement "LOCK TABLE pg_class IN SHARE MODE NOWAIT"
+PL/pgSQL function gp_move_orphaned_files(text) line 4 at SQL statement
+reset role;
+drop role check_file_test_role;
+\! chmod 700 @testtablespace@/moving_orphaned_file_test
+-- should correctly move the orphaned files,
+-- filter out exact paths as that could vary
+\a
+select gp_segment_id, move_success, regexp_replace(oldpath, '^.*/(.+)$', '\1') as oldpath, regexp_replace(newpath, '^.*/(.+)$', '\1') as newpath
+from gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_test');
+gp_segment_id|move_success|oldpath|newpath
+1|t|987654|seg1_pg_tblspc_17816_GPDB_6_302307241_17470_987654
+1|t|987654.3|seg1_pg_tblspc_17816_GPDB_6_302307241_17470_987654.3
+(2 rows)
+\a
+-- The moved orphaned files are in the target directory tree with a name that indicates its original location in data directory
+\cd @testtablespace@/moving_orphaned_file_test/
+-- should see the orphaned files being moved
+\! ls
+seg1_pg_tblspc_37385_GPDB_6_302307241_37039_987654
+seg1_pg_tblspc_37385_GPDB_6_302307241_37039_987654.3
+-- no orphaned files can be found now
+select gp_segment_id, filename from run_orphaned_files_view();
+ gp_segment_id | filename 
+---------------+----------
+(0 rows)
+
+-- should not affect existing tables
+select count(*) from checkmissing_heap;
+ count 
+-------
+   100
+(1 row)
+
+-- go back to the valid data directory
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+--
+-- Tests for missing files
+--
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under
 -- the test tablespace). Also just delete one and only one file that


### PR DESCRIPTION
## Backport notes

Backport from #16584. Changes applied:
* Add a commit to allow specifying absolute path for `pg_file_rename`.
* There's no cluster-wide system views such as `gp_settings`. Use `gp_dist_random('pg_settings')` instead.
* Add a new extension script for `1.1` besides the upgrade script `1.0.0--1.1`, because 6X does not support automatically upgrade to newer version via `CREATE EXTENSION` (which was supported in https://github.com/greenplum-db/gpdb/commit/40b449ae84dc). Also removed the current `1.0.0` script.
  * Note that the new version is a two-number version 1.1 instead of three-number like 1.0.1, since it does not seem to make sense to have a three-number version in the first place. We cannot change the existing so just make future versions correct (thanks to @soumyadeep2007 to catch that).

## Original Description

Provide a UDF `gp_move_orphaned_files` to move orphaned files found by `gp_check_orphaned_files` into a location specified by user, which can then be removed/backup by the user later.
```sql
gp_move_orphaned_files(target_directory text)
```

After moving, the file will be renamed to something that indicates its original location in the data directory. For example, say the file '12345' in the default tablespace is orphaned on primary segment 2, it will be moved like this:

Original location:
```
    <data_directory>/base/13700/12345
```
After moving:
```
    <target_directory>/seg2_base_13700_12345
```

The function will return each moved file's before/after paths, and whether the move succeeded. E.g.:

```sql
    postgres=# select * from gp_move_orphaned_files('/target_dir');
     gp_segment_id | move_success |           oldpath          |         newpath
    ---------------+--------------+----------------------------+-----------------------------------
                -1 | t            | /data_dir/base/13715/99999 | /target_dir/seg-1_base_13715_99999
                 1 | t            | /data_dir/base/13715/99999 | /target_dir/seg1_base_13715_99999
                 2 | t            | /data_dir/base/13715/99999 | /target_dir/seg2_base_13715_99999
    (3 rows)
```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/orphaned_file_move-6x