### PR TITLE
Fix CColRefSet's DbgPrint

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -48,7 +48,7 @@ using IntToColRefMap =
 //		member functions inaccessible
 //
 //---------------------------------------------------------------------------
-class CColRefSet : public CBitSet, public DbgPrintMixin<CColRefSet>
+class CColRefSet : public CBitSet
 {
 	// bitset iter needs to access internals
 	friend class CColRefSetIter;
@@ -127,7 +127,7 @@ public:
 	ULONG HashValue();
 
 	// debug print
-	IOstream &OsPrint(IOstream &os) const;
+	IOstream &OsPrint(IOstream &os) const override;
 	IOstream &OsPrint(IOstream &os, ULONG ulLenMax) const;
 
 	// extract all column ids

--- a/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRefSet.cpp
@@ -19,8 +19,6 @@
 
 using namespace gpopt;
 
-FORCE_GENERATE_DBGSTR(CColRefSet);
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CColRefSet::CColRefSet

--- a/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
@@ -154,7 +154,7 @@ public:
 	}
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const;
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 };	// class CBitSet
 


### PR DESCRIPTION
This re-allows debugging via `colrefset->DbgPrint()`. Previously trying to do this resulted in an error, as both CColRefSet and CBitSet inherited from DbgPrintMixin.