### PR TITLE
Fix for issues/15226: Improvement of cancelation and termination

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -30,6 +30,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdbgang.h"
 
+extern int  client_connection_check_interval;
 
 static uint32 cdbconn_get_motion_listener_port(PGconn *conn);
 static void cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc);
@@ -316,7 +317,7 @@ cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc)
 		if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
 			elog(LOG, "Finishing connection with %s; %s", segdbDesc->whoami, transStatusToString(status));
 
-		if (status == PQTRANS_ACTIVE)
+		if (status == PQTRANS_ACTIVE && 0 == client_connection_check_interval)
 		{
 			char		errbuf[256];
 			bool		sent;


### PR DESCRIPTION
Do not notify in case the client_connection_check_interval is set. All QEs will check for a valid connection, and will terminate properely. The QD just closes all connections here, without notifications.

Issue:
https://github.com/greenplum-db/gpdb/issues/15226

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x ] Pass `make installcheck`
- [ x] Review a PR in return to support the community
