### PR TITLE
docs - optimizer_enable_orderedagg guc added to gp7

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2514,6 +2514,18 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 |-----------|-------|-------------------|
 |Boolean|off|coordinator, session, reload|
 
+## <a id="optimizer_enable_orderedagg"></a>optimizer\_enable\_orderedagg 
+
+When GPORCA is enabled \(the default\), this parameter determines whether or not GPORCA generates a query plan for ordered aggregates.
+
+The default value is `on`, GPORCA generates a plan for a query that includes an ordered aggregate. When `off`, the query falls back to the Postgres-based planner.
+
+You can set this parameter for a database system, an individual database, or a session or query.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|on|coordinator, session, reload|
+
 ## <a id="optimizer_enable_push_join_below_union_all"></a>optimizer\_enable\_push\_join\_below\_union\_all
 
 When GPORCA is enabled \(the default\), the `optimizer_enable_push_join_below_union_all` parameter controls GPORCA's behaviour when it encounters a query that includes a `JOIN` of a `UNION ALL`.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -121,6 +121,7 @@ These parameters control the usage of GPORCA by Greenplum Database. For informat
 - [optimizer_enable_indexonlyscan](guc-list.html#optimizer_enable_indexonlyscan)
 - [optimizer_enable_coordinator_only_queries](guc-list.html#optimizer_enable_coordinator_only_queries)
 - [optimizer_enable_multiple_distinct_aggs](guc-list.html#optimizer_enable_multiple_distinct_aggs)
+- [optimizer_enable_orderedagg](guc-list.html#optimizer_enable_orderedagg)
 - [optimizer_enable_push_join_below_union_all](guc-list.html#optimizer_enable_push_join_below_union_all)
 - [optimizer_enable_replicated_table](guc-list.html#optimizer_enable_replicated_table)
 - [optimizer_force_agg_skew_avoidance](guc-list.html#optimizer_force_agg_skew_avoidance)

--- a/gpdb-doc/markdown/ref_guide/guc-changes-6to7.html.md.erb
+++ b/gpdb-doc/markdown/ref_guide/guc-changes-6to7.html.md.erb
@@ -171,7 +171,6 @@ The following server configuration parameters are removed in Greenplum 7:
 - `memory_spill_ratio`
 - `optimizer_analyze_enable_merge_of_leaf_stats`
 - `optimizer_enable_dml_triggers`
-- `optimizer_enable_orderedagg`
 - `optimizer_enable_partial_index`
 - `optimizer_prune_unused_columns`
 - `password_hash_algorithm`
@@ -182,10 +181,10 @@ The following server configuration parameters are removed in Greenplum 7:
 
 These server configuration parameters are changed in Greenplum 7:
 
+- The server configuration paramater `optimizer_enable_orderedagg` has a new default value of `on`.
 - The server configuration parameter `vacuum_cost_page_miss` has a new default value of 2.
 - The default value for the server configuration parameter `gp_interconnect_address_type` changed from `wildcard` to `unicast`.
 - The `wal_keep_segments` server configuration parameter has been replaced by the `wal_keep_size` parameter.
 - The `autovacuum` server configuration parameter is now enabled for all databases by default, rather than just for the `template0` and `template1` databases.
 - The `gp_autostats_mode` server configuration parameter default value has been changed to `none`.
 - The `gp_default_storage_options` parameter no longer supports the `appendonly` and `appendoptimized` keywords. Use the `default_table_access_method` parameter instead.
-


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/16491.

in this PR:
- add reference info for this guc.  i pulled the text from greenplum 6 guc description.  
- gp6 default is off, gp7 is on, so add to list of guc changes.
