### PR TITLE
Added rsync version requirement for gpstate -e

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gpstate.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpstate.html.md
@@ -41,7 +41,8 @@ The `gpstate` utility displays information about a running Greenplum Database in
     -   Whether any segments are down.
     -   Whether any primary-mirror segment pairs are out of sync – including information on how many bytes are remaining to sync \(as displayed in the `WAL sync remaining bytes` output field\).
 
-    > **Note** `gpstate -e`does not display segment pairs that are in sync.
+    > **Note** `gpstate -e` does not display segment pairs that are in sync.
+
     > **Note** You must have `rsync` version 3.1.x or higher installed in order to view the tracking information for segments undergoing a differential recovery.
 
     -   Whether any primary-mirror segment pairs are not in their preferred roles.

--- a/gpdb-doc/markdown/utility_guide/ref/gpstate.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpstate.html.md
@@ -41,7 +41,8 @@ The `gpstate` utility displays information about a running Greenplum Database in
     -   Whether any segments are down.
     -   Whether any primary-mirror segment pairs are out of sync – including information on how many bytes are remaining to sync \(as displayed in the `WAL sync remaining bytes` output field\).
 
-        > **Note** `gpstate -e`does not display segment pairs that are in sync.
+    > **Note** `gpstate -e`does not display segment pairs that are in sync.
+    > **Note** You must have `rsync` version 3.1.x or higher installed in order to view the tracking information for segments undergoing a differential recovery.
 
     -   Whether any primary-mirror segment pairs are not in their preferred roles.
 


### PR DESCRIPTION
This PR adds a note to indicate the minimum version of rsync in order to view the tracking information for segments undergoing a differential recovery.