### PR TITLE
fix memory allocation in abort transaction

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -92,7 +92,13 @@ typedef struct CdbDispatchCmdAsync
 	 */
 	char	   *query_text;
 	int			query_text_len;
+
+	/*
+	 * added[i]: whether ith QE's segment sock has added to the DispWaitSet
+	 * when check dispathed QE's result
+	 */
 	int		*added;
+	/* WaitEvent: array of occurred events which can process results from */
 	WaitEvent *revents;
 
 } CdbDispatchCmdAsync;

--- a/src/backend/storage/ipc/latch.c
+++ b/src/backend/storage/ipc/latch.c
@@ -662,6 +662,10 @@ ResetWaitEventSet(WaitEventSet **pset, MemoryContext context, int nevents)
 		}
 	}
 
+	/* reuse the epoll object and free the old memory */
+	int     old_epoll_fd = set->epoll_fd;
+	pfree(set);
+
 	/* the same alloc logic as CreateWaitEventSet() */
 	char	   *data;
 	Size		sz = 0;
@@ -669,10 +673,6 @@ ResetWaitEventSet(WaitEventSet **pset, MemoryContext context, int nevents)
 	sz += MAXALIGN(sizeof(WaitEvent) * nevents);
 	sz += MAXALIGN(sizeof(struct epoll_event) * nevents);
 	data = (char *) MemoryContextAllocZero(context, sz);
-
-	/* reuse the epoll object and free the old memory */
-	int	old_epoll_fd = set->epoll_fd;
-	pfree(set);
 
 	set = (WaitEventSet *) data;
 	data += MAXALIGN(sizeof(WaitEventSet));


### PR DESCRIPTION
During transaction abort, before cleanup dispatcher state, need to receive and process results from all running QEs, it will allocate a pollfd array to store QES' connect info. More segments request more memory. If transaction abort is due to OOM error, OOM error can continue to occur during abort, and then loop in rollback until panic with ERRORDATA_STACK_SIZE exceeded.

Add attribute WaitEvent and int array to CdbDispatchCmdAsync, and pre-allocate memory when make makeDispatchParams. Memory will be freed when destroy DispatcherState by deleting the memory context, it happens after finish query or during transaction abort.

Also free the old allocated WaitEventSet before allocate memory for the new WaitEventSet.

different from gpdb6, gpdb7 also allocate memory for DispWaitSet, and it's used for all DispatcherState.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
