### PR TITLE
docs - gp_move_orphaned_files() UDF (6x)

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
@@ -1,6 +1,6 @@
 # gp_check_functions
 
-The `gp_check_functions` module implements views that identify missing and orphaned relation files.
+The `gp_check_functions` module implements views that identify missing and orphaned relation files. The module also exposes a user-defined function that you can use to move orphaned files.
 
 The `gp_check_functions` module is a Greenplum Database extension.
 
@@ -68,6 +68,38 @@ The `gp_check_missing_files_ext` view scans only append-optimized, column-orient
 | filename | The file name of the missing extended data file. |
 
 
+## <a id="moveorphanfiles"></a>Moving Orphaned Data Files
+
+The `gp_move_orphaned_files()` user-defined function (UDF) moves orphaned files found by the [gp_check_orphaned_files](#orphaned) view into a file system location that you specify.
+
+The function signature is: `gp_move_orphaned_files( <target_directory> TEXT )`.
+
+`<target_directory>` must exist on all segment hosts before you move the files, and the specified directory must be accessible by the `gpadmin` user. If you specify a relative path for `<target_directory>`, it is considered relative to the data directory, `$COORDINATOR_DATA_DIRECTORY`.
+
+Greenplum Database renames each moved data file to one that reflects the original location of the file in the data directory. The file name format differs depending on the tablespace in which the orphaned file resides:
+
+| Tablespace | Renamed File Format|
+|------|-----------|
+| default | `seg<num>_base_<database-oid>_<relfilenode>` |
+| global | `seg<num>_global_<relfilenode>` |
+| user-defined | `seg<num>_pg_tblspc_<tablespace-oid>_<gpdb-version>_<database-oid>_<relfilenode>` |
+
+For example, if a file named `12345` in the default tablespace is orphaned on primary segment 2,
+
+```
+SELECT * FROM gp_move_orphaned_files('/home/gpadmin/orphaned')`;
+```
+
+moves and renames the file as follows:
+
+| Original Location | New Location and File Name |
+|------|-----------|
+| `$COORDINATOR_DATA_DIRECTORY/base/13700/12345` | `/home/gpadmin/orphaned/seg2_base_13700_12345` |
+
+`gp_move_orphaned_files()` returns both the original and the new file system locations for each file that it moves, and also provides an indication of the success or failure of the move operation.
+
+Once you move the orphaned files, you may choose to remove them or to back them up.
+
 ## <a id="examples"></a>Examples
 
 Check for missing and orphaned non-extended files:
@@ -81,5 +113,11 @@ Check for missing extended data files for append-optimized, column-oriented tabl
 
 ``` sql
 SELECT * FROM gp_check_missing_files_ext;
+```
+
+Move orphaned files to the `/home/gpadmin/orphaned` directory:
+
+``` sql
+SELECT * FROM gp_move_orphaned_files('/home/gpadmin/orphaned');
 ```
 

--- a/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
@@ -74,7 +74,7 @@ The `gp_move_orphaned_files()` user-defined function (UDF) moves orphaned files 
 
 The function signature is: `gp_move_orphaned_files( <target_directory> TEXT )`.
 
-`<target_directory>` must exist on all segment hosts before you move the files, and the specified directory must be accessible by the `gpadmin` user. If you specify a relative path for `<target_directory>`, it is considered relative to the data directory, `$COORDINATOR_DATA_DIRECTORY`.
+`<target_directory>` must exist on all segment hosts before you move the files, and the specified directory must be accessible by the `gpadmin` user. If you specify a relative path for `<target_directory>`, it is considered relative to the data directories of the coordinator and segments.
 
 Greenplum Database renames each moved data file to one that reflects the original location of the file in the data directory. The file name format differs depending on the tablespace in which the orphaned file resides:
 
@@ -94,7 +94,7 @@ moves and renames the file as follows:
 
 | Original Location | New Location and File Name |
 |------|-----------|
-| `$COORDINATOR_DATA_DIRECTORY/base/13700/12345` | `/home/gpadmin/orphaned/seg2_base_13700_12345` |
+| `<data_directory>/base/13700/12345` | `/home/gpadmin/orphaned/seg2_base_13700_12345` |
 
 `gp_move_orphaned_files()` returns both the original and the new file system locations for each file that it moves, and also provides an indication of the success or failure of the move operation.
 

--- a/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
@@ -39,7 +39,7 @@ The `gp_check_orphaned_files` view scans the default and user-defined tablespace
 | gp_segment_id | The Greenplum Database segment identifier. |
 | tablespace | The identifier of the tablespace in which the orphaned file resides. |
 | filename | The file name of the orphaned data file. |
-| filepath | The file system path of the orphaned data file, relative to `$MASTER_DATA_DIRECTORY`. |
+| filepath | The file system path of the orphaned data file, relative to the data directory of the master or segment. |
 
 > **Caution** Use this view as one of many data points to identify orphaned data files. Do not delete files based solely on results from querying this view.
 
@@ -74,7 +74,7 @@ The `gp_move_orphaned_files()` user-defined function (UDF) moves orphaned files 
 
 The function signature is: `gp_move_orphaned_files( <target_directory> TEXT )`.
 
-`<target_directory>` must exist on all segment hosts before you move the files, and the specified directory must be accessible by the `gpadmin` user. If you specify a relative path for `<target_directory>`, it is considered relative to the data directories of the coordinator and segments.
+`<target_directory>` must exist on all segment hosts before you move the files, and the specified directory must be accessible by the `gpadmin` user. If you specify a relative path for `<target_directory>`, it is considered relative to the data directory of the master or segment.
 
 Greenplum Database renames each moved data file to one that reflects the original location of the file in the data directory. The file name format differs depending on the tablespace in which the orphaned file resides:
 

--- a/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_check_functions.html.md
@@ -87,7 +87,7 @@ Greenplum Database renames each moved data file to one that reflects the origina
 For example, if a file named `12345` in the default tablespace is orphaned on primary segment 2,
 
 ```
-SELECT * FROM gp_move_orphaned_files('/home/gpadmin/orphaned')`;
+SELECT * FROM gp_move_orphaned_files('/home/gpadmin/orphaned');
 ```
 
 moves and renames the file as follows:

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -16,7 +16,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [diskquota](diskquota.html) - Allows administrators to set disk usage quotas for Greenplum Database roles and schemas.
 -   [fuzzystrmatch](fuzzystrmatch.html) - Determines similarities and differences between strings.
 -   [gp\_array\_agg](gp_array_agg.html) - Implements a parallel `array_agg()` aggregate function for Greenplum Database.
--   [gp\_check\_functions](gp_check_functions.html) - Provides views to check for orphaned and missing relation files.
+-   [gp\_check\_functions](gp_check_functions.html) - Provides views to check for orphaned and missing relation files and a user-defined function to move orphaned files.
 -   [gp\_legacy\_string\_agg](gp_legacy_string_agg.html) - Implements a legacy, single-argument `string_agg()` aggregate function that was present in Greenplum Database 5.
 -   [gp\_parallel\_retrieve\_cursor](gp_parallel_retrieve_cursor.html) - Provides extended cursor functionality to retrieve data, in parallel, directly from Greenplum Database segments.
 -   [gp\_percentile\_agg](gp_percentile_agg.html) - Improves GPORCA performance for ordered-set aggregate functions.


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/16645.  gp_move_orphaned_files() UDF added to the gp_check_functions module (a new module in greenplum 6.26).

note:  similar content will be added to the greenplum 7 gp_toolkit docs via a separate PR.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Greenplum/gp_check_functions/greenplum-database/GUID-ref_guide-modules-gp_check_functions.html#moving-orphaned-data-files
