### PR TITLE
Docs: relax requirements for anti-virus

### DIFF
--- a/gpdb-doc/markdown/admin_guide/perf_intro.html.md
+++ b/gpdb-doc/markdown/admin_guide/perf_intro.html.md
@@ -22,7 +22,7 @@ Several key performance factors influence database performance. Understanding th
 
 Database performance relies heavily on disk I/O and memory usage. To accurately set performance expectations, you need to know the baseline performance of the hardware on which your DBMS is deployed. Performance of hardware components such as CPUs, hard disks, disk controllers, RAM, and network interfaces will significantly affect how fast your database performs.
 
-> **Caution** Do not install anti-virus software of any type on Greenplum Database hosts. VMware Greenplum is not supported for use with anti-virus software because the additional CPU and IO load interferes with Greenplum Database operations.
+> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html.md) for more information.
 
 ### <a id="topic4"></a>Workload 
 

--- a/gpdb-doc/markdown/admin_guide/perf_intro.html.md
+++ b/gpdb-doc/markdown/admin_guide/perf_intro.html.md
@@ -22,7 +22,7 @@ Several key performance factors influence database performance. Understanding th
 
 Database performance relies heavily on disk I/O and memory usage. To accurately set performance expectations, you need to know the baseline performance of the hardware on which your DBMS is deployed. Performance of hardware components such as CPUs, hard disks, disk controllers, RAM, and network interfaces will significantly affect how fast your database performs.
 
-> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html.md) for more information.
+> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html#endpoint_security) for more information.
 
 ### <a id="topic4"></a>Workload 
 

--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -10,7 +10,7 @@ Greenplum Database 7 runs on the following operating system platforms:
 -   Oracle Linux 64-bit 8.7 or later, using the Red Hat Compatible Kernel \(RHCK\)
 -   Rocky Linux 8.7 or later
 
-> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html.md) for more information.
+> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html#endpoint_security) for more information.
 
 > **Caution** A kernel issue in Red Hat Enterprise Linux 8.5 and 8.6 can cause I/O freezes and synchronization problems with XFS filesystems. This issue is fixed in RHEL 8.7. See [RHEL8: xfs_buf deadlock between inode deletion and block allocation](https://access.redhat.com/solutions/6984334).
 

--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -10,7 +10,7 @@ Greenplum Database 7 runs on the following operating system platforms:
 -   Oracle Linux 64-bit 8.7 or later, using the Red Hat Compatible Kernel \(RHCK\)
 -   Rocky Linux 8.7 or later
 
-> **Caution** Do not install anti-virus software of any type on Greenplum Database hosts. VMware Greenplum is not supported for use with anti-virus software because the additional CPU and IO load interferes with Greenplum Database operations.
+> **Note** If you use endpoint security software on your Greenplum Database hosts, it may affect your database performance and stability. See [About Endpoint Security Sofware](../security-guide/topics/preface.html.md) for more information.
 
 > **Caution** A kernel issue in Red Hat Enterprise Linux 8.5 and 8.6 can cause I/O freezes and synchronization problems with XFS filesystems. This issue is fixed in RHEL 8.7. See [RHEL8: xfs_buf deadlock between inode deletion and block allocation](https://access.redhat.com/solutions/6984334).
 

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -4,8 +4,6 @@ title: Configuring Your Systems
 
 Describes how to prepare your operating system environment for Greenplum Database software installation.
 
-> **Caution** Do not install anti-virus software of any type on Greenplum Database hosts. VMware Greenplum is not supported for use with anti-virus software because the additional CPU and IO load interferes with Greenplum Database operations.
-
 Perform the following tasks in order:
 
 1.  Make sure your host systems meet the requirements described in [On-Premise Hardware Requirements](./platform-requirements-overview.html#on-prem).

--- a/gpdb-doc/markdown/security-guide/topics/preface.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/preface.html.md
@@ -25,7 +25,7 @@ Describes basic security best practices that you should follow to ensure the hig
 
 ## <a id="endpoint_security"></a>About Endpoint Security Software
 
-If you install any endpoint security software on your Greenplum Database hosts, such as anti-virus, data protection, network security, or other security related software, it may affect your database performance. The additional CPU and IO load interferes with Greenplum Database operations and it may affect your database performance and stability.
+If you install any endpoint security software on your Greenplum Database hosts, such as anti-virus, data protection, network security, or other security related software, the additional CPU, IO, network or memory load can interfere with Greenplum Database operations and may affect database performance and stability.
 
-VMware Greenplum does not provide a set of best practices regarding the use of endpoint security software. Refer to your endpoint security vendor for information on how to prevent or address any database performance issues when using their software.
+Refer to your endpoint security vendor and perform careful testing in a non-production environment to ensure it does not have any negative impact on Greenplum Database operations.
 

--- a/gpdb-doc/markdown/security-guide/topics/preface.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/preface.html.md
@@ -23,3 +23,9 @@ Describes how to encrypt data at rest in the database or in transit over the net
 -   **[Security Best Practices](../topics/BestPractices.html)**  
 Describes basic security best practices that you should follow to ensure the highest level of system security. 
 
+## <a id="endpoint_security"></a>About Endpoint Security Software
+
+If you install any endpoint security software on your Greenplum Database hosts, such as anti-virus, data protection, network security, or other security related software, it may affect your database performance. The additional CPU and IO load interferes with Greenplum Database operations and it may affect your database performance and stability.
+
+VMware Greenplum does not provide a set of best practices regarding the use of endpoint security software. Refer to your endpoint security vendor for information on how to prevent or address any database performance issues when using their software.
+


### PR DESCRIPTION
This PR rephrases the current statement on the GPDB docs about anti-virus software:
- We broaden the term to refer to endpoint security instead of anti-virus.
- We do not state it is not supported, but instead that user should reach out to your vendor if any issues occur.
- There is a separate section within the Security guide instead of a Caution note so support can link customers to this section.
- Any other references in the GPDB documentation point to this new section in the Security Guide.
- This content will also be ported to the 6X documentation when approved.


Staging site:

https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-antivirus/greenplum-database/security-guide-topics-preface.html

Other pages linking to new content:

https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-antivirus/greenplum-database/install_guide-platform-requirements-overview.html
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-antivirus/greenplum-database/admin_guide-perf_intro.html
