### PR TITLE
[ORCA] Add plan hints for scan types

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/Hint-BitmapScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-BitmapScan-Over-Table.mdp
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a scan hint is used
+    specifying a bitmap scan on index (e.g. our_incredible_index), then that's
+    the scan type and index that should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+      CREATE INDEX some_bitmap_index ON hint_table_1 USING bitmap(a);
+      CREATE INDEX another_bitmap_index ON hint_table_1 USING bitmap(a);
+
+      /*+
+          BitmapScan(hint_table_1 some_bitmap_index)
+       */
+      EXPLAIN SELECT * FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="BitmapScan" IndexName="some_bitmap_index"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Index Mdid="7.389311.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389310.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389309.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389308.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.389305.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.389305.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.389308.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389309.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389310.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389311.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389312.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389315.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.389305.1.0" Name="hint_table_1"/>
+      <dxl:Index Mdid="7.389315.1.0" Name="another_bitmap_index" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389312.1.0" Name="some_bitmap_index" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.389305.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.389305.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="391.295563" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:BitmapTableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="391.295528" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:RecheckCond>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:RecheckCond>
+          <dxl:BitmapIndexProbe>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="7.389312.1.0" IndexName="some_bitmap_index"/>
+          </dxl:BitmapIndexProbe>
+          <dxl:TableDescriptor Mdid="6.389305.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:BitmapTableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-IndexOnlyScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-IndexOnlyScan-Over-Table.mdp
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a scan hint is used
+    specifying an index (e.g. our_incredible_index), then that's the index that
+    should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          IndexOnlyScan(hint_table_1 our_incredible_index)
+       */
+       EXPLAIN SELECT a FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="IndexOnlyScan" IndexName="our_incredible_index"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.389297.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.389297.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.389300.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389301.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389302.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389303.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.389303.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389302.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389301.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389300.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.389297.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.389297.1.0" Name="hint_table_1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000120" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexOnlyScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000102" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.389302.1.0" IndexName="our_incredible_index"/>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexOnlyScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-IndexScan-Over-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-IndexScan-Over-Join.mdp
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a join on table with multiple indexes, if a scan hint is
+    used specifying an index (e.g. our_incredible_index), then that's the index
+    that should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          IndexScan(t1 our_incredible_index)
+       */
+      EXPLAIN SELECT * FROM hint_table_1 AS t1 JOIN hint_table_1 AS t2 ON t1.a=t2.a;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="t1" OperatorName="IndexScan" IndexName="our_incredible_index"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.123814.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="6.123814.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.123817.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.123818.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.123819.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.123820.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.123820.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.123819.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.123818.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.123817.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.123814.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.123814.1.0" Name="hint_table_1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.123814.1.0" TableName="t1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.123814.1.0" TableName="t2" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="437.000225" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="437.000166" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.123814.1.0" TableName="t2" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:IndexScan IndexScanDirection="Forward">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:Partitions/>
+            <dxl:IndexDescriptor Mdid="7.123819.1.0" IndexName="our_incredible_index"/>
+            <dxl:TableDescriptor Mdid="6.123814.1.0" TableName="t1" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:IndexScan>
+          <dxl:NLJIndexParamList>
+            <dxl:NLJIndexParam ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:NLJIndexParamList>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-IndexScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-IndexScan-Over-Table.mdp
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a scan hint is used
+    specifying an index (e.g. our_incredible_index), then that's the index that
+    should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          IndexScan(hint_table_1 our_incredible_index)
+       */
+       EXPLAIN SELECT * FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="IndexScan" IndexName="our_incredible_index"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.119969.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="6.119969.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.119972.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.119973.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.119974.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.119974.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.119973.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.119972.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.119969.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.119969.1.0" Name="hint_table_1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.119969.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000136" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.119973.1.0" IndexName="our_incredible_index"/>
+          <dxl:TableDescriptor Mdid="6.119969.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-NoBitmapScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-NoBitmapScan-Over-Table.mdp
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with a bitmap index, if a no bitmap scan hint is
+    used , then plan should not include bitmap scan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX some_bitmap_index ON hint_table_1 USING bitmap(a);
+      CREATE INDEX another_bitmap_index ON hint_table_1 USING bitmap(a);
+
+      /*+
+          NoBitmapScan(hint_table_1)
+       */
+      EXPLAIN SELECT * FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="NoBitmapScan" IndexName="some_bitmap_index"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.322285.1.0" Name="hint_table_1"/>
+      <dxl:Index Mdid="7.322291.1.0" Name="another_bitmap_index" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322288.1.0" Name="some_bitmap_index" IsClustered="false" AmCanOrder="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.322285.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.322285.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.322288.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322291.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.322285.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.322285.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.322285.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-NoIndexOnlyScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-NoIndexOnlyScan-Over-Table.mdp
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a scan hint is used
+    specifying no index only scan, then plan should not include index only scan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          NoIndexOnlyScan(hint_table_1)
+       */
+       EXPLAIN SELECT a FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="NoIndexOnlyScan"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.322277.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.322277.1.0" Name="hint_table_1"/>
+      <dxl:RelationStatistics Mdid="2.322277.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.322277.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.322280.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322281.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322282.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322283.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.322283.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322282.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322281.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322280.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.322277.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="5">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.000119" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.322280.1.0" IndexName="my_awesome_index"/>
+          <dxl:TableDescriptor Mdid="6.322277.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-NoIndexScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-NoIndexScan-Over-Table.mdp
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a no index scan hint is
+    used then no indexes should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          NoSeqScan(hint_table_1)
+       */
+       EXPLAIN SELECT * FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="NoIndexScan"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationExtendedStatistics Mdid="10.322269.1.0" Name="hint_table_1"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Index Mdid="7.322275.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322274.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.322269.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Index Mdid="7.322273.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.322272.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.322269.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.322269.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.322272.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322273.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322274.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.322275.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.322269.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.322269.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-SeqScan-Over-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-SeqScan-Over-Join.mdp
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a seq scan hint is used
+    then no indexes should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          SeqScan(t1)
+          SeqScan(t2)
+       */
+      EXPLAIN SELECT * FROM hint_table_1 AS t1 JOIN hint_table_1 AS t2 ON t1.a=t2.a;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="t1" OperatorName="SeqScan"/>
+        <dxl:ScanHint Alias="t2" OperatorName="SeqScan"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.389297.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.389297.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.389300.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389301.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389302.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389303.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.389303.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389302.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389301.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389300.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.389297.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.389297.1.0" Name="hint_table_1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="t1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="t2" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="8">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000610" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000550" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="t1" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="t2" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Hint-SeqScan-Over-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hint-SeqScan-Over-Table.mdp
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Given a table with multiple indexes, if a seq scan hint is used
+    then no indexes should be used in the plan.
+
+      LOAD 'pg_hint_plan';
+
+      -- Test hints using scan types
+      CREATE TABLE hint_table_1(a int, b int);
+      CREATE INDEX my_awesome_index ON hint_table_1(a);
+      CREATE INDEX your_amazing_index ON hint_table_1(a);
+      CREATE INDEX our_incredible_index ON hint_table_1(a);
+      CREATE INDEX their_awesome_index ON hint_table_1(a);
+
+      /*+
+          SeqScan(hint_table_1)
+       */
+       EXPLAIN SELECT * FROM hint_table_1 WHERE a=42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint>
+        <dxl:ScanHint Alias="hint_table_1" OperatorName="SeqScan"/>
+      </dxl:PlanHint>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.389297.1.0" Name="hint_table_1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.389297.1.0" Name="hint_table_1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.389300.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389301.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389302.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.389303.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.389303.1.0" Name="their_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389302.1.0" Name="our_incredible_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389301.1.0" Name="your_amazing_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Index Mdid="7.389300.1.0" Name="my_awesome_index" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="" ReturnableColumns="0" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.389297.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationExtendedStatistics Mdid="10.389297.1.0" Name="hint_table_1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.389297.1.0" TableName="hint_table_1" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/hints/CHintUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/hints/CHintUtils.h
@@ -1,0 +1,53 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CHintUtils.h
+//---------------------------------------------------------------------------
+#ifndef GPOS_CHintUtils_H
+#define GPOS_CHintUtils_H
+
+#include "gpos/base.h"
+
+#include "gpopt/hints/CPlanHint.h"
+#include "gpopt/operators/CLogicalDynamicGet.h"
+#include "gpopt/operators/CLogicalDynamicIndexGet.h"
+#include "gpopt/operators/CLogicalGet.h"
+#include "gpopt/operators/CLogicalIndexGet.h"
+#include "gpopt/operators/COperator.h"
+#include "gpopt/operators/CScalarBitmapIndexProbe.h"
+
+namespace gpopt
+{
+class CHintUtils
+{
+public:
+	// Check if CLogicalGet operator satisfies plan hints
+	static BOOL SatisfiesPlanHints(CLogicalGet *pop, CPlanHint *plan_hint);
+
+	// Check if CLogicalIndexGet operator satisfies plan hints
+	static BOOL SatisfiesPlanHints(CLogicalIndexGet *pop, CPlanHint *plan_hint);
+
+	// Check if CLogicalDynamicGet operator satisfies plan hints
+	static BOOL SatisfiesPlanHints(CLogicalDynamicGet *pop,
+								   CPlanHint *plan_hint);
+
+	// Check if CLogicalDynamicIndexGet operator satisfies plan hints
+	static BOOL SatisfiesPlanHints(CLogicalDynamicIndexGet *pop,
+								   CPlanHint *plan_hint);
+
+	// Check if CScalarBitmapIndexProbe operator satisfies plan hints
+	static BOOL SatisfiesPlanHints(CScalarBitmapIndexProbe *pop,
+								   CPlanHint *plan_hint);
+
+	static const WCHAR *ScanHintEnumToString(CScanHint::EType type);
+
+	static CScanHint::EType ScanHintStringToEnum(const WCHAR *type);
+};
+
+}  // namespace gpopt
+
+#endif	// !GPOS_CHintUtils_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/hints/CPlanHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/hints/CPlanHint.h
@@ -1,0 +1,58 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CPlanHint.h
+//
+//	@doc:
+//		CPlanHint is a container for all hints (IHint) used by a query.
+//---------------------------------------------------------------------------
+#ifndef GPOS_CPlanHint_H
+#define GPOS_CPlanHint_H
+
+#include "gpos/base.h"
+#include "gpos/common/CDynamicPtrArray.h"
+#include "gpos/common/CRefCount.h"
+
+#include "gpopt/hints/CScanHint.h"
+#include "gpopt/hints/IHint.h"
+#include "gpopt/operators/COperator.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+namespace gpopt
+{
+//---------------------------------------------------------------------------
+//	@class:
+//		CPlanHint
+//---------------------------------------------------------------------------
+class CPlanHint : public CRefCount, public DbgPrintMixin<CPlanHint>
+{
+private:
+	CMemoryPool *m_mp{nullptr};
+
+	ScanHintList *m_scan_hints{nullptr};
+
+public:
+	CPlanHint(CMemoryPool *mp);
+
+	~CPlanHint() override;
+
+	// Add a scan hint
+	void AddHint(CScanHint *hint);
+
+	// Get a scan hint that matches a name (table or alias)
+	CScanHint *GetScanHint(const char *name);
+	CScanHint *GetScanHint(const CWStringBase *name);
+
+	IOstream &OsPrint(IOstream &os) const;
+
+	void Serialize(CXMLSerializer *xml_serializer) const;
+};	// class CPlanHint
+
+}  // namespace gpopt
+
+
+#endif	// !GPOS_CPlanHint_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/hints/CScanHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/hints/CScanHint.h
@@ -1,0 +1,112 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CScanHint.h
+//
+//	@doc:
+//		CScanHint represents an ORCA optimizer hint that favors a specific scan
+//		type (e.g. index scan, bitmap scan, seq scan) on a specific relation
+//		(identified by table name or alias) in a query.
+//---------------------------------------------------------------------------
+#ifndef GPOS_CScanHint_H
+#define GPOS_CScanHint_H
+
+#include <vector>
+
+#include "gpos/base.h"
+#include "gpos/common/CDynamicPtrArray.h"
+#include "gpos/common/CEnumSet.h"
+#include "gpos/common/CEnumSetIter.h"
+#include "gpos/common/CRefCount.h"
+
+#include "gpopt/hints/IHint.h"
+#include "gpopt/operators/COperator.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+namespace gpopt
+{
+class CScanHint : public IHint, public DbgPrintMixin<CScanHint>
+{
+public:
+	enum EType
+	{
+		SeqScan,
+		NoSeqScan,
+		IndexScan,
+		NoIndexScan,
+		IndexOnlyScan,
+		NoIndexOnlyScan,
+		BitmapScan,
+		NoBitmapScan,
+
+		Sentinal
+	};
+
+	using CEHintTypeSet = CEnumSet<CScanHint::EType, CScanHint::Sentinal>;
+	using CEHintTypeSetSetIter =
+		CEnumSetIter<CScanHint::EType, CScanHint::Sentinal>;
+
+protected:
+	CMemoryPool *m_mp;
+
+private:
+	// relation or alias used in the query
+	const CWStringBase *m_name;
+
+	// specfied index names (if any) for index and bitmap scans
+	StringPtrArray *m_indexnames;
+
+	// all scan hint associated with this relation
+	CEHintTypeSet *m_types;
+
+public:
+	CScanHint(CMemoryPool *mp, const CWStringBase *name,
+			  StringPtrArray *indexnames)
+		: m_mp(mp),
+		  m_name(name),
+		  m_indexnames(indexnames),
+		  m_types(GPOS_NEW(mp) CEHintTypeSet(mp))
+	{
+	}
+
+	~CScanHint() override
+	{
+		GPOS_DELETE(m_name);
+		m_indexnames->Release();
+		m_types->Release();
+	}
+
+	const CWStringBase *
+	GetName() const
+	{
+		return m_name;
+	}
+
+	const StringPtrArray *
+	GetIndexNames() const
+	{
+		return m_indexnames;
+	}
+
+	void
+	AddType(CScanHint::EType type)
+	{
+		m_types->ExchangeSet(type);
+	}
+
+	virtual BOOL SatisfiesOperator(COperator *op) const;
+
+	virtual IOstream &OsPrint(IOstream &os) const;
+
+	virtual void Serialize(CXMLSerializer *xml_serializer) const;
+};
+
+using ScanHintList = CDynamicPtrArray<CScanHint, CleanupRelease>;
+
+}  // namespace gpopt
+
+#endif	// !GPOS_CScanHint_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/hints/IHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/hints/IHint.h
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		IHint.h
+//---------------------------------------------------------------------------
+#ifndef GPOS_IHint_H
+#define GPOS_IHint_H
+
+#include "gpos/base.h"
+#include "gpos/common/CRefCount.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+class IHint : public CRefCount
+{
+};
+
+
+}  // namespace gpopt
+
+#endif	// !GPOS_IHint_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarBitmapIndexProbe.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarBitmapIndexProbe.h
@@ -20,6 +20,7 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CScalar.h"
 
 namespace gpopt
