### PR TITLE
[6x]Remove redundant constants as converting DISTINCT to GROUP BY

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2353,6 +2353,15 @@ is_pseudo_constant_clause(Node *clause)
 	return false;
 }
 
+/*
+ * is_dummy_constant_clause
+ *    Detect whether an expression is "pseudo constant" as converting DISTINCT
+ *    to GROUP BY specially in GPDB.
+ *
+ *    1. Detect Vars in clause include outer-level and current-level Vars
+ *    2. Detect volatile_functions
+ *    3. Detect Subplans exist in clasue
+ */
 bool
 is_dummy_constant_clause(Node *clause)
 {
@@ -2360,7 +2369,7 @@ is_dummy_constant_clause(Node *clause)
 	 * We could implement this check in one recursive scan.  But since the
 	 * check for volatile functions is both moderately expensive and unlikely
 	 * to fail, it seems better to look for Vars first and only check for
-	 * volatile functions if we find no Vars.
+	 * volatile functions if we find no Vars and check subplans in final.
 	 */
 	if (!contain_all_vars_clause(clause) &&
 		!contain_volatile_functions(clause) &&

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2363,7 +2363,8 @@ is_dummy_constant_clause(Node *clause)
 	 * volatile functions if we find no Vars.
 	 */
 	if (!contain_all_vars_clause(clause) &&
-		!contain_volatile_functions(clause))
+		!contain_volatile_functions(clause) &&
+		!contain_subplans(clause))
 		return true;
 	return false;
 }

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2353,6 +2353,21 @@ is_pseudo_constant_clause(Node *clause)
 	return false;
 }
 
