### PR TITLE
icw: Disable autovacuum for col_proj test

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -287,6 +287,8 @@ test: dpe
 # run this near the end of the schedule for more chance to catch abnormalities
 # Have to run it w/o autovacuum to make sure it won't cause gp_check_orphaned_files to fail in any way.
 test: gp_check_files
+# test column projection for various operations
+test: aoco_projection
 test: enable_autovacuum
 
 test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics
@@ -337,8 +339,6 @@ test: uao_dml/uao_dml_unique_index_delete_row uao_dml/uao_dml_unique_index_delet
 # test CREATE UNIQUE INDEX on AO/CO tables.
 test: uao_dml/ao_unique_index_build_row uao_dml/ao_unique_index_build_column
 
-# test column projection for various operations
-test: aoco_projection
 # test resource queue, can not put other test in resource queue.
 test: resource_manager_switch_to_queue
 test: resource_queue


### PR DESCRIPTION
Helps avoid flakes like:
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_main/jobs/icw_planner_icproxy_rocky8/builds/878