### PR TITLE
Fix issue that segment index might be wrong in slice->segments

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -155,15 +155,15 @@ EXPLAIN ANALYZE SELECT * FROM gp_ft1;
 
 -- test whether segment index in slice->segments is valid or not when
 -- the value of option num_segments is larger than the number of gpdb actual segments.
-CREATE TABLE tmp_tbl (
+CREATE TABLE table_dist_in_3_segments (
 	f1 int,
 	f2 text,
 	f3 text
 ) DISTRIBUTED BY (f1);
-EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Insert on postgres_fdw_gp.tmp_tbl
+ Insert on postgres_fdw_gp.table_dist_in_3_segments
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
          Hash Key: gp_ft1.f1
@@ -177,8 +177,8 @@ EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
  Optimizer: Postgres-based planner
 (12 rows)
 
-INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
-DROP TABLE tmp_tbl;
+INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE table_dist_in_3_segments;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -153,6 +153,32 @@ EXPLAIN ANALYZE SELECT * FROM gp_ft1;
  Execution Time: 45.320 ms
 (8 rows)
 
+-- test whether segment index in slice->segments is valid or not when
+-- the value of option num_segments is larger than the number of gpdb actual segments.
+CREATE TABLE tmp_tbl (
+	f1 int,
+	f2 text,
+	f3 text
+) DISTRIBUTED BY (f1);
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Insert on postgres_fdw_gp.tmp_tbl
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+         Hash Key: gp_ft1.f1
+         ->  Limit
+               Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+               ->  Gather Motion 4:1  (slice2; segments: 4)
+                     Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+                     ->  Foreign Scan on postgres_fdw_gp.gp_ft1
+                           Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+                           Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1" LIMIT 5::bigint
+ Optimizer: Postgres-based planner
+(12 rows)
+
+INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE tmp_tbl;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -152,6 +152,32 @@ EXPLAIN ANALYZE SELECT * FROM gp_ft1;
  Execution Time: 45.320 ms
 (8 rows)
 
+-- test whether segment index in slice->segments is valid or not when
+-- the value of option num_segments is larger than the number of gpdb actual segments.
+CREATE TABLE tmp_tbl (
+	f1 int,
+	f2 text,
+	f3 text
+) DISTRIBUTED BY (f1);
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Insert on postgres_fdw_gp.tmp_tbl
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+         Hash Key: gp_ft1.f1
+         ->  Limit
+               Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+               ->  Gather Motion 4:1  (slice2; segments: 4)
+                     Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+                     ->  Foreign Scan on postgres_fdw_gp.gp_ft1
+                           Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
+                           Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1" LIMIT 5::bigint
+ Optimizer: Postgres-based planner
+(12 rows)
+
+INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE tmp_tbl;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -154,15 +154,15 @@ EXPLAIN ANALYZE SELECT * FROM gp_ft1;
 
 -- test whether segment index in slice->segments is valid or not when
 -- the value of option num_segments is larger than the number of gpdb actual segments.
-CREATE TABLE tmp_tbl (
+CREATE TABLE table_dist_in_3_segments (
 	f1 int,
 	f2 text,
 	f3 text
 ) DISTRIBUTED BY (f1);
-EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Insert on postgres_fdw_gp.tmp_tbl
+ Insert on postgres_fdw_gp.table_dist_in_3_segments
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Output: gp_ft1.f1, gp_ft1.f2, gp_ft1.f3
          Hash Key: gp_ft1.f1
@@ -176,8 +176,8 @@ EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
  Optimizer: Postgres-based planner
 (12 rows)
 
-INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
-DROP TABLE tmp_tbl;
+INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE table_dist_in_3_segments;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -113,14 +113,14 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 EXPLAIN ANALYZE SELECT * FROM gp_ft1;
 -- test whether segment index in slice->segments is valid or not when
 -- the value of option num_segments is larger than the number of gpdb actual segments.
-CREATE TABLE tmp_tbl (
+CREATE TABLE table_dist_in_3_segments (
 	f1 int,
 	f2 text,
 	f3 text
 ) DISTRIBUTED BY (f1);
-EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
-INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
-DROP TABLE tmp_tbl;
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
+INSERT INTO table_dist_in_3_segments SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE table_dist_in_3_segments;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -111,6 +111,16 @@ set search_path=postgres_fdw_gp;
 alter server loopback options(add num_segments '4');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
 EXPLAIN ANALYZE SELECT * FROM gp_ft1;
+-- test whether segment index in slice->segments is valid or not when
+-- the value of option num_segments is larger than the number of gpdb actual segments.
+CREATE TABLE tmp_tbl (
+	f1 int,
+	f2 text,
+	f3 text
+) DISTRIBUTED BY (f1);
+EXPLAIN (VERBOSE, COSTS FALSE) INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+INSERT INTO tmp_tbl SELECT * FROM gp_ft1 LIMIT 5;
+DROP TABLE tmp_tbl;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3105,6 +3105,7 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 
 		case CdbLocusType_SingleQE:
 			{
+				int gp_segment_count = getgpsegmentCount();
 				sendSlice->gangType = GANGTYPE_SINGLETON_READER;
 				sendSlice->numsegments = 1;
 				/*
@@ -3115,7 +3116,6 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 				 *
 				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
 				 */
-				int gp_segment_count = getgpsegmentCount();
 				sendSlice->segindex = gp_session_id % Min(subpath->locus.numsegments, gp_segment_count);
 				break;
 			}
@@ -3127,21 +3127,10 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 			break;
 
 		case CdbLocusType_SegmentGeneral:
-			{
-				sendSlice->gangType = GANGTYPE_SINGLETON_READER;
-				sendSlice->numsegments = subpath->locus.numsegments;
-				/*
-				 * sendSlice->segindex must be smaller than the number of gpdb actual segments.
-				 *
-				 * For foreign table, subpath->locus.numsegments might be larger than the number of
-				 * gpdb actual segments.
-				 *
-				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
-				 */
-				int gp_segment_count = getgpsegmentCount();
-				sendSlice->segindex = gp_session_id % Min(subpath->locus.numsegments, gp_segment_count);
-				break;
-			}
+			sendSlice->gangType = GANGTYPE_SINGLETON_READER;
+			sendSlice->numsegments = subpath->locus.numsegments;
+			sendSlice->segindex = gp_session_id % subpath->locus.numsegments;
+			break;
 
 		case CdbLocusType_Replicated:
 			// is probably writer, set already

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3104,10 +3104,21 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 			break;
 
 		case CdbLocusType_SingleQE:
-			sendSlice->gangType = GANGTYPE_SINGLETON_READER;
-			sendSlice->numsegments = 1;
-			sendSlice->segindex = gp_session_id % subpath->locus.numsegments;
-			break;
+			{
+				sendSlice->gangType = GANGTYPE_SINGLETON_READER;
+				sendSlice->numsegments = 1;
+				/*
+				 * sendSlice->segindex must be smaller than the number of gpdb actual segments.
+				 *
+				 * For foreign table, subpath->locus.numsegments might be larger than the number of
+				 * gpdb actual segments.
+				 *
+				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
+				 */
+				int gp_segment_count = getgpsegmentCount();
+				sendSlice->segindex = gp_session_id % Min(subpath->locus.numsegments, gp_segment_count);
+				break;
+			}
 
 		case CdbLocusType_General:
 			sendSlice->gangType = GANGTYPE_SINGLETON_READER;
@@ -3116,10 +3127,21 @@ create_motion_plan(PlannerInfo *root, CdbMotionPath *path)
 			break;
 
 		case CdbLocusType_SegmentGeneral:
-			sendSlice->gangType = GANGTYPE_SINGLETON_READER;
-			sendSlice->numsegments = subpath->locus.numsegments;
-			sendSlice->segindex = gp_session_id % subpath->locus.numsegments;
-			break;
+			{
+				sendSlice->gangType = GANGTYPE_SINGLETON_READER;
+				sendSlice->numsegments = subpath->locus.numsegments;
+				/*
+				 * sendSlice->segindex must be smaller than the number of gpdb actual segments.
+				 *
+				 * For foreign table, subpath->locus.numsegments might be larger than the number of
+				 * gpdb actual segments.
+				 *
+				 * So we need to use the minimum of numsegments and getgpsegmentCount() here.
+				 */
+				int gp_segment_count = getgpsegmentCount();
+				sendSlice->segindex = gp_session_id % Min(subpath->locus.numsegments, gp_segment_count);
+				break;
+			}
 
 		case CdbLocusType_Replicated:
 			// is probably writer, set already


### PR DESCRIPTION
### 1. Issue description
For foreign table, if its remote server specifies the option `num_segments` and the value of option `num_segments` is larger than the number of local gpdb actual segments,
accessing such foreign table might encounter an issue as follows.
```
testdb=# insert into l_tbl select * from f_tbl limit 5;
FATAL:  unexpected content id 3, should be [-1, 2]
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```

We can reproduce the issue by steps below.
```
create extension postgres_fdw;
create server multi_pg_servers foreign data wrapper postgres_fdw options (mpp_execute 'all segments', num_segments '4', multi_hosts '10.117.190.206 10.117.190.206 10.117.190.206 10.117.190.206', multi_ports '5432 5555 6666 7777', dbname 'pg_testdb');
create user mapping for gpadmin server multi_pg_servers options (user 'postgres');
create foreign table f_tbl (c1 int, c2 int) server multi_pg_servers options (table_name 'demo_local_tbl');

create table l_tbl (c1 int, c2 int);

insert into l_tbl select * from f_tbl limit 10;
```

### 2. The reason why this issue might arise

https://github.com/greenplum-db/gpdb/blob/8b135bf3ffa7cec6852e79ec96f3e4f9650fb186/src/backend/optimizer/plan/createplan.c#L3106-L3110

`sendSlice->segindex` is the index of gpdb actual segments, so it can't be more than the number of segments.

```
testdb=# explain verbose insert into l_tbl select * from f_tbl limit 5;
                                            QUERY PLAN
---------------------------------------------------------------------------------------------------
 Insert on public.l_tbl  (cost=100.00..100.22 rows=2 width=8)
   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=100.00..100.22 rows=2 width=8)
         Output: f_tbl.c1, f_tbl.c2
         Hash Key: f_tbl.c1
         ->  Limit  (cost=100.00..100.10 rows=5 width=8)
               Output: f_tbl.c1, f_tbl.c2
               ->  Gather Motion 4:1  (slice2; segments: 4)  (cost=100.00..100.40 rows=20 width=8)
                     Output: f_tbl.c1, f_tbl.c2
                     ->  Foreign Scan on public.f_tbl  (cost=100.00..100.15 rows=5 width=8)
                           Output: f_tbl.c1, f_tbl.c2
                           Remote SQL: SELECT c1, c2 FROM public.demo_local_table LIMIT 5::bigint
 Optimizer: Postgres-based planner
(12 rows)
```

But for this SQL, `subpath->locus.numsegments` will be 4.
Then `sendSlice->segindex` might be 3 which is not in [-1, 2].
That is why this issue arrises.

So we modify the method to decide segment index to fix this issue.

Co-authored-by: Yongtao Huang <yongtaoh@vmware.com>