+bool
+is_dummy_constant_clause(Node *clause)
+{
+	/*
+	 * We could implement this check in one recursive scan.  But since the
+	 * check for volatile functions is both moderately expensive and unlikely
+	 * to fail, it seems better to look for Vars first and only check for
+	 * volatile functions if we find no Vars.
+	 */
+	if (!contain_all_vars_clause(clause) &&
+		!contain_volatile_functions(clause))
+		return true;
+	return false;
+}
+
 /*
  * is_pseudo_constant_clause_relids
  *	  Same as above, except caller already has available the var membership

--- a/src/backend/optimizer/util/var.c
+++ b/src/backend/optimizer/util/var.c
@@ -78,6 +78,7 @@ static bool pull_varnos_walker(Node *node,
 static bool pull_varattnos_walker(Node *node, pull_varattnos_context *context);
 static bool pull_vars_walker(Node *node, pull_vars_context *context);
 static bool contain_var_clause_walker(Node *node, void *context);
+static bool contain_all_vars_clause_walker(Node *node, void *context);
 static bool contain_vars_of_level_walker(Node *node, int *sublevels_up);
 static bool locate_var_of_level_walker(Node *node,
 						   locate_var_of_level_context *context);
@@ -478,6 +479,24 @@ contain_var_clause_walker(Node *node, void *context)
 	return expression_tree_walker(node, contain_var_clause_walker, context);
 }
 
+bool
+contain_all_vars_clause(Node *node)
+{
+	return contain_all_vars_clause_walker(node, NULL);
+}
+
+static bool
+contain_all_vars_clause_walker(Node *node, void *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Var))
+		return true;		/* abort the tree traversal and return true */
+	if (IsA(node, CurrentOfExpr))
+		return true;
+
+	return expression_tree_walker(node, contain_all_vars_clause_walker, context);
+}
 
 /*
  * contain_vars_of_level

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -97,6 +97,7 @@ extern char check_execute_on_functions(Node *clause);
 
 extern bool is_pseudo_constant_clause(Node *clause);
 extern bool is_pseudo_constant_clause_relids(Node *clause, Relids relids);
+extern bool is_dummy_constant_clause(Node *clause);
 
 extern int	NumRelids(Node *clause);
 

--- a/src/include/optimizer/var.h
+++ b/src/include/optimizer/var.h
@@ -52,6 +52,7 @@ extern void pull_varattnos(Node *node, Index varno, Bitmapset **varattnos);
 extern List *pull_vars_of_level(Node *node, int levelsup);
 extern bool contain_ctid_var_reference(Scan *scan);
 extern bool contain_var_clause(Node *node);
+extern bool contain_all_vars_clause(Node *node);
 extern bool contain_vars_of_level(Node *node, int levelsup);
 extern bool contain_vars_of_level_or_above(Node *node, int levelsup);
 extern int	locate_var_of_level(Node *node, int levelsup);

--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1703,6 +1703,45 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display of distinct convert to agg
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+           pg_get_viewdef           
+------------------------------------
+  SELECT tdis.a,                   +
+     tdis.b,                       +
+     tdis.c,                       +
+     - 1                           +
+    FROM tdis                      +
+   GROUP BY tdis.a, tdis.b, tdis.c;
+(1 row)
+
+create view tdis_v2 as select distinct a, b, (select tdis.c) from tdis;
+select pg_get_viewdef('tdis_v2', true);
+                pg_get_viewdef                
+----------------------------------------------
+  SELECT tdis.a,                             +
+     tdis.b,                                 +
+     ( SELECT tdis.c) AS c                   +
+    FROM tdis                                +
+   GROUP BY tdis.a, tdis.b, ( SELECT tdis.c);
+(1 row)
+
+create view tdis_v3 as select distinct a, b, c, random() from tdis;
+select pg_get_viewdef('tdis_v3', true);
+                pg_get_viewdef                
+----------------------------------------------
+  SELECT tdis.a,                             +
+     tdis.b,                                 +
+     tdis.c,                                 +
+     random() AS random                      +
+    FROM tdis                                +
+   GROUP BY tdis.a, tdis.b, tdis.c, random();
+(1 row)
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1703,6 +1703,45 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display of distinct convert to agg
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+           pg_get_viewdef           
+------------------------------------
+  SELECT tdis.a,                   +
+     tdis.b,                       +
+     tdis.c,                       +
+     - 1                           +
+    FROM tdis                      +
+   GROUP BY tdis.a, tdis.b, tdis.c;
+(1 row)
+
+create view tdis_v2 as select distinct a, b, (select tdis.c) from tdis;
+select pg_get_viewdef('tdis_v2', true);
+                pg_get_viewdef                
+----------------------------------------------
+  SELECT tdis.a,                             +
+     tdis.b,                                 +
+     ( SELECT tdis.c) AS c                   +
+    FROM tdis                                +
+   GROUP BY tdis.a, tdis.b, ( SELECT tdis.c);
+(1 row)
+
+create view tdis_v3 as select distinct a, b, c, random() from tdis;
+select pg_get_viewdef('tdis_v3', true);
+                pg_get_viewdef                
+----------------------------------------------
+  SELECT tdis.a,                             +
+     tdis.b,                                 +
+     tdis.c,                                 +
+     random() AS random                      +
+    FROM tdis                                +
+   GROUP BY tdis.a, tdis.b, tdis.c, random();
+(1 row)
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/sql/create_view.sql
+++ b/src/test/regress/sql/create_view.sql
@@ -584,6 +584,18 @@ select pg_get_viewdef('tt23v', true);
 select pg_get_ruledef(oid, true) from pg_rewrite
   where ev_class = 'tt23v'::regclass and ev_type = '1';
 
+-- test display of distinct convert to agg
+create table tdis(a int, b int, c int);
+
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+
+create view tdis_v2 as select distinct a, b, (select tdis.c) from tdis;
+select pg_get_viewdef('tdis_v2', true);
+
+create view tdis_v3 as select distinct a, b, c, random() from tdis;
+select pg_get_viewdef('tdis_v3', true);
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;


### PR DESCRIPTION
In GPDB6, the optimizer will try to convert DISTINCT to GROUP BY for better performance
in some scenarios. However, if there are constants especially negative constants in targetlist,
the SQL from view or dump/restore based on those plans could pop out ERROR
`GROUP BY position -1 is not in select list` the root cause should be special
typecast on negative number, which is hard to avoid.
```
postgres=# create view v1 as select distinct a, b, c, -1::int from t1;                                                                                                                                                                             
CREATE VIEW
postgres=# \d+ v1;
                    View "public.v1"
  Column  |  Type   | Modifiers | Storage | Description 
----------+---------+-----------+---------+-------------
 a        | integer |           | plain   | 
 b        | integer |           | plain   | 
 c        | integer |           | plain   | 
 ?column? | integer |           | plain   | 
View definition:
 SELECT t1.a,
    t1.b,
    t1.c,
    - 1
   FROM t1
  GROUP BY t1.a, t1.b, t1.c, - 1;
```
-1 in GROUP BY is obviously wrong and such SQL could not be executed.

So we consider to remove redundant constants as converting DISTINCT to GROUP BY, mainly on CONST.
If there are vars and const combined in targetlist just keep vars and get rid of const.
If there are only const,  and no vars in targetlist then need to remain all const.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
