### PR TITLE
[6X backport] Fix issue that segment index might be wrong in slice->segments

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5019,6 +5019,7 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 			break;
 		case GANGTYPE_SINGLETON_READER:
 			{
+				int gp_segment_count = getgpsegmentCount();
 				slice->gangSize = 1;
 				/*
 				 * numsegments might be larger than the number of gpdb actual segments for foreign table.
@@ -5027,7 +5028,6 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 				 *
 				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
 				 */
-				int gp_segment_count = getgpsegmentCount();
 				slice->segments = list_make1_int(gp_session_id % Min(numsegments, gp_segment_count));
 				break;
 			}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5027,10 +5027,7 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 			 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
 			 */
 			int gp_segment_count = getgpsegmentCount();
-			if (numsegments < gp_segment_count)
-				slice->segments = list_make1_int(gp_session_id % numsegments);
-			else
-				slice->segments = list_make1_int(gp_session_id % gp_segment_count);
+			slice->segments = list_make1_int(gp_session_id % Min(numsegments, gp_segment_count));
 			break;
 		default:
 			elog(ERROR, "unexpected gang type");

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5018,17 +5018,19 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 			slice->segments = list_make1_int(-1);
 			break;
 		case GANGTYPE_SINGLETON_READER:
-			slice->gangSize = 1;
-			/*
-			 * numsegments might be larger than the number of gpdb actual segments for foreign table.
-			 * For example, for gp2gp, when remote gpdb cluster has more segments than local gpdb,
-			 * numsegments will be larger than getgpsegmentCount().
-			 *
-			 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
-			 */
-			int gp_segment_count = getgpsegmentCount();
-			slice->segments = list_make1_int(gp_session_id % Min(numsegments, gp_segment_count));
-			break;
+			{
+				slice->gangSize = 1;
+				/*
+				 * numsegments might be larger than the number of gpdb actual segments for foreign table.
+				 * For example, for gp2gp, when remote gpdb cluster has more segments than local gpdb,
+				 * numsegments will be larger than getgpsegmentCount().
+				 *
+				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
+				 */
+				int gp_segment_count = getgpsegmentCount();
+				slice->segments = list_make1_int(gp_session_id % Min(numsegments, gp_segment_count));
+				break;
+			}
 		default:
 			elog(ERROR, "unexpected gang type");
 	}


### PR DESCRIPTION
### 1. Issue description
gp2gp might encounter the issue when remote gpdb cluster has more segments than local gpdb cluster.
For example, local gpdb cluster has 3 segments and remote gpdb cluster has 4 segments.
```
testdb=# insert into l_tbl select * from f_tbl limit 10;
FATAL:  unexpected content id 3, should be [-1, 2]
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```
We can reproduce the issue by steps below.
**Note: remote gpdb cluster must have more segments than local gpdb cluster.**
```
create extension greenplum_fdw;
create server gpdb_server foreign data wrapper greenplum_fdw options (host '10.117.190.206', port '7000', mpp_execute 'all segments', num_segments '4');
create user mapping for gpadmin server gpdb_server;
create foreign table f_tbl (c1 int, c2 int) server gpdb_server options (table_name 'demo_local_tbl');

create table l_tbl (c1 int, c2 int);

insert into l_tbl select * from f_tbl limit 10;
```

### 2. The reason why this issue might arise

https://github.com/greenplum-db/gpdb/blob/283eea57100c690cb05b672b14eef7d0382e4e16/src/backend/executor/execMain.c#L5020-L5023

slice->segments[i] is the index of gpdb actual segments, so it can't be more than the number of segments.

```
testdb=# explain verbose insert into l_tbl select * from f_tbl limit 10;
                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
 Insert on public.l_tbl  (cost=100.00..100.61 rows=4 width=8)
   ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=100.00..100.51 rows=10 width=8)
         Output: f_tbl.c1, f_tbl.c2
         Hash Key: f_tbl.c1
         ->  Limit  (cost=100.00..100.51 rows=10 width=8)
               Output: f_tbl.c1, f_tbl.c2
               ->  Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..100.51 rows=10 width=8)
                     Output: f_tbl.c1, f_tbl.c2
                     ->  Limit  (cost=100.00..100.31 rows=3 width=8)
                           Output: f_tbl.c1, f_tbl.c2
                           ->  Foreign Scan on public.f_tbl  (cost=100.00..417.20 rows=2560 width=8)
                                 Output: f_tbl.c1, f_tbl.c2
                                 Remote SQL: SELECT c1, c2 FROM public.demo_local_table
 Optimizer: Postgres query optimizer
(14 rows)
```

But for this SQL, `numsegments` will be 4.
Then segment index in `slice->segments` might be 3 which is not in [-1, 2].
That is why this issue arrises.

So we modify the method to decide segment index to fix this issue.

### 3. It's hard to add test cases
We don't add extra test cases for this fix.
Because greenplum_fdw isn't in gpdb code and we need two gpdb cluster with different size.
We will add related test cases in greenplum_fdw in the future.

We built a pipeline for this PR and all related jobs are green now.
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-fix_wrong_segment_index-centos7

Co-authored-by: Yongtao Huang <yongtaoh@vmware.com>