### PR TITLE
Be more wary about NULL values for GUC string variables.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7818,8 +7818,7 @@ SetConfigOption(const char *name, const char *value,
 /*
  * Fetch the current value of the option `name', as a string.
  *
- * If the option doesn't exist, return NULL if missing_ok is true (NOTE that
- * this cannot be distinguished from a string variable with a NULL value!),
+ * If the option doesn't exist, return NULL if missing_ok is true,
  * otherwise throw an ereport and don't return.
  *
  * If restrict_privileged is true, we also enforce that only superusers and
@@ -7869,7 +7868,8 @@ GetConfigOption(const char *name, bool missing_ok, bool restrict_privileged)
 			return buffer;
 
 		case PGC_STRING:
-			return *((struct config_string *) record)->variable;
+			return *((struct config_string *) record)->variable ?
+				*((struct config_string *) record)->variable : "";
 
 		case PGC_ENUM:
 			return config_enum_lookup_by_value((struct config_enum *) record,
@@ -7919,7 +7919,8 @@ GetConfigOptionResetString(const char *name)
 			return buffer;
 
 		case PGC_STRING:
-			return ((struct config_string *) record)->reset_val;
+			return ((struct config_string *) record)->reset_val ?
+				((struct config_string *) record)->reset_val : "";
 
 		case PGC_ENUM:
 			return config_enum_lookup_by_value((struct config_enum *) record,

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -9401,7 +9401,12 @@ bool is_guc_modified(struct config_generic *conf)
 		{
 			struct config_string *lconf = (struct config_string *) conf;
 
-			modified = (strcmp(lconf->boot_val, *(lconf->variable)) != 0);
+			if (lconf->boot_val == NULL && *lconf->variable == NULL)
+				modified = false;
+            else if (lconf->boot_val == NULL || *lconf->variable == NULL)
+                modified = true;
+            else
+                modified = (strcmp(lconf->boot_val, *(lconf->variable)) != 0);
 		}
 		break;
 
@@ -10193,7 +10198,8 @@ write_one_nondefault_variable(FILE *fp, struct config_generic *gconf)
 			{
 				struct config_string *conf = (struct config_string *) gconf;
 
-				fprintf(fp, "%s", *conf->variable);
+				if (*conf->variable)
+					fprintf(fp, "%s", *conf->variable);
 			}
 			break;
 

--- a/src/include/utils/guc_tables.h
+++ b/src/include/utils/guc_tables.h
@@ -268,6 +268,16 @@ struct config_real
 	void	   *reset_extra;
 };
 
+/*
+ * A note about string GUCs: the boot_val is allowed to be NULL, which leads
+ * to the reset_val and the actual variable value (*variable) also being NULL.
+ * However, there is no way to set a NULL value subsequently using
+ * set_config_option or any other GUC API.  Also, GUC APIs such as SHOW will
+ * display a NULL value as an empty string.  Callers that choose to use a NULL
+ * boot_val should overwrite the setting later in startup, or else be careful
+ * that NULL doesn't have semantics that are visibly different from an empty
+ * string.
+ */
 struct config_string
 {
 	struct config_generic gen;


### PR DESCRIPTION
This PR cherry-picked two commits from upstream, about being more wary about NULL values for GUC string variables.

- Commit: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=0bc726d95a305ca923b1f284159f40f0d5cf5725
- Commit: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=7704a1a72e879daaefa1742916e01505edd2ce47
- Background issue reported: https://github.com/greenplum-db/gpdb/issues/16502
- Related PR: https://github.com/greenplum-db/gpdb/pull/16504
- Upstream discussion: https://www.postgresql.org/message-id/flat/CACpMh%2BAyDx5YUpPaAgzVwC1d8zfOL4JoD-uyFDnNSa1z0EsDQQ%40mail.gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
