### PR TITLE
Fix flaky test function_extensions

### DIFF
--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -499,11 +499,12 @@ CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=20360)
--- Temp file number after running INITPLAN function. All the files should've
--- been cleaned up
+-- Temp file number after running INITPLAN function. All the files generated during this time should've
+-- been cleaned up, so the number of files should not be more than previously (it could be less, if some
+-- existing temp file happens to be cleaned up at the same time).
 SELECT get_temp_file_num() AS num_temp_files_after
 \gset
-SELECT :num_temp_files_before = :num_temp_files_after;
+SELECT :num_temp_files_before >= :num_temp_files_after;
  ?column? 
 ----------
  t

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -501,11 +501,12 @@ CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=20360)
--- Temp file number after running INITPLAN function. All the files should've
--- been cleaned up
+-- Temp file number after running INITPLAN function. All the files generated during this time should've
+-- been cleaned up, so the number of files should not be more than previously (it could be less, if some
+-- existing temp file happens to be cleaned up at the same time).
 SELECT get_temp_file_num() AS num_temp_files_after
 \gset
-SELECT :num_temp_files_before = :num_temp_files_after;
+SELECT :num_temp_files_before >= :num_temp_files_after;
  ?column? 
 ----------
  t

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -263,11 +263,12 @@ SELECT count(*) FROM t3_function_scan;
 DROP TABLE IF EXISTS t4_function_scan;
 CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL SELECT * FROM get_country();
 
--- Temp file number after running INITPLAN function. All the files should've
--- been cleaned up
+-- Temp file number after running INITPLAN function. All the files generated during this time should've
+-- been cleaned up, so the number of files should not be more than previously (it could be less, if some
+-- existing temp file happens to be cleaned up at the same time).
 SELECT get_temp_file_num() AS num_temp_files_after
 \gset
-SELECT :num_temp_files_before = :num_temp_files_after;
+SELECT :num_temp_files_before >= :num_temp_files_after;
 
 -- test join case with two INITPLAN functions
 DROP TABLE IF EXISTS t5_function_scan;


### PR DESCRIPTION
The failure diff:
```
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/function_extensions_optimizer.out	2023-09-19 15:16:27.567037328 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/function_extensions.out	2023-09-19 15:16:27.591039792 +0000
@@ -525,7 +526,7 @@
 SELECT :num_temp_files_before = :num_temp_files_after;
  ?column?
 ----------
- t
+ f
 (1 row)
```

In the log we can see what are the numbers:
```
2023-09-19 15:16:24.455922 ......"statement: SELECT 1 = 0;",,,,,,,0,,"postgres.c",1729
```
So it seems that some existing file just happened to be cleaned up at the same time, so the number-before > the number-after. We should allow such a case.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/flake-function_extensions

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
