### PR TITLE
Fix ValueError exception if there is an empty lock directory

### DIFF
--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -83,6 +83,12 @@ class PIDLockFile:
             if self.PID == self.read_pid():
                 # remove the dir and PID file inside of it
                 shutil.rmtree(self.path)
+
+                # Eventhough we remove the directory, it is not guaranteed that the directory is removed
+                # at the disk level. So it is necessary to make this call to sync the changes at the disk level.
+                # Refer https://stackoverflow.com/questions/7127075/what-exactly-is-file-flush-doing for more context.
+                os.sync()
+
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 pass
@@ -162,7 +168,11 @@ class SimpleMainLock:
             return None
 
         # look for a lock file
-        self.pidfilepid = self.pidlockfile.read_pid()
+        try:
+            self.pidfilepid = self.pidlockfile.read_pid()
+        except ValueError:
+            shutil.rmtree(self.ppath)
+
         if self.pidfilepid is not None:
 
             # we found a lock file

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -207,3 +207,10 @@ Feature: gpstop behave tests
         And the user runs gpstop -a and selects f
         And gpstop should return a return code of 0
 
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpstop removes the lock directory when it is empty
+        Given the database is running
+        Then a sample gpstop.lock directory is created using the background pid in coordinator_data_directory
+        And the user runs "gpstop -a"
+        And gpstop should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -22,9 +22,13 @@ def impl(context):
 @then('a sample {lock_file} directory is created using the background pid in coordinator_data_directory')
 @given('a sample {lock_file} directory is created using the background pid in coordinator_data_directory')
 def impl(context, lock_file):
-    bg_pid = context.bg_pid
-    if not unix.check_pid(bg_pid):
-        raise Exception("The background process with PID {} is not running.".format(bg_pid))
+    if 'bg_pid' in context:
+        bg_pid = context.bg_pid
+        if not unix.check_pid(bg_pid):
+            raise Exception("The background process with PID {} is not running.".format(bg_pid))
+    else:
+        bg_pid = ""
+
     lock_dir = os.path.join(get_coordinatordatadir() + '/{0}'.format(lock_file))
     os.mkdir(lock_dir)
 


### PR DESCRIPTION
This commit fixes the issue, where the `gpstop` errors out when there is an empty PID file in the `gpstop.lock` directory.
```
20231013:03:18:29:033818 gpstart:mdw:gpadmin-[CRITICAL]:-Error occurred: non-zero rc: 1
 Command was: '$GPHOME/bin/gpstop -a -m -M immediate -d /data1/master/gpseg-1 -v -B 64'
rc=1, stdout='', stderr='Traceback (most recent call last):
  File "/usr/local/greenplum-db-6.25.3/bin/gpstop", line 1098, in <module>
    simple_main(GpStop.createParser, GpStop.createProgram, GpStop.mainOptions())
  File "/usr/local/greenplum-db-6.25.3/lib/python/gppylib/mainUtils.py", line 263, in simple_main
    simple_main_internal(createOptionParserFn, createCommandFn, mainOptions)
  File "/usr/local/greenplum-db-6.25.3/lib/python/gppylib/mainUtils.py", line 288, in simple_main_internal
    otherpid = sml.acquire()
  File "/usr/local/greenplum-db-6.25.3/lib/python/gppylib/mainUtils.py", line 165, in acquire
    self.pidfilepid = self.pidlockfile.read_pid()
  File "/usr/local/greenplum-db-6.25.3/lib/python/gppylib/mainUtils.py", line 102, in read_pid
    owner = int(p.read())
ValueError: invalid literal for int() with base 10: ''
Exception ValueError: ValueError("invalid literal for int() with base 10: ''",) in <bound method PIDLockFile.__del__ of <gppylib.mainUtils.PIDLockFile instance at 0x7f11fed9b0a0>> ignored
```

Due to the empty file, whenever it reads and tries to convert the contents to an integer, we get a `ValueError` exception. With this change, we will now automatically delete the lock directory in such situations so that `gpstop` can go ahead and create a new lock directory.

Another issue was that, even though we delete the lock directory at the end of the process execution, it does not guarantee that it is completely deleted at the disk level. This issue came up when `gpsnap` created a snapshot after running `gpstop` and when the data was restored back using `gpsnap restore`, we saw that the `gpstop` lock directory reappeared with an empty PID file indicating that the directory was not completely removed.

So to guarantee that the changes are written on to the disk, a call to `os.sync()` has been added after the lock directory is removed. Refer [here](https://stackoverflow.com/questions/7127075/what-exactly-is-file-flush-doing) for more info on how python handles file operations.

NOTE: These changes have been manually verified by the GPCP team on their AWS cluster.