### PR TITLE
[7x]: Added Support for -i flag with differential recovery

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -107,7 +107,9 @@ class GpRecoverSegmentProgram:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.disableReplayLag, self.__options.replayLag)
 
         instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.outputSampleConfigFile, self.__options.parallelDegree)
-        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization) for t in instance.getTriplets()]
+
+        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization, t.recovery_type) for t in instance.getTriplets()]
+
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree,
                                    instance.getInterfaceHostnameWarnings(),
@@ -278,14 +280,15 @@ class GpRecoverSegmentProgram:
         optionCnt = 0
         if self.__options.newRecoverHosts is not None:
             optionCnt += 1
-        if self.__options.recoveryConfigFile is not None:
-            optionCnt += 1
         if self.__options.rebalanceSegments:
             optionCnt += 1
-        if self.__options.differentialResynchronization:
-            optionCnt += 1
         if optionCnt > 1:
-            raise ProgramArgumentValidationException("Only one of -i, -p, -r and --differential may be specified")
+            raise ProgramArgumentValidationException("Only one of -p and -r may be specified")
+        if optionCnt > 0 and self.__options.recoveryConfigFile is not None:
+            raise ProgramArgumentValidationException("Only one of -i, -p and -r may be specified")
+
+        if optionCnt > 0 and self.__options.differentialResynchronization:
+            raise ProgramArgumentValidationException("Only one of -p, -r and --differential may be specified")
 
         # verify "mode to recover" options
         if self.__options.forceFullResynchronization and self.__options.differentialResynchronization:

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -173,7 +173,7 @@ Lines beginning with # are treated as comments and ignored.
 
 Segments to Recover
 Each line after the first specifies a segment to recover. This line can 
-have one of two formats. In the event of in-place recovery, enter one 
+have one of three formats. In the event of in-place recovery, enter one
 group of colon delimited fields in the line:
 
 failedAddress|failedPort|failedDataDirectory
@@ -184,6 +184,17 @@ add additional spaces.
 
 failedAddress|failedPort|failedDataDirectorySPACEnewAddress|newPort|
 newDataDirectory
+
+To do mix recovery, include a field with values I/D/F/i/d/f on each line. Default is
+incremental recovery if recovery_type field is not provided.
+
+recoveryType|failedAddress|failedPort|failedDataDirectory
+
+recoveryType field supports below values:
+    I/i for incremental recovery
+    D/d for differential recovery
+    F/f for full recovery
+
 
 Examples
 
@@ -198,6 +209,15 @@ sdw1-1|50001|/data1/mirror/gpseg16 SPACE sdw4-1|50001|51001|/data1/recover1/gpse
 Recovery of a single mirror to a new host with hostname specified:
 sdw1|sdw1-1|50001|/data1/mirror/gpseg16 SPACE
 sdw4|sdw4-1|50001|51001|/data1/recover1/gpseg16
+
+In-place recovery of down mirrors with recovery type:
+sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery (By default)
+I|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+i|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+D|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+d|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+F|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
+f|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
 
 Obtaining a Sample File
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -811,11 +811,8 @@ def impl(context, command, out_msg, num):
     msg_list = context.stdout_message.split('\n')
     msg_list = [x.strip() for x in msg_list]
 
-    count = 0
-    for line in msg_list:
-        if out_msg in line:
-            count += 1
-    if count != int(num):
+    match_count = len(re.findall(out_msg, context.stdout_message))
+    if match_count != int(num):
         raise Exception("Expected %s to occur %s times. Found %d. stdout: %s" % (out_msg, num, count, msg_list))
 
 
@@ -4279,5 +4276,3 @@ def verify_elements_in_file(filename, elements):
                 return False
 
         return True
-
-

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -102,7 +102,7 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 -i recover\_config\_file
 :   Specifies the name of a file with the details about failed segments to recover.
 
-    Each line in the config file specifies a segment to recover. This line can have one of two formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
+    Each line in the config file specifies a segment to recover. This line can have one of three formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
 
     ```
     failedAddress|failedPort|failedDataDirectory
@@ -125,6 +125,18 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     ```
     failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newHostname|newAddress|newPort|newDataDirectory
     ```
+    
+    To do mix recovery, include a field with values I/D/F/i/d/f on each line. Default is incremental recovery if recovery_type field is not provided.
+  
+    ```
+    recoveryType|failedAddress|failedPort|failedDataDirectory
+    ```
+
+    recoveryType field supports below values:
+        I/i for incremental recovery
+        D/d for differential recovery
+        F/f for full recovery
+
 
     > **Note** Lines beginning with `#` are treated as comments and ignored.
 
@@ -142,6 +154,18 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     sdw1-1|50001|/data1/mirror/gpseg16<SPACE>sdw4-1|50001|/data1/recover1/gpseg16
     ```
 
+    In-place recovery of down mirrors with recovery type:
+
+    ```
+    sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery (By default)
+    I|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+    i|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+    D|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+    d|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+    F|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
+    f|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
+    ```
+    
     **Obtaining a Sample File**
 
     You can use the `-o` option to output a sample recovery configuration file to use as a starting point. The output file lists the currently invalid segments and their default recovery location. This file format can be used with the `-i` option for in-place \(incremental\) recovery.


### PR DESCRIPTION
This PR added support for using the -i flag with differential recovery in the gprecoverseg command, enhancing its capabilities.

Implementation: 
**Simultaneous Use of -i and --differential:**
Added the functionality to allow the use of both the -i and --differential options simultaneously in the gprecoverseg command. This means that by providing a recovery configuration file with the -i flag and specifying the --differential flag, you will initiate a differential recovery process for all hosts listed in the recovery configuration file, similar to how the -i and -F options currently work together

**Recovery Type Specification in Recovery Configuration File:** 
Added the functionality to specify I/D/F as a recovery type for each line in recovery_config_file and based on that recovery type respective recovery will be performed. The aim is to support existing formats of recovery config files, maintain backward compatibility, and add support for differential recovery.
 E.g; A sample config file will look as follows:
```
I|sdw1|50001|/data1/primary/gpseg4  # Does incremental recovery
D|sdw1|50001|/data1/primary/gpseg4  # Does differential recovery
F|sdw1|50001|/data1/primary/gpseg4  # Does full recovery
sdw1|50001|/data1/primary/gpseg4     # Does incremental recovery 
sdw1-1|sdw1|50001|/data1/primary/gpseg4  # Does incremental recovery 
D|sdw1-1|sdw1|50001|/data1/primary/gpseg4  # Does differential recovery 
```

**Test:**
Added unit and behave test cases

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
