### PR TITLE
docs - tablefunc to xref to pg v12 docs

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/tablefunc.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/tablefunc.html.md
@@ -16,5 +16,5 @@ CREATE EXTENSION tablefunc;
 
 ## <a id="topic_info"></a>Module Documentation 
 
-See [tablefunc](https://www.postgresql.org/docs/9.4/tablefunc.html) in the PostgreSQL documentation for detailed information about the individual functions in this module.
+See [tablefunc](https://www.postgresql.org/docs/12/tablefunc.html) in the PostgreSQL documentation for detailed information about the individual functions in this module.
 


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/16641 adds tablefunc to the 7 greenplum distribution.  we already have docs for this module, same as in greenplum 6:  https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-modules-tablefunc.html.

this PR updates the postgres xref to point to v12 version of the docs.

question:  these docs have been in greenplum 6 for a while.  let me know if i should create docs based on the postgres docs rather than link off.