### PR TITLE
Fix ORCA producing incorrect plan when handling SEMI join with randomly distributed table 

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
@@ -266,9 +266,12 @@ CXformJoin2IndexApplyGeneric::Transform(CXformContext *pxfctxt,
 				pexprGet = pexprCurrInnerChild;
 
 				if (NULL != groupingColsToCheck.Value() &&
-					!groupingColsToCheck->ContainsAll(distributionCols))
+					(!groupingColsToCheck->ContainsAll(distributionCols) ||
+					 ptabdescInner->GetRelDistribution() ==
+						 IMDRelation::EreldistrRandom))
 				{
-					// the grouping columns are not a superset of the distribution columns
+					// the grouping columns are not a superset of the distribution columns,
+					// or distribution columns are empty when the table is randomly distributed
 					return;
 				}
 			}
@@ -281,6 +284,16 @@ CXformJoin2IndexApplyGeneric::Transform(CXformContext *pxfctxt,
 				ptabdescInner = popDynamicGet->Ptabdesc();
 				distributionCols = popDynamicGet->PcrsDist();
 				pexprGet = pexprCurrInnerChild;
+
+				if (NULL != groupingColsToCheck.Value() &&
+					(!groupingColsToCheck->ContainsAll(distributionCols) ||
+					 ptabdescInner->GetRelDistribution() ==
+						 IMDRelation::EreldistrRandom))
+				{
+					// the grouping columns are not a superset of the distribution columns,
+					// or distribution columns are empty when the table is randomly distributed
+					return;
+				}
 			}
 			break;
 

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3146,3 +3146,173 @@ SELECT c FROM t0;
  Optimizer: Postgres query optimizer
 (16 rows)
 
+--
+-- Test case for ORCA semi join with random table
+-- See https://github.com/greenplum-db/gpdb/issues/16611
+--
+--- case for random distribute 
+create table table_left (l1 int, l2 int) distributed by (l1);
+create table table_right (r1 int, r2 int) distributed randomly;
+create index table_right_idx on table_right(r1);
+insert into table_left values (1,1);
+insert into table_right select i, i from generate_series(1, 300) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+--- make sure the same value (1,1) rows are inserted into different segments
+select count(distinct gp_segment_id) > 1 from table_right where r1 = 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+analyze table_left;
+analyze table_right;
+-- two types of semi join tests
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right.r1
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right.r1
+                     ->  Seq Scan on table_right
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right.r1
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right.r1
+                     ->  Seq Scan on table_right
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+--- case for replicate distribute
+alter table table_right set distributed replicated;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right.r1
+               ->  Seq Scan on table_right
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right.r1
+               ->  Seq Scan on table_right
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+--- case for partition table with random distribute
+drop table table_right;
+create table table_right (r1 int, r2 int) distributed randomly partition by range (r1) ( start (0) end (300) every (100));
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_1" for table "table_right"
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_2" for table "table_right"
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_3" for table "table_right"
+create index table_right_idx on table_right(r1);
+insert into table_right select i, i from generate_series(1, 299) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+analyze table_right;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right_1_prt_1.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right_1_prt_1.r1
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right_1_prt_1.r1
+                     ->  Append
+                           ->  Seq Scan on table_right_1_prt_1
+                           ->  Seq Scan on table_right_1_prt_2
+                           ->  Seq Scan on table_right_1_prt_3
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (table_right_1_prt_1.r1 = table_left.l1)
+         ->  HashAggregate
+               Group Key: table_right_1_prt_1.r1
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right_1_prt_1.r1
+                     ->  Append
+                           ->  Seq Scan on table_right_1_prt_1
+                           ->  Seq Scan on table_right_1_prt_2
+                           ->  Seq Scan on table_right_1_prt_3
+         ->  Hash
+               ->  Seq Scan on table_left
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+-- clean up
+drop table table_left;
+drop table table_right;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3287,3 +3287,173 @@ SELECT c FROM t0;
  Optimizer: Postgres query optimizer
 (16 rows)
 
