### PR TITLE
[6X] Fix SET command that sends DTX protocol command when shouldn't

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -315,12 +315,18 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 		cdbdisp_dispatchToGang(ds, rg, -1);
 	}
-	addToGxactDtxSegments(primaryGang);
 
 	/*
-	 * No need for two-phase commit, so no need to call
-	 * addToGxactDtxSegments.
+	 * If there is an explicit BEGIN, we'll begin transaction and setup DTX 
+	 * context on QEs at the time of the first SET command. So we need to
+	 * add dtxSegments to make sure we end the transaction at the time of END/COMMIT.
+	 *
+	 * We shouldn't do this when there's no explicit BEGIN, though, because
+	 * if QEs do not have DTX context being setup, they would not recognize
+	 * the DTX protocol command that is going to be sent to the dtxSegments.
 	 */
+	if (isDtxExplicitBegin())
+		addToGxactDtxSegments(primaryGang);
 
 	cdbdisp_waitDispatchFinish(ds);
 

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -885,3 +885,37 @@ select count(gp_segment_id) from distxact1_4 group by gp_segment_id; -- sanity c
      1
 (2 rows)
 
+-- Explicit transaction block will send Distributed Commit, even if there is only SET command in it.
+-- On the other hand, implicit transaction block involving only SET command will not send it.
+create table tbl_dtx(a int, b int) distributed by (a);
+insert into tbl_dtx values(1,1);
+create or replace function dtx_set_bug()
+  returns void
+  language plpgsql
+as $function$
+begin
+    execute 'update tbl_dtx set b = 1 where a = 1;';
+    set optimizer=off;
+end;
+$function$;
+set Test_print_direct_dispatch_info = true;
+-- 1. explicit BEGIN/END
+begin;
+set optimizer=false;
+end;
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+-- 2. implicit transaction block with just SET
+set optimizer=false;
+-- 3. still implicit transaction block, but with UPDATE that will send DTX protocol command to *some* QEs
+-- due to direct dispatch. Planner needs to be used for direct dispatch here.
+-- This is to verify that the QEs that are not involved in the UDPATE won't receive DTX protocol command 
+-- that they are not supposed to see.
+select dtx_set_bug();
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+ dtx_set_bug 
+-------------
+ 
+(1 row)
+
+reset Test_print_direct_dispatch_info;

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -608,3 +608,36 @@ end;
 reset test_print_direct_dispatch_info;
 reset optimizer;
 select count(gp_segment_id) from distxact1_4 group by gp_segment_id; -- sanity check: tuples should be in > 1 segments
+
+-- Explicit transaction block will send Distributed Commit, even if there is only SET command in it.
+-- On the other hand, implicit transaction block involving only SET command will not send it.
+create table tbl_dtx(a int, b int) distributed by (a);
+insert into tbl_dtx values(1,1);
+
+create or replace function dtx_set_bug()
+  returns void
+  language plpgsql
+as $function$
+begin
+    execute 'update tbl_dtx set b = 1 where a = 1;';
+    set optimizer=off;
+end;
+$function$;
+
+set Test_print_direct_dispatch_info = true;
+
+-- 1. explicit BEGIN/END
+begin;
+set optimizer=false;
+end;
+
+-- 2. implicit transaction block with just SET
+set optimizer=false;
+
+-- 3. still implicit transaction block, but with UPDATE that will send DTX protocol command to *some* QEs
+-- due to direct dispatch. Planner needs to be used for direct dispatch here.
+-- This is to verify that the QEs that are not involved in the UDPATE won't receive DTX protocol command 
+-- that they are not supposed to see.
+select dtx_set_bug();
+
+reset Test_print_direct_dispatch_info;


### PR DESCRIPTION
Backport from #16675. Clean merge, no conflict.

Original commit message:

If there is an explicit BEGIN, and if the transaction only has SET command, we will begin transaction and setup DTX context on QEs at the time of the first SET command. So we need to add dtxSegments in SET to make sure we end the transaction at the time of END/COMMIT. This is required since b43629b where we no longer start DTX at the time of BEGIN.

However, we should not do this when there's NO explicit BEGIN. Because in that case, QEs will not have DTX context setup with the SET command, so if we decide to send DTX protocol command later (e.g. we have some direct-dispatch command that requires DTX with part of the QEs), we will send DTX protocol command to ALL dtxSegments. As a result, some QE might fail to recognize the DTX protocol command and throw error. E.g.:

	create table t1(a int, b int);

	CREATE OR REPLACE FUNCTION dtx_bug()
	  RETURNS void
	  LANGUAGE plpgsql
	AS $function$
	BEGIN
	    EXECUTE 'UPDATE t1 set b = 1 where a = 1;';
	    set optimizer=off;
	END;
	$function$;

	postgres=# SELECT dtx_bug();
	ERROR:  Distributed transaction 16607 not found (cdbtm.c:2185)  (seg2 127.0.1.1:7004 pid=32375) (cdbtm.c:2185)

Fix the case by skipping adding dtxSegments when w/o explicit BEGIN/END. Also fix the comment in code and add test cases.
