### PR TITLE
docs - pgbouncer supports encrypted ldap password

### DIFF
--- a/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
+++ b/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
@@ -218,7 +218,7 @@ $ echo -n $encrypted_passwd > "${HOME}/.ldapbindpass"
 An excerpt of an example PgBouncer HBA file named `hba_bouncer_with_ldap_encrypted.conf` that specifies LDAP authentication with an encrypted password follows:
 
 ``` pre
-host all user2 0.0.0.0/0 ldap ldapserver=<ldap-server-address> ldapbindpasswd="\$bindpasswd" ldapbasedn="CN=Users,DC=greenplum,DC=org" ldapbinddn="CN=Administrator,CN=Users,DC=greenplum,DC=org" ldapsearchattribute="SomeAttrName"
+host all user2 0.0.0.0/0 ldap ldapserver=<ldap-server-address> ldapbindpasswd="$bindpasswd" ldapbasedn="CN=Users,DC=greenplum,DC=org" ldapbinddn="CN=Administrator,CN=Users,DC=greenplum,DC=org" ldapsearchattribute="SomeAttrName"
 ```
 
 Example excerpt from the related `pgbouncer.ini` configuration file:

--- a/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
+++ b/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
@@ -193,6 +193,51 @@ auth_hba_file = hba_bouncer_for_ldap.conf
 ...
 ```
 
+#### <a id="pgb_ldap_encrypt_passwd"></a>About Specifying an Encrypted LDAP Password
+
+Starting in Greenplum Database version 6.26, PgBouncer supports encrypted LDAP passwords. To utilize an encrypted LDAP password with PgBouncer, you must:
+
+- Place the encrypted password in the `${HOME}/.ldapbindpass` file.
+- Specify `ldapbindpasswd="$bindpasswd"` in the HBA-based authentication file for PgBouncer.
+- Specify the file system path to the encryption key in the `auth_key_file` setting in the `pgbouncer.ini` configuration file.
+- Specify the encryption cipher in the `auth_cipher` setting in the `pgbouncer.ini` configuration file.
+
+The following example commands create an encrypted password and place it in `${HOME}/.ldapbindpass`:
+
+```
+# generate a key file named ldkeyfile
+$ openssl rand -base64 256 | tr -d '\n' > ldkeyfile
+
+# encrypt the password
+$ encrypted_passwd=$(echo -n "your_secret_password_here" | openssl enc -aes-256-cbc -base64 -md sha256 -pass file:ldkeyfile
+
+# copy the encrypted password to required location
+$ echo -n $encrypted_passwd > "${HOME}/.ldapbindpass"
+```
+
+An excerpt of an example PgBouncer HBA file named `hba_bouncer_with_ldap_encrypted.conf` that specifies LDAP authentication with an encrypted password follows:
+
+``` pre
+host all user2 0.0.0.0/0 ldap ldapserver=<ldap-server-address> ldapbindpasswd="\$bindpasswd" ldapbasedn="CN=Users,DC=greenplum,DC=org" ldapbinddn="CN=Administrator,CN=Users,DC=greenplum,DC=org" ldapsearchattribute="SomeAttrName"
+```
+
+Example excerpt from the related `pgbouncer.ini` configuration file:
+
+``` pre
+[databases]
+* = port = 6000 host=127.0.0.1
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+
+auth_type = hba
+auth_hba_file = hba_bouncer_with_ldap_encrypted.conf
+auth_key_file = /home/user2/ldkeyfile
+auth_cipher = -aes-128-ecb
+...
+```
+
 ## <a id="pgb_start"></a>Starting PgBouncer 
 
 You can run PgBouncer on the Greenplum Database master or on another server. If you install PgBouncer on a separate server, you can easily switch clients to the standby master by updating the PgBouncer configuration file and reloading the configuration using the PgBouncer Administration Console.

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
@@ -183,6 +183,16 @@ auth\_type
     - `trust`: No authentication is performed. The username must still exist in the `auth_file`.
     - `any`: Like the `trust` method, but the username supplied is ignored. Requires that all databases are configured to log in with a specific user. Additionally, the console database allows any user to log in as admin.
 
+auth_key_file
+:   If you are connecting to LDAP with an encrypted password, `auth_key_file` identifies the file system location of the encryption key. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
+
+    Default: not set
+
+auth_cipher
+:   If you are connecting to LDAP with an encrypted password, `auth_cipher` identifies the cipher algorithm for password authentication. PgBouncer accepts any cipher supported by OpenSSL on the system. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
+
+    Default: `aes-256-cbc`
+
 auth\_query
 :   Query to load a user's password from the database.
 

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
@@ -189,7 +189,7 @@ auth_key_file
     Default: not set
 
 auth_cipher
-:   If you are connecting to LDAP with an encrypted password, `auth_cipher` identifies the cipher algorithm for password authentication. PgBouncer accepts any cipher supported by OpenSSL on the system. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
+:   If you are connecting to LDAP with an encrypted password, `auth_cipher` identifies the cipher algorithm for password authentication. PgBouncer accepts any cipher supported by OpenSSL on the system. When FIPS mode is enabled, specify only a cipher that is considered safe in FIPS mode. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
 
     Default: `aes-256-cbc`
 

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
@@ -184,12 +184,12 @@ auth\_type
     - `any`: Like the `trust` method, but the username supplied is ignored. Requires that all databases are configured to log in with a specific user. Additionally, the console database allows any user to log in as admin.
 
 auth_key_file
-:   If you are connecting to LDAP with an encrypted password, `auth_key_file` identifies the file system location of the encryption key. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
+:   If you are connecting to LDAP with an encrypted password, `auth_key_file` identifies the file system location of the encryption key. Refer to [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
 
     Default: not set
 
 auth_cipher
-:   If you are connecting to LDAP with an encrypted password, `auth_cipher` identifies the cipher algorithm for password authentication. PgBouncer accepts any cipher supported by OpenSSL on the system. When FIPS mode is enabled, specify only a cipher that is considered safe in FIPS mode. Refer to the [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
+:   If you are connecting to LDAP with an encrypted password, `auth_cipher` identifies the cipher algorithm for password authentication. PgBouncer accepts any cipher supported by OpenSSL on the system. When FIPS mode is enabled, specify only a cipher that is considered safe in FIPS mode. Refer to [About Specifying an Encrypted LDAP Password](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap_encrypt_passwd) for more information.
 
     Default: `aes-256-cbc`
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pgbouncer/pull/27.   the user can now provide an encrypted ldap password for pgbouncer.   this PR is against 6X_STABLE because the pgbouncer docs are pending addition to the main branch.   this content will be applied to main when that is in place.

in this PR:
- add new topic "About Specifying an Encrypted LDAP Password" to the pgbouncer using page.   includes requirements and example configuration.
- add descriptions of auth_key_file and auth_cipher to the pgbouncer.ini reference page.

questions:
1. it wasn't clear to me if any updates were required to the pgbouncer ldap intro docs (https://docs.vmware.com/en/draft/VMware-Greenplum/pgb-encpasswd/greenplum-database/admin_guide-access_db-topics-pgbouncer.html#configuring-ldap-based-authentication-for-pgbouncer).  please review this section and let me know if any updates are required.
2. i am assuming that ldapbindpasswd="$bindpasswd" is applicable only for a pgbouncer hba file, not a general greenplum hba file.   is this correct?   i initially added info about it to https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/security-guide-topics-Authenticate.html#ldap-authentication, but that didn't seem right after thinking about it some more.

doc review site links (behind vpn):
- pgbouncer.ini (scroll down to auth_key_file) - https://docs-staging.vmware.com/en/draft/VMware-Greenplum/pgb-encpasswd/greenplum-database/utility_guide-ref-pgbouncer-ini.html#topic_orc_gkd_gs
- new "About Specifying an Encrypted LDAP Password" topic (scroll down a little) - https://docs-staging.vmware.com/en/draft/VMware-Greenplum/pgb-encpasswd/greenplum-database/admin_guide-access_db-topics-pgbouncer.html#configuring-ldap-based-authentication-for-pgbouncer
