### PR TITLE
Use finish_heap_swap to swap relation files and else in ALTER TABLE EXPAND TABLE

### DIFF
--- a/src/test/regress/expected/expand_table.out
+++ b/src/test/regress/expected/expand_table.out
@@ -960,3 +960,31 @@ select numsegments from gp_distribution_policy where localoid='expand_domain_tab
 reset search_path;
 drop schema test_reshuffle cascade;
 -- end_ignore
+-- Check that after EXPAND TABLE, the toast table name is still 'pg_toast_<tableoid>'
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+------------
+ 2
+(1 row)
+
+create table atexpand_toastname(a text, b int);
+alter table atexpand_toastname expand table;
+select reltoastrelid::regclass = ('pg_toast.pg_toast_' || oid::text)::regclass
+from pg_class where relname = 'atexpand_toastname';
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Check that after EXPAND TABLE, index is being re-indexed. Verify one of the segments is enough.
+create table atexpand_reindex(a text, b int);
+create index atexpand_reindex_i on atexpand_reindex(b);
+select relfilenode from gp_dist_random('pg_class') where relname = 'atexpand_reindex' and gp_segment_id = 0
+\gset
+alter table atexpand_reindex expand table;
+select :relfilenode = relfilenode from gp_dist_random('pg_class') where relname = 'atexpand_reindex' and gp_segment_id = 0;
+ ?column? 
+----------
+ f
+(1 row)
+

--- a/src/test/regress/sql/expand_table.sql
+++ b/src/test/regress/sql/expand_table.sql
@@ -453,3 +453,18 @@ select numsegments from gp_distribution_policy where localoid='expand_domain_tab
 reset search_path;
 drop schema test_reshuffle cascade;
 -- end_ignore
+
+-- Check that after EXPAND TABLE, the toast table name is still 'pg_toast_<tableoid>'
+select gp_debug_set_create_table_default_numsegments(2);
+create table atexpand_toastname(a text, b int);
+alter table atexpand_toastname expand table;
+select reltoastrelid::regclass = ('pg_toast.pg_toast_' || oid::text)::regclass
+from pg_class where relname = 'atexpand_toastname';
+
+-- Check that after EXPAND TABLE, index is being re-indexed. Verify one of the segments is enough.
+create table atexpand_reindex(a text, b int);
+create index atexpand_reindex_i on atexpand_reindex(b);
+select relfilenode from gp_dist_random('pg_class') where relname = 'atexpand_reindex' and gp_segment_id = 0
+\gset
+alter table atexpand_reindex expand table;
+select :relfilenode = relfilenode from gp_dist_random('pg_class') where relname = 'atexpand_reindex' and gp_segment_id = 0;


### PR DESCRIPTION
Similar to AT SET DISTRIBUTE BY, AT EXPAND TABLE also misses a few steps in swapping the existing table and temp table during the table-rewriting process (in fact, it probably used the exact same code as AT DISTRIBUTE BY). Therefore, similar to 001a1415f02b1c01b60913b205135c3692fcacdc, we should use finish_heap_swap in AT EXPAND TABLE as well.  

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/at-expand-toast

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