+--
+-- Test case for ORCA semi join with random table
+-- See https://github.com/greenplum-db/gpdb/issues/16611
+--
+--- case for random distribute 
+create table table_left (l1 int, l2 int) distributed by (l1);
+create table table_right (r1 int, r2 int) distributed randomly;
+create index table_right_idx on table_right(r1);
+insert into table_left values (1,1);
+insert into table_right select i, i from generate_series(1, 300) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+--- make sure the same value (1,1) rows are inserted into different segments
+select count(distinct gp_segment_id) > 1 from table_right where r1 = 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+analyze table_left;
+analyze table_right;
+-- two types of semi join tests
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (table_left.l1 = table_right.r1)
+         ->  Seq Scan on table_left
+               Filter: (NOT (l1 IS NULL))
+         ->  Hash
+               ->  Result
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: table_right.r1
+                           ->  Seq Scan on table_right
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (table_left.l1 = table_right.r1)
+         ->  Seq Scan on table_left
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right.r1
+                     ->  Seq Scan on table_right
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+--- case for replicate distribute
+alter table table_right set distributed replicated;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on table_left
+                     Filter: (NOT (l1 IS NULL))
+         ->  GroupAggregate
+               Group Key: table_right.r1
+               ->  Result
+                     ->  Index Scan using table_right_idx on table_right
+                           Index Cond: (r1 = table_left.l1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on table_left
+         ->  GroupAggregate
+               Group Key: table_right.r1
+               ->  Index Scan using table_right_idx on table_right
+                     Index Cond: (r1 = table_left.l1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+--- case for partition table with random distribute
+drop table table_right;
+create table table_right (r1 int, r2 int) distributed randomly partition by range (r1) ( start (0) end (300) every (100));
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_1" for table "table_right"
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_2" for table "table_right"
+NOTICE:  CREATE TABLE will create partition "table_right_1_prt_3" for table "table_right"
+create index table_right_idx on table_right(r1);
+insert into table_right select i, i from generate_series(1, 299) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+analyze table_right;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (table_left.l1 = table_right.r1)
+         ->  Seq Scan on table_left
+               Filter: (NOT (l1 IS NULL))
+         ->  Hash
+               ->  Result
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: table_right.r1
+                           ->  Sequence
+                                 ->  Partition Selector for table_right (dynamic scan id: 1)
+                                       Partitions selected: 3 (out of 3)
+                                 ->  Dynamic Seq Scan on table_right (dynamic scan id: 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (table_left.l1 = table_right.r1)
+         ->  Seq Scan on table_left
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: table_right.r1
+                     ->  Sequence
+                           ->  Partition Selector for table_right (dynamic scan id: 1)
+                                 Partitions selected: 3 (out of 3)
+                           ->  Dynamic Seq Scan on table_right (dynamic scan id: 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+ l1 | l2 
+----+----
+  1 |  1
+(1 row)
+
+-- clean up
+drop table table_left;
+drop table table_right;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1230,3 +1230,49 @@ explain (COSTS OFF) with t0 AS (
         JOIN s as t ON  true
    )
 SELECT c FROM t0;
+
+--
+-- Test case for ORCA semi join with random table
+-- See https://github.com/greenplum-db/gpdb/issues/16611
+--
+--- case for random distribute 
+create table table_left (l1 int, l2 int) distributed by (l1);
+create table table_right (r1 int, r2 int) distributed randomly;
+create index table_right_idx on table_right(r1);
+insert into table_left values (1,1);
+insert into table_right select i, i from generate_series(1, 300) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+
+--- make sure the same value (1,1) rows are inserted into different segments
+select count(distinct gp_segment_id) > 1 from table_right where r1 = 1;
+analyze table_left;
+analyze table_right;
+
+-- two types of semi join tests
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+
+--- case for replicate distribute
+alter table table_right set distributed replicated;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+
+--- case for partition table with random distribute
+drop table table_right;
+create table table_right (r1 int, r2 int) distributed randomly partition by range (r1) ( start (0) end (300) every (100));
+create index table_right_idx on table_right(r1);
+insert into table_right select i, i from generate_series(1, 299) i;
+insert into table_right select 1, 1 from generate_series(1, 100) i;
+analyze table_right;
+explain (costs off) select * from table_left where exists (select 1 from table_right where l1 = r1);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+explain (costs off) select * from table_left where l1 in (select r1 from table_right);
+select * from table_left where exists (select 1 from table_right where l1 = r1);
+
+-- clean up
+drop table table_left;
+drop table table_right;


### PR DESCRIPTION
This is a backport of #16615

When ORCA transforms a SEMI join to an INNER join, a LogicalGbAgg is introduced in the inner side of the INNER join to remove duplicate inner keys. Subsequently, this join is attempted to be transformed into a LogicalIndexApply. ORCA determines if this transformation can be done by checking if the inner side's grouping columns contain all distribution columns.

However, when the inner side's distribution columns come from a RANDOM table, the checking always evaluates to true and allows the transform to proceed. But RANDOM distribution cannot satisfy this transformation because the same 'distribution' key may appear in different segments.

This commit resolves the issue by adding a check for the size of RANDOM distribution columns and forbidding the illegal transform.

Fix #16611