### PR TITLE
Use finish_heap_swap to swap relation files and else in ALTER TABLE DISTRIBUTED BY

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17936,9 +17936,9 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	 * d) Update our parse tree to include the details of the newly created
 	 *    table
 	 * e) Update the ownership of the temporary table
-	 * f) Swap the relfilenodes of the existing table and the temporary table
+	 * f) Finish swapping the relfilenodes of the existing table and the temporary
+	 *    table, and other cleanup tasks.
 	 * g) Update the policy on the QD to reflect the underlying data
-	 * h) Drop the temporary table -- and with it, the old copy of the data
 	 *--
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -18246,22 +18246,16 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		/*
 		 * Step (f) - swap relfilenodes and MORE !!!
 		 */
-		rel = NULL;
 		tmprelid = RangeVarGetRelid(tmprv, NoLock, false);
-		swap_relation_files(tarrelid, tmprelid,
-							false, /* target_is_pg_class */
+		finish_heap_swap(tarrelid, tmprelid,
+						 	false, /* is_system_catalog */
 							false, /* swap_toast_by_content */
 							false, /* swap_stats */
-							true,
+						 	false, /* check_constraints */
+						 	true, /* is_internal */
 							RecentXmin,
 							ReadNextMultiXactId(),
-							NULL);
-
-		/* Make changes from swapping relation files visible. */
-		CommandCounterIncrement();
-
-		/* now, reindex */
-		reindex_relation(tarrelid, 0, 0);
+						 	rel->rd_rel->relpersistence);
 	}
 
 	/* Step (g) */
@@ -18273,17 +18267,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		cmd->policy = policy;
 	}
 
-	/* Step (h) Drop the table */
-	if (need_reorg)
-	{
-		ObjectAddress object;
-		object.classId = RelationRelationId;
-		object.objectId = tmprelid;
-		object.objectSubId = 0;
-
-		performDeletion(&object, DROP_RESTRICT, 0);
-	}
-	
 l_distro_fini:
 
 	/* MPP-6929: metadata tracking */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1792,3 +1792,25 @@ HINT:  consider separating into multiple statements
 ALTER TABLE atsdby_multiple SET WITH (reorganize=true), ADD COLUMN k int;
 ERROR:  cannot alter distribution with other subcommands for relation "atsdby_multiple"
 HINT:  consider separating into multiple statements
+-- Check that after AT SET DISTRIBUTED BY, the toast table name is still 'pg_toast_<tableoid>'
+create table atsdby_toastname(a text, b int);
+alter table atsdby_toastname set distributed by (b);
+select reltoastrelid::regclass = ('pg_toast.pg_toast_' || oid::text)::regclass
+from pg_class where relname = 'atsdby_toastname';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Check that after AT SET DISTRIBUTED BY, index is being re-indexed. Verify one of the segments is enough.
+create table atsdby_reindex(a text, b int);
+create index atsdby_reindex_i on atsdby_reindex(b);
+select relfilenode from gp_dist_random('pg_class') where relname = 'atsdby_reindex' and gp_segment_id = 0
+\gset
+alter table atsdby_reindex set distributed by (b);
+select :relfilenode = relfilenode from gp_dist_random('pg_class') where relname = 'atsdby_reindex' and gp_segment_id = 0;
+ ?column? 
+----------
+ f
+(1 row)
+


### PR DESCRIPTION
Currently we are doing `swap_relation_files` and a few other steps in ALTER TABLE DISTRIBUTE BY. However, we are missing some necessary steps such as renaming toast tables or clearing missing-attribute related stuff (RelationClearMissing). The `finish_heap_swap()` function which is used by the other ALTER TABLE commands should be used to take care of these general table-rewriting tasks (apart from toast table renaming, also including things like reindex of the old table and deletion of the new table). There should be no reason that ALTER TABLE DISTRIBUTED BY could not use `finish_heap_swap`. It appears that it is just at the time when the related changes of ALTER TABLE DISTRIBUTED BY was introduced, we did not have finish_heap_swap yet (e.g. https://github.com/pivotal/gp-gpdb-historical/commit/5c13332a5bb3).

Fix #15534, which was initially fixed in d38d978e54b1b0375cf1fb29c0726bca4de65a78 but was reverted due to problem in #16650.

P.S. `swap_relation_files` is still directly used by EXPAND TABLE too (`ATExecExpandTableCTAS`) so similar issue might exists there. Will test and address that later.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/at-dist-by-toast

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
