### PR TITLE
Fix uninitialized-use warning in CTranslatorDXLToPlStmt.cpp

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1202,6 +1202,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 			// NullTest only has one arg
 			left_arg = (Node *) (((NullTest *) index_cond_expr)->arg);
 			is_null_test_type = true;
+			right_arg = nullptr;
 		}
 		else
 		{


### PR DESCRIPTION
Warning fixed:
```
../../../../src/include/nodes/nodes.h:656:68: warning: ‘right_arg’ may be used uninitialized in this function [-Wmaybe-uninitialized]


CTranslatorDXLToPlStmt.cpp:1198:23: note: ‘right_arg’ was declared here
 1198 |                 Node *right_arg;
      |                       ^~~~~~~~~

```

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/translator_warning?group=all