### PR TITLE
Fix error is thrown even if group by clause does not reference a recursive CTE

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1945,3 +1945,63 @@ contains_outer_params(Node *node, void *context)
 	}
 	return expression_tree_walker(node, contains_outer_params, context);
 }
+
+typedef struct CTEMotionSearchContext
+{
+	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
+	bool    bellowMotion;      /* True if we are under a Motion node */
+} CTEMotionSearchContext;
+
+/*
+ * GPDB:
+ * We can not pass params by a motion.
+ * So there should not be any motion between RecursiveUnion and WorkTableScan.
+ * Check if there is a motion between RecursiveUnion and WorkTableScan.
+ */
+static bool
+cte_motion_search_walker(Node *node, CTEMotionSearchContext *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Motion))
+	{
+		bool savedBellowMotion = context->bellowMotion;
+		context->bellowMotion = true;
+		plan_tree_walker(node, cte_motion_search_walker, context, true);
+		context->bellowMotion = savedBellowMotion;
+		return false;
+	}
+	if (IsA(node, RecursiveUnion))
+	{
+		/*
+		 * We process RecursiveUnion recursively in create_recursiveunion_plan
+		 * here, we do not process repeatedly.
+		 */
+		return false;
+	}
+	if (IsA(node, WorkTableScan))
+	{
+		if (context->bellowMotion)
+		{
+			elog(ERROR, "Passing parameters across motion is not supported.");
+		}
+		return false;
+	}
+	return plan_tree_walker(node, cte_motion_search_walker, context, true);
+}
+
+/*
+ * GPDB does not support pass params by a motion.
+ * Check the rightplan of RecursiveUnion, wether there is a motion above WorkTableScan,
+ * If true, throw an error.
+ */
+void
+checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root)
+{
+	CTEMotionSearchContext context;
+	planner_init_plan_tree_base(&context.base, root);
+	context.bellowMotion = false;
+
+	(void) cte_motion_search_walker(node, (void *) &context);
+}

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2823,6 +2823,11 @@ create_recursiveunion_plan(PlannerInfo *root, RecursiveUnionPath *best_path)
 								best_path->distinctList,
 								numGroups);
 
+	/*
+	 * Check whether there is a motion above WorkTableScan
+	 */
+	checkMotionAboveWorkTableScan((Node *)rightplan, root);
+
 	copy_generic_path_info(&plan->plan, (Path *) best_path);
 
 	return plan;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3276,16 +3276,15 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel,
 		CdbPathLocus_MakeEntry(&result);
 	else if (ctelocus.locustype == CdbLocusType_SingleQE)
 		CdbPathLocus_MakeSingleQE(&result, ctelocus.numsegments);
-	else if (ctelocus.locustype == CdbLocusType_General)
-		CdbPathLocus_MakeGeneral(&result);
 	else if (ctelocus.locustype == CdbLocusType_OuterQuery)
 		CdbPathLocus_MakeOuterQuery(&result);
-	else if (ctelocus.locustype == CdbLocusType_SegmentGeneral)
+	else if (ctelocus.locustype == CdbLocusType_SegmentGeneral
+				|| ctelocus.locustype == CdbLocusType_General)
 	{
 		/* See comments in set_worktable_pathlist */
 		elog(ERROR,
 			 "worktable scan path can never have "
-			 "segmentgeneral locus.");
+			 "segmentgeneral or general locus.");
 	}
 	else
 		CdbPathLocus_MakeStrewn(&result, ctelocus.numsegments);

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -55,5 +55,5 @@ extern void remove_subquery_in_RTEs(Node *node);
 extern Plan *cdbpathtoplan_create_sri_plan(RangeTblEntry *rte, PlannerInfo *subroot, Path *subpath, int createplan_flags);
 
 extern bool contains_outer_params(Node *node, void *context);
-
+extern void checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root);
 #endif   /* CDBMUTATE_H */

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -776,3 +776,82 @@ select * from x ;
  10
 (10 rows)
 
