### PR TITLE
Add guc: gp_resource_group_cgroup_parent

### DIFF
--- a/.abi-check/7.0.0/postgres.symbols.ignore
+++ b/.abi-check/7.0.0/postgres.symbols.ignore
@@ -1,5 +1,6 @@
 ConfigureNamesInt_gp
 ConfigureNamesBool_gp
 ConfigureNamesEnum_gp
+ConfigureNamesString_gp
 UpdateOrAddAttributeEncodings
 createDir

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -172,15 +172,18 @@ class Guc:
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
         elif self.name == "gp_resource_group_cgroup_parent":
             base = newval.strip("'")
-            if '/' in base:
-                return "cannot contain '/'"
+            if not re.match("^[0-9a-zA-Z][-._0-9a-zA-Z]*$", base):
+                return "resource group cgroup parent can only contains alphabet, number, and non-leading . _ -"
 
             path = None
             for partition in psutil.disk_partitions(all=True):
                 if partition.fstype == "cgroup2":
                     path = partition.mountpoint + "/" + base
-                    if os.path.realpath(path) == os.path.realpath(partition.mountpoint):
+                    path = os.path.realpath(path)
+                    if path == partition.mountpoint:
                         return "resource group cgroup parent cannot be the root of system cgroup"
+                    if not path.startswith(partition.mountpoint):
+                        return "resource group cgroup parent must be under the root of system cgroup"
                     break
             if path is None:
                 return "cannot find cgroup v2 mountpoint"

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -172,10 +172,15 @@ class Guc:
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
         elif self.name == "gp_resource_group_cgroup_parent":
             base = newval.strip("'")
+            if '/' in base:
+                return "cannot contain '/'"
+
             path = None
             for partition in psutil.disk_partitions(all=True):
                 if partition.fstype == "cgroup2":
                     path = partition.mountpoint + "/" + base
+                    if os.path.realpath(path) == os.path.realpath(partition.mountpoint):
+                        return "resource group cgroup parent cannot be the root of system cgroup"
                     break
             if path is None:
                 return "cannot find cgroup v2 mountpoint"

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -179,11 +179,6 @@ class Guc:
             for partition in psutil.disk_partitions(all=True):
                 if partition.fstype == "cgroup2":
                     path = partition.mountpoint + "/" + base
-                    path = os.path.realpath(path)
-                    if path == partition.mountpoint:
-                        return "resource group cgroup parent cannot be the root of system cgroup"
-                    if not path.startswith(partition.mountpoint):
-                        return "resource group cgroup parent must be under the root of system cgroup"
                     break
             if path is None:
                 return "cannot find cgroup v2 mountpoint"

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -171,7 +171,7 @@ class Guc:
             elif newval != "'queue'" and newval != "'none'":
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
         elif self.name == "gp_resource_group_cgroup_parent":
-            base = newval.strip('\'')
+            base = newval.strip("'")
             path = None
             for partition in psutil.disk_partitions(all=True):
                 if partition.fstype == "cgroup2":

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -15,6 +15,7 @@
 import os
 import sys
 import re
+import psutil
 from psycopg2 import DatabaseError
 try:
     from gppylib.gpparseopts import OptParser, OptChecker
@@ -169,6 +170,18 @@ class Guc:
                     return msg
             elif newval != "'queue'" and newval != "'none'":
                 return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
+        elif self.name == "gp_resource_group_cgroup_parent":
+            base = newval.strip('\'')
+            path = None
+            for partition in psutil.disk_partitions(all=True):
+                if partition.fstype == "cgroup2":
+                    path = partition.mountpoint + "/" + base
+                    break
+            if path is None:
+                return "cannot find cgroup v2 mountpoint"
+            if not os.path.isdir(path):
+                return "'%s' doesn't exists or is not a directory" % path
+
 
         elif self.name == 'unix_socket_permissions':
             if newval[0] != '0':

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -17,9 +17,11 @@
  *
  *-------------------------------------------------------------------------
  */
+#include "catalog/pg_collation_d.h"
 #include "postgres.h"
 
 #include "miscadmin.h"
+#include "regex/regex.h"
 #include "utils/guc.h"
 #include "cdb/cdbvars.h"
 #include "libpq-fe.h"
