### PR TITLE
[6X Backport] gprecoverseg: Validate options with -o

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -253,6 +253,12 @@ class GpRecoverSegmentProgram:
         if self.__options.differentialResynchronization and self.__options.outputSampleConfigFile:
             raise ProgramArgumentValidationException("Invalid -o provided with --differential argument")
 
+        if self.__options.recoveryConfigFile and self.__options.outputSampleConfigFile:
+            raise ProgramArgumentValidationException("Invalid -i provided with -o argument")
+
+        if self.__options.rebalanceSegments and self.__options.outputSampleConfigFile:
+            raise ProgramArgumentValidationException("Invalid -r provided with -o argument")
+
         if self.__options.replayLag and not self.__options.rebalanceSegments:
             raise ProgramArgumentValidationException("--replay-lag should be used only with -r")
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -682,6 +682,19 @@ Feature: gprecoverseg tests
         | differential | -a --differential  |
         | full         | -aF                |
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg throws exception when -o flag used with invalid flags
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    When the user runs "gprecoverseg -o output_config -i input_config"
+    Then gprecoverseg should return a return code of 2
+    And gprecoverseg should print "Invalid -i provided with -o argument" to stdout
+    When the user runs "gprecoverseg -o /tmp/output_config -r"
+    Then gprecoverseg should return a return code of 2
+    And gprecoverseg should print "Invalid -r provided with -o argument" to stdout
+
   @concourse_cluster
   Scenario Outline: <scenario> incremental recovery works with tablespaces on a multi-host environment
     Given the database is running


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/16529

Validate options with -o

Issue: There is no requirement of following flag combinations:

```
-o with -r: No need of output config file when rebalancing
-o with -i: Can't think of any valid usecase for this combination
```

Fix: gprecoverseg should raise an exception when invalid flags are used with -o

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
