### PR TITLE
Fix bug of very long UTF-8 encoded query string truncation  [6X]

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3667,7 +3667,7 @@ append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 	 */
 	if (len >= PIPE_MAX_PAYLOAD * 20)
 	{
-		len = PIPE_MAX_PAYLOAD * 20 - 1;
+		len = pg_mbcliplen(input, len, PIPE_MAX_PAYLOAD * 20 - 1);
 	}
 
 	char *data = buffer->data + buffer->hdr.len;

--- a/src/pl/plpython/expected/plpython_test.out
+++ b/src/pl/plpython/expected/plpython_test.out
@@ -98,7 +98,7 @@ SELECT elog_test_string_truncate();
  
 (1 row)
 
-SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;
+SELECT logseverity FROM gp_toolkit.__gp_log_master_ext order by logtime desc limit 5;
  logseverity 
 -------------
  LOG

--- a/src/pl/plpython/expected/plpython_test.out
+++ b/src/pl/plpython/expected/plpython_test.out
@@ -78,3 +78,33 @@ CONTEXT:  Traceback (most recent call last):
   PL/Python function "elog_test", line 10, in <module>
     plpy.error('error')
 PL/Python function "elog_test"
+-- Long query Log will be truncated when writing log.csv. 
+-- If a UTF-8 character is truncated in its middle,
+-- the encoding ERROR will appear due to the half of a UTF-8 character, like �.
+-- PR-11946 can fix it.
+-- If you want more detail, please refer to ISSUE-15319
+SET client_encoding TO 'UTF8';
+CREATE FUNCTION elog_test_string_truncate() RETURNS void
+AS $$
+plpy.log("1"+("床前明月光疑是地上霜举头望明月低头思故乡\n"+
+"独坐幽篁里弹琴复长啸深林人不知明月来相照\n"+
+"千山鸟飞绝万径人踪灭孤舟蓑笠翁独钓寒江雪\n"+
+"白日依山尽黄河入海流欲穷千里目更上一层楼\n"+
+"好雨知时节当春乃发生随风潜入夜润物细无声\n")*267)
+$$ LANGUAGE plpythonu;
+SELECT elog_test_string_truncate();
+ elog_test_string_truncate 
+---------------------------
+ 
+(1 row)
+
+SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;
+ logseverity 
+-------------
+ LOG
+ LOG
+ LOG
+ LOG
+ LOG
+(5 rows)
+

--- a/src/pl/plpython/sql/plpython_test.sql
+++ b/src/pl/plpython/sql/plpython_test.sql
@@ -51,3 +51,23 @@ plpy.error('error')
 $$ LANGUAGE plpythonu;
 
 SELECT elog_test();
+
+-- Long query Log will be truncated when writing log.csv. 
+-- If a UTF-8 character is truncated in its middle,
+-- the encoding ERROR will appear due to the half of a UTF-8 character, like �.
+-- PR-11946 can fix it.
+-- If you want more detail, please refer to ISSUE-15319
+SET client_encoding TO 'UTF8';
+
+CREATE FUNCTION elog_test_string_truncate() RETURNS void
+AS $$
+plpy.log("1"+("床前明月光疑是地上霜举头望明月低头思故乡\n"+
+"独坐幽篁里弹琴复长啸深林人不知明月来相照\n"+
+"千山鸟飞绝万径人踪灭孤舟蓑笠翁独钓寒江雪\n"+
+"白日依山尽黄河入海流欲穷千里目更上一层楼\n"+
+"好雨知时节当春乃发生随风潜入夜润物细无声\n")*267)
+$$ LANGUAGE plpythonu;
+
+SELECT elog_test_string_truncate();
+
+SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;

--- a/src/pl/plpython/sql/plpython_test.sql
+++ b/src/pl/plpython/sql/plpython_test.sql
@@ -70,4 +70,4 @@ $$ LANGUAGE plpythonu;
 
 SELECT elog_test_string_truncate();
 
-SELECT logseverity FROM gp_toolkit.__gp_log_coordinator_ext order by logtime desc limit 5;
+SELECT logseverity FROM gp_toolkit.__gp_log_master_ext order by logtime desc limit 5;


### PR DESCRIPTION
This pr cherry-picks #11946 and #16669 into 6X_STABLE.

Long query log will be truncated when writing log.csv. 
UTF-8 is a variable-length encoding of 1~4 bytes, 
so UTF-8 characters may be truncated in the middle.

Without code change, the test case will meet encoding ERROR:
```
ERROR:  invalid byte sequence for encoding "UTF8": 0xe9 0xa3 0x22
```
because the long query log is truncated, 
please refer to the special char in the log.csv `�` as below:
```
床前明月光疑是地上霜举头望明月低头思故乡
独坐幽篁里弹琴复长啸深林人不知明月来相照
千山鸟�",,,,,"PL/Python function "
```

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-hyt-centos6-elog

Co-authored-by: t1mursadykov <sti@arenadata.io>
Co-authored-by: Yongtao Huang <yongtaoh@vmware.com>