### PR TITLE
Fix a flakiness in gpcontrib/gp_toolkit test

### DIFF
--- a/gpcontrib/gp_toolkit/expected/gp_toolkit.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit.out
@@ -414,8 +414,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
--- primary_conninfo can be different due to failovers in isolation2 tests
-select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
+-- primary_slot_name/primary_conninfo can be different due to failovers.
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo' and psdname != 'primary_slot_name';
  psdname | psdvalue | psdcount 
 ---------+----------+----------
 (0 rows)

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit_resgroup.out
@@ -418,8 +418,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
--- primary_conninfo can be different due to failovers in isolation2 tests
-select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
+-- primary_slot_name/primary_conninfo can be different due to failovers.
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo' and psdname != 'primary_slot_name';
  psdname | psdvalue | psdcount 
 ---------+----------+----------
 (0 rows)

--- a/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
@@ -246,8 +246,8 @@ select paramsegment,paramname from gp_toolkit.gp_param_settings() where paramnam
 
 -- Expected to have no results
 -- However it will show there is a difference if segment guc is different
--- primary_conninfo can be different due to failovers in isolation2 tests
-select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
+-- primary_slot_name/primary_conninfo can be different due to failovers.
+select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo' and psdname != 'primary_slot_name';
 
 
 -- gp_locks_on_relation


### PR DESCRIPTION
The test was flaky with a diff like:

```
--- /tmp/build/e18b2f02/gpdb_src/gpcontrib/gp_toolkit/expected/gp_toolkit.out	2023-11-07 20:06:36.276652825 +0000
+++ /tmp/build/e18b2f02/gpdb_src/gpcontrib/gp_toolkit/results/gp_toolkit.out	2023-11-07 20:06:36.304655494 +0000
@@ -399,9 +399,11 @@
 -- However it will show there is a difference if segment guc is different
 -- primary_conninfo can be different due to failovers in isolation2 tests
 select * from gp_toolkit.gp_param_settings_seg_value_diffs where psdname != 'primary_conninfo';
- psdname | psdvalue | psdcount
----------+----------+----------
-(0 rows)
+      psdname      |           psdvalue            | psdcount
+-------------------+-------------------------------+----------
+ primary_slot_name |                               |        2
+ primary_slot_name | internal_wal_replication_slot |        1
+(2 rows)

 -- gp_locks_on_relation
```

The reason is that primary_slot_name just like primary_conninfo, can be different between primary segments when some primary has previously been a mirror so these mirror-specific GUCs persist. We might want to clean them up properly in future but currently just ignore the GUCs in test.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/flake-gp_toolkit

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
