### PR TITLE
docs - ip4r version 2.4.2

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
@@ -2,7 +2,7 @@
 
 The `ip4r` module provides IPv4 and IPv6 data types, IPv4 and IPv6 range index data types, and related functions and operators.
 
-The Greenplum Database `ip4r` module is equivalent to version 2.4.1 of the `ip4r` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
+The Greenplum Database `ip4r` module is equivalent to version 2.4.2 of the `ip4r` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
 
 ## <a id="topic_reg"></a>Installing and Registering the Module 
 


### PR DESCRIPTION
version 2.4.2 is bundled.

questions:  
1. the control file specifies version 2.4.  does this mean that the user will automatically get this new version of the ip4r library after they upgrade greenplum?  i.e. if the user is already using ip4r, it did not seem to me that an ALTER EXTENSION ... UPDATE TO ... was required here.  let me know if i am missing something.
2. will upcoming greenplum v6.26.0 include ip4r 2.4.2?