@@ -42,6 +43,9 @@ private:
 	// index descriptor
 	CIndexDescriptor *m_pindexdesc;
 
+	// table descriptor
+	CTableDescriptor *m_ptabdesc;
+
 	// bitmap type id
 	IMDId *m_pmdidBitmapType;
 
@@ -51,7 +55,7 @@ private:
 public:
 	// ctor
 	CScalarBitmapIndexProbe(CMemoryPool *mp, CIndexDescriptor *pindexdesc,
-							IMDId *pmdidBitmapType);
+							CTableDescriptor *ptabdesc, IMDId *pmdidBitmapType);
 
 	// ctor
 	// only for transforms
@@ -65,6 +69,13 @@ public:
 	Pindexdesc() const
 	{
 		return m_pindexdesc;
+	}
+
+	// return table's descriptor
+	CTableDescriptor *
+	Ptabdesc() const
+	{
+		return m_ptabdesc;
 	}
 
 	// bitmap type id

--- a/src/backend/gporca/libgpopt/include/gpopt/optimizer/COptimizerConfig.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/optimizer/COptimizerConfig.h
@@ -21,6 +21,7 @@
 #include "gpopt/engine/CEnumeratorConfig.h"
 #include "gpopt/engine/CHint.h"
 #include "gpopt/engine/CStatisticsConfig.h"
+#include "gpopt/hints/CPlanHint.h"
 
 namespace gpopt
 {
@@ -62,6 +63,9 @@ private:
 	// hint configuration
 	CHint *m_hint;
 
+	// optimizer plan hints
+	CPlanHint *m_plan_hint{nullptr};
+
 	// default window oids
 	CWindowOids *m_window_oids;
 
@@ -69,7 +73,7 @@ public:
 	// ctor
 	COptimizerConfig(CEnumeratorConfig *pec, CStatisticsConfig *stats_config,
 					 CCTEConfig *pcteconf, ICostModel *pcm, CHint *phint,
-					 CWindowOids *pdefoidsGPDB);
+					 CPlanHint *pplanhint, CWindowOids *pdefoidsGPDB);
 
 	// dtor
 	~COptimizerConfig() override;
@@ -115,6 +119,12 @@ public:
 	GetHint() const
 	{
 		return m_hint;
+	}
+
+	CPlanHint *
+	GetPlanHint() const
+	{
+		return m_plan_hint;
 	}
 
 	// generate default optimizer configurations

--- a/src/backend/gporca/libgpopt/src/Makefile
+++ b/src/backend/gporca/libgpopt/src/Makefile
@@ -10,7 +10,7 @@ include $(top_builddir)/src/Makefile.global
 
 include $(top_srcdir)/src/backend/gporca/gporca.mk
 
-SUBDIRS     = base engine eval mdcache metadata minidump operators optimizer search translate xforms
+SUBDIRS     = base engine eval hints mdcache metadata minidump operators optimizer search translate xforms
 OBJS        = exception.o init.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/gporca/libgpopt/src/hints/CHintUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/hints/CHintUtils.cpp