+-- issues: https://github.com/greenplum-db/gpdb/issues/16422
+-- Without a reference to CTE in subselect and with a group clause
+CREATE TABLE test_cte (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select a as c1 , max(b) as c2 from test_cte group by c1
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (test_cte_1.a = test_cte.a)
+         ->  Recursive Union
+               ->  Seq Scan on test_cte test_cte_1
+               ->  Hash Join
+                     Hash Cond: (r.c1 = tmp_table.c1)
+                     ->  WorkTable Scan on r
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Subquery Scan on tmp_table
+                                       ->  HashAggregate
+                                             Group Key: test_cte_2.a
+                                             ->  Seq Scan on test_cte test_cte_2
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Seq Scan on test_cte
+ Optimizer: Postgres-based planner
+(18 rows)
+
+-- Without a reference to CTE in subselect and with a distinct clause
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select max (distinct a )as c1 ,max (distinct b) as c2 from test_cte
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (test_cte_1.a = test_cte.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: test_cte_1.a
+               ->  Recursive Union
+                     ->  Seq Scan on test_cte test_cte_1
+                     ->  Hash Join
+                           Hash Cond: (r.c1 = tmp_table.c1)
+                           ->  WorkTable Scan on r
+                           ->  Hash
+                                 ->  Broadcast Motion 1:3  (slice3; segments: 1)
+                                       ->  Subquery Scan on tmp_table
+                                             ->  Finalize Aggregate
+                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                         ->  Partial Aggregate
+                                                               ->  Seq Scan on test_cte test_cte_2
+         ->  Hash
+               ->  Seq Scan on test_cte
+ Optimizer: Postgres-based planner
+(20 rows)
+
+Drop TABLE test_cte;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1149,21 +1149,20 @@ select sum(o.four), sum(ss.a) from
     select * from x
   ) ss
 where o.ten = 1;
-                       QUERY PLAN                        
----------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Nested Loop
-                     ->  Seq Scan on onek o
-                           Filter: (ten = 1)
-                     ->  Materialize
-                           ->  Recursive Union
-                                 ->  Result
-                                 ->  WorkTable Scan on x
-                                       Filter: (a < 10)
- Optimizer: Postgres query optimizer
-(12 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Aggregate
+   ->  Nested Loop
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on onek o
+                     Filter: (ten = 1)
+         ->  Materialize
+               ->  Recursive Union
+                     ->  Result
+                     ->  WorkTable Scan on x
+                           Filter: (a < 10)
+ Optimizer: Postgres-based planner
+(11 rows)
 
 select sum(o.four), sum(ss.a) from
   onek o cross join lateral (

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1199,21 +1199,20 @@ select sum(o.four), sum(ss.a) from
     select * from x
   ) ss
 where o.ten = 1;
-                       QUERY PLAN                        
----------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Nested Loop
-                     ->  Seq Scan on onek o
-                           Filter: (ten = 1)
-                     ->  Materialize
-                           ->  Recursive Union
-                                 ->  Result
-                                 ->  WorkTable Scan on x
-                                       Filter: (a < 10)
- Optimizer: Postgres query optimizer
-(12 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Aggregate
+   ->  Nested Loop
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on onek o
+                     Filter: (ten = 1)
+         ->  Materialize
+               ->  Recursive Union
+                     ->  Result
+                     ->  WorkTable Scan on x
+                           Filter: (a < 10)
+ Optimizer: Postgres-based planner
+(11 rows)
 
 select sum(o.four), sum(ss.a) from
   onek o cross join lateral (

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -944,6 +944,25 @@ DELETE FROM y USING t WHERE t.a = y.a RETURNING y.a;
 SELECT * FROM y;
  a  
 ----
+  7
+  9
+  2
+  4
+  1
+  3
+  5
+  6
+  8
+ 10
+(10 rows)
+
+DROP TABLE y;
+-- although there is a distinct or group by in recursive part of cte,
+-- but there is no motion above worktablescan, that is ok.
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x limit 10;
+ n  
+----
   1
   2
   3
@@ -956,7 +975,46 @@ SELECT * FROM y;
  10
 (10 rows)
 
-DROP TABLE y;
+CREATE TEMPORARY TABLE z(x int primary key);
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
+	SELECT * FROM x limit 10;
+ n  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+CREATE TEMPORARY TABLE bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 |  2
+(1 row)
+
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2::bigint
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 |  2
+(1 row)
+
 --
 -- error cases
 --
@@ -987,18 +1045,6 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION [ALL] recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
--- GPDB Specific Error Cases
--- Set operations within the recursive term with a self-reference.
--- Currently set operations in the recursive term involving the cte itself must
--- be prevented. The reason for this is that such a query may lead to a plan
--- where there is a motion between the RecursiveUnion node and the
--- WorkTableScan node.
-CREATE TEMPORARY TABLE z(x int primary key);
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
-ERROR:  recursive reference to query "x" must not appear within a subquery
-LINE 1: ...SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SE...
-                                                             ^
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
 CREATE TEMPORARY TABLE u(x int primary key);
@@ -1028,33 +1074,7 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-ERROR:  recursive reference to query "cte" must not appear within a subquery
-LINE 4:  SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, ba...
-                                               ^
--- recursive term with a distinct operation is not allowed
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
-  SELECT * FROM x;
-ERROR:  DISTINCT in a recursive query is not implemented
--- recursive term with a group by operation is not allowed
-CREATE TEMPORARY TABLE bar(c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, c FROM x, bar GROUP BY 1,2)
-  SELECT * FROM x LIMIT 10;
-ERROR:  GROUP BY in a recursive query is not implemented
-LINE 4:  SELECT level+1, c FROM x, bar GROUP BY 1,2)
-                                                ^
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, row_number() over() FROM x, bar)
-  SELECT * FROM x LIMIT 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
-                         ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2216,9 +2216,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select (first_value(c) over (partition by b))::int, a+x
-                  ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2230,9 +2228,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select first_value(c) over (partition by b), a+x
-                 ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2219,9 +2219,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select (first_value(c) over (partition by b))::int, a+x
-                  ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2233,9 +2231,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select first_value(c) over (partition by b), a+x
-                 ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -964,6 +964,64 @@ SELECT * FROM y;
 (10 rows)
 
 DROP TABLE y;
+-- although there is a distinct or group by in recursive part of cte,
+-- but there is no motion above worktablescan, that is ok.
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x limit 10;
+ n  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+CREATE TEMPORARY TABLE z(x int primary key);
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
+	SELECT * FROM x limit 10;
+ n  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+
+CREATE TEMPORARY TABLE bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 |  2
+(1 row)
+
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2::bigint
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 |  2
+(1 row)
+
 --
 -- error cases
 --
@@ -994,18 +1052,6 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION [ALL] recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
--- GPDB Specific Error Cases
--- Set operations within the recursive term with a self-reference.
--- Currently set operations in the recursive term involving the cte itself must
--- be prevented. The reason for this is that such a query may lead to a plan
--- where there is a motion between the RecursiveUnion node and the
--- WorkTableScan node.
-CREATE TEMPORARY TABLE z(x int primary key);
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
-ERROR:  recursive reference to query "x" must not appear within a subquery
-LINE 1: ...SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SE...
-                                                             ^
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
 CREATE TEMPORARY TABLE u(x int primary key);
@@ -1035,33 +1081,7 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-ERROR:  recursive reference to query "cte" must not appear within a subquery
-LINE 4:  SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, ba...
-                                               ^
--- recursive term with a distinct operation is not allowed
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
-  SELECT * FROM x;
-ERROR:  DISTINCT in a recursive query is not implemented
--- recursive term with a group by operation is not allowed
-CREATE TEMPORARY TABLE bar(c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, c FROM x, bar GROUP BY 1,2)
-  SELECT * FROM x LIMIT 10;
-ERROR:  GROUP BY in a recursive query is not implemented
-LINE 4:  SELECT level+1, c FROM x, bar GROUP BY 1,2)
-                                                ^
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, row_number() over() FROM x, bar)
-  SELECT * FROM x LIMIT 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
-                         ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN
@@ -1202,8 +1222,6 @@ LINE 2:    (SELECT i::numeric(3,0) FROM (VALUES(1),(2)) t(i)
 HINT:  Cast the output of the non-recursive term to the correct type.
 -- disallow OLD/NEW reference in CTE
 CREATE TEMPORARY TABLE x (n integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE RULE r2 AS ON UPDATE TO x DO INSTEAD
     WITH t AS (SELECT OLD.*) UPDATE y SET a = t.n FROM t;
 ERROR:  cannot refer to OLD within WITH query

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -170,6 +170,9 @@ s/.//gs
 m/\(dbsize\.c\:\d+\)/
 s/\(dbsize\.c:\d+\)/\(dbsize\.c:XXX\)/
 
+m/\(cdbmutate\.c\:\d+\)/
+s/\(cdbmutate\.c:\d+\)/\(cdbmutate\.c:XXX\)/
+
 # remove the cdbdisp_async suffix of some ERROR messages
 m/ \(cdbdisp_async\.c.*\)/
 s/ \(cdbdisp_async\.c.*\)//

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -414,6 +414,29 @@ SELECT * FROM y;
 
 DROP TABLE y;
 
+
+-- although there is a distinct or group by in recursive part of cte,
+-- but there is no motion above worktablescan, that is ok.
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x limit 10;
+
+CREATE TEMPORARY TABLE z(x int primary key);
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
+	SELECT * FROM x limit 10;
+
+CREATE TEMPORARY TABLE bar(c int);
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2::bigint
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+
 --
 -- error cases
 --
@@ -435,15 +458,7 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT SELECT n+1 FROM x)
 WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 	SELECT * FROM x;
 
--- GPDB Specific Error Cases
--- Set operations within the recursive term with a self-reference.
--- Currently set operations in the recursive term involving the cte itself must
--- be prevented. The reason for this is that such a query may lead to a plan
--- where there is a motion between the RecursiveUnion node and the
--- WorkTableScan node.
-CREATE TEMPORARY TABLE z(x int primary key);
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
+
 
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
@@ -466,24 +481,6 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-
--- recursive term with a distinct operation is not allowed
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
-  SELECT * FROM x;
-
--- recursive term with a group by operation is not allowed
-CREATE TEMPORARY TABLE bar(c int);
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, c FROM x, bar GROUP BY 1,2)
-  SELECT * FROM x LIMIT 10;
-
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, row_number() over() FROM x, bar)
-  SELECT * FROM x LIMIT 10;
 
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);


