### PR TITLE
Project pg_basebackup, pg_rewind or pg_ctl start errors to gprecoverseg output

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1429,6 +1429,8 @@ Feature: gprecoverseg tests
     And check if incremental recovery failed for mirrors with content 0 for gprecoverseg
     And check if full recovery was successful for mirrors with content 1
     And check if full recovery failed for mirrors with content 2 for gprecoverseg
+    And gprecoverseg should print "error:.*required WAL directory ""pg_wal"" does not exist" to stdout
+    And gprecoverseg should print "error: pg_basebackup: error: could not access directory.* Permission denied" to stdout
     And gprecoverseg should not print "Segments successfully recovered" to stdout
     And check if mirrors on content 0,1,2 are in their original configuration
     And the gp_configuration_history table should contain a backout entry for the primary segment for contents 2
@@ -2471,6 +2473,40 @@ Feature: gprecoverseg tests
         And all the segments are running
         And user can start transactions
 
+    @demo_cluster
+    @concourse_cluster
+    Scenario: gprecoverseg reports correct segment startup error messages to stdout
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And user immediately stops all primary processes for content 1
+        And user can start transactions
+        And a gprecoverseg directory under '/tmp' with mode '0700' is created
+        And a gprecoverseg input file is created
+        And edit the input file to recover mirror with content 1 to a new directory on remote host with mode 0755
+      When the user runs gprecoverseg with input file and additional args "-a"
+      Then gprecoverseg should return a return code of 1
+        And user can start transactions
+        And check if start failed for contents 1 during full recovery for gprecoverseg
+        And gprecoverseg should print "Failed to start the following segments" to stdout
+        And gprecoverseg should print "error:.*data directory.* has invalid permissions" to stdout
+        And verify that mirror on content 1 is down
+      When the mode of all the created data directories is non-recursively changed to '0500'
+        And the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 1
+        And user can start transactions
+        And gprecoverseg should print "Failed to start the following segments" to stdout
+        And gprecoverseg should print "error:.*could not create lock file" to stdout
+        And verify that mirror on content 1 is down
+      When the mode of all the created data directories is changed to 0700
+        And the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 0
+        And user can start transactions
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
+
     @remove_rsync_bash
     @concourse_cluster
     Scenario: None of the accumulated wal (after running pg_start_backup and before copying the pg_control file) is lost during differential
@@ -2491,4 +2527,3 @@ Feature: gprecoverseg tests
         And user can start transactions
        Then the row count of table test_recoverseg in "postgres" should be 2000
         And the cluster is recovered in full and rebalanced
-

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -50,6 +50,7 @@ Feature: gprecoverseg tests involving migrating to a new host
     Then gprecoverseg should return a return code of 1
 #    And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "sdw2" contains entries for "sdw5"
     And check if start failed for full recovery for mirrors with hostname sdw5
+    And gprecoverseg should print "error:.*data directory.* has invalid permissions" to stdout
     And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
     And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
@@ -87,6 +88,7 @@ Feature: gprecoverseg tests involving migrating to a new host
     And gprecoverseg should print "Recovery Target instance port        = 20001" to stdout
     And gprecoverseg should print "Recovery Target instance port        = 20002" to stdout
     And gprecoverseg should print "Recovery Target instance port        = 20003" to stdout
+    And gprecoverseg should print "error: could not access directory.* Permission denied" to stdout
     And the cluster configuration is saved for "after_backout"
     And the "before_recoverseg" and "after_backout" cluster configuration matches for gprecoverseg newhost
     And datadirs from "before_recoverseg" configuration for "sdw1" are created on "sdw5" with mode 700

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -484,6 +484,16 @@ def impl(context):
 
     context.data_dirs_created.clear()
 
+@given("the mode of all the created data directories is non-recursively changed to {mode}")
+@when("the mode of all the created data directories is non-recursively changed to {mode}")
+@then("the mode of all the created data directories is non-recursively changed to {mode}")
+def impl(context, mode):
+    for hostname, data_dirs in context.data_dirs_created.items():
+        for data_dir in data_dirs:
+            command = 'ssh {} "chmod {} {}"'.format(hostname, mode, data_dir)
+            run_command(context, command)
+
+
 #TODO improve this function
 def make_temp_dir_on_remote(context, hostname, tmp_base_dir_remote, mode='700'):
     if not tmp_base_dir_remote:


### PR DESCRIPTION
Currently when gprecoverseg fails, it records the error in a log file. This log file can be pg_basebackup/pg_rewind file depending on the type of recovery the failed segments were undergoing.
So in case of gprecoverseg failure, the user has to navigate through the log file to get the reason for failure.

With these changes it will enable the user to get a primal understanding on the reason for failure by displaying a snippet of error on console. Gprecoverseg will obtain last occurring error/panic/fatal message from the log file and display it. For more details the user can dive into the reported logfile.

`20231106:15:28:00:087928 gprecoverseg:sshirishaXG4C7:sshirisha-[INFO]:-------------------------------
20231106:15:28:00:087928 gprecoverseg:sshirishaXG4C7:sshirisha-[INFO]:-Failed to recover the following segments
20231106:15:28:00:087928 gprecoverseg:sshirishaXG4C7:sshirisha-[INFO]:- hostname: sshirishaXG4C7.vmware.com; port: 7004; logfile: /Users/sshirisha/gpAdminLogs/pg_basebackup.20231106_152757.dbid4.out; recoverytype: full; error: pg_basebackup: error: could not get write-ahead log end position from server: ERROR:  could not open file "./tmpfile": Permission denied`

Startup related errors are reported either in startup.log or latest gpdb*.csv file.
This depends on the state of postmaster process when this error occurred. 
So latest error is fetched from both the files and the one with latest timestamp among these is reported on console.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