@@ -1,0 +1,241 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CHintUtils.cpp
+//
+//	@doc:
+//		Utilitiies for plan hint objects
+//---------------------------------------------------------------------------
+
+#include "gpopt/hints/CHintUtils.h"
+
+#include "gpos/common/clibwrapper.h"
+
+using namespace gpopt;
+
+
+// Find a scan hint that matches the operator based on the relation or alias
+// name.
+template <typename T>
+static CScanHint *
+GetScanHint(T *pop, CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	if (nullptr == plan_hint)
+	{
+		// no parsed hints
+		return nullptr;
+	}
+
+	const CWStringConst *name = pop->Ptabdesc()->Name().Pstr();
+
+	return plan_hint->GetScanHint(name);
+}
+
+
+BOOL
+CHintUtils::SatisfiesPlanHints(CLogicalGet *pop, CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	CScanHint *scan_hint = GetScanHint(pop, plan_hint);
+	if (scan_hint == nullptr)
+	{
+		// no matched hint, so everything goes...
+		return true;
+	}
+
+	// If opertor matches hint operator _or_ it doesn't match and is a not.
+	return scan_hint->SatisfiesOperator(pop);
+}
+
+BOOL
+CHintUtils::SatisfiesPlanHints(CLogicalIndexGet *pop, CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	CScanHint *scan_hint = GetScanHint(pop, plan_hint);
+	if (scan_hint == nullptr)
+	{
+		// no matched hint, so everything goes...
+		return true;
+	}
+
+	for (ULONG ul = 0; ul < scan_hint->GetIndexNames()->Size(); ul++)
+	{
+		if (pop->Pindexdesc()->Name().Pstr()->Equals(
+				(*scan_hint->GetIndexNames())[ul]))
+		{
+			// If opertor matches hint operator and index matches hint index.
+			return scan_hint->SatisfiesOperator(pop);
+		}
+	}
+
+	return scan_hint->GetIndexNames()->Size() == 0 &&
+		   scan_hint->SatisfiesOperator(pop);
+}
+
+
+BOOL
+CHintUtils::SatisfiesPlanHints(CLogicalDynamicGet *pop, CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	CScanHint *scan_hint = GetScanHint(pop, plan_hint);
+	if (scan_hint == nullptr)
+	{
+		// no matched hint, so everything goes...
+		return true;
+	}
+
+	return scan_hint->SatisfiesOperator(pop);
+}
+
+
+BOOL
+CHintUtils::SatisfiesPlanHints(CLogicalDynamicIndexGet *pop,
+							   CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	CScanHint *scan_hint = GetScanHint(pop, plan_hint);
+	if (scan_hint == nullptr)
+	{
+		// no matched hint, so everything goes...
+		return true;
+	}
+
+	for (ULONG ul = 0; ul < scan_hint->GetIndexNames()->Size(); ul++)
+	{
+		if (pop->Pindexdesc()->Name().Pstr()->Equals(
+				(*scan_hint->GetIndexNames())[ul]))
+		{
+			// If opertor matches hint operator and index matches hint index.
+			return scan_hint->SatisfiesOperator(pop);
+		}
+	}
+
+	return scan_hint->GetIndexNames()->Size() == 0 &&
+		   scan_hint->SatisfiesOperator(pop);
+}
+
+
+BOOL
+CHintUtils::SatisfiesPlanHints(CScalarBitmapIndexProbe *pop,
+							   CPlanHint *plan_hint)
+{
+	GPOS_ASSERT(nullptr != pop);
+
+	CScanHint *scan_hint = GetScanHint(pop, plan_hint);
+	if (scan_hint == nullptr)
+	{
+		// no matched hint, so everything goes...
+		return true;
+	}
+
+	for (ULONG ul = 0; ul < scan_hint->GetIndexNames()->Size(); ul++)
+	{
+		if (pop->Pindexdesc()->Name().Pstr()->Equals(
+				(*scan_hint->GetIndexNames())[ul]))
+		{
+			// If opertor matches hint operator and index matches hint index.
+			return scan_hint->SatisfiesOperator(pop);
+		}
+	}
+
+	return scan_hint->GetIndexNames()->Size() == 0 &&
+		   scan_hint->SatisfiesOperator(pop);
+}
+
+const WCHAR *
+CHintUtils::ScanHintEnumToString(CScanHint::EType type)
+{
+	switch (type)
+	{
+		case CScanHint::SeqScan:
+		{
+			return GPOS_WSZ_LIT("SeqScan");
+		}
+		case CScanHint::NoSeqScan:
+		{
+			return GPOS_WSZ_LIT("NoSeqScan");
+		}
+		case CScanHint::IndexScan:
+		{
+			return GPOS_WSZ_LIT("IndexScan");
+		}
+		case CScanHint::NoIndexScan:
+		{
+			return GPOS_WSZ_LIT("NoIndexScan");
+		}
+		case CScanHint::IndexOnlyScan:
+		{
+			return GPOS_WSZ_LIT("IndexOnlyScan");
+		}
+		case CScanHint::NoIndexOnlyScan:
+		{
+			return GPOS_WSZ_LIT("NoIndexOnlyScan");
+		}
+		case CScanHint::BitmapScan:
+		{
+			return GPOS_WSZ_LIT("BitmapScan");
+		}
+		case CScanHint::NoBitmapScan:
+		{
+			return GPOS_WSZ_LIT("NoBitmapScan");
+		}
+		default:
+		{
+			return nullptr;
+		}
+	}
+}
+
+CScanHint::EType
+CHintUtils::ScanHintStringToEnum(const WCHAR *type)
+{
+	if (0 ==
+		clib::Wcsncmp(type, GPOS_WSZ_LIT("SeqScan"), gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::SeqScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("NoSeqScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::NoSeqScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("IndexScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::IndexScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("NoIndexScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::NoIndexScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("IndexOnlyScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::IndexOnlyScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("NoIndexOnlyScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::NoIndexOnlyScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("BitmapScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::BitmapScan;
+	}
+	if (0 == clib::Wcsncmp(type, GPOS_WSZ_LIT("NoBitmapScan"),
+						   gpos::clib::Wcslen(type)))
+	{
+		return CScanHint::NoBitmapScan;
+	}
+	return CScanHint::Sentinal;
+}

--- a/src/backend/gporca/libgpopt/src/hints/CPlanHint.cpp
+++ b/src/backend/gporca/libgpopt/src/hints/CPlanHint.cpp
@@ -1,0 +1,93 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CPlanHint.cpp
+//
+//	@doc:
+//		Container of plan hint objects
+//---------------------------------------------------------------------------
+
+#include "gpopt/hints/CPlanHint.h"
+
+#include "gpos/base.h"
+
+using namespace gpopt;
+
+FORCE_GENERATE_DBGSTR(CPlanHint);
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPlanHint::CPlanHint
+//---------------------------------------------------------------------------
+CPlanHint::CPlanHint(CMemoryPool *mp)
+	: m_mp(mp), m_scan_hints(GPOS_NEW(mp) ScanHintList(mp))
+{
+}
+
+CPlanHint::~CPlanHint()
+{
+	m_scan_hints->Release();
+}
+
+void
+CPlanHint::AddHint(CScanHint *hint)
+{
+	m_scan_hints->Append(hint);
+}
+
+CScanHint *
+CPlanHint::GetScanHint(const char *relname)
+{
+	CWStringConst *name = GPOS_NEW(m_mp) CWStringConst(m_mp, relname);
+	CScanHint *hint = GetScanHint(name);
+	GPOS_DELETE(name);
+	return hint;
+}
+
+CScanHint *
+CPlanHint::GetScanHint(const CWStringBase *name)
+{
+	for (ULONG ul = 0; ul < m_scan_hints->Size(); ul++)
+	{
+		CScanHint *hint = (*m_scan_hints)[ul];
+		if (name->Equals(hint->GetName()))
+		{
+			return hint;
+		}
+	}
+	return nullptr;
+}
+
+IOstream &
+CPlanHint::OsPrint(IOstream &os) const
+{
+	os << "PlanHint: [";
+	if (nullptr == m_scan_hints)
+	{
+		os << "]";
+		return os;
+	}
+
+	os << "\n";
+	for (ULONG ul = 0; ul < m_scan_hints->Size(); ul++)
+	{
+		os << "  ";
+		(*m_scan_hints)[ul]->OsPrint(os) << "\n";
+	}
+	os << "]";
+	return os;
+}
+
+void
+CPlanHint::Serialize(CXMLSerializer *xml_serializer) const
+{
+	for (ULONG ul = 0; ul < m_scan_hints->Size(); ul++)
+	{
+		(*m_scan_hints)[ul]->Serialize(xml_serializer);
+	}
+}
+
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/hints/CScanHint.cpp
+++ b/src/backend/gporca/libgpopt/src/hints/CScanHint.cpp
@@ -1,0 +1,146 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2023 VMware, Inc. or its affiliates. All Rights Reserved.
+//
+//	@filename:
+//		CScanHint.cpp
+//
+//	@doc:
+//		Container of plan hint objects
+//---------------------------------------------------------------------------
+
+#include "gpopt/hints/CScanHint.h"
+
+#include "gpopt/exception.h"
+#include "gpopt/hints/CHintUtils.h"
+#include "naucrates/dxl/CDXLUtils.h"
+
+using namespace gpopt;
+
+FORCE_GENERATE_DBGSTR(CScanHint);
+
+
+BOOL
+CScanHint::SatisfiesOperator(COperator *op) const
+{
+	BOOL is_satisfied = true;
+
+	CEHintTypeSetSetIter type_info(*m_types);
+	while (type_info.Advance() && is_satisfied)
+	{
+		switch (type_info.TBit())
+		{
+			case SeqScan:
+			{
+				is_satisfied = op->Eopid() == COperator::EopLogicalDynamicGet ||
+							   op->Eopid() == COperator::EopLogicalGet;
+				break;
+			}
+			case NoSeqScan:
+			{
+				is_satisfied = op->Eopid() != COperator::EopLogicalDynamicGet &&
+							   op->Eopid() != COperator::EopLogicalGet;
+				break;
+			}
+			case IndexScan:
+			{
+				is_satisfied =
+					op->Eopid() == COperator::EopLogicalDynamicIndexGet ||
+					op->Eopid() == COperator::EopLogicalIndexGet;
+				break;
+			}
+			case NoIndexScan:
+			{
+				is_satisfied =
+					op->Eopid() != COperator::EopLogicalDynamicIndexGet &&
+					op->Eopid() != COperator::EopLogicalIndexGet;
+				break;
+			}
+			case IndexOnlyScan:
+			{
+				is_satisfied =
+					op->Eopid() == COperator::EopLogicalDynamicIndexOnlyGet ||
+					op->Eopid() == COperator::EopLogicalIndexOnlyGet;
+				break;
+			}
+			case NoIndexOnlyScan:
+			{
+				is_satisfied =
+					op->Eopid() != COperator::EopLogicalDynamicIndexOnlyGet &&
+					op->Eopid() != COperator::EopLogicalIndexOnlyGet;
+				break;
+			}
+			case BitmapScan:
+			{
+				is_satisfied =
+					op->Eopid() == COperator::EopScalarBitmapIndexProbe;
+				break;
+			}
+			case NoBitmapScan:
+			{
+				is_satisfied =
+					op->Eopid() != COperator::EopScalarBitmapIndexProbe;
+				break;
+			}
+			default:
+			{
+				CWStringDynamic *error_message = GPOS_NEW(m_mp)
+					CWStringDynamic(m_mp, GPOS_WSZ_LIT("Unknown scan type: "));
+
+				GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
+						   error_message->GetBuffer());
+			}
+		}
+	}
+	return is_satisfied;
+}
+
+IOstream &
+CScanHint::OsPrint(IOstream &os) const
+{
+	os << "ScanHint: " << m_name->GetBuffer() << "[";
+	os << "indexes:";
+	CWStringDynamic *indexes =
+		CDXLUtils::SerializeToCommaSeparatedString(m_mp, GetIndexNames());
+	os << indexes->GetBuffer();
+	GPOS_DELETE(indexes);
+
+	os << " types:";
+	CWStringDynamic *hints =
+		CDXLUtils::Serialize(m_mp, m_types, CHintUtils::ScanHintEnumToString);
+	os << hints->GetBuffer();
+	GPOS_DELETE(hints);
+
+	os << "]";
+	return os;
+}
+
+void
+CScanHint::Serialize(CXMLSerializer *xml_serializer) const
+{
+	xml_serializer->OpenElement(
+		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
+		CDXLTokens::GetDXLTokenStr(EdxltokenScanHint));
+
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenAlias),
+								 GetName());
+
+	CWStringDynamic *hints =
+		CDXLUtils::Serialize(m_mp, m_types, CHintUtils::ScanHintEnumToString);
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenOpName),
+								 hints);
+	GPOS_DELETE(hints);
+
+	if (GetIndexNames()->Size() > 0)
+	{
+		CWStringDynamic *indexes =
+			CDXLUtils::SerializeToCommaSeparatedString(m_mp, GetIndexNames());
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenIndexName), indexes);
+		GPOS_DELETE(indexes);
+	}
+
+	xml_serializer->CloseElement(
+		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
+		CDXLTokens::GetDXLTokenStr(EdxltokenScanHint));
+}

--- a/src/backend/gporca/libgpopt/src/hints/Makefile
+++ b/src/backend/gporca/libgpopt/src/hints/Makefile
@@ -1,0 +1,16 @@
+#
+# Makefile for optimizer
+#
+# src/backend/gporca/libgpopt/src/hints/Makefile
+#
+
+subdir = src/backend/gporca/libgpopt/src/hints
+top_builddir = ../../../../../..
+include $(top_builddir)/src/Makefile.global
+
+include $(top_srcdir)/src/backend/gporca/gporca.mk
+
+OBJS        = CPlanHint.o CScanHint.o CHintUtils.o
+
+include $(top_srcdir)/src/backend/common.mk
+

--- a/src/backend/gporca/libgpopt/src/hints/README
+++ b/src/backend/gporca/libgpopt/src/hints/README
@@ -1,0 +1,116 @@
+What are hints?
+--------------
+
+A hint allows the user to override the optimizer in order to coerce a plan
+shape by disregarding its estimated cost compared to alternative plans. It may
+only be used to coerce plans that exist in ORCA's plan space.
+
+In Greenplum, plan hints are enabled through a custom extension [1] that
+provides a similar interface to pg_hint_plan [2], which is based on Postgres.
+
+
+Parser
+------
+
+Writing a parser is hard. Instead, let's utilize the parser provided by
+pg_hint_plan. But, how can ORCA access an extension's parsed data structures?
+Hooks!
+
+When the hint extension is loaded, it sets plan_hint_hook to the hint parser
+routine. When ORCA finds plan_hint_hook is set, it executes the parser routine
+and then translates the pg_hint_plan HintState into ORCA hint structures.
+
+There are 4 hint types:
+
+  1. Scan
+  2. Row
+  3. Join
+  4. Motion
+
+
+Hint Container
+--------------
+
+CPlanHint is a container that holds all the parsed hints. It is a globally
+accessible structure attached to COptimizerConfig.
+
+In DXL format it might look like:
+```
+<dxl:OptimizerConfig>
+  ...
+  <dxl:PlanHint>
+    <dxl:ScanHint Alias="table_1" OperatorName="NoIndexScan,NoIndexOnlyScan"/>
+    <dxl:ScanHint Alias="table_2" OperatorName="ScanScan"/>
+    <dxl:ScanHint Alias="table_3" OperatorName="IndexScan" IndexName="my_awesome_index"/>
+  </dxl:PlanHint>
+  ...
+</dxl:OptimizerConfig>
+```
+
+
+Scan Hints
+----------
+
+How is it represented?
+
+CScanHint contains all the scan hints on a single relation. There may be more
+than one hint per relation.
+
+How does it work?
+
+In exploration phase, transfoms add logical plan alternatives. If scan hints
+are specified, then the transformed operators must satisfy the hints in order
+to be considered as a valid alternative.
+
+Each relevant operator has a CHintUtils::SatisfiesPlanHints() function. That
+function is responsible for checking that the proposed alternative operator
+satisfies all corresponding hints.
+
+Each scan hint specifies one ore more scan types (e.g. NoSeqScan, NoIndexScan,
+etc). It is the responsiblity of CScanHint::SatisfiesOperator() to check that
+the proposed alternative operator satisfies all of the hint's scan types.
+
+
+Row Hints
+---------
+TODO
+
+
+Join Hints
+----------
+TODO
+
+
+Motion Hints
+------------
+TODO
+
+
+Supported Hints
+---------------
+  SeqScan
+  NoSeqScan
+  IndexScan
+  NoIndexScan
+  IndexOnlyScan
+  NoIndexOnlyScan,
+  BitmapScan
+  NoBitmapScan.
+
+
+Unsupported Hints
+-----------------
+  TidScan
+  NoTidScan
+  NestLoop
+  NoNestLoop
+  HashJoin
+  NoHashJoin
+  MergeJoin,
+  NoMergeJoin
+  Leading
+  Rows
+  Parallel
+
+[1] https://github.com/pivotal/pg_hint_plan/tree/PG12
+[2] https://github.com/ossc-db/pg_hint_plan

--- a/src/backend/gporca/libgpopt/src/operators/CScalarBitmapIndexProbe.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarBitmapIndexProbe.cpp
@@ -38,11 +38,16 @@ using namespace gpopt;
 //---------------------------------------------------------------------------
 CScalarBitmapIndexProbe::CScalarBitmapIndexProbe(CMemoryPool *mp,
 												 CIndexDescriptor *pindexdesc,
+												 CTableDescriptor *ptabdesc,
 												 IMDId *pmdidBitmapType)
