### PR TITLE
[7x]: Fix  gpstart issues for large  segment host

### DIFF
--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -121,8 +121,8 @@ class StartSegmentsOperation:
                 mirrorDbs = [seg for seg in segments if seg.isSegmentMirror(True)]
                 primaryDbs = [seg for seg in segments if seg.isSegmentPrimary(True)]
 
-                self.__runStartCommand(mirrorDbs, startMethod, numContentsInCluster, result, gpArray, era)
                 self.__runStartCommand(primaryDbs, startMethod, numContentsInCluster, result, gpArray, era)
+                self.__runStartCommand(mirrorDbs, startMethod, numContentsInCluster, result, gpArray, era)
 
             elif startMethod == START_AS_MIRRORLESS:
                 # bring them up in mirrorless mode

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -217,7 +217,7 @@ class StartSegmentsOperation:
                                     resultOut.addSuccess(segment)
                                 else:
                                     resultOut.addFailure(segment, reasonStr, reasonCode)
-                if cmd.get_results().stderr is not None:
+                if cmd.get_results().stderr is not None and cmd.get_results().stderr.strip() != "":
                     logger.info(cmd.get_results().stderr)
             else:
                 for segment in cmd.dblist:

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -191,3 +191,13 @@ Feature: gpstart behave tests
 
           When the user runs psql with "-c 'drop user foouser;'" against database "postgres"
           Then psql should return a return code of 0
+
+
+    @concourse_cluster
+    Scenario: gpstart with batch size is less than the number of segments host
+        Given the database is not running
+          And the user runs "gpstart -a -B 1"
+          And "gpstart -a -B 1" should return a return code of 0
+          Then gpcheckcat should not print "Number of segments which failed to start:.*" to stdout
+
+

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -196,8 +196,8 @@ Feature: gpstart behave tests
     @concourse_cluster
     Scenario: gpstart with batch size is less than the number of segments host
         Given the database is not running
-          And the user runs "gpstart -a -B 1"
-          And "gpstart -a -B 1" should return a return code of 0
-          Then gpcheckcat should not print "Number of segments which failed to start:.*" to stdout
+         When the user runs "gpstart -a -B 1"
+         Then "gpstart -a -B 1" should return a return code of 0
+          And gpcheckcat should not print "Number of segments which failed to start:.*" to stdout
 
 


### PR DESCRIPTION
**Issue 1** - While running gpstart with 64 segment nodes with 384 primary and 384 mirror,
a warning message is displayed: "`[WARNING]:-Number of segments which failed to start: 384.`"
However, when checking with "gpstate," all segments appear to be in a normal state.

**RCA** - When the batch size (-B) is less than the number of segments host gpstart starts
the mirror segment before the primary segment. From segment logs, we found out `pg_ctl -w start` 
for mirror is timeout out with a nonzero exit status. This leads to a warning
in gpstart for mirror segments - `[WARNING]:-Number of segments which failed to start: 384`.
The PR(https://github.com/greenplum-db/gpdb/pull/15994) introduced the changed pg_ctl start
with -w flag for Mirrors now wait until walreceiver is started to be marked as up - which can
only happen if primary is up due to these mirror segments leading to the timeout issue.
The mirror start operations still run in the background and when its primary is up mirror
is also started this leads to a warning in gpstart for mirror segments.

**Solution** - Implement the changes to start the primary before the mirror, resolving the timeout problem.

**Test** - Added behave test case to verify it.


**Issue 2** - During the execution of "gpstart," empty lines are printed. These blank lines are generated for every segment.

**Solution** - Added a check to verify the resulting string is not empty.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