@@ -580,19 +582,41 @@ gpvars_show_gp_resource_manager_policy(void)
 
 bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, GucSource source)
 {
-	if (strstr(*newval, "/") != NULL)
+	int		  regres;
+	char	  err[128];
+	regex_t  *re = palloc(sizeof(regex_t));
+	char	 *pattern = "^[0-9a-zA-Z][-._0-9a-zA-Z]*$";
+	pg_wchar *wpattern = palloc((strlen(pattern) + 1) * sizeof(pg_wchar));
+	int		  wlen = pg_mb2wchar_with_len(pattern, wpattern, strlen(pattern));
+	pg_wchar *data = palloc((strlen(*newval) + 1) * sizeof(pg_wchar));
+	int		  data_len = pg_mb2wchar_with_len(*newval, data, sizeof(*newval));
+	bool	  match = true;
+
+	regres = pg_regcomp(re, wpattern, wlen, REG_ADVANCED, DEFAULT_COLLATION_OID);
+	if (regres != REG_OKAY)
 	{
-		GUC_check_errmsg("gp_resource_group_cgroup_parent must be a valid folder name, cannot contain '/': '%s'", *newval);
+		CHECK_FOR_INTERRUPTS();
+		pg_regerror(regres, re, err, sizeof(err));
+		GUC_check_errmsg("compile regex failed: %s", err);
+
+		pfree(wpattern);
+		pfree(data);
+
 		return false;
 	}
 
-	if (strlen(*newval) == 0)
+	regres = pg_regexec(re, data, data_len, 0, NULL, 0, NULL, 0);
+	if (regres != REG_OKAY)
 	{
-		GUC_check_errmsg("gp_resource_group_cgroup_parent is empty");
-		return false;
+		match = false;
+		GUC_check_errmsg("gp_resource_group_cgroup_parent can only contains alphabet, number and non-leading . _ -");
 	}
 
-	return true;
+	pg_regfree(re);
+	pfree(wpattern);
+	pfree(data);
+
+	return match;
 }
 
 /*

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -585,6 +585,13 @@ bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, G
 		GUC_check_errmsg("gp_resource_group_cgroup_parent must be a valid folder name, cannot contain '/': '%s'", *newval);
 		return false;
 	}
+
+	if (strlen(*newval) == 0)
+	{
+		GUC_check_errmsg("gp_resource_group_cgroup_parent is empty");
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -595,7 +595,6 @@ bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, G
 	regres = pg_regcomp(re, wpattern, wlen, REG_ADVANCED, DEFAULT_COLLATION_OID);
 	if (regres != REG_OKAY)
 	{
-		CHECK_FOR_INTERRUPTS();
 		pg_regerror(regres, re, err, sizeof(err));
 		GUC_check_errmsg("compile regex failed: %s", err);
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -578,6 +578,16 @@ gpvars_show_gp_resource_manager_policy(void)
 	}
 }
 
+bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, GucSource source)
+{
+	if (strstr(*newval, "/") != NULL)
+	{
+		GUC_check_errmsg("gp_resource_group_cgroup_parent must be a valid folder name, cannot contain '/': '%s'", *newval);
+		return false;
+	}
+	return true;
+}
+
 /*
  * gpvars_assign_statement_mem
  */

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -584,7 +584,7 @@ bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, G
 {
 	int		  regres;
 	char	  err[128];
-	regex_t  *re = palloc(sizeof(regex_t));
+	regex_t  re;
 	char	 *pattern = "^[0-9a-zA-Z][-._0-9a-zA-Z]*$";
 	pg_wchar *wpattern = palloc((strlen(pattern) + 1) * sizeof(pg_wchar));
 	int		  wlen = pg_mb2wchar_with_len(pattern, wpattern, strlen(pattern));
@@ -592,10 +592,10 @@ bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, G
 	int		  data_len = pg_mb2wchar_with_len(*newval, data, sizeof(*newval));
 	bool	  match = true;
 
-	regres = pg_regcomp(re, wpattern, wlen, REG_ADVANCED, DEFAULT_COLLATION_OID);
+	regres = pg_regcomp(&re, wpattern, wlen, REG_ADVANCED, DEFAULT_COLLATION_OID);
 	if (regres != REG_OKAY)
 	{
-		pg_regerror(regres, re, err, sizeof(err));
+		pg_regerror(regres, &re, err, sizeof(err));
 		GUC_check_errmsg("compile regex failed: %s", err);
 
 		pfree(wpattern);
@@ -604,14 +604,14 @@ bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, G
 		return false;
 	}
 
-	regres = pg_regexec(re, data, data_len, 0, NULL, 0, NULL, 0);
+	regres = pg_regexec(&re, data, data_len, 0, NULL, 0, NULL, 0);
 	if (regres != REG_OKAY)
 	{
 		match = false;
 		GUC_check_errmsg("gp_resource_group_cgroup_parent can only contains alphabet, number and non-leading . _ -");
 	}
 
-	pg_regfree(re);
+	pg_regfree(&re);
 	pfree(wpattern);
 	pfree(data);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4584,7 +4584,7 @@ struct config_string ConfigureNamesString_gp[] =
 		},
 		&gp_resource_group_cgroup_parent,
 		"gpdb.service",
