### PR TITLE
Disable SET DISTRIBUTED REPLICATED for ALTER EXTERNAL TABLE

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17761,7 +17761,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			if (ldistro && ldistro->ptype == POLICYTYPE_REPLICATED)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("SET DISTRIBUTED REPLICATED is not supported for external table.")));
+						 errmsg("SET DISTRIBUTED REPLICATED is not supported for external table")));
 		}
 	}
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17757,6 +17757,11 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("cannot set distribution policy of readable external table \"%s\"",
 								RelationGetRelationName(rel))));
+
+			if (ldistro && ldistro->ptype == POLICYTYPE_REPLICATED)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("SET DISTRIBUTED REPLICATED is not supported for external table.")));
 		}
 	}
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3622,6 +3622,10 @@ SELECT * FROM test_part_integrity;
 
 DROP TABLE test_part_integrity;
 
+-- Testing creating external table with replicated distribution
+-- Should report error
+CREATE WRITABLE EXTERNAL WEB TABLE ext_dist_repl(a int, b int) EXECUTE 'some command' FORMAT 'TEXT' DISTRIBUTED REPLICATED;
+
 -- Testing altering the distribution policy of external tables.
 CREATE WRITABLE EXTERNAL WEB TABLE ext_w_dist(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/ext_w_dist.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE ext_w_dist SET WITH (reorganize=true); -- should error out if forcing reorganize
@@ -3630,6 +3634,7 @@ ALTER TABLE ext_w_dist SET DISTRIBUTED BY (b);
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_dist'::regclass;
 ALTER TABLE ext_w_dist SET DISTRIBUTED RANDOMLY;
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_dist'::regclass;
+ALTER TABLE ext_w_dist SET DISTRIBUTED REPLICATED; -- ERROR
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';
 ALTER TABLE ext_r_dist SET DISTRIBUTED BY (a); -- should error out altering readable external tables' distribution policy

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4927,6 +4927,10 @@ SELECT * FROM test_part_integrity;
 (4 rows)
 
 DROP TABLE test_part_integrity;
+-- Testing creating external table with replicated distribution
+-- Should report error
+CREATE WRITABLE EXTERNAL WEB TABLE ext_dist_repl(a int, b int) EXECUTE 'some command' FORMAT 'TEXT' DISTRIBUTED REPLICATED;
+ERROR:  external tables can't have DISTRIBUTED REPLICATED clause
 -- Testing altering the distribution policy of external tables.
 CREATE WRITABLE EXTERNAL WEB TABLE ext_w_dist(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/ext_w_dist.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE ext_w_dist SET WITH (reorganize=true); -- should error out if forcing reorganize
@@ -4951,6 +4955,8 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
  p          | 
 (1 row)
 
+ALTER TABLE ext_w_dist SET DISTRIBUTED REPLICATED; -- ERROR
+ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table.
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
 ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4956,7 +4956,7 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
 (1 row)
 
 ALTER TABLE ext_w_dist SET DISTRIBUTED REPLICATED; -- ERROR
-ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table.
+ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
 ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -4958,7 +4958,7 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
 (1 row)
 
 ALTER TABLE ext_w_dist SET DISTRIBUTED REPLICATED; -- ERROR
-ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table.
+ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
 ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -4929,6 +4929,10 @@ SELECT * FROM test_part_integrity;
 (4 rows)
 
 DROP TABLE test_part_integrity;
+-- Testing creating external table with replicated distribution
+-- Should report error
+CREATE WRITABLE EXTERNAL WEB TABLE ext_dist_repl(a int, b int) EXECUTE 'some command' FORMAT 'TEXT' DISTRIBUTED REPLICATED;
+ERROR:  external tables can't have DISTRIBUTED REPLICATED clause
 -- Testing altering the distribution policy of external tables.
 CREATE WRITABLE EXTERNAL WEB TABLE ext_w_dist(a int, b int) EXECUTE 'cat > @abs_srcdir@/data/ext_w_dist.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ') DISTRIBUTED BY (a);
 ALTER TABLE ext_w_dist SET WITH (reorganize=true); -- should error out if forcing reorganize
@@ -4953,6 +4957,8 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
  p          | 
 (1 row)
 
+ALTER TABLE ext_w_dist SET DISTRIBUTED REPLICATED; -- ERROR
+ERROR:  SET DISTRIBUTED REPLICATED is not supported for external table.
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
 ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
 CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';


### PR DESCRIPTION
This PR is to fix the issue https://github.com/greenplum-db/gpdb/issues/16769.

Now `CREATE EXTERNAL TABLE ... DISTRIBUTED REPLICATED` will fail because gpdb don't support it.
But `ALTER EXTERNAL TABLE ... SET DISTRIBUTED REPLICATED` will succeed. This is unreasonable.
```
// Fail
testdb=# create writable external table tmp_ext_table_gpfdist_writable (id int, category text) location ('gpfdist://localhost.localdomain:8801/testWritable.tbl') format 'custom' (formatter="delimited_in", delimiter=";;;") distributed replicated;
ERROR:  external tables can't have DISTRIBUTED REPLICATED clause

// Succeed (NOT reasonable)
testdb=# create writable external table tmp_ext_table_gpfdist_writable (id int, category text) location ('gpfdist://localhost.localdomain:8801/testWritable.tbl') format 'custom' (formatter="delimited_in", delimiter=";;;");
CREATE EXTERNAL TABLE
testdb=# alter external table tmp_ext_table_gpfdist_writable set distributed replicated;
ALTER FOREIGN TABLE
testdb=# \d+ tmp_ext_table_gpfdist_writable
                           Foreign table "public.tmp_ext_table_gpfdist_writable"
  Column  |  Type   | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description
----------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
 id       | integer |           |          |         |             | plain    |              |
 category | text    |           |          |         |             | extended |              |
FDW options: (formatter 'delimited_in', delimiter ';;;', format 'custom', location_uris 'gpfdist://localhost.localdomain:8801/testWritable.tbl', execute_on 'ALL_SEGMENTS', log_errors 'disable', encoding 'UTF8', is_writable 'true')
Distributed Replicated
```

So this PR disables `ALTER EXTERNAL TABLE ... SET DISTRIBUTED REPLICATED`.