-	: CScalar(mp), m_pindexdesc(pindexdesc), m_pmdidBitmapType(pmdidBitmapType)
+	: CScalar(mp),
+	  m_pindexdesc(pindexdesc),
+	  m_ptabdesc(ptabdesc),
+	  m_pmdidBitmapType(pmdidBitmapType)
 {
 	GPOS_ASSERT(nullptr != mp);
 	GPOS_ASSERT(nullptr != pindexdesc);
+	GPOS_ASSERT(nullptr != ptabdesc);
 	GPOS_ASSERT(nullptr != pmdidBitmapType);
 }
 
@@ -57,6 +62,7 @@ CScalarBitmapIndexProbe::CScalarBitmapIndexProbe(CMemoryPool *mp,
 CScalarBitmapIndexProbe::~CScalarBitmapIndexProbe()
 {
 	m_pindexdesc->Release();
+	m_ptabdesc->Release();
 	m_pmdidBitmapType->Release();
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicGet2DynamicTableScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicGet2DynamicTableScan.cpp
@@ -13,10 +13,12 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/hints/CHintUtils.h"
 #include "gpopt/metadata/CPartConstraint.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CLogicalDynamicGet.h"
 #include "gpopt/operators/CPhysicalDynamicTableScan.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 
 using namespace gpopt;
 
@@ -69,6 +71,13 @@ CXformDynamicGet2DynamicTableScan::Transform(CXformContext *pxfctxt,
 	GPOS_ASSERT(FCheckPattern(pexpr));
 
 	CLogicalDynamicGet *popGet = CLogicalDynamicGet::PopConvert(pexpr->Pop());
+	if (!CHintUtils::SatisfiesPlanHints(
+			popGet,
+			COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetPlanHint()))
+	{
+		return;
+	}
+
 	CMemoryPool *mp = pxfctxt->Pmp();
 
 	// create/extract components for alternative

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexGet2DynamicIndexScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexGet2DynamicIndexScan.cpp
@@ -13,11 +13,13 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/hints/CHintUtils.h"
 #include "gpopt/metadata/CPartConstraint.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CLogicalDynamicIndexGet.h"
 #include "gpopt/operators/CPatternLeaf.h"
 #include "gpopt/operators/CPhysicalDynamicIndexScan.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 
 using namespace gpopt;
 
@@ -80,6 +82,13 @@ CXformDynamicIndexGet2DynamicIndexScan::Transform(
 	CLogicalDynamicIndexGet *popIndexGet =
 		CLogicalDynamicIndexGet::PopConvert(pexpr->Pop());
 	CMemoryPool *mp = pxfctxt->Pmp();
+
+	if (!CHintUtils::SatisfiesPlanHints(
+			popIndexGet,
+			COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetPlanHint()))
+	{
+		return;
+	}
 
 	// create/extract components for alternative
 	CName *pname = GPOS_NEW(mp) CName(mp, popIndexGet->Name());

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexOnlyGet2DynamicIndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicIndexOnlyGet2DynamicIndexOnlyScan.cpp
@@ -13,11 +13,13 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/hints/CHintUtils.h"
 #include "gpopt/metadata/CPartConstraint.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CLogicalDynamicIndexOnlyGet.h"
 #include "gpopt/operators/CPatternLeaf.h"
 #include "gpopt/operators/CPhysicalDynamicIndexOnlyScan.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 #include "gpopt/xforms/CXformUtils.h"
 
 using namespace gpopt;
@@ -86,6 +88,13 @@ CXformDynamicIndexOnlyGet2DynamicIndexOnlyScan::Transform(
 
 	CLogicalDynamicIndexOnlyGet *popIndexGet =
 		CLogicalDynamicIndexOnlyGet::PopConvert(pexpr->Pop());
+	if (!CHintUtils::SatisfiesPlanHints(
+			popIndexGet,
+			COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetPlanHint()))
+	{
+		return;
+	}
+
 	CMemoryPool *mp = pxfctxt->Pmp();
 
 	CTableDescriptor *ptabdesc = popIndexGet->Ptabdesc();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformGet2TableScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformGet2TableScan.cpp
@@ -13,10 +13,12 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/hints/CHintUtils.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CPhysicalTableScan.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 
 using namespace gpopt;
 
@@ -76,6 +78,13 @@ CXformGet2TableScan::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	GPOS_ASSERT(FCheckPattern(pexpr));
 
 	CLogicalGet *popGet = CLogicalGet::PopConvert(pexpr->Pop());
+	if (!CHintUtils::SatisfiesPlanHints(
+			popGet,
+			COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetPlanHint()))
+	{
+		return;
+	}
+
 	CMemoryPool *mp = pxfctxt->Pmp();
 
 	// create/extract components for alternative

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexOnlyGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexOnlyGet2IndexOnlyScan.cpp
@@ -16,12 +16,14 @@
 #include "gpos/base.h"
 
 #include "gpopt/base/COptCtxt.h"
+#include "gpopt/hints/CHintUtils.h"
 #include "gpopt/metadata/CIndexDescriptor.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CLogicalIndexOnlyGet.h"
 #include "gpopt/operators/CPatternLeaf.h"
 #include "gpopt/operators/CPhysicalIndexOnlyScan.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 #include "gpopt/xforms/CXformUtils.h"
 #include "naucrates/md/CMDIndexGPDB.h"
 
@@ -95,6 +97,13 @@ CXformIndexOnlyGet2IndexOnlyScan::Transform(CXformContext *pxfctxt,
 	CExpression *pexprIndexCond = (*pexpr)[0];
 	if (pexprIndexCond->DeriveHasSubquery() ||
 		!CXformUtils::FCoverIndex(mp, pindexdesc, ptabdesc, pdrgpcrOutput))
+	{
+		return;
+	}
+
+	if (!CHintUtils::SatisfiesPlanHints(
+			pop,
+			COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetPlanHint()))
 	{
 		return;
 	}

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/CDXLUtils.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/CDXLUtils.h
@@ -16,6 +16,8 @@
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoP.h"
+#include "gpos/common/CEnumSet.h"
+#include "gpos/common/CEnumSetIter.h"
 #include "gpos/io/IOstream.h"
 #include "gpos/string/CWStringDynamic.h"
 
@@ -251,6 +253,11 @@ public:
 	static CWStringDynamic *Serialize(
 		CMemoryPool *mp, const CDynamicPtrArray<T, CleanupFn> *arr);
 
+	template <typename T, ULONG sentinel_index>
+	static CWStringDynamic *Serialize(
+		CMemoryPool *mp, const CEnumSet<T, sentinel_index> *dynamic_set,
+		const WCHAR *(*func)(T));
+
 	// serialize a list of lists of integers into a comma-separate string
 	static CWStringDynamic *Serialize(CMemoryPool *mp,
 									  const ULongPtr2dArray *pdrgpul);
@@ -258,6 +265,10 @@ public:
 	// serialize a list of chars into a comma-separate string
 	static CWStringDynamic *SerializeToCommaSeparatedString(
 		CMemoryPool *mp, const CharPtrArray *pdrgpsz);
+
+	// serialize a list of strings into a comma-separate string
+	static CWStringDynamic *SerializeToCommaSeparatedString(
+		CMemoryPool *mp, const StringPtrArray *pdrgpsz);
 
 	// decode a byte array from a string
 	static BYTE *DecodeByteArrayFromString(CMemoryPool *mp,
@@ -319,6 +330,32 @@ CDXLUtils::Serialize(CMemoryPool *mp,
 	}
 
 	return string_var.Reset();
+}
+
+template <typename T, ULONG sentinel_index>
+CWStringDynamic *
+CDXLUtils::Serialize(CMemoryPool *mp,
+					 const CEnumSet<T, sentinel_index> *dynamic_set,
+					 const WCHAR *(*func)(T))
+{
+	CAutoP<CWStringDynamic> str(GPOS_NEW(mp) CWStringDynamic(mp));
+
+	CEnumSetIter<T, sentinel_index> iter(*dynamic_set);
+	ULONG idx = 0;
+	while (iter.Advance())
+	{
+		const WCHAR *index = func(iter.TBit());
+		str->AppendWideCharArray(index);
+		if (idx != dynamic_set->Size() - 1)
+		{
+			str->AppendFormat(
+				GPOS_WSZ_LIT("%ls"),
+				CDXLTokens::GetDXLTokenStr(EdxltokenComma)->GetBuffer());
+		}
+		idx += 1;
+	}
+
+	return str.Reset();
 }
 
 }  // namespace gpdxl

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerBase.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerBase.h
@@ -43,6 +43,7 @@ enum EDxlParseHandlerType
 	EdxlphStatisticsConfig,
 	EdxlphCTEConfig,
 	EdxlphHint,
+	EdxlphPlanHint,
 	EdxlphWindowOids,
 	EdxlphTraceFlags,
 	EdxlphPlan,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -132,6 +132,11 @@ private:
 		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
 		CParseHandlerBase *parse_handler_root);
 
+	// construct plan hint parse handler
+	static CParseHandlerBase *CreatePlanHintParseHandler(
+		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+		CParseHandlerBase *parse_handler_root);
+
 	// construct window oids parse handler
 	static CParseHandlerBase *CreateWindowOidsParseHandler(
 		CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPlanHint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPlanHint.h
@@ -1,0 +1,76 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CParseHandlerPlanHint.h
+//
+//	@doc:
+//		SAX parse handler class for parsing hint configuration
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CParseHandlerPlanHint_H
+#define GPDXL_CParseHandlerPlanHint_H
+
+#include "gpos/base.h"
+
+#include "gpopt/hints/CPlanHint.h"
+#include "naucrates/dxl/parser/CParseHandlerBase.h"
+
+namespace gpdxl
+{
+using namespace gpos;
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CParseHandlerPlanHint
+//
+//	@doc:
+//		SAX parse handler class for parsing hint configuration options
+//
+//---------------------------------------------------------------------------
+class CParseHandlerPlanHint : public CParseHandlerBase
+{
+private:
+	// hint configuration
+	CPlanHint *m_hint;
+
+	// process the start of an element
+	void StartElement(
+		const XMLCh *const element_uri,			// URI of element's namespace
+		const XMLCh *const element_local_name,	// local part of element's name
+		const XMLCh *const element_qname,		// element's qname
+		const Attributes &attr					// element's attributes
+		) override;
+
+	// process the end of an element
+	void EndElement(
+		const XMLCh *const element_uri,			// URI of element's namespace
+		const XMLCh *const element_local_name,	// local part of element's name
+		const XMLCh *const element_qname		// element's qname
+		) override;
+
+public:
+	CParseHandlerPlanHint(const CParseHandlerPlanHint &) = delete;
+
+	// ctor
+	CParseHandlerPlanHint(CMemoryPool *mp,
+						  CParseHandlerManager *parse_handler_mgr,
+						  CParseHandlerBase *parse_handler_root);
+
+	// dtor
+	~CParseHandlerPlanHint() override;
+
+	// type of the parse handler
+	EDxlParseHandlerType GetParseHandlerType() const override;
+
+	// hint configuration
+	CPlanHint *GetPlanHint() const;
+};
+}  // namespace gpdxl
+
+#endif	// !GPDXL_CParseHandlerPlanHint_H
+
+// EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
@@ -110,6 +110,7 @@
 #include "naucrates/dxl/parser/CParseHandlerPhysicalTVF.h"
 #include "naucrates/dxl/parser/CParseHandlerPhysicalWindow.h"
 #include "naucrates/dxl/parser/CParseHandlerPlan.h"
+#include "naucrates/dxl/parser/CParseHandlerPlanHint.h"
 #include "naucrates/dxl/parser/CParseHandlerProjElem.h"
 #include "naucrates/dxl/parser/CParseHandlerProjList.h"
 #include "naucrates/dxl/parser/CParseHandlerProperties.h"

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -58,6 +58,8 @@ enum Edxltoken
 	EdxltokenCostModelType,
 	EdxltokenSegmentsForCosting,
 	EdxltokenHint,
+	EdxltokenPlanHint,
+	EdxltokenScanHint,
 	EdxltokenJoinArityForAssociativityCommutativity,
 	EdxltokenArrayExpansionThreshold,
 	EdxltokenJoinOrderDPThreshold,

--- a/src/backend/gporca/libnaucrates/src/CDXLUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/CDXLUtils.cpp
@@ -1706,6 +1706,33 @@ CDXLUtils::SerializeToCommaSeparatedString(CMemoryPool *mp,
 	return dxl_string;
 }
 
+// Serialize a list of chars into a comma-separated string
+CWStringDynamic *
+CDXLUtils::SerializeToCommaSeparatedString(CMemoryPool *mp,
+										   const StringPtrArray *str_ptr_array)
+{
+	CWStringDynamic *dxl_string = GPOS_NEW(mp) CWStringDynamic(mp);
+
+	ULONG length = str_ptr_array->Size();
+	for (ULONG ul = 0; ul < length; ul++)
+	{
+		CWStringBase *value = (*str_ptr_array)[ul];
+		if (ul == length - 1)
+		{
+			// last element: do not print a comma
+			dxl_string->AppendFormat(GPOS_WSZ_LIT("%ls"), value->GetBuffer());
+		}
+		else
+		{
+			dxl_string->AppendFormat(
+				GPOS_WSZ_LIT("%ls%ls"), value->GetBuffer(),
+				CDXLTokens::GetDXLTokenStr(EdxltokenComma)->GetBuffer());
+		}
+	}
+
+	return dxl_string;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CDXLUtils::CreateMultiByteCharStringFromWCString

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -3083,7 +3083,7 @@ CDXLOperatorFactory::ExtractConvertSegmentIdsToArray(
 //		CDXLOperatorFactory::ExtractConvertStrsToArray
 //
 //	@doc:
-//		Parse a semicolon-separated list of strings into a dynamic array.
+//		Parse a comma-separated list of strings into a dynamic array.
 //
 //---------------------------------------------------------------------------
 StringPtrArray *
@@ -3094,8 +3094,8 @@ CDXLOperatorFactory::ExtractConvertStrsToArray(
 
 	StringPtrArray *array_strs = GPOS_NEW(mp) StringPtrArray(mp);
 
-	XMLStringTokenizer mdid_components(
-		xml_val, CDXLTokens::XmlstrToken(EdxltokenSemicolon));
+	XMLStringTokenizer mdid_components(xml_val,
+									   CDXLTokens::XmlstrToken(EdxltokenComma));
 	const ULONG num_tokens = mdid_components.countTokens();
 
 	for (ULONG ul = 0; ul < num_tokens; ul++)

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -61,6 +61,7 @@ CParseHandlerFactory::Init(CMemoryPool *mp)
 		{EdxltokenCTEConfig, &CreateCTECfgParseHandler},
 		{EdxltokenCostModelConfig, &CreateCostModelCfgParseHandler},
 		{EdxltokenHint, &CreateHintParseHandler},
+		{EdxltokenPlanHint, &CreatePlanHintParseHandler},
 		{EdxltokenWindowOids, &CreateWindowOidsParseHandler},
 
 		{EdxltokenRelation, &CreateMDRelationParseHandler},
@@ -433,6 +434,16 @@ CParseHandlerFactory::CreateHintParseHandler(
 {
 	return GPOS_NEW(mp)
 		CParseHandlerHint(mp, parse_handler_mgr, parse_handler_root);
+}
+
+// creates a parse handler for parsing plan hint configuration
+CParseHandlerBase *
+CParseHandlerFactory::CreatePlanHintParseHandler(
+	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+	CParseHandlerBase *parse_handler_root)
+{
+	return GPOS_NEW(mp)
+		CParseHandlerPlanHint(mp, parse_handler_mgr, parse_handler_root);
 }
 
 // creates a parse handler for parsing window oids configuration

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPlanHint.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPlanHint.cpp
@@ -1,0 +1,177 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CParseHandlerPlanHint.cpp
+//
+//	@doc:
+//		Implementation of the SAX parse handler class for parsing hint
+//		configuration
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerPlanHint.h"
+
+#include "gpopt/hints/CHintUtils.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+#include "naucrates/dxl/parser/CParseHandlerManager.h"
+#include "naucrates/dxl/xml/dxltokens.h"
+
+using namespace gpdxl;
+using namespace gpopt;
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::CParseHandlerPlanHint
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CParseHandlerPlanHint::CParseHandlerPlanHint(
+	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
+	CParseHandlerBase *parse_handler_root)
+	: CParseHandlerBase(mp, parse_handler_mgr, parse_handler_root),
+	  m_hint(nullptr)
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::~CParseHandlerPlanHint
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CParseHandlerPlanHint::~CParseHandlerPlanHint()
+{
+	CRefCount::SafeRelease(m_hint);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::StartElement
+//
+//	@doc:
+//		Invoked by Xerces to process an opening tag
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerPlanHint::StartElement(
+	const XMLCh *const element_uri GPOS_UNUSED,
+	const XMLCh *const element_local_name,
+	const XMLCh *const element_qname GPOS_UNUSED, const Attributes &attrs)
+{
+	if (0 ==
+		XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenPlanHint),
+								 element_local_name))
+	{
+		m_hint = GPOS_NEW(m_mp) CPlanHint(m_mp);
+	}
+	else if (0 == XMLString::compareString(
+					  CDXLTokens::XmlstrToken(EdxltokenScanHint),
+					  element_local_name))
+	{
+		CWStringBase *alias = CDXLOperatorFactory::ExtractConvertAttrValueToStr(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenAlias,
+			EdxltokenPlanHint);
+
+		const XMLCh *attr_val_xml_hints = CDXLOperatorFactory::ExtractAttrValue(
+			attrs, EdxltokenOpName, EdxltokenPlanHint);
+		StringPtrArray *hint_names = nullptr;
+		if (nullptr != attr_val_xml_hints)
+		{
+			hint_names = CDXLOperatorFactory::ExtractConvertStrsToArray(
+				m_parse_handler_mgr->GetDXLMemoryManager(), attr_val_xml_hints);
+		}
+
+		const XMLCh *attr_val_xml = CDXLOperatorFactory::ExtractAttrValue(
+			attrs, EdxltokenIndexName, EdxltokenPlanHint, true);
+		StringPtrArray *index_names = nullptr;
+		if (nullptr != attr_val_xml)
+		{
+			index_names = CDXLOperatorFactory::ExtractConvertStrsToArray(
+				m_parse_handler_mgr->GetDXLMemoryManager(), attr_val_xml);
+		}
+		else
+		{
+			index_names = GPOS_NEW(m_mp) StringPtrArray(m_mp);
+		}
+
+		CScanHint *hint = GPOS_NEW(m_mp) CScanHint(m_mp, alias, index_names);
+		for (ULONG ul = 0; ul < hint_names->Size(); ul++)
+		{
+			hint->AddType(CHintUtils::ScanHintStringToEnum(
+				(*hint_names)[ul]->GetBuffer()));
+		}
+		hint_names->Release();
+
+		m_hint->AddHint(hint);
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::EndElement
+//
+//	@doc:
+//		Invoked by Xerces to process a closing tag
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerPlanHint::EndElement(const XMLCh *const,  // element_uri,
+								  const XMLCh *const element_local_name,
+								  const XMLCh *const  // element_qname
+)
+{
+	if (0 ==
+		XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenPlanHint),
+								 element_local_name))
+	{
+		// deactivate handler
+		m_parse_handler_mgr->DeactivateHandler();
+	}
+	else if (0 != XMLString::compareString(
+					  CDXLTokens::XmlstrToken(EdxltokenScanHint),
+					  element_local_name))
+	{
+		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(
+			m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,
+				   str->GetBuffer());
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::GetParseHandlerType
+//
+//	@doc:
+//		Return the type of the parse handler.
+//
+//---------------------------------------------------------------------------
+EDxlParseHandlerType
+CParseHandlerPlanHint::GetParseHandlerType() const
+{
+	return EdxlphPlanHint;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerPlanHint::GetPlanHint
+//
+//	@doc:
+//		Returns the hint configuration
+//
+//---------------------------------------------------------------------------
+CPlanHint *
+CParseHandlerPlanHint::GetPlanHint() const
+{
+	return m_hint;
+}
+
+// EOF

--- a/src/backend/gporca/libnaucrates/src/parser/Makefile
+++ b/src/backend/gporca/libnaucrates/src/parser/Makefile
@@ -108,6 +108,7 @@ OBJS        = CParseHandlerAgg.o \
               CParseHandlerPhysicalTVF.o \
               CParseHandlerPhysicalWindow.o \
               CParseHandlerPlan.o \
+              CParseHandlerPlanHint.o \
               CParseHandlerProjElem.o \
               CParseHandlerProjList.o \
               CParseHandlerProperties.o \

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -74,6 +74,8 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenCostModelType, GPOS_WSZ_LIT("CostModelType")},
 		{EdxltokenSegmentsForCosting, GPOS_WSZ_LIT("SegmentsForCosting")},
 		{EdxltokenHint, GPOS_WSZ_LIT("Hint")},
+		{EdxltokenPlanHint, GPOS_WSZ_LIT("PlanHint")},
+		{EdxltokenScanHint, GPOS_WSZ_LIT("ScanHint")},
 		{EdxltokenJoinArityForAssociativityCommutativity,
 		 GPOS_WSZ_LIT("JoinArityForAssociativityCommutativity")},
 		{EdxltokenArrayExpansionThreshold,

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -414,6 +414,12 @@ CoveringIndexTest:
 CoveringIndex-1 CoveringIndex-2 CoveringIndex-3 CoveringIndex-Cost-1 CoveringIndex-Cost-2
 CoveringIndex-DoesSupport-Gist CoveringIndex-DoesNotSupport-Gin;
 
+CPlanHintsTest:
+Hint-SeqScan-Over-Table Hint-SeqScan-Over-Join
+Hint-IndexScan-Over-Table Hint-IndexScan-Over-Join Hint-NoIndexScan-Over-Table
+Hint-IndexOnlyScan-Over-Table Hint-NoIndexOnlyScan-Over-Table
+Hint-BitmapScan-Over-Table Hint-NoBitmapScan-Over-Table;
+
 CForeignPartTest:
 ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE ForeignScanExecLocAnySimpleScan ForeignScanExecLocAnyJoin ForeignPartOneTimeFilterDPE
 ")

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3537,7 +3537,8 @@ CTestUtils::EresSamplePlans(const CHAR *rgszFileNames[], ULONG ulTests,
 					CEnumeratorConfig(mp, 0 /*plan_id*/, 1000 /*ullSamples*/),
 				CStatisticsConfig::PstatsconfDefault(mp),
 				CCTEConfig::PcteconfDefault(mp), ICostModel::PcmDefault(mp),
-				CHint::PhintDefault(mp), CWindowOids::GetWindowOids(mp));
+				CHint::PhintDefault(mp), nullptr,
+				CWindowOids::GetWindowOids(mp));
 		}
 		else
 		{
@@ -3675,7 +3676,8 @@ CTestUtils::EresCheckPlans(const CHAR *rgszFileNames[], ULONG ulTests,
 					CEnumeratorConfig(mp, 0 /*plan_id*/, 1000 /*ullSamples*/),
 				CStatisticsConfig::PstatsconfDefault(mp),
 				CCTEConfig::PcteconfDefault(mp), ICostModel::PcmDefault(mp),
-				CHint::PhintDefault(mp), CWindowOids::GetWindowOids(mp));
+				CHint::PhintDefault(mp), nullptr,
+				CWindowOids::GetWindowOids(mp));
 		}
 		else
 		{

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -303,7 +303,7 @@ CICGTest::EresUnittest_NegativeIndexApplyTests()
 				CEnumeratorConfig::GetEnumeratorCfg(mp, 0 /*plan_id*/),
 				CStatisticsConfig::PstatsconfDefault(mp),
 				CCTEConfig::PcteconfDefault(mp), pcm, CHint::PhintDefault(mp),
-				CWindowOids::GetWindowOids(mp));
+				nullptr /* pplanhint */, CWindowOids::GetWindowOids(mp));
 			CDXLNode *pdxlnPlan = CMinidumperUtils::PdxlnExecuteMinidump(
 				mp, rgszNegativeIndexApplyFileNames[ul],
 				GPOPT_TEST_SEGMENTS /*ulSegments*/, 1 /*ulSessionId*/,

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
@@ -126,7 +126,8 @@ CMiniDumperDXLTest::EresUnittest_Basic()
 			CEnumeratorConfig::GetEnumeratorCfg(mp, 0 /*plan_id*/),
 			CStatisticsConfig::PstatsconfDefault(mp),
 			CCTEConfig::PcteconfDefault(mp), ICostModel::PcmDefault(mp),
-			CHint::PhintDefault(mp), CWindowOids::GetWindowOids(mp));
+			CHint::PhintDefault(mp), nullptr /* pplanhint */,
+			CWindowOids::GetWindowOids(mp));
 
 		// setup opt ctx
 		CAutoOptCtxt aoc(mp, &mda, nullptr, /* pceeval */

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CMissingStatsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CMissingStatsTest.cpp
@@ -88,7 +88,7 @@ CMissingStatsTest::EresUnittest_RunTests()
 			CEnumeratorConfig::GetEnumeratorCfg(mp, 0 /*plan_id*/),
 			CStatisticsConfig::PstatsconfDefault(mp),
 			CCTEConfig::PcteconfDefault(mp), pcm, CHint::PhintDefault(mp),
-			CWindowOids::GetWindowOids(mp));
+			nullptr /* pplanhint */, CWindowOids::GetWindowOids(mp));
 		SMissingStatsTestCase testCase = rgtc[ul];
 
 		CDXLNode *pdxlnPlan = CMinidumperUtils::PdxlnExecuteMinidump(

--- a/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/operators/CExpressionTest.cpp
@@ -389,8 +389,10 @@ CExpressionTest::EresUnittest_BitmapGet()
 	CMDIdGPDB *mdid = GPOS_NEW(mp) CMDIdGPDB(CMDIdGPDB::m_mdid_unknown);
 	CIndexDescriptor *pindexdesc =
 		CIndexDescriptor::Pindexdesc(mp, ptabdesc, pmdindex);
+	ptabdesc->AddRef();
 	CExpression *pexprBitmapIndex = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CScalarBitmapIndexProbe(mp, pindexdesc, mdid),
+		mp,
+		GPOS_NEW(mp) CScalarBitmapIndexProbe(mp, pindexdesc, ptabdesc, mdid),
 		pexprIndexCond);
 
 	CColRefArray *pdrgpcrTable = GPOS_NEW(mp) CColRefArray(mp);
@@ -440,8 +442,10 @@ CExpressionTest::EresUnittest_BitmapGet()
 		CIndexDescriptor::Pindexdesc(mp, ptabdesc, pmdindex);
 	CExpression *pexprIndexCond2 = CUtils::PexprScalarEqCmp(
 		mp, pcrFirst, CUtils::PexprScalarConstInt4(mp, 20 /*val*/));
+	ptabdesc->AddRef();
 	CExpression *pexprBitmapIndex2 = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CScalarBitmapIndexProbe(mp, pindexdesc2, pmdid2),
+		mp,
+		GPOS_NEW(mp) CScalarBitmapIndexProbe(mp, pindexdesc2, ptabdesc, pmdid2),
 		pexprIndexCond2);
 	CWStringDynamic strIndex2(mp);
 	COstreamString ossIndex2(&strIndex2);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -42,6 +42,7 @@ class CMDAccessor;
 class CQueryContext;
 class COptimizerConfig;
 class ICostModel;
+class CPlanHint;
 }  // namespace gpopt
 
 struct PlannedStmt;
@@ -120,7 +121,8 @@ private:
 
 	// create optimizer configuration object
 	static COptimizerConfig *CreateOptimizerConfig(CMemoryPool *mp,
-												   ICostModel *cost_model);
+												   ICostModel *cost_model,
+												   CPlanHint *plan_hints);
 
 	// optimize a query to a physical DXL
 	static void *OptimizeTask(void *ptr);
@@ -142,6 +144,9 @@ private:
 
 	// generate an instance of optimizer cost model
 	static ICostModel *GetCostModel(CMemoryPool *mp, ULONG num_segments);
+
+	// create optimizer plan hints
+	static CPlanHint *GetPlanHints(CMemoryPool *mp, Query *query);
 
 	// print warning messages for columns with missing statistics
 	static void PrintMissingStatsWarning(CMemoryPool *mp,

--- a/src/include/optimizer/hints.h
+++ b/src/include/optimizer/hints.h
@@ -1,0 +1,235 @@
+/*
+ * Copied from pg_hint_plan.c
+ */
+
+extern "C" {
+#include "postgres.h"
+#include "nodes/pathnodes.h"
+#include "utils/guc.h"
+}
+
+/* hint keyword of enum type*/
+typedef enum HintKeyword
+{
+	HINT_KEYWORD_SEQSCAN,
+	HINT_KEYWORD_INDEXSCAN,
+	HINT_KEYWORD_INDEXSCANREGEXP,
+	HINT_KEYWORD_BITMAPSCAN,
+	HINT_KEYWORD_BITMAPSCANREGEXP,
+	HINT_KEYWORD_TIDSCAN,
+	HINT_KEYWORD_NOSEQSCAN,
+	HINT_KEYWORD_NOINDEXSCAN,
+	HINT_KEYWORD_NOBITMAPSCAN,
+	HINT_KEYWORD_NOTIDSCAN,
+	HINT_KEYWORD_INDEXONLYSCAN,
+	HINT_KEYWORD_INDEXONLYSCANREGEXP,
+	HINT_KEYWORD_NOINDEXONLYSCAN,
+
+	HINT_KEYWORD_NESTLOOP,
+	HINT_KEYWORD_MERGEJOIN,
+	HINT_KEYWORD_HASHJOIN,
+	HINT_KEYWORD_NONESTLOOP,
+	HINT_KEYWORD_NOMERGEJOIN,
+	HINT_KEYWORD_NOHASHJOIN,
+
+	HINT_KEYWORD_LEADING,
+	HINT_KEYWORD_SET,
+	HINT_KEYWORD_ROWS,
+	HINT_KEYWORD_PARALLEL,
+
+	HINT_KEYWORD_UNRECOGNIZED
+} HintKeyword;
+
+#define SCAN_HINT_ACCEPTS_INDEX_NAMES(kw) \
+	(kw == HINT_KEYWORD_INDEXSCAN ||			\
+	 kw == HINT_KEYWORD_INDEXSCANREGEXP ||		\
+	 kw == HINT_KEYWORD_INDEXONLYSCAN ||		\
+	 kw == HINT_KEYWORD_INDEXONLYSCANREGEXP ||	\
+	 kw == HINT_KEYWORD_BITMAPSCAN ||				\
+	 kw == HINT_KEYWORD_BITMAPSCANREGEXP)
+
+
+typedef struct Hint Hint;
+typedef struct HintState HintState;
+
+typedef Hint *(*HintCreateFunction) (const char *hint_str,
+									 const char *keyword,
+									 HintKeyword hint_keyword);
+typedef void (*HintDeleteFunction) (Hint *hint);
+typedef void (*HintDescFunction) (Hint *hint, StringInfo buf, bool nolf);
+typedef int (*HintCmpFunction) (const Hint *a, const Hint *b);
+typedef const char *(*HintParseFunction) (Hint *hint, HintState *hstate,
+										  Query *parse, const char *str);
+
+/* hint types */
+#define NUM_HINT_TYPE	6
+typedef enum HintType
+{
+	HINT_TYPE_SCAN_METHOD,
+	HINT_TYPE_JOIN_METHOD,
+	HINT_TYPE_LEADING,
+	HINT_TYPE_SET,
+	HINT_TYPE_ROWS,
+	HINT_TYPE_PARALLEL
+} HintType;
+
+typedef enum HintTypeBitmap
+{
+	HINT_BM_SCAN_METHOD = 1,
+	HINT_BM_PARALLEL = 2
+} HintTypeBitmap;
+
+/* hint status */
+typedef enum HintStatus
+{
+	HINT_STATE_NOTUSED = 0,		/* specified relation not used in query */
+	HINT_STATE_USED,			/* hint is used */
+	HINT_STATE_DUPLICATION,		/* specified hint duplication */
+	HINT_STATE_ERROR			/* execute error (parse error does not include
+								 * it) */
+} HintStatus;
+
+/* common data for all hints. */
+struct Hint
+{
+	const char		   *hint_str;		/* must not do pfree */
+	const char		   *keyword;		/* must not do pfree */
+	HintKeyword			hint_keyword;
+	HintType			type;
+	HintStatus			state;
+	HintDeleteFunction	delete_func;
+	HintDescFunction	desc_func;
+	HintCmpFunction		cmp_func;
+	HintParseFunction	parse_func;
+};
+
+/* scan method hints */
+typedef struct ScanMethodHint
+{
+	Hint			base;
+	char		   *relname;
+	List		   *indexnames;
+	bool			regexp;
+	unsigned char	enforce_mask;
+} ScanMethodHint;
+
+typedef struct ParentIndexInfo
+{
+	bool		indisunique;
+	Oid			method;
+	List	   *column_names;
+	char	   *expression_str;
+	Oid		   *indcollation;
+	Oid		   *opclass;
+	int16	   *indoption;
+	char	   *indpred_str;
+} ParentIndexInfo;
+
+/* join method hints */
+typedef struct JoinMethodHint
+{
+	Hint			base;
+	int				nrels;
+	int				inner_nrels;
+	char		  **relnames;
+	unsigned char	enforce_mask;
+	Relids			joinrelids;
+	Relids			inner_joinrelids;
+} JoinMethodHint;
+
+/* join order hints */
+typedef struct OuterInnerRels
+{
+	char   *relation;
+	List   *outer_inner_pair;
+} OuterInnerRels;
+
+typedef struct LeadingHint
+{
+	Hint			base;
+	List		   *relations;	/* relation names specified in Leading hint */
+	OuterInnerRels *outer_inner;
+} LeadingHint;
+
+/* change a run-time parameter hints */
+typedef struct SetHint
+{
+	Hint	base;
+	char   *name;				/* name of variable */
+	char   *value;
+	List   *words;
+} SetHint;
+
+/* rows hints */
+typedef enum RowsValueType {
+	RVT_ABSOLUTE,		/* Rows(... #1000) */
+	RVT_ADD,			/* Rows(... +1000) */
+	RVT_SUB,			/* Rows(... -1000) */
+	RVT_MULTI,			/* Rows(... *1.2) */
+} RowsValueType;
+typedef struct RowsHint
+{
+	Hint			base;
+	int				nrels;
+	int				inner_nrels;
+	char		  **relnames;
+	Relids			joinrelids;
+	Relids			inner_joinrelids;
+	char		   *rows_str;
+	RowsValueType	value_type;
+	double			rows;
+} RowsHint;
+
+/* parallel hints */
+typedef struct ParallelHint
+{
+	Hint			base;
+	char		   *relname;
+	char		   *nworkers_str;	/* original string of nworkers */
+	int				nworkers;		/* num of workers specified by Worker */
+	bool			force_parallel;	/* force parallel scan */
+} ParallelHint;
+
+/*
+ * Describes a context of hint processing.
+ */
+struct HintState
+{
+	char		   *hint_str;			/* original hint string */
+
+	/* all hint */
+	int				nall_hints;			/* # of valid all hints */
+	int				max_all_hints;		/* # of slots for all hints */
+	Hint		  **all_hints;			/* parsed all hints */
+
+	/* # of each hints */
+	int				num_hints[NUM_HINT_TYPE];
+
+	/* for scan method hints */
+	ScanMethodHint **scan_hints;		/* parsed scan hints */
+
+	/* Initial values of parameters  */
+	int				init_scan_mask;		/* enable_* mask */
+	int				init_nworkers;		/* max_parallel_workers_per_gather */
+	/* min_parallel_table_scan_size*/
+	int				init_min_para_tablescan_size;
+	/* min_parallel_index_scan_size*/
+	int				init_min_para_indexscan_size;
+	double			init_paratup_cost;	/* parallel_tuple_cost */
+	double			init_parasetup_cost;/* parallel_setup_cost */
+
+	PlannerInfo	   *current_root;		/* PlannerInfo for the followings */
+	Index			parent_relid;		/* inherit parent of table relid */
+	ScanMethodHint *parent_scan_hint;	/* scan hint for the parent */
+	ParallelHint   *parent_parallel_hint; /* parallel hint for the parent */
+	List		   *parent_index_infos; /* list of parent table's index */
+
+	JoinMethodHint **join_hints;		/* parsed join hints */
+	int				init_join_mask;		/* initial value join parameter */
+	List		  **join_hint_level;
+	LeadingHint	  **leading_hint;		/* parsed Leading hints */
+	SetHint		  **set_hints;			/* parsed Set hints */
+	GucContext		context;			/* which GUC parameters can we set? */
+	RowsHint	  **rows_hints;			/* parsed Rows hints */
+	ParallelHint  **parallel_hints;		/* parsed Parallel hints */
+};

--- a/src/include/optimizer/orca.h
+++ b/src/include/optimizer/orca.h
@@ -24,6 +24,10 @@
 extern PlannedStmt * optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams);
 extern Node *transformGroupedWindows(Node *node, void *context);
 
+// plan_hint_hook generates HintState by parsing a Query.
+typedef void *(*plan_hint_hook_type) (Query *parse);
+extern PGDLLIMPORT plan_hint_hook_type plan_hint_hook;
+
 #endif
 
 #endif /* ORCA_H */

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -134,5 +134,6 @@ extern Oid	attnumCollationId(Relation rd, int attid);
 extern bool isQueryUsingTempRelation(Query *query);
 
 extern bool isSimplyUpdatableRelation(Oid relid, bool noerror);
+extern bool isAliasPartitionedTable(Query *query, const char *alias);
 
 #endif							/* PARSE_RELATION_H */

--- a/src/test/regress/expected/planhints.out
+++ b/src/test/regress/expected/planhints.out
@@ -1,0 +1,1564 @@
+-- Test Optimizer Plan Hints Feature
+--
+-- Purpose: Test that plan hints may be used to coerce the plan shape generated
+-- by the optimizer.
+LOAD 'pg_hint_plan';
+DROP SCHEMA IF EXISTS planhints CASCADE;
+NOTICE:  schema "planhints" does not exist, skipping
+CREATE SCHEMA planhints;
+SET search_path=planhints;
+SET optimizer_trace_fallback=on;
+-- Setup tables
+CREATE TABLE my_table(a int, b int);
+CREATE INDEX my_awesome_index ON my_table(a);
+CREATE INDEX my_amazing_index ON my_table(a);
+CREATE INDEX my_incredible_index ON my_table(a);
+CREATE INDEX my_bitmap_index ON my_table USING bitmap (a);
+CREATE TABLE your_table(a int, b int) WITH (appendonly=true);
+CREATE INDEX your_awesome_index ON your_table(a);
+CREATE INDEX your_amazing_index ON your_table(a);
+CREATE INDEX your_incredible_index ON your_table(a);
+CREATE INDEX your_bitmap_index ON your_table USING bitmap (a);
+CREATE TABLE our_table(a int, b int) PARTITION BY RANGE (a) (PARTITION p1 START(0) END(10) EVERY(3));
+CREATE INDEX our_awesome_index ON our_table(a);
+CREATE INDEX our_amazing_index ON our_table(a);
+CREATE INDEX our_incredible_index ON our_table(a);
+CREATE INDEX our_bitmap_index ON our_table USING bitmap (a);
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+--------------------------------------------------------------------
+--
+-- 1. [JOIN] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Hash Join
+               Hash Cond: (my_table.a = our_table.a)
+               ->  Seq Scan on my_table
+                     Filter: (a < 42)
+               ->  Hash
+                     ->  Dynamic Seq Scan on our_table
+                           Number of partitions to scan: 4 (out of 4)
+                           Filter: (a < 42)
+         ->  Hash
+               ->  Seq Scan on your_table
+                     Filter: (a < 42)
+ Optimizer: GPORCA
+(15 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_incredible_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_amazing_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Only Scan using my_incredible_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Only Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Only Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Only Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+--------------------------------------------------------------------
+--
+-- 2. [SCAN] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+/*+
+    SeqScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    SeqScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on your_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    SeqScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Dynamic Seq Scan on our_table  (cost=0.00..431.00 rows=1 width=4)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(5 rows)
+
+/*+
+    IndexScan(t1 my_incredible_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Scan using my_incredible_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    IndexScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Scan using my_awesome_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+--/*+
+--    IndexScan(t2 your_amazing_index)
+-- */
+--EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+--/*+
+--    IndexScan(t2)
+-- */
+--EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+/*+
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Scan on our_amazing_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+/*+
+    IndexScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Scan on our_awesome_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Only Scan using my_incredible_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    IndexOnlyScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Only Scan using my_awesome_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    IndexOnlyScan(t2 your_amazing_index)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.01 rows=1 width=4)
+   ->  Index Only Scan using your_amazing_index on your_table  (cost=0.00..6.01 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    IndexOnlyScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.01 rows=1 width=4)
+   ->  Index Only Scan using your_awesome_index on your_table  (cost=0.00..6.01 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Only Scan on our_amazing_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+/*+
+    IndexOnlyScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Only Scan on our_awesome_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on my_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on my_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    BitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on my_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on my_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    BitmapScan(t2 your_bitmap_index)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on your_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on your_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    BitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on your_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on your_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.97 rows=1 width=4)
+   ->  Dynamic Bitmap Heap Scan on our_table  (cost=0.00..387.97 rows=1 width=4)
+         Number of partitions to scan: 4 (out of 4)
+         Recheck Cond: (a < 42)
+         Filter: (a < 42)
+         ->  Dynamic Bitmap Index Scan on our_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(8 rows)
+
+/*+
+    BitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.97 rows=1 width=4)
+   ->  Dynamic Bitmap Heap Scan on our_table  (cost=0.00..387.97 rows=1 width=4)
+         Number of partitions to scan: 4 (out of 4)
+         Recheck Cond: (a < 42)
+         Filter: (a < 42)
+         ->  Dynamic Bitmap Index Scan on our_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(8 rows)
+
+--------------------------------------------------------------------
+--
+-- 3. [JOIN] No scan type
+--
+--------------------------------------------------------------------
+/*+
+    NoSeqScan(t1)
+    NoSeqScan(t2)
+    NoSeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    NoIndexScan(t1)
+    NoIndexScan(t2)
+    NoIndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Only Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Only Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    NoIndexOnlyScan(t1)
+    NoIndexOnlyScan(t2)
+    NoIndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(16 rows)
+
+/*+
+    NoBitmapScan(t1)
+    NoBitmapScan(t2)
+    NoBitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+--------------------------------------------------------------------
+--
+-- 4. [SCAN] No scan type
+--
+-- Note that pg_hint_plan does not support multiple No.*Scan hints, so the
+-- parser will generate warnings indicating conflicting hints.
+--
+--------------------------------------------------------------------
+--
+-- Make SeqScan is only valid plan
+--
+/*+
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on your_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Dynamic Seq Scan on our_table  (cost=0.00..431.00 rows=1 width=4)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(5 rows)
+
+--
+-- Make IndexScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Scan using my_awesome_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoSeqScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..775.42 rows=28700 width=4)
+   ->  Seq Scan on your_table t2  (cost=0.00..392.75 rows=9567 width=4)
+         Filter: (a < 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+/*+
+    NoSeqScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Scan on our_awesome_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+--
+-- Make IndexOnlyScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoBitmapScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Only Scan using my_awesome_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoBitmapScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.01 rows=1 width=4)
+   ->  Index Only Scan using your_awesome_index on your_table  (cost=0.00..6.01 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoBitmapScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Dynamic Index Only Scan on our_awesome_index on our_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+         Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(5 rows)
+
+--
+-- Make BitmapScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on my_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on my_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ "
+DETAIL:  Conflict scan method hint.
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Bitmap Heap Scan on your_table  (cost=0.00..391.30 rows=1 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on your_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(6 rows)
+
+/*+
+    NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ "
+DETAIL:  Conflict scan method hint.
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..387.97 rows=1 width=4)
+   ->  Dynamic Bitmap Heap Scan on our_table  (cost=0.00..387.97 rows=1 width=4)
+         Number of partitions to scan: 4 (out of 4)
+         Recheck Cond: (a < 42)
+         Filter: (a < 42)
+         ->  Dynamic Bitmap Index Scan on our_bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: (a < 42)
+ Optimizer: GPORCA
+(8 rows)
+
+--------------------------------------------------------------------
+--
+-- 5. [VIEWS] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+CREATE VIEW everybody_view AS SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Hash Join
+               Hash Cond: (my_table.a = our_table.a)
+               ->  Seq Scan on my_table
+                     Filter: (a < 42)
+               ->  Hash
+                     ->  Dynamic Seq Scan on our_table
+                           Number of partitions to scan: 4 (out of 4)
+                           Filter: (a < 42)
+         ->  Hash
+               ->  Seq Scan on your_table
+                     Filter: (a < 42)
+ Optimizer: GPORCA
+(15 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_incredible_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_amazing_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Only Scan using my_incredible_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Only Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (your_table.a = our_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Only Scan using your_awesome_index on your_table
+                     Index Cond: (a < 42)
+               ->  Index Only Scan using my_awesome_index on my_table
+                     Index Cond: ((a = your_table.a) AND (a < 42))
+         ->  Hash
+               ->  Dynamic Index Only Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+ Optimizer: GPORCA
+(14 rows)
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+--------------------------------------------------------------------
+--
+-- 6. [CTE] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Hash Join
+               Hash Cond: (my_table.a = our_table.a)
+               ->  Seq Scan on my_table
+                     Filter: (a < 42)
+               ->  Hash
+                     ->  Dynamic Seq Scan on our_table
+                           Number of partitions to scan: 4 (out of 4)
+                           Filter: (a < 42)
+         ->  Hash
+               ->  Seq Scan on your_table
+                     Filter: (a < 42)
+ Optimizer: GPORCA
+(15 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Index Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+               ->  Index Scan using my_incredible_index on my_table
+                     Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Index Only Scan using your_incredible_index on your_table
+               Index Cond: ((a = my_table.a) AND (a < 42))
+ Optimizer: GPORCA
+(13 rows)
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Index Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+               ->  Index Scan using my_awesome_index on my_table
+                     Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Index Only Scan using your_incredible_index on your_table
+               Index Cond: ((a = my_table.a) AND (a < 42))
+ Optimizer: GPORCA
+(13 rows)
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Index Only Scan on our_amazing_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+               ->  Index Only Scan using my_incredible_index on my_table
+                     Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Index Only Scan using your_amazing_index on your_table
+               Index Cond: ((a = my_table.a) AND (a < 42))
+ Optimizer: GPORCA
+(13 rows)
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Index Only Scan on our_awesome_index on our_table
+                     Index Cond: (a < 42)
+                     Number of partitions to scan: 4 (out of 4)
+               ->  Index Only Scan using my_awesome_index on my_table
+                     Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Index Only Scan using your_incredible_index on your_table
+               Index Cond: ((a = my_table.a) AND (a < 42))
+ Optimizer: GPORCA
+(13 rows)
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (my_table.a = your_table.a)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Dynamic Bitmap Heap Scan on our_table
+                     Number of partitions to scan: 4 (out of 4)
+                     Recheck Cond: (a < 42)
+                     Filter: (a < 42)
+                     ->  Dynamic Bitmap Index Scan on our_bitmap_index
+                           Index Cond: (a < 42)
+               ->  Bitmap Heap Scan on my_table
+                     Recheck Cond: ((a = our_table.a) AND (a < 42))
+                     ->  Bitmap Index Scan on my_bitmap_index
+                           Index Cond: ((a = our_table.a) AND (a < 42))
+         ->  Hash
+               ->  Bitmap Heap Scan on your_table
+                     Recheck Cond: (a < 42)
+                     ->  Bitmap Index Scan on your_bitmap_index
+                           Index Cond: (a < 42)
+ Optimizer: GPORCA
+(21 rows)
+
+--------------------------------------------------------------------
+--
+-- 7. Unsupported hints
+--
+--------------------------------------------------------------------
+/*+
+    TidScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Operator Unsupported plan hint: TidScan not supported
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000775.42 rows=28700 width=4)
+   ->  Seq Scan on my_table t1  (cost=10000000000.00..10000000392.75 rows=9567 width=4)
+         Filter: (a < 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+/*+
+    NoTidScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Operator Unsupported plan hint: NoTidScan not supported
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=225.64..761.89 rows=28700 width=4)
+   ->  Bitmap Heap Scan on my_table t1  (cost=225.64..379.23 rows=9567 width=4)
+         Recheck Cond: (a < 42)
+         ->  Bitmap Index Scan on my_bitmap_index  (cost=0.00..223.25 rows=9567 width=0)
+               Index Cond: (a < 42)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+/*+
+    IndexScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Operator Unsupported plan hint: IndexScanRegexp not supported
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000775.42 rows=28700 width=4)
+   ->  Seq Scan on my_table t1  (cost=10000000000.00..10000000392.75 rows=9567 width=4)
+         Filter: (a < 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+/*+
+    IndexOnlyScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Operator Unsupported plan hint: IndexOnlyScanRegexp not supported
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000775.42 rows=28700 width=4)
+   ->  Seq Scan on my_table t1  (cost=10000000000.00..10000000392.75 rows=9567 width=4)
+         Filter: (a < 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+/*+
+    BitmapScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Operator Unsupported plan hint: BitmapScanRegexp not supported
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000775.42 rows=28700 width=4)
+   ->  Seq Scan on my_table t1  (cost=10000000000.00..10000000392.75 rows=9567 width=4)
+         Filter: (a < 42)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+--------------------------------------------------------------------
+--
+-- 8. Miscellaneous cases
+--
+--------------------------------------------------------------------
+-- Missing hint relation name argument
+/*+
+    SeqScan()
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "
+ "
+DETAIL:  SeqScan hint requires a relation.
+INFO:  pg_hint_plan: hint syntax error at or near "
+ "
+DETAIL:  SeqScan hint requires a relation.
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Index Scan using my_awesome_index on my_table  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+-- Mixing NoIndexScan and SeqScan hints
+/*+
+    SeqScan(t1) NoIndexScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "SeqScan(t1) NoIndexScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "SeqScan(t1) NoIndexScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+
+/*+
+    NoIndexScan(t1) SeqScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1) SeqScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+INFO:  pg_hint_plan: hint syntax error at or near "NoIndexScan(t1) SeqScan(t1)
+ "
+DETAIL:  Conflict scan method hint.
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=4)
+         Filter: (a < 42)
+ Optimizer: GPORCA
+(4 rows)
+

--- a/src/test/regress/sql/planhints.sql
+++ b/src/test/regress/sql/planhints.sql
@@ -1,0 +1,546 @@
+-- Test Optimizer Plan Hints Feature
+--
+-- Purpose: Test that plan hints may be used to coerce the plan shape generated
+-- by the optimizer.
+
+LOAD 'pg_hint_plan';
+
+DROP SCHEMA IF EXISTS planhints CASCADE;
+
+CREATE SCHEMA planhints;
+SET search_path=planhints;
+SET optimizer_trace_fallback=on;
+
+-- Setup tables
+CREATE TABLE my_table(a int, b int);
+CREATE INDEX my_awesome_index ON my_table(a);
+CREATE INDEX my_amazing_index ON my_table(a);
+CREATE INDEX my_incredible_index ON my_table(a);
+CREATE INDEX my_bitmap_index ON my_table USING bitmap (a);
+
+CREATE TABLE your_table(a int, b int) WITH (appendonly=true);
+CREATE INDEX your_awesome_index ON your_table(a);
+CREATE INDEX your_amazing_index ON your_table(a);
+CREATE INDEX your_incredible_index ON your_table(a);
+CREATE INDEX your_bitmap_index ON your_table USING bitmap (a);
+
+CREATE TABLE our_table(a int, b int) PARTITION BY RANGE (a) (PARTITION p1 START(0) END(10) EVERY(3));
+CREATE INDEX our_awesome_index ON our_table(a);
+CREATE INDEX our_amazing_index ON our_table(a);
+CREATE INDEX our_incredible_index ON our_table(a);
+CREATE INDEX our_bitmap_index ON our_table USING bitmap (a);
+
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+--------------------------------------------------------------------
+--
+-- 1. [JOIN] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+
+--------------------------------------------------------------------
+--
+-- 2. [SCAN] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+
+/*+
+    SeqScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    SeqScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    SeqScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    IndexScan(t1 my_incredible_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    IndexScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+--/*+
+--    IndexScan(t2 your_amazing_index)
+-- */
+--EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+--/*+
+--    IndexScan(t2)
+-- */
+--EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    IndexScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    IndexOnlyScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    IndexOnlyScan(t2 your_amazing_index)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    IndexOnlyScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    IndexOnlyScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    BitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    BitmapScan(t2 your_bitmap_index)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    BitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+/*+
+    BitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+
+--------------------------------------------------------------------
+--
+-- 3. [JOIN] No scan type
+--
+--------------------------------------------------------------------
+
+/*+
+    NoSeqScan(t1)
+    NoSeqScan(t2)
+    NoSeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    NoIndexScan(t1)
+    NoIndexScan(t2)
+    NoIndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    NoIndexOnlyScan(t1)
+    NoIndexOnlyScan(t2)
+    NoIndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    NoBitmapScan(t1)
+    NoBitmapScan(t2)
+    NoBitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT t1.a, t2.a, t3.a FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+
+--------------------------------------------------------------------
+--
+-- 4. [SCAN] No scan type
+--
+-- Note that pg_hint_plan does not support multiple No.*Scan hints, so the
+-- parser will generate warnings indicating conflicting hints.
+--
+--------------------------------------------------------------------
+
+--
+-- Make SeqScan is only valid plan
+--
+/*+
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+--
+-- Make IndexScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexOnlyScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    NoSeqScan(t2)
+    NoIndexOnlyScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    NoSeqScan(t3)
+    NoIndexOnlyScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+--
+-- Make IndexOnlyScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoBitmapScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoBitmapScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoBitmapScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+--
+-- Make BitmapScan is only valid plan
+--
+/*+
+    NoSeqScan(t1)
+    NoIndexScan(t1)
+    NoIndexOnlyScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    NoSeqScan(t2)
+    NoIndexScan(t2)
+    NoIndexOnlyScan(t2)
+ */
+EXPLAIN SELECT t2.a FROM your_table AS t2 WHERE t2.a<42;
+
+/*+
+    NoSeqScan(t3)
+    NoIndexScan(t3)
+    NoIndexOnlyScan(t3)
+ */
+EXPLAIN SELECT t3.a FROM our_table AS t3 WHERE t3.a<42;
+
+--------------------------------------------------------------------
+--
+-- 5. [VIEWS] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+
+CREATE VIEW everybody_view AS SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a WHERE t1.a<42;
+
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) SELECT * FROM everybody_view;
+
+--------------------------------------------------------------------
+--
+-- 6. [CTE] Specific explicit scan type and implicit/explicit index
+--
+--------------------------------------------------------------------
+
+/*+
+    SeqScan(t1)
+    SeqScan(t2)
+    SeqScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1 my_incredible_index)
+    IndexScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+-- NB: IndexScan on AO table is invalid because AO tables do not support index
+--     scan (e.g. t2)
+/*+
+    IndexScan(t1)
+    IndexScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+/*+
+    IndexOnlyScan(t1 my_incredible_index)
+    IndexOnlyScan(t2 your_amazing_index)
+    IndexOnlyScan(t3 our_amazing_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+/*+
+    IndexOnlyScan(t1)
+    IndexOnlyScan(t2)
+    IndexOnlyScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+/*+
+    BitmapScan(t1 my_bitmap_index)
+    BitmapScan(t2 your_bitmap_index)
+    BitmapScan(t3 our_bitmap_index)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+/*+
+    BitmapScan(t1)
+    BitmapScan(t2)
+    BitmapScan(t3)
+ */
+EXPLAIN (costs off) WITH cte AS
+(
+    SELECT t1.a AS a1, t2.a AS a2, t3.a AS a3 FROM my_table AS t1 JOIN your_table AS t2 ON t1.a=t2.a JOIN our_table AS t3 ON t3.a=t2.a
+)
+SELECT a1, a2, a3 FROM cte WHERE a1<42;
+
+
+--------------------------------------------------------------------
+--
+-- 7. Unsupported hints
+--
+--------------------------------------------------------------------
+
+/*+
+    TidScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    NoTidScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    IndexScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    IndexOnlyScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+/*+
+    BitmapScanRegexp(t1 '*awesome*')
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+
+--------------------------------------------------------------------
+--
+-- 8. Miscellaneous cases
+--
+--------------------------------------------------------------------
+
+-- Missing hint relation name argument
+/*+
+    SeqScan()
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+
+-- Mixing NoIndexScan and SeqScan hints
+/*+
+    SeqScan(t1) NoIndexScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
+/*+
+    NoIndexScan(t1) SeqScan(t1)
+ */
+EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;


### PR DESCRIPTION
Plan hints is a way to override the optimizer in order to coerce a plan
shape by disregarding its estimated cost compared to alternative plans.
The feature offers two significant benefits:

  1) It enables an immediate customer workaround for bugs in the
     optimizer when optimizer generates an inferior plan.

  2) It enables easy testing of plan performance which in turn can be
     used to drive optimizer improvements.

