### PR TITLE
Retry gang creation for non-recovery failures

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -228,6 +228,29 @@ segment_failure_due_to_missing_writer(const char *error_message)
 	return false;
 }
 
+#ifdef FAULT_INJECTOR
+bool
+segment_failure_due_to_fault_injector(const char *error_message)
+{
+	char	   *fatal = NULL,
+			   *ptr = NULL;
+	int			fatal_len = 0;
+
+	if (error_message == NULL)
+		return false;
+
+	fatal = _("FATAL");
+	fatal_len = strlen(fatal);
+
+	ptr = strstr(error_message, fatal);
+	if ((ptr != NULL) && ptr[fatal_len] == ':' &&
+		strstr(error_message, "fault triggered"))
+		return true;
+
+	return false;
+}
+#endif
+
 
 /*
  * Reads the GP catalog tables and build a CdbComponentDatabases structure.

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -52,6 +52,7 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	Gang	*newGangDefinition;
 	int		create_gang_retry_counter = 0;
 	int		in_recovery_mode_count = 0;
+	int		other_failures = 0;
 	int		successful_connections = 0;
 	int		poll_timeout = 0;
 	int		i = 0;
@@ -112,6 +113,7 @@ create_gang_retry:
 	Assert(newGangDefinition->size == size);
 	successful_connections = 0;
 	in_recovery_mode_count = 0;
+	other_failures = 0;
 	retry = false;
 
 	pollingStatus = palloc(sizeof(PostgresPollingStatusType) * size);
@@ -252,16 +254,43 @@ create_gang_retry:
 						if (segment_failure_due_to_recovery(PQerrorMessage(segdbDesc->conn)))
 						{
 							in_recovery_mode_count++;
+							/* Mark it as done, so we can consider retrying */
 							connStatusDone[i] = true;
 							elog(LOG, "segment is in reset/recovery mode (%s)", segdbDesc->whoami);
 						}
-						else
+						else if (segment_failure_due_to_missing_writer(PQerrorMessage(segdbDesc->conn)))
 						{
-							if (segment_failure_due_to_missing_writer(PQerrorMessage(segdbDesc->conn)))
-								markCurrentGxactWriterGangLost();
+							markCurrentGxactWriterGangLost();
 							ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 											errmsg("failed to acquire resources on one or more segments"),
 											errdetail("%s (%s)", PQerrorMessage(segdbDesc->conn), segdbDesc->whoami)));
+						}
+#ifdef FAULT_INJECTOR
+						else if (segment_failure_due_to_fault_injector(PQerrorMessage(segdbDesc->conn)))
+						{
+							ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+								errmsg("failed to acquire resources on one or more segments: fault injector"),
+								errdetail("%s (%s)", PQerrorMessage(segdbDesc->conn), segdbDesc->whoami)));
+						}
+#endif
+						else
+						{
+							/* Failed for some other reason */
+							if (gp_gang_creation_retry_count <= 0 ||
+								create_gang_retry_counter >= gp_gang_creation_retry_count)
+							{
+								/*
+								 * If we exhausted all of our retries, ERROR out
+								 * with the appropriate message.
+								 */
+								ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+									errmsg("failed to acquire resources on one or more segments"),
+									errdetail("%s (%s)", PQerrorMessage(segdbDesc->conn), segdbDesc->whoami)));
+							}
+
+							/* Mark it as done, so we can consider retrying below */
+							connStatusDone[i] = true;
+							other_failures++;
 						}
 						break;
 
@@ -329,7 +358,7 @@ create_gang_retry:
 		/* some segments are in reset/recovery mode */
 		if (successful_connections != size)
 		{
-			Assert(successful_connections + in_recovery_mode_count == size);
+			Assert(successful_connections + in_recovery_mode_count + other_failures == size);
 
 			if (gp_gang_creation_retry_count <= 0 ||
 				create_gang_retry_counter++ >= gp_gang_creation_retry_count)

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -88,6 +88,9 @@ bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, in
 extern void makeOptions(char **options, char **diff_options);
 extern bool segment_failure_due_to_recovery(const char *error_message);
 extern bool segment_failure_due_to_missing_writer(const char *error_message);
+#ifdef FAULT_INJECTOR
+extern bool segment_failure_due_to_fault_injector(const char *error_message);
+#endif
 
 /*
  * cdbgang_parse_gpqeid_params

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -445,7 +445,7 @@ select cleanupAllGangs();
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
-ERROR:  failed to acquire resources on one or more segments
+ERROR:  failed to acquire resources on one or more segments: fault injector
 DETAIL:  FATAL:  fault triggered, fault name:'send_qe_details_init_backend' fault type:'error'
  (seg0 127.0.0.1:40000)
 -- expect no resuable gang exist
@@ -492,7 +492,7 @@ select cleanupAllGangs();
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
-ERROR:  failed to acquire resources on one or more segments
+ERROR:  failed to acquire resources on one or more segments: fault injector
 DETAIL:  FATAL:  fault triggered, fault name:'send_qe_details_init_backend' fault type:'error'
  (seg0 127.0.0.1:40000)
 -- expect resuable gang exist


### PR DESCRIPTION
Before this commit, any error from a segment that is unrelated to
recovery, would result in an immediate termination with the following:

ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
	errmsg("failed to acquire resources on one or more segments"),
	errdetail("%s (%s)", PQerrorMessage(segdbDesc->conn), segdbDesc->whoami)));

In other words, this termination did not respect
gp_gang_creation_retry_count. From now on, we exhaust the retries first,
before emitting this ERROR.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Reviewed-by: Xin Zhang <xinzweb@users.noreply.github.com>
Reviewed-by: Huansong Fu <fuhuansong@gmail.com>
Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gang_retry
