### PR TITLE
Adjust subquery's locus for recurse_set_operations

### DIFF
--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -301,13 +301,8 @@ recurse_set_operations(Node *setOp, PlannerInfo *root,
 		 * the SubqueryScanPath with nil pathkeys.  (XXX that should change
 		 * soon too, likely.)
 		 */
-		/*
-		 * GPDB_96_MERGE_FIXME: can we really use the subpath's locus here unmodified?
-		 * Shouldn't we convert it to use Vars pointing to the outputs of the subquery,
-		 * like in subquery_pathlist()
-		 */
 		path = (Path *) create_subqueryscan_path(root, rel, subpath,
-												 NIL, subpath->locus, NULL);
+												 NIL, cdbpathlocus_from_subquery(root, rel, subpath), NULL);
 
 		add_path(rel, path);
 
@@ -325,7 +320,7 @@ recurse_set_operations(Node *setOp, PlannerInfo *root,
 			partial_subpath = linitial(final_rel->partial_pathlist);
 			partial_path = (Path *)
 				create_subqueryscan_path(root, rel, partial_subpath,
-										 NIL, partial_subpath->locus, NULL);
+										 NIL, cdbpathlocus_from_subquery(root, rel, partial_subpath), NULL);
 			add_partial_path(rel, partial_path);
 		}
 

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -359,16 +359,14 @@ select count(*) from
                ->  Subquery Scan on ss
                      ->  HashSetOp Intersect
                            ->  Append
+                                 ->  Subquery Scan on "*SELECT* 1"
+                                       ->  Seq Scan on tenk1
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: "*SELECT* 1".unique1
-                                       ->  Subquery Scan on "*SELECT* 1"
-                                             ->  Seq Scan on tenk1
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: "*SELECT* 2".fivethous
                                        ->  Subquery Scan on "*SELECT* 2"
                                              ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Postgres query optimizer
-(15 rows)
+(13 rows)
 
 select count(*) from
   ( select unique1 from tenk1 intersect select fivethous from tenk1 ) ss;
@@ -384,17 +382,15 @@ select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashSetOp Except
          ->  Append
+               ->  Subquery Scan on "*SELECT* 1"
+                     ->  Seq Scan on tenk1
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: "*SELECT* 1".unique1
-                     ->  Subquery Scan on "*SELECT* 1"
-                           ->  Seq Scan on tenk1
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: "*SELECT* 2".unique2
                      ->  Subquery Scan on "*SELECT* 2"
                            ->  Seq Scan on tenk1 tenk1_1
                                  Filter: (unique2 <> 10)
  Optimizer: Postgres query optimizer
-(13 rows)
+(11 rows)
 
 select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
  unique1 
@@ -416,16 +412,14 @@ select count(*) from
                            ->  Sort
                                  Sort Key: "*SELECT* 1".unique1
                                  ->  Append
+                                       ->  Subquery Scan on "*SELECT* 1"
+                                             ->  Seq Scan on tenk1
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                             Hash Key: "*SELECT* 1".unique1
-                                             ->  Subquery Scan on "*SELECT* 1"
-                                                   ->  Seq Scan on tenk1
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: "*SELECT* 2".fivethous
                                              ->  Subquery Scan on "*SELECT* 2"
                                                    ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Postgres query optimizer
-(17 rows)
+(15 rows)
 
 select count(*) from
   ( select unique1 from tenk1 intersect select fivethous from tenk1 ) ss;
@@ -443,17 +437,15 @@ select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
          ->  Sort
                Sort Key: "*SELECT* 1".unique1
                ->  Append
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on tenk1
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: "*SELECT* 1".unique1
-                           ->  Subquery Scan on "*SELECT* 1"
-                                 ->  Seq Scan on tenk1
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: "*SELECT* 2".unique2
                            ->  Subquery Scan on "*SELECT* 2"
                                  ->  Seq Scan on tenk1 tenk1_1
                                        Filter: (unique2 <> 10)
  Optimizer: Postgres query optimizer
-(15 rows)
+(13 rows)
 
 select unique1 from tenk1 except select unique2 from tenk1 where unique2 != 10;
  unique1 


### PR DESCRIPTION
For union case, it will add motion atop Append node, and hash on all non-junk attributes, convert locus for SubqueryScanPath has no effect.

But for INTERSECT/EXCEPT, it will add motion(if needed) below the Append for hashed locus, and also hash on all non-junk attributes. When subquery's DistributionKey expr are same with the non-junk attributes, convert subpath's locus to use Vars pointing to the outputs of the subquery can eliminate redistribute motion.

Remove GPDB_96_MERGE_FIXME.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