For more discussion (including drawbacks) refer to gpdb-dev thread [1].

This change is the first to implement support for plan hints in GPDB.
In this patch, only scan hints are implemented and the syntax mirrors
Postgres extension pg_hint_plan [2]. Following hints are supported:

  SeqScan, NoSeqScan, IndexScan, NoIndexScan, IndexOnlyScan,
  NoIndexOnlyScan, BitmapScan, NoBitmapScan

Example usage:
```sql
  LOAD 'pg_hint_plan';
  CREATE TABLE my_table(a int, b int);
  CREATE INDEX my_awesome_index ON my_table(a);
  CREATE INDEX my_incredible_index ON my_table(a);

  /*+
      IndexScan(t1 my_incredible_index)
   */
  EXPLAIN SELECT t1.a FROM my_table AS t1 WHERE t1.a<42;
```
Note: This feature depends on a patch version of pg_hint_plan installed
on the GPDB cluster. And this specific change is only relevant for ORCA
optimizer.

[1] https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/V-p8mASZmEo/m/d22ai2ldDwAJ
[2] https://github.com/ossc-db/pg_hint_plan

---

Note for reviewers: I tried to separate this change into logical commits.  I strongly recommend reading them separately.  The patch version of pg_hint_plan is not yet published.  After I get the go ahead to do so, I will add a link to it.

Patched version of pg_hint_plan used by this PR: https://github.com/pivotal/pg_hint_plan