### PR DESCRIPTION
After pr #14656, following sql raises ERROR "GROUP BY in a recursive query is not implemented"
```
create table test_cte (a int, b int);

EXPLAIN
WITH RECURSIVE r(c1, c2) as 
(
  select a as c1, b as c2 from test_cte
  union all
  select r.c1, r.c2 from r
  join 
  (
    select a as c1 , max(b) as c2 from test_cte group by c1
  ) as tmp_table
  on r.c1 = tmp_table.c1
)
select * from r join test_cte on r.c1 = a;
```

Analysis:
The slices of workTableScan and RecursiveUnion must be the same.
We add commit: https://github.com/greenplum-db/gpdb/commit/3f5cf5c730f in GPDB to process above problems, 
Currently Recursive CTE's do not support the following operations in the recursive term:
    - Group By
    - Window Functions
    - Subqueries with a self-reference
    - Distinct
Sometimes this is over-restricted. Although there is group by or distinct clause in recursive term, 
The slices of workTableScan and RecursiveUnion are still the same. 
In this situation, the SQL should be executed.

Solution:
Revert the commit: https://github.com/greenplum-db/gpdb/commit/3f5cf5c730f to Align with upstream.
Add a walker to check whether there is a motion above workTableScan.

issue: [16422](https://github.com/greenplum-db/gpdb/issues/16422) 