### PR TITLE
[6X] Post fix for ABI checking pipeline.

### DIFF
--- a/.abi-check/6.25.3/postgres.symbols.ignore
+++ b/.abi-check/6.25.3/postgres.symbols.ignore
@@ -1,1 +1,2 @@
 DummySymbol
+ConfigureNamesInt_gp

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -2,6 +2,14 @@ name: Greenplum ABI Tests
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'concourse/scripts/**'
+      - 'src/**'
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+      - '.abi-check/**'
+
   push:
     branches:
       - 6X_STABLE
@@ -157,7 +165,9 @@ jobs:
                                  -old build-baseline/postgres*.abi \
                                  -new build-latest/postgres*.abi
 
-          ## Dump the reports to stdout.
+      - name: Print out ABI report
+        if: always()
+        run: |
           lynx -dump $(find compat_reports/ | grep html)
 
       - name: Upload ABI Comparison


### PR DESCRIPTION
- The symbol 'ConfigureNamesInt_gp' is changed due to 11d915a908117278a0c2edcc92a63f8826b5bb07 [^1]. It's Greenplum specific GUC and it will not be referenced by other programs. So, it's safe to ignore it.

- We should always print the HTML report to stdout, even if the job is failed.

- I also enabled running ABI checking for pull-requests.

[^1]: https://github.com/greenplum-db/gpdb/commit/11d915a908117278a0c2edcc92a63f8826b5bb07