### PR TITLE
[ORCA] Allow alias name to represent table name

### DIFF
--- a/contrib/file_fdw/output/gp_file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/gp_file_fdw_optimizer.source
@@ -128,7 +128,7 @@ explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a
          Hash Cond: (word1 = bar.a)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
                Hash Key: word1
-               ->  Foreign Scan on text_csv_coordinator  (cost=0.00..431.00 rows=1 width=8)
+               ->  Foreign Scan on text_csv_coordinator ft1  (cost=0.00..431.00 rows=1 width=8)
                      Foreign File: @abs_srcdir@/file_fdw/data/text.csv
                      Foreign File Size: 86 b
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -512,7 +512,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                      ->  Redistribute Motion 1:3  (slice2)
                            Output: c1
                            Hash Key: c1
-                           ->  Foreign Scan on public.ft2
+                           ->  Foreign Scan on public.ft2 t1
                                  Output: c1
                                  Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                ->  Index Scan using t1_pkey on "S 1"."T 1"
@@ -557,7 +557,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                      ->  Redistribute Motion 1:3  (slice2)
                            Output: c1
                            Hash Key: c1
-                           ->  Foreign Scan on public.ft2
+                           ->  Foreign Scan on public.ft2 t1
                                  Output: c1
                                  Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                ->  Index Scan using t1_pkey on "S 1"."T 1"
@@ -611,14 +611,14 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                        Hash Cond: (c1 = c1)
                                        ->  Redistribute Motion 1:3  (slice3)
                                              Output: c1
-                                             ->  Foreign Scan on public.ft1
+                                             ->  Foreign Scan on public.ft1 t2
                                                    Output: c1
                                                    Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                                        ->  Hash
                                              Output: c1
                                              ->  Broadcast Motion 1:3  (slice4)
                                                    Output: c1
-                                                   ->  Foreign Scan on public.ft2
+                                                   ->  Foreign Scan on public.ft2 t3
                                                          Output: c1
                                                          Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -667,7 +667,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                  ->  Redistribute Motion 1:3  (slice2)
                                        Output: c1
                                        Hash Key: c1
-                                       ->  Foreign Scan on public.ft1
+                                       ->  Foreign Scan on public.ft1 t2
                                              Output: c1
                                              Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                            ->  Sort
@@ -676,7 +676,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                  ->  Redistribute Motion 1:3  (slice3)
                                        Output: c1
                                        Hash Key: c1
-                                       ->  Foreign Scan on public.ft2
+                                       ->  Foreign Scan on public.ft2 t3
                                              Output: c1
                                              Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                      ->  Hash
@@ -735,7 +735,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                        ->  Redistribute Motion 1:3  (slice2)
                                              Output: c1
                                              Hash Key: c1
-                                             ->  Foreign Scan on public.ft1
+                                             ->  Foreign Scan on public.ft1 t2
                                                    Output: c1
                                                    Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
                                  ->  Sort
@@ -744,7 +744,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
                                        ->  Redistribute Motion 1:3  (slice3)
                                              Output: c1
                                              Hash Key: c1
-                                             ->  Foreign Scan on public.ft2
+                                             ->  Foreign Scan on public.ft2 t3
                                                    Output: c1
                                                    Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -889,7 +889,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
  Hash Join
    Output: "T 1"."C 1", "T 1".c2, "T 1".c3, "T 1".c4, "T 1".c5, "T 1".c6, "T 1".c7, "T 1".c8, c1, c2, c3, c4, c5, c6, c7, c8
    Hash Cond: (c1 = "T 1".c2)
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on public.ft2 b
          Output: c1, c2, c3, c4, c5, c6, c7, c8
          Remote SQL: SELECT "C 1", c2, c3, c4, c5, c6, c7, c8 FROM "S 1"."T 1"
    ->  Hash

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -124,10 +124,12 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidRel, rel_oid);
 
 	const IMDRelation *rel = md_accessor->RetrieveRel(mdid);
-
 	// look up table name
-	const CWStringConst *tablename = rel->Mdname().GetMDName();
-	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
+	CMDName *table_mdname =
+		rte->alias
+			? GPOS_NEW(mp) CMDName(
+				  GPOS_NEW(mp) CWStringConst(mp, rte->alias->aliasname), true)
+			: GPOS_NEW(mp) CMDName(mp, rel->Mdname().GetMDName());
 
 	ULONG required_perms = static_cast<ULONG>(rte->requiredPerms);
 	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(


### PR DESCRIPTION
Access to alias name will be necessary when hints reference the same
relation multiple times in a query (e.g. self-join). It provides a way
to distinguish each reference to the relation.