### PR TITLE
Docs: edit the description for gpload option MAX_LINE_LENGHT

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gpfdist.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpfdist.html.md
@@ -63,7 +63,7 @@ Most likely, you will want to run `gpfdist` on your ETL machines rather than the
 :   Sets the number of seconds that `gpfdist` waits before cleaning up the session when there are no `POST` requests from the segments. Default is 300. Allowed values are 300 to 86400. You may increase this value when experiencing heavy network traffic.
 
 -m max\_length
-:   Sets the maximum allowed data row length in bytes. Default is 32768. Should be used when user data includes very wide rows \(or when `line too long` error message occurs\). Should not be used otherwise as it increases resource allocation. Valid range is 32K to 256MB. \(The upper limit is 1MB on Windows systems.\)
+:   Sets the maximum allowed data row length in bytes. Default is 32768. Should be used when user data includes very wide rows \(or when `line too long` error message occurs\). Should not be used otherwise as it increases resource allocation. Valid range is 32K to 256MB. The upper limit is 1MB on Windows systems.
 
 :   > **Note** Memory issues might occur if you specify a large maximum row length and run a large number of `gpfdist` concurrent connections. For example, setting this value to the maximum of 256MB with 96 concurrent `gpfdist` processes requires approximately 24GB of memory \(`(96 + 1) x 246MB`\).
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpload.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpload.html.md
@@ -231,7 +231,7 @@ GPLOAD
     :   Required when `TRANSFORM` is specified. Specifies the location of the transformation configuration file that is specified in the `TRANSFORM` parameter, above.
 
     MAX\_LINE\_LENGTH
-    :   Optional. An integer that specifies the maximum length of a line in the XML transformation data passed to `gpload`.
+    :   Optional. Sets the maximum allowed data row length in bytes. Default is 32768. Should be used when user data includes very wide rows (or when line too long error message occurs). Should not be used otherwise as it increases resource allocation. Valid range is 32K to 256MB. (The upper limit is 1MB on Windows systems.)
 
     FORMAT
     :   Optional. Specifies the format of the source data file\(s\) - either plain text \(`TEXT`\) or comma separated values \(`CSV`\) format. Defaults to `TEXT` if not specified. For more information about the format of the source data, see [Loading and Unloading Data](../../admin_guide/load/topics/g-loading-and-unloading-data.html).

--- a/gpdb-doc/markdown/utility_guide/ref/gpload.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpload.html.md
@@ -231,7 +231,7 @@ GPLOAD
     :   Required when `TRANSFORM` is specified. Specifies the location of the transformation configuration file that is specified in the `TRANSFORM` parameter, above.
 
     MAX\_LINE\_LENGTH
-    :   Optional. Sets the maximum allowed data row length in bytes. Default is 32768. Should be used when user data includes very wide rows (or when line too long error message occurs). Should not be used otherwise as it increases resource allocation. Valid range is 32K to 256MB. (The upper limit is 1MB on Windows systems.)
+    :   Optional. Sets the maximum allowed data row length in bytes. Default is 32768. Should be used when user data includes very wide rows (or when `line too long` error message occurs). Should not be used otherwise as it increases resource allocation. Valid range is 32K to 256MB. The upper limit is 1MB on Windows systems.
 
     FORMAT
     :   Optional. Specifies the format of the source data file\(s\) - either plain text \(`TEXT`\) or comma separated values \(`CSV`\) format. Defaults to `TEXT` if not specified. For more information about the format of the source data, see [Loading and Unloading Data](../../admin_guide/load/topics/g-loading-and-unloading-data.html).


### PR DESCRIPTION
This PR modifies the description for the option MAX_LINE_LENGHT of gpload to align with -m option of gpfdist. Let me know if this is correct.
