### PR TITLE
Add analyze functionality for mpp file fdw.

### DIFF
--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -792,10 +792,10 @@ fileEndForeignScan(ForeignScanState *node)
 }
 
 /*
- * Modify the filename in cstate->filename, and cstate->cdbsreh if any,
- * for COPY ON SEGMENT.
+ * Modify the filename when it contains <SEGID> or <SEG_DATA_DIR> if any.
  *
  * Replaces the "<SEGID>" token in the filename with this segment's ID.
+ * Replaces the "<SEG_DATA_DIR>" token in the filename with DataDir.
  */
 static char *
 fileMangleFileName(const char *filename)
@@ -841,7 +841,12 @@ fileAnalyzeForeignTable(Relation relation,
 
 	table = GetForeignTable(RelationGetRelid(relation));
 	if (Gp_role == GP_ROLE_DISPATCH && table->exec_location == FTEXECLOCATION_ALL_SEGMENTS) {
+		/* 
+		 * It is not easy to fetch all the reomte files from all segments, so
+		 * we set it to the same default value in estimate_size() 
+		 */
 		*totalpages = 10;
+		/* This function could dispatch gp_acquire_sample_rows to all segments */
 		*func = gp_acquire_sample_rows_func;
 		return true;
 	}

--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -798,7 +798,7 @@ fileEndForeignScan(ForeignScanState *node)
  * Replaces the "<SEG_DATA_DIR>" token in the filename with DataDir.
  */
 static char *
-fileMangleFileName(const char *filename)
+fileFdwMangleFileName(const char *filename)
 {
 	StringInfoData filepath;
 	char segid_buf[8];
@@ -852,7 +852,7 @@ fileAnalyzeForeignTable(Relation relation,
 	}
 
 	/* Copy codes from MangleCopyFileName function */
-	filename = fileMangleFileName(filename);
+	filename = fileFdwMangleFileName(filename);
 	/*
 	 * Get size of the file.  (XXX if we fail here, would it be better to just
 	 * return false to skip analyzing the table?)

--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -840,7 +840,8 @@ fileAnalyzeForeignTable(Relation relation,
 		return false;
 
 	table = GetForeignTable(RelationGetRelid(relation));
-	if (Gp_role == GP_ROLE_DISPATCH && table->exec_location == FTEXECLOCATION_ALL_SEGMENTS) {
+	if (Gp_role == GP_ROLE_DISPATCH && table->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
+	{
 		/* 
 		 * It is not easy to fetch all the reomte files from all segments, so
 		 * we set it to the same default value in estimate_size() 
@@ -852,7 +853,10 @@ fileAnalyzeForeignTable(Relation relation,
 	}
 
 	/* Copy codes from MangleCopyFileName function */
-	filename = fileFdwMangleFileName(filename);
+	if (table->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
+	{
+		filename = fileFdwMangleFileName(filename);
+	}
 	/*
 	 * Get size of the file.  (XXX if we fail here, would it be better to just
 	 * return false to skip analyzing the table?)

--- a/contrib/file_fdw/input/gp_file_fdw.source
+++ b/contrib/file_fdw/input/gp_file_fdw.source
@@ -34,6 +34,8 @@ CREATE FOREIGN TABLE text_csv_all (
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text<SEGID>.csv', mpp_execute 'all segments');
 EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
 SELECT * FROM text_csv_all ORDER BY word1;
+-- Analyze 'all segments' option table when filename is like "text<SEGID>.csv"
+Analyze text_csv_all;
 CREATE FOREIGN TABLE text_csv_any_from_server (
     word1 text, word2 text
 ) SERVER file_server

--- a/contrib/file_fdw/output/gp_file_fdw.source
+++ b/contrib/file_fdw/output/gp_file_fdw.source
@@ -49,6 +49,8 @@ SELECT * FROM text_csv_all ORDER BY word1;
  FOO   | bar
 (3 rows)
 
+-- Analyze 'all segments' option table when filename is like "text<SEGID>.csv"
+Analyze text_csv_all;
 CREATE FOREIGN TABLE text_csv_any_from_server (
     word1 text, word2 text
 ) SERVER file_server

--- a/contrib/file_fdw/output/gp_file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/gp_file_fdw_optimizer.source
@@ -49,6 +49,8 @@ SELECT * FROM text_csv_all ORDER BY word1;
  FOO   | bar
 (3 rows)
 
+-- Analyze 'all segments' option table when filename is like "text<SEGID>.csv"
+Analyze text_csv_all;
 CREATE FOREIGN TABLE text_csv_any_from_server (
     word1 text, word2 text
 ) SERVER file_server

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -112,6 +112,7 @@ SELECT * FROM mpp_ft1 ORDER BY c1;
  10 |  0
 (10 rows)
 
+ANALYZE mpp_ft1;
 ALTER FOREIGN TABLE mpp_ft1 OPTIONS (add use_remote_estimate 'true');
 EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
                                     QUERY PLAN                                     

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -70,6 +70,7 @@ ALTER SERVER pgserver OPTIONS (set num_segments '2');
 -- ===================================================================
 EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
 SELECT * FROM mpp_ft1 ORDER BY c1;
+ANALYZE mpp_ft1;
 
 ALTER FOREIGN TABLE mpp_ft1 OPTIONS (add use_remote_estimate 'true');
 EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -185,9 +185,6 @@ static int acquire_sample_rows(Relation onerel, int elevel,
 static int acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 										  HeapTuple *rows, int targrows,
 										  double *totalrows, double *totaldeadrows);
-static int gp_acquire_sample_rows_func(Relation onerel, int elevel,
-									   HeapTuple *rows, int targrows,
-									   double *totalrows, double *totaldeadrows);
 static BlockNumber acquire_index_number_of_blocks(Relation indexrel, Relation tablerel);
 
 static void gp_acquire_correlations_dispatcher(Oid relOid, bool inh, float4 *correlations, bool *correlationsIsNull);

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -367,7 +367,9 @@ extern bool vacuumStatement_IsTemporary(Relation onerel);
 extern void analyze_rel(Oid relid, RangeVar *relation,
 						VacuumParams *params, List *va_cols, bool in_outer_xact,
 						BufferAccessStrategy bstrategy, gp_acquire_sample_rows_context *ctx);
-
+extern int gp_acquire_sample_rows_func(Relation onerel, int elevel,
+									   HeapTuple *rows, int targrows,
+									   double *totalrows, double *totaldeadrows);
 /* in commands/vacuumlazy.c */
 extern void lazy_vacuum_rel_heap(Relation onerel,
 							VacuumParams *params, BufferAccessStrategy bstrategy);


### PR DESCRIPTION
For file_fdw, the analyze method `fileAnalyzeForeignTable()` is just forked from upstream. There are no adaptation modifications for this analyze callback. So when the file_fdw foreign table in greenplum point to multiple files with mpp_execute option is set to `all segments`, it can not do all the sampling work from QD process, because the remote files may be stored on each segment which may be different hosts.

So this PR adds some adaptation work for the analyze callback function to deal with this situation. Also this PR tries to fix this issue: https://github.com/greenplum-db/gpdb/issues/16700

Pipeline link:https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-zhaorui
 