-		NULL, NULL, NULL
+		gpvars_check_gp_resource_group_cgroup_parent, NULL, NULL
 	},
 
 	/* for pljava */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -224,6 +224,7 @@ double		gp_resource_group_cpu_limit;
 bool		gp_resource_group_bypass;
 bool		gp_resource_group_bypass_catalog_query;
 bool		gp_resource_group_bypass_direct_dispatch;
+char	   *gp_resource_group_cgroup_parent;
 
 /* Metrics collector debug GUC */
 bool		vmem_process_interrupt = false;
@@ -4573,6 +4574,17 @@ struct config_string ConfigureNamesString_gp[] =
 		gpvars_check_gp_resource_manager_policy,
 		gpvars_assign_gp_resource_manager_policy,
 		gpvars_show_gp_resource_manager_policy,
+	},
+
+	{
+		{"gp_resource_group_cgroup_parent", PGC_POSTMASTER, RESOURCES,
+			gettext_noop("The root of gpdb cgroup hierarchy."),
+			NULL,
+			GUC_SUPERUSER_ONLY
+		},
+		&gp_resource_group_cgroup_parent,
+		"gpdb.service",
+		NULL, NULL, NULL
 	},
 
 	/* for pljava */

--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -174,7 +174,7 @@ buildPathSafe(Oid group,
 		 * for cgroup v2, we just have the top level and child level,
 		 * don't need to care about the component.
 		 */
-		base_dir = base == BASEDIR_GPDB ? "gpdb" : "";
+		base_dir = base == BASEDIR_GPDB ? gp_resource_group_cgroup_parent : "";
 		len = snprintf(path, path_size, "%s/%s%s/%s",
 					   cgroupSystemInfo->cgroup_dir, base_dir, group_dir, filename);
 	}

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -809,6 +809,7 @@ extern void gpvars_assign_gp_resource_manager_policy(const char *newval, void *e
 extern const char *gpvars_show_gp_resource_manager_policy(void);
 extern const char *gpvars_assign_gp_resqueue_memory_policy(const char *newval, bool doit, GucSource source);
 extern const char *gpvars_show_gp_resqueue_memory_policy(void);
+extern bool gpvars_check_gp_resource_group_cgroup_parent(char **newval, void **extra, GucSource source);
 extern bool gpvars_check_statement_mem(int *newval, void **extra, GucSource source);
 extern bool gpvars_check_rg_query_fixed_mem(int *newval, void **extra, GucSource source);
 extern int guc_name_compare(const char *namea, const char *nameb);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -109,6 +109,7 @@ extern int gp_resource_group_queuing_timeout;
 extern bool gp_resource_group_bypass_catalog_query;
 extern int gp_resource_group_move_timeout;
 extern bool gp_resource_group_bypass_direct_dispatch;
+extern char *gp_resource_group_cgroup_parent;
 
 /*
  * Non-GUC global variables.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -222,6 +222,7 @@
 		"gp_resource_group_bypass_direct_dispatch",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_group_move_timeout",
+		"gp_resource_group_cgroup_parent",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",
 		"gp_resqueue_priority",

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -23,7 +23,7 @@ ERROR:  language "plpython3u" already exists
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group-v2;
 
-! gpconfig -c gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
+! gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
 
 ! gpconfig -c max_connections -v 250 -m 25;
 

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -23,6 +23,8 @@ ERROR:  language "plpython3u" already exists
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group-v2;
 
+! gpconfig -c gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
+
 ! gpconfig -c max_connections -v 250 -m 25;
 
 ! gpconfig -c runaway_detector_activation_percent -v 100;

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -21,7 +21,7 @@ CREATE LANGUAGE plpython3u;
 -- enable resource group and restart cluster.
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group-v2;
-! gpconfig -c gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
+! gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -21,6 +21,7 @@ CREATE LANGUAGE plpython3u;
 -- enable resource group and restart cluster.
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group-v2;
+! gpconfig -c gpconfig -c gp_resource_group_cgroup_parent -v "gpdb"
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;


### PR DESCRIPTION
Add guc: gp_resource_group_cgroup_parent (only for cgroup v2).

Current gpdb doesn't support change root cgroup path of resource group. For some situations, it's better if gpdb can change the root cgroup path of resource group.

For example, on the OS with systemd, user maybe want to create a delegated  cgroup to gpdb via systemd, but the delegated cgroup must end with `.service` which typically is `/sys/fs/cgroup/gpdb.service`. And in other OS without systemd, user maybe want to use `/sys/fs/cgroup/gpdb` or other locations directly. So add the `gp_resource_group_cgroup_parent` can make the resource group more flexible.