### PR TITLE
Fix bug: cannot use LOCALE flag with a str pattern

### DIFF
--- a/gpMgmt/bin/gppylib/gpparseopts.py
+++ b/gpMgmt/bin/gppylib/gpparseopts.py
@@ -85,7 +85,7 @@ class OptChecker(Option):
     def regexCheck(option, opt, value):
         # value is a string to be compiled as a regular expression pattern
         global _gCase
-        flags = re.LOCALE
+        flags = 0
         if _gCase and _gCase.startswith('i'):
             flags |= re.IGNORECASE
         try:


### PR DESCRIPTION
This commit can fix the bug reported in #16665 
Since Python 3.6, `re.LOCALE` can be used only with bytes patterns and is not compatible with re.ASCII.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
