### PR TITLE
Add test case for PR-11946

### DIFF
--- a/src/pl/plpython/expected/plpython_test.out
+++ b/src/pl/plpython/expected/plpython_test.out
@@ -91,3 +91,33 @@ CONTEXT:  Traceback (most recent call last):
   PL/Python function "elog_test_basic", line 10, in <module>
     plpy.error('error')
 PL/Python function "elog_test_basic"
+-- Long query Log will be truncated when writing log.csv. 
+-- If a UTF-8 character is truncated in its middle,
+-- the encoding ERROR will appear due to the half of a UTF-8 character, like �.
+-- PR-11946 can fix it.
+-- If you want more detail, please refer to ISSUE-15319
+SET client_encoding TO 'UTF8';
+CREATE FUNCTION elog_test_string_truncate() RETURNS void
+AS $$
+plpy.log("1"+("床前明月光疑是地上霜举头望明月低头思故乡\n"+
+"独坐幽篁里弹琴复长啸深林人不知明月来相照\n"+
+"千山鸟飞绝万径人踪灭孤舟蓑笠翁独钓寒江雪\n"+
+"白日依山尽黄河入海流欲穷千里目更上一层楼\n"+
+"好雨知时节当春乃发生随风潜入夜润物细无声\n")*267)
+$$ LANGUAGE plpythonu;
+SELECT elog_test_string_truncate();
+ elog_test_string_truncate 
+---------------------------
+ 
+(1 row)
+
+SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;
+ logseverity 
+-------------
+ LOG
+ LOG
+ LOG
+ LOG
+ LOG
+(5 rows)
+

--- a/src/pl/plpython/sql/plpython_test.sql
+++ b/src/pl/plpython/sql/plpython_test.sql
@@ -50,3 +50,23 @@ plpy.error('error')
 $$ LANGUAGE plpythonu;
 
 SELECT elog_test_basic();
+
+-- Long query Log will be truncated when writing log.csv. 
+-- If a UTF-8 character is truncated in its middle,
+-- the encoding ERROR will appear due to the half of a UTF-8 character, like �.
+-- PR-11946 can fix it.
+-- If you want more detail, please refer to ISSUE-15319
+SET client_encoding TO 'UTF8';
+
+CREATE FUNCTION elog_test_string_truncate() RETURNS void
+AS $$
+plpy.log("1"+("床前明月光疑是地上霜举头望明月低头思故乡\n"+
+"独坐幽篁里弹琴复长啸深林人不知明月来相照\n"+
+"千山鸟飞绝万径人踪灭孤舟蓑笠翁独钓寒江雪\n"+
+"白日依山尽黄河入海流欲穷千里目更上一层楼\n"+
+"好雨知时节当春乃发生随风潜入夜润物细无声\n")*267)
+$$ LANGUAGE plpythonu;
+
+SELECT elog_test_string_truncate();
+
+SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;


### PR DESCRIPTION
**Long log:**

Long query log will be truncated when writing log.csv. 
UTF-8 is a variable-length encoding of 1~4 bytes, 
so UTF-8 characters may be truncated in the middle.

Without #11946, the test case will meet encoding ERROR:
```
ERROR:  invalid byte sequence for encoding "UTF8": 0xe9 0xa3 0x22
CONTEXT:  External table __gp_log_coordinator_ext, line 1392 of file execute:cat $GP_SEG_LOGDIR/*.csv
```
because the long query log is truncated, 
please refer to the special char in the log.csv `�` as below:
```
床前明月光疑是地上霜举头望明月低头思故乡
独坐幽篁里弹琴复长啸深林人不知明月来相照
千山鸟�",,,,,"PL/Python function ""elog_test_string_truncate""","SELECT elog_test_string_truncate();",0,,"plpy_plpymodule.c",563,
```

This commit adds the test case to verify the code change in #11946 .

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-hyt-rocky9-elog

**Signed-off-by:** Yongtao Huang <yongtaoh@vmware.com>