### PR TITLE
fix GPDB_96_MERGE_FIXME in create_ctescan_path

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3132,8 +3132,6 @@ create_ctescan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->parallel_aware = false;
 	pathnode->parallel_safe = rel->consider_parallel;
 	pathnode->parallel_workers = 0;
-	// GPDB_96_MERGE_FIXME: Why do we set pathkeys in GPDB, but not in Postgres?
-	// pathnode->pathkeys = NIL;	/* XXX for now, result is always unordered */
 	pathnode->pathkeys = pathkeys;
 	pathnode->locus = locus;
 


### PR DESCRIPTION
fixme in create_ctescan_path is as bellow:
```
// GPDB_96_MERGE_FIXME: Why do we set pathkeys in GPDB, but not in Postgres?
// pathnode->pathkeys = NIL;    /* XXX for now, result is always unordered */
pathnode->pathkeys = pathkeys;
```
By now we can not find the commit info of why we use pathkeys in GPDB, but not in Postgres.
The codes "pathnode->pathkeys = pathkeys;" are already introduced after commit: 6b0e52bead. 
And I can not find much more infos in historical repos too.

Sometimes we can reduce extra sort path when the pathkeys of cte node and the pathkeys of subpath node are the same.
So we should keep these codes. Just remove GPDB_96_MERGE_FIXME.
```
explain WITH EmployeeCTE AS (
    SELECT
        employee_id,
        employee_name,
        salary 
    FROM employees order by employee_id  
)                                      
SELECT employee_id, id,
    salary
FROM EmployeeCTE ,foo  
WHERE employee_id = id  order by employee_id;

--if we use the pathkeys of subpath.
Gather Motion 3:1  (slice1; segments: 3)  (cost=2914.20..11157.35 rows=548910 width=24)
   Merge Key: employeecte.employee_id
   ->  Merge Join  (cost=2914.20..3838.55 rows=182970 width=24)
         Merge Cond: (employeecte.employee_id = foo.id)
         ->  Subquery Scan on employeecte  (cost=156.47..161.22 rows=1900 width=20)
               ->  Sort  (cost=156.47..161.22 rows=1900 width=536)
                     Sort Key: employees.employee_id
                     ->  Seq Scan on employees  (cost=0.00..53.00 rows=1900 width=536)
         ->  Sort  (cost=2757.73..2837.98 rows=32100 width=4)
               Sort Key: foo.id
               ->  Seq Scan on foo  (cost=0.00..355.00 rows=32100 width=4)
 Optimizer: Postgres-based planner

--if we do not use pathkeys of subpath, we will add an extra Sort node above Subquery node
 Gather Motion 3:1  (slice1; segments: 3)  (cost=3022.42..11265.57 rows=548910 width=24)
   Merge Key: employeecte.employee_id
   ->  Merge Join  (cost=3022.42..3946.77 rows=182970 width=24)
         Merge Cond: (employeecte.employee_id = foo.id)
         ->  Sort  (cost=264.69..269.44 rows=1900 width=20)
               Sort Key: employeecte.employee_id
               ->  Subquery Scan on employeecte  (cost=156.47..161.22 rows=1900 width=20)
                     ->  Sort  (cost=156.47..161.22 rows=1900 width=536)
                           Sort Key: employees.employee_id
                           ->  Seq Scan on employees  (cost=0.00..53.00 rows=1900 width=53
6)
         ->  Sort  (cost=2757.73..2837.98 rows=32100 width=4)
               Sort Key: foo.id
               ->  Seq Scan on foo  (cost=0.00..355.00 rows=32100 width=4)
 Optimizer: Postgres-based planner
(14 rows)
```
