### PR TITLE
docs - add pgbouncer reference and using content

### DIFF
--- a/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
+++ b/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
@@ -1,0 +1,297 @@
+---
+title: Using the PgBouncer Connection Pooler 
+---
+
+The PgBouncer utility manages connection pools for PostgreSQL and Greenplum Database connections.
+
+The following topics describe how to set up and use PgBouncer with Greenplum Database. Refer to the [PgBouncer web site](https://pgbouncer.github.io) for information about using PgBouncer with PostgreSQL.
+
+-   [Overview](#topic_nzk_nqg_cs)
+-   [Migrating PgBouncer](#pgb_migrate)
+-   [Configuring PgBouncer](#pgb_config)
+-   [Starting PgBouncer](#pgb_start)
+-   [Managing PgBouncer](#topic_manage)
+
+**Parent topic:** [Accessing the Database](../../access_db/topics/g-accessing-the-database.html)
+
+## <a id="topic_nzk_nqg_cs"></a>Overview 
+
+A database connection pool is a cache of database connections. Once a pool of connections is established, connection pooling eliminates the overhead of creating new database connections, so clients connect much faster and the server load is reduced.
+
+The PgBouncer connection pooler, from the PostgreSQL community, is included in your Greenplum Database installation. PgBouncer is a light-weight connection pool manager for Greenplum and PostgreSQL. PgBouncer maintains a pool for connections for each database and user combination. PgBouncer either creates a new database connection for a client or reuses an existing connection for the same user and database. When the client disconnects, PgBouncer returns the connection to the pool for re-use.
+
+In order not to compromise transaction semantics for connection pooling, PgBouncer supports several types of pooling when rotating connections:
+
+- *Session pooling* - Most polite method. When a client connects, a server connection will be assigned to it for the whole duration the client stays connected. When the client disconnects, the server connection will be put back into the pool. This is the default method.
+
+- *Transaction pooling* - A server connection is assigned to a client only during a transaction. When PgBouncer notices that transaction is over, the server connection will be put back into the pool.
+
+- *Statement pooling* - Most aggressive method. The server connection will be put back into the pool immediately after a query completes. Multi-statement transactions are disallowed in this mode as they would break.
+
+You can set a default pool mode for the PgBouncer instance. You can override this mode for individual databases and users.
+
+PgBouncer supports the standard connection interface shared by PostgreSQL and Greenplum Database. The Greenplum Database client application \(for example, `psql`\) connects to the host and port on which PgBouncer is running rather than the Greenplum Database master host and port.
+
+PgBouncer includes a `psql`-like administration console. Authorized users can connect to a virtual database to monitor and manage PgBouncer. You can manage a PgBouncer daemon process via the admin console. You can also use the console to update and reload PgBouncer configuration at runtime without stopping and restarting the process.
+
+PgBouncer natively supports TLS.
+
+## <a id="pgb_migrate"></a>Migrating PgBouncer 
+
+When you migrate to a new Greenplum Database version, you must migrate your PgBouncer instance to that in the new Greenplum Database installation.
+
+-   **If you are migrating to a Greenplum Database version 5.8.x or earlier**, you can migrate PgBouncer without dropping connections. Launch the new PgBouncer process with the `-R` option and the configuration file that you started the process with:
+
+    ```
+    $ pgbouncer -R -d pgbouncer.ini
+    ```
+
+    The `-R` \(reboot\) option causes the new process to connect to the console of the old process through a Unix socket and issue the following commands:
+
+    ```
+    SUSPEND;
+    SHOW FDS;
+    SHUTDOWN;
+    ```
+
+    When the new process detects that the old process is gone, it resumes the work with the old connections. This is possible because the `SHOW FDS` command sends actual file descriptors to the new process. If the transition fails for any reason, kill the new process and the old process will resume.
+
+-   **If you are migrating to a Greenplum Database version 5.9.0 or later**, you must shut down the PgBouncer instance in your old installation and reconfigure and restart PgBouncer in your new installation.
+-   If you used stunnel to secure PgBouncer connections in your old installation, you must configure SSL/TLS in your new installation using the built-in TLS capabilities of PgBouncer 1.8.1 and later.
+-   If you currently use the built-in PAM LDAP integration, you may choose to migrate to the new native LDAP PgBouncer integration introduced in Greenplum Database version 6.22; refer to [Configuring LDAP-based Authentication for PgBouncer](#pgb_ldap) for configuration information.
+
+## <a id="pgb_config"></a>Configuring PgBouncer 
+
+You configure PgBouncer and its access to Greenplum Database via a configuration file. This configuration file, commonly named `pgbouncer.ini`, provides location information for Greenplum databases. The `pgbouncer.ini` file also specifies process, connection pool, authorized users, and authentication configuration for PgBouncer.
+
+Sample `pgbouncer.ini` file contents:
+
+```
+[databases]
+postgres = host=127.0.0.1 port=5432 dbname=postgres
+pgb_mydb = host=127.0.0.1 port=5432 dbname=mydb
+
+[pgbouncer]
+pool_mode = session
+listen_port = 6543
+listen_addr = 127.0.0.1
+auth_type = md5
+auth_file = users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = gpadmin
+```
+
+Refer to the [pgbouncer.ini](../../../utility_guide/ref/pgbouncer-ini.html) reference page for the PgBouncer configuration file format and the list of configuration properties it supports.
+
+When a client connects to PgBouncer, the connection pooler looks up the the configuration for the requested database \(which may be an alias for the actual database\) that was specified in the `pgbouncer.ini` configuration file to find the host name, port, and database name for the database connection. The configuration file also identifies the authentication mode in effect for the database.
+
+PgBouncer requires an authentication file, a text file that contains a list of Greenplum Database users and passwords. The contents of the file are dependent on the `auth_type` you configure in the `pgbouncer.ini` file. Passwords may be either clear text or MD5-encoded strings. You can also configure PgBouncer to query the destination database to obtain password information for users that are not in the authentication file.
+
+### <a id="pgb_auth"></a>PgBouncer Authentication File Format 
+
+PgBouncer requires its own user authentication file. You specify the name of this file in the `auth_file` property of the `pgbouncer.ini` configuration file. `auth_file` is a text file in the following format:
+
+```
+"username1" "password" ...
+"username2" "md5abcdef012342345" ...
+"username2" "SCRAM-SHA-256$<iterations>:<salt>$<storedkey>:<serverkey>"
+```
+
+`auth_file` contains one line per user. Each line must have at least two fields, both of which are enclosed in double quotes \(`" "`\). The first field identifies the Greenplum Database user name. The second field is either a plain-text password, an MD5-encoded password, or or a SCRAM secret. PgBouncer ignores the remainder of the line.
+
+\(The format of `auth_file` is similar to that of the `pg_auth` text file that Greenplum Database uses for authentication information. PgBouncer can work directly with this Greenplum Database authentication file.\)
+
+Use an MD5 encoded password. The format of an MD5 encoded password is:
+
+```
+"md5" + MD5_encoded(<password><username>)
+```
+
+You can also obtain the MD5-encoded passwords of all Greenplum Database users from the `pg_shadow` view.
+
+PostgreSQL SCRAM secret format:
+
+```
+SCRAM-SHA-256$<iterations>:<salt>$<storedkey>:<serverkey>
+```
+
+See the PostgreSQL documentation and RFC 5803 for details on this.
+
+The passwords or secrets stored in the authentication file serve two purposes. First, they are used to verify the passwords of incoming client connections, if a password-based authentication method is configured. Second, they are used as the passwords for outgoing connections to the backend server, if the backend server requires password-based authentication \(unless the password is specified directly in the database’s connection string\). The latter works if the password is stored in plain text or MD5-hashed.
+
+SCRAM secrets can only be used for logging into a server if the client authentication also uses SCRAM, the PgBouncer database definition does not specify a user name, and the SCRAM secrets are identical in PgBouncer and the PostgreSQL server \(same salt and iterations, not merely the same password\). This is due to an inherent security property of SCRAM: The stored SCRAM secret cannot by itself be used for deriving login credentials.
+
+The authentication file can be written by hand, but it’s also useful to generate it from some other list of users and passwords. See `./etc/mkauth.py` for a sample script to generate the authentication file from the `pg_shadow` system table. Alternatively, use
+
+```
+auth_query
+```
+
+instead of `auth_file` to avoid having to maintain a separate authentication file.
+
+### <a id="pgb_hba"></a>Configuring HBA-based Authentication for PgBouncer 
+
+PgBouncer supports HBA-based authentication. To configure HBA-based authentication for PgBouncer, you set `auth_type=hba` in the `pgbouncer.ini` configuration file. You also provide the filename of the HBA-format file in the `auth_hba_file` parameter of the `pgbouncer.ini` file.
+
+Contents of an example PgBouncer HBA file named `hba_bouncer.conf`:
+
+```
+local       all     bouncer             trust
+host        all     bouncer      127.0.0.1/32       trust
+```
+
+Example excerpt from the related `pgbouncer.ini` configuration file:
+
+```
+[databases]
+p0 = port=15432 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
+p1 = port=15432 host=127.0.0.1 dbname=p1 user=bouncer
+...
+
+[pgbouncer]
+...
+auth_type = hba
+auth_file = userlist.txt
+auth_hba_file = hba_bouncer.conf
+...
+```
+
+Refer to the [HBA file format](https://pgbouncer.github.io/config.html#hba-file-format) discussion in the PgBouncer documentation for information about PgBouncer support of the HBA authentication file format.
+
+### <a id="pgb_ldap"></a>Configuring LDAP-based Authentication for PgBouncer 
+
+Starting in Greenplum Database version 6.22, PgBouncer supports native LDAP authentication between the `psql` client and the `pgbouncer` process. Configuring this LDAP-based authentication is similar to configuring HBA-based authentication for PgBouncer:
+
+- Specify `auth-type=hba` in the `pgbouncer.ini` configuration file.
+- Provide the file name of an HBA-format file in the `auth_hba_file` parameter of the `pgbouncer.ini` file, and specify the LDAP parameters (server address, base DN, bind DN, bind password, search attribute, etc.) in the file.
+
+> **Note** You may, but are not required to, specify LDAP user names and passwords in the `auth-file`. When you do *not* specify these strings in the `auth-file`, LDAP user password changes require no PgBouncer configuration changes.
+
+If you enable LDAP authentication between `psql` and `pgbouncer` and you use `md5`, `password`, or `scram-sha-256` for authentication between PgBouncer and Greenplum Database, ensure that you configure the latter password independently.
+
+Excerpt of an example PgBouncer HBA file named `hba_bouncer_for_ldap.conf` that specifies LDAP authentication follows:
+
+``` pre
+host all user1 0.0.0.0/0 ldap ldapserver=<ldap-server-address> ldapbasedn="CN=Users,DC=greenplum,DC=org" ldapbinddn="CN=Administrator,CN=Users,DC=greenplum,DC=org" ldapbindpasswd="ChangeMe1!!" ldapsearchattribute="SomeAttrName"
+```
+
+Refer to the Greenplum Database [LDAP Authentication](../../../security-guide/topics/Authenticate.html#ldap_auth) discussion for more information on configuring an HBA file for LDAP.
+
+Example excerpt from the related `pgbouncer.ini` configuration file:
+
+``` pre
+[databases]
+* = port = 6000 host=127.0.0.1
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+
+auth_type = hba
+auth_hba_file = hba_bouncer_for_ldap.conf
+...
+```
+
+## <a id="pgb_start"></a>Starting PgBouncer 
+
+You can run PgBouncer on the Greenplum Database master or on another server. If you install PgBouncer on a separate server, you can easily switch clients to the standby master by updating the PgBouncer configuration file and reloading the configuration using the PgBouncer Administration Console.
+
+Follow these steps to set up PgBouncer.
+
+1.  Create a PgBouncer configuration file. For example, add the following text to a file named `pgbouncer.ini`:
+
+    ```
+    [databases]
+    postgres = host=127.0.0.1 port=5432 dbname=postgres
+    pgb_mydb = host=127.0.0.1 port=5432 dbname=mydb
+    
+    [pgbouncer]
+    pool_mode = session
+    listen_port = 6543
+    listen_addr = 127.0.0.1
+    auth_type = md5
+    auth_file = users.txt
+    logfile = pgbouncer.log
+    pidfile = pgbouncer.pid
+    admin_users = gpadmin
+    ```
+
+    The file lists databases and their connection details. The file also configures the PgBouncer instance. Refer to the [pgbouncer.ini](../../../utility_guide/ref/pgbouncer-ini.html) reference page for information about the format and content of a PgBouncer configuration file.
+
+2.  Create an authentication file. The filename should be the name you specified for the `auth_file` parameter of the `pgbouncer.ini` file, `users.txt`. Each line contains a user name and password. The format of the password string matches the `auth_type` you configured in the PgBouncer configuration file. If the `auth_type` parameter is `plain`, the password string is a clear text password, for example:
+
+    ```
+    "gpadmin" "gpadmin1234"
+    ```
+
+    If the `auth_type` in the following example is `md5`, the authentication field must be MD5-encoded. The format for an MD5-encoded password is:
+
+    ```
+    "md5" + MD5_encoded(<password><username>)
+    ```
+
+3.  Launch `pgbouncer`:
+
+    ```
+    $ $GPHOME/bin/pgbouncer -d pgbouncer.ini
+    ```
+
+    The `-d` option runs PgBouncer as a background \(daemon\) process. Refer to the [pgbouncer](../../../utility_guide/ref/pgbouncer.html) reference page for the `pgbouncer` command syntax and options.
+
+4.  Update your client applications to connect to `pgbouncer` instead of directly to Greenplum Database server. For example, to connect to the Greenplum database named `mydb` configured above, run `psql` as follows:
+
+    ```
+    $ psql -p 6543 -U someuser pgb_mydb
+    ```
+
+    The `-p` option value is the `listen_port` that you configured for the PgBouncer instance.
+
+
+## <a id="topic_manage"></a>Managing PgBouncer 
+
+PgBouncer provides a `psql`-like administration console. You log in to the PgBouncer Administration Console by specifying the PgBouncer port number and a virtual database named `pgbouncer`. The console accepts SQL-like commands that you can use to monitor, reconfigure, and manage PgBouncer.
+
+For complete documentation of PgBouncer Administration Console commands, refer to the [pgbouncer-admin](../../../utility_guide/ref/pgbouncer-admin.html) command reference.
+
+Follow these steps to get started with the PgBouncer Administration Console.
+
+1.  Use `psql` to log in to the `pgbouncer` virtual database:
+
+    ```
+    $ psql -p 6543 -U username pgbouncer
+    ```
+
+    The username that you specify must be listed in the `admin_users` parameter in the `pgbouncer.ini` configuration file. You can also log in to the PgBouncer Administration Console with the current Unix username if the `pgbouncer` process is running under that user's UID.
+
+2.  To view the available PgBouncer Administration Console commands, run the `SHOW help` command:
+
+    ```
+    pgbouncer=# SHOW help;
+    NOTICE:  Console usage
+    DETAIL:
+        SHOW HELP|CONFIG|DATABASES|FDS|POOLS|CLIENTS|SERVERS|SOCKETS|LISTS|VERSION|...
+        SET key = arg
+        RELOAD
+        PAUSE
+        SUSPEND
+        RESUME
+        SHUTDOWN
+        [...]
+    ```
+
+3.  If you update PgBouncer configuration by editing the `pgbouncer.ini` configuration file, you use the `RELOAD` command to reload the file:
+
+    ```
+    pgbouncer=# RELOAD;
+    ```
+
+
+### <a id="mapbouncclient"></a>Mapping PgBouncer Clients to Greenplum Database Server Connections 
+
+To map a PgBouncer client to a Greenplum Database server connection, use the PgBouncer Administration Console `SHOW CLIENTS` and `SHOW SERVERS` commands:
+
+1.  Use `ptr` and `link` to map the local client connection to the server connection.
+2.  Use the `addr` and the `port` of the client connection to identify the TCP connection from the client.
+3.  Use `local_addr` and `local_port` to identify the TCP connection to the server.
+

--- a/gpdb-doc/markdown/security-guide/topics/ports_and_protocols.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/ports_and_protocols.html.md
@@ -69,6 +69,7 @@ Some add-on products and services that work with Greenplum Database have additio
 |EMC Data Domain and DD Boost|TCP 2052|Main port used by NFS mountd. This port can be set on the Data Domain system using the `nfs set mountd-port` command .|
 |EMC Data Domain and DD Boost|TCP 2049, NFS|Main port used by NFS. This port can be configured using the `nfs set server-port` command on the Data Domain server.|
 |EMC Data Domain and DD Boost|TCP 2051, replication|Used when replication is configured on the Data Domain system. This port can be configured using the `replication modify` command on the Data Domain server.|
+|Pgbouncer connection pooler|TCP, libpq|The pgbouncer connection pooler runs between libpq clients and Greenplum (or PostgreSQL) databases. While you can run it on the Greenplum coordinator host, running pgbouncer on a host outside of the Greenplum cluster is recommended. When it runs on a separate host, pgbouncer can act as a warm standby mechanism for the Greenplum coordinator host, switching to the Greenplum standby host without requiring clients to reconfigure. Set the client connection port and the Greenplum coordinator host address and port in the [pgbouncer.ini](../../utility_guide/ref/pgbouncer-ini.html) configuration file.|
 
 **Parent topic:** [Greenplum Database Security Configuration Guide](../topics/preface.html)
 

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-admin.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-admin.html.md
@@ -1,0 +1,357 @@
+---
+title: pgbouncer-admin 
+---
+
+PgBouncer Administration Console.
+
+## <a id="syn"></a>Synopsis 
+
+```
+psql -p <port> pgbouncer
+```
+
+## <a id="desc"></a>Description 
+
+The PgBouncer Administration Console is available via `psql`. Connect to the PgBouncer `<port>` and the virtual database named `pgbouncer` to log in to the console.
+
+Users listed in the `pgbouncer.ini` configuration parameters `admin_users` and `stats_users` have privileges to log in to the PgBouncer Administration Console. When `auth_type=any`, then any user is allowed in as a stats_user.
+
+Additionally, the user name `pgbouncer` is allowed to log in without password when the login comes via the Unix socket and the client has same Unix user UID as the running process.
+
+You can control connections between PgBouncer and Greenplum Database from the console. You can also set PgBouncer configuration parameters.
+
+## <a id="opt"></a>Options 
+
+-p \<port\>
+:   The PgBouncer port number.
+
+## <a id="topic_bk3_3jc_dt"></a>Command Syntax 
+
+```
+pgbouncer=# SHOW help;
+NOTICE:  Console usage
+DETAIL:  
+    SHOW HELP|CONFIG|USERS|DATABASES|POOLS|CLIENTS|SERVERS|VERSION
+    SHOW FDS|SOCKETS|ACTIVE_SOCKETS|LISTS|MEM
+    SHOW DNS_HOSTS|DNS_ZONES
+    SHOW STATS|STATS_TOTALS|STATS_AVERAGES
+    SHOW TOTALS
+    SET key = arg
+    RELOAD
+    PAUSE [<db>]
+    RESUME [<db>]
+    DISABLE <db>
+    ENABLE <db>
+    RECONNECT [<db>]
+    KILL <db>
+    SUSPEND
+    SHUTDOWN
+```
+
+## <a id="topic_bf5_jcl_gs"></a>Administration Commands 
+
+The following PgBouncer administration commands control the running `pgbouncer` process.
+
+PAUSE \[\<db\>\]
+:   If no database is specified, PgBouncer tries to disconnect from all servers, first waiting for all queries to complete. The command will not return before all queries are finished. This command is to be used to prepare to restart the database.
+
+:   If a database name is specified, PgBouncer pauses only that database.
+
+:   New client connections to a paused database will wait until a `RESUME` command is invoked.
+
+DISABLE \<db\>
+:   Reject all new client connections on the database.
+
+ENABLE \<db\>
+:   Allow new client connections after a previous `DISABLE` command.
+
+RECONNECT
+:   Close each open server connection for the given database, or all databases, after it is released \(according to the pooling mode\), even if its lifetime is not up yet. New server connections can be made immediately and will connect as necessary according to the pool size settings.
+
+:   This command is useful when the server connection setup has changed, for example to perform a gradual switchover to a new server. It is not necessary to run this command when the connection string in `pgbouncer.ini` has been changed and reloaded (see `RELOAD`) or when DNS resolution has changed, because then the equivalent of this command will be run automatically. This command is only necessary if something downstream of PgBouncer routes the connections.
+
+:   After this command is run, there could be an extended period where some server connections go to an old destination and some server connections go to a new destination. This is likely only sensible when switching read-only traffic between read-only replicas, or when switching between nodes of a multimaster replication setup. If all connections need to be switched at the same time, `PAUSE` is recommended instead. To close server connections without waiting (for example, in emergency failover rather than gradual switchover scenarios), also consider `KILL`.
+
+KILL \<db\>
+:   Immediately drop all client and server connections to the named database.
+
+:   New client connections to a killed database will wait until `RESUME` is called.
+
+SUSPEND
+:   All socket buffers are flushed and PgBouncer stops listening for data on them. The command will not return before all buffers are empty. To be used when rebooting PgBouncer online.
+
+:   New client connections to a suspended database will wait until `RESUME` is called.
+
+RESUME \[\<db\>\]
+:   Resume work from a previous `KILL`, `PAUSE`, or `SUSPEND` command.
+
+SHUTDOWN
+:   The PgBouncer process will exit. To exit from the `psql` command line session, enter `\q`.
+
+RELOAD
+:   The PgBouncer process reloads the current configuration file and updates the changeable settings.
+
+:   PgBouncer notices when a configuration file reload changes the connection parameters of a database definition. An existing server connection to the old destination will be closed when the server connection is next released (according to the pooling mode), and new server connections will immediately use the updated connection parameters
+
+WAIT\_CLOSE \[\<db\>\]
+:   Wait until all server connections, either of the specified database or of all databases, have cleared the “close\_needed” state \(see `SHOW SERVERS`\). This can be called after a `RECONNECT` or `RELOAD` to wait until the respective configuration change has been fully activated, for example in switchover scripts.
+
+SET key = value
+:   Changes the specified configuration setting. See the [`SHOW CONFIG;`](#CONFIG) command.
+
+:   (Note that this command is run on the PgBouncer admin console and sets PgBouncer settings. A `SET` command run on another database will be passed to the PostgreSQL backend like any other SQL command.)
+
+## <a id="topic_zfh_2dl_gs"></a>SHOW Command 
+
+The `SHOW <category>` command displays different types of PgBouncer information. You can specify one of the following categories:
+
+-   [CLIENTS](#CLIENTS)
+-   [CONFIG](#CONFIG)
+-   [DATABASES](#DATABASES)
+-   [DNS\_HOSTS](#DNS_HOSTS)
+-   [DNS\_ZONES](#DNS_ZONES)
+-   [FDS](#FDS)
+-   [LISTS](#LISTS)
+-   [MEM](#MEM)
+-   [POOLS](#POOLS)
+-   [SERVERS](#SERVERS)
+-   [SOCKETS, ACTIVE\_SOCKETS](#SOCKETS), 
+-   [STATS](#STATS)
+-   [STATS\_TOTALS](#STATS_TOTALS)
+-   [STATS\_AVERAGES](#STATS_AVERAGES)
+-   [TOTALS](#TOTALS)
+-   [USERS](#USERS)
+-   [VERSION](#VERSION)
+
+### <a id="CLIENTS"></a>CLIENTS 
+
+|Column|Description|
+|------|-----------|
+|type|C, for client.|
+|user|Client connected user.|
+|database|Database name.|
+|state|State of the client connection, one of `active` or `waiting`.|
+|addr|IP address of client.|
+|port|Port client is connected to.|
+|local\_addr|Connection end address on local machine.|
+|local\_port|Connection end port on local machine.|
+|connect\_time|Timestamp of connect time.|
+|request\_time|Timestamp of latest client request.|
+|wait|Current Time waiting in seconds.|
+|wait\_us|Microsecond part of the current waiting time.|
+|ptr|Address of internal object for this connection. Used as unique ID.|
+|link|Address of server connection the client is paired with.|
+|remote\_pid|Process ID, if client connects with Unix socket and the OS supports getting it.|
+|tls|A string with TLS connection information, or empty if not using TLS.|
+
+### <a id="CONFIG"></a>CONFIG 
+
+Show the current PgBouncer configuration settings, one per row, with the following columns:
+
+|Column|Description|
+|------|-----------|
+|key|Configuration variable name|
+|value|Configuration value|
+|default|Configuration default value|
+|changeable|Either `yes` or `no`. Shows whether the variable can be changed while running. If `no`, the variable can be changed only at boot time. Use `SET` to change a variable at run time.|
+
+### <a id="DATABASES"></a>DATABASES 
+
+|Column|Description|
+|------|-----------|
+|name|Name of configured database entry.|
+|host|Host pgbouncer connects to.|
+|port|Port pgbouncer connects to.|
+|database|Actual database name pgbouncer connects to.|
+|force\_user|When user is part of the connection string, the connection between pgbouncer and the database server is forced to the given user, whatever the client user.|
+|pool\_size|Maximum number of server connections.|
+|min\_pool\_size|Minimum number of server connections.|
+|reserve\_pool|The maximum number of additional connections for this database.|
+|pool\_mode|The database's override `pool_mode` or NULL if the default will be used instead.|
+|max\_connections|Maximum number of allowed connections for this database, as set by `max_db_connections`, either globally or per-database.|
+|current\_connections|The current number of connections for this database.|
+|paused|Paused/unpaused state of the database. 1 if this database is currently paused, else 0.|
+|disabled|Enabled/disabled state of the database. 1 if this database is currently disabled, else 0.|
+
+### <a id="DNS_HOSTS"></a>DNS\_HOSTS 
+
+Show host names in DNS cache.
+
+|Column|Description|
+|------|-----------|
+|hostname|Host name|
+|ttl|How many seconds until next lookup.|
+|addrs|Comma-separated list of addresses.|
+
+### <a id="DNS_ZONES"></a>DNS\_ZONES 
+
+Show DNS zones in cache.
+
+|Column|Description|
+|------|-----------|
+|zonename|Zone name|
+|serial|Current DNS serial number|
+|count|Hostnames belonging to this zone|
+
+### <a id="FDS"></a>FDS 
+
+`SHOW FDS` is an internal command used for an online restart, for example when upgrading to a new PgBouncer version. It displays a list of file descriptors in use with the internal state attached to them. This command blocks the internal event loop, so it should not be used while PgBouncer is in use.
+
+When the connected user has username "pgbouncer", connects through a Unix socket, and has the same UID as the running process, the actual file descriptors are passed over the connection. This mechanism is used to do an online restart.
+
+|Column|Description|
+|------|-----------|
+|fd|File descriptor numeric value.|
+|task|One of `pooler`, `client`, or `server`.|
+|user|User of the connection using the file descriptor.|
+|database|Database of the connection using the file descriptor.|
+|addr|IP address of the connection using the file descriptor, `unix` if a Unix socket is used.|
+|port|Port used by the connection using the file descriptor.|
+|cancel|Cancel key for this connection.|
+|link|File descriptor for corresponding server/client. NULL if idle.|
+
+### <a id="LISTS"></a>LISTS 
+
+Shows the following PgBouncer internal information, in columns (not rows):
+
+|Item|Description|
+|----|-----------|
+|databases|Count of databases.|
+|users|Count of users.|
+|pools|Count of pools.|
+|free\_clients|Count of free clients.|
+|used\_clients|Count of used clients.|
+|login\_clients|Count of clients in `login` state.|
+|free\_servers|Count of free servers.|
+|used\_servers|Count of used servers.|
+|dns\_names|Count of DNS names in the cache.|
+|dns\_zones|Count of DNS zones in the cache.|
+|dns\_queries|Count of in-flight DNS queries.|
+|dns\_pending| not used |
+
+### <a id="MEM"></a>MEM 
+
+Shows low-level information about the current sizes of various internal memory allocations. The information presented is subject to change.
+
+### <a id="POOLS"></a>POOLS 
+
+A new pool entry is made for each pair of \(database, user\).
+
+|Column|Description|
+|------|-----------|
+|database|Database name.|
+|user|User name.|
+|cl\_active|Client connections that are linked to server connection and can process queries.|
+|cl\_waiting|Client connections that have sent queries but have not yet got a server connection.|
+|cl\_cancel_req|Client connections that have not yet forwarded query cancellations to the server.|
+|sv\_active|Server connections that are linked to client.|
+|sv\_idle|Server connections that are unused and immediately usable for client queries.|
+|sv\_used|Server connections that have been idle more than `server_check_delay`. The `server_check_query` query must be run on them before they can be used again.|
+|sv\_tested|Server connections that are currently running either `server_reset_query` or `server_check_query`.|
+|sv\_login|Server connections currently in the process of logging in.|
+|maxwait|How long the first \(oldest\) client in the queue has waited, in seconds. If this begins to increase, the current pool of servers does not handle requests quickly enough. The cause may be either an overloaded server or the `pool_size` setting is too small.|
+|maxwait\_us|Microsecond part of the maximum waiting time.|
+|pool\_mode|The pooling mode in use.|
+
+### <a id="SERVERS"></a>SERVERS 
+
+|Column|Description|
+|------|-----------|
+|type|S, for server.|
+|user|User name that `pgbouncer` uses to connect to server.|
+|database|Database name.|
+|state|State of the `pgbouncer` server connection, one of `active`, `idle`, `used`, `tested`, or `new`.|
+|addr|IP address of the Greenplum or PostgreSQL server.|
+|port|Port of the Greenplum or PostgreSQL server.|
+|local\_addr|Connection start address on local machine.|
+|local\_port|Connection start port on local machine.|
+|connect\_time|When the connection was made.|
+|request\_time|When the last request was issued.|
+|wait|Current waiting time in seconds.|
+|wait\_us|Microsecond part of the current waiting time.|
+|close\_needed|1 if the connection will be closed as soon as possible, because a configuration file reload or DNS update changed the connection information or `RECONNECT` was issued.|
+|ptr|Address of the internal object for this connection. Used as unique ID.|
+|link|Address of the client connection the server is paired with.|
+|remote\_pid|Pid of backend server process. If the connection is made over Unix socket and the OS supports getting process ID info, it is the OS pid. Otherwise it is extracted from the cancel packet the server sent, which should be PID in case server is PostgreSQL, but it is a random number in case server is another PgBouncer.|
+|tls|A string with TLS connection information, or empty if not using TLS.|
+
+### <a id="SOCKETS"></a>SOCKETS, ACTIVE\_SOCKETS
+
+Shows low-level information about sockets or only active sockets. This includes the information shown under `SHOW CLIENTS` and `SHOW SERVERS` as well as other more low-level information.
+
+### <a id="STATS"></a>STATS 
+
+Shows statistics. In this and related commands, the total figures are since process start, the averages are updated every `stats_period`.
+
+|Column|Description|
+|------|-----------|
+|database|Statistics are presented per database.|
+|total\_xact\_count|Total number of SQL transactions pooled by PgBouncer.|
+|total\_query\_count|Total number of SQL queries pooled by PgBouncer.|
+|total\_received|Total volume in bytes of network traffic received by `pgbouncer`.|
+|total\_sent|Total volume in bytes of network traffic sent by `pgbouncer`.|
+|total\_xact\_time|Total number of microseconds spent by PgBouncer when connected to Greenplum Database in a transaction, either idle in transaction or executing queries.|
+|total\_query\_time|Total number of microseconds spent by `pgbouncer` when actively connected to the database server.|
+|total\_wait\_time|Time spent \(in microseconds\) by clients waiting for a server.|
+|avg\_xact\_count|Average number of transactions per second in the last stat period.|
+|avg\_query\_count|Average queries per second in the last stats period.|
+|avg\_recv|Average received \(from clients\) bytes per second.|
+|avg\_sent|Average sent \(to clients\) bytes per second.|
+|avg\_xact\_time|Average transaction duration in microseconds.|
+|avg\_query\_time|Average query duration in microseconds.|
+|avg\_wait\_time|Time spent by clients waiting for a server in microseconds \(average per second\).|
+
+### <a id="STATS_AVERAGES"></a>STATS\_AVERAGES 
+
+Subset of `SHOW STATS` showing the average values for selected statistics (`avg_`)
+
+### <a id="STATS_TOTALS"></a>STATS\_TOTALS 
+
+Subset of `SHOW STATS` showing the total values for selected statistics (`total_`)
+
+### <a id="TOTALS"></a>TOTALS
+
+Like `SHOW STATS` but aggregated across all databases.
+
+### <a id="USERS"></a>USERS 
+
+|Column|Description|
+|------|-----------|
+|name|The user name|
+|pool\_mode|The user's override pool\_mode, or NULL if the default will be used instead.|
+
+### <a id="VERSION"></a>VERSION 
+
+Display PgBouncer version information.
+
+> **Note** This reference documentation is based on the PgBouncer 1.16 documentation.
+
+## <a id="signals"></a>Signals
+
+SIGHUP : Reload config. Same as issuing the command `RELOAD` on the console.
+
+SIGINT : Safe shutdown. Same as issuing `PAUSE` and `SHUTDOWN` on the console.
+
+SIGTERM : Immediate shutdown. Same as issuing `SHUTDOWN` on the console.
+
+SIGUSR1 : Same as issuing `PAUSE` on the console.
+
+SIGUSR2 : Same as issuing `RESUME` on the console.
+
+## <a id="libevent"></a>Libevent Settings
+
+From the Libevent documentation:
+
+```
+It is possible to disable support for epoll, kqueue, devpoll, poll or select by
+setting the environment variable EVENT_NOEPOLL, EVENT_NOKQUEUE, EVENT_NODEVPOLL,
+EVENT_NOPOLL or EVENT_NOSELECT, respectively.
+
+By setting the environment variable EVENT_SHOW_METHOD, libevent displays the
+kernel notification method that it uses.
+```
+
+## <a id="seealso"></a>See Also 
+
+[pgbouncer](pgbouncer.html), [pgbouncer.ini](pgbouncer-ini.html)
+

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
@@ -1,0 +1,731 @@
+---
+title: pgbouncer.ini 
+---
+
+PgBouncer configuration file.
+
+## <a id="syn"></a>Synopsis 
+
+```
+[databases]
+db = ...
+
+[pgbouncer]
+...
+
+[users]
+...
+```
+
+## <a id="desc"></a>Description 
+
+You specify PgBouncer configuration parameters and identify user-specific configuration parameters in a configuration file.
+
+The PgBouncer configuration file \(typically named `pgbouncer.ini`\) is specified in `.ini` format. Files in `.ini` format are composed of sections, parameters, and values. Section names are enclosed in square brackets, for example, `[<section_name>]`. Parameters and values are specified in `key=value` format. Lines beginning with a semicolon \(`;`\) or pound sign \(`#`\) are considered comment lines and are ignored.
+
+The PgBouncer configuration file can contain `%include` directives, which specify another file to read and process. This enables you to split the configuration file into separate parts. For example:
+
+```
+%include filename
+```
+
+If the filename provided is not an absolute path, the file system location is taken as relative to the current working directory.
+
+The PgBouncer configuration file includes the following sections, described in detail below:
+
+-   [\[databases\] Section](#topic_fmd_ckd_gs)
+-   [\[pgbouncer\] Section](#topic_orc_gkd_gs)
+-   [\[users\] Section](#topic_lzk_zjd_gs)
+
+## <a id="topic_fmd_ckd_gs"></a>\[databases\] Section 
+
+The `[databases]` section contains `key=value` pairs, where the `key` is a database name and the `value` is a `libpq` connect-string list of `key`=`value` pairs. Not all features known from `libpq` can be used (service=, .pgpass), since the actual `libpq` is not used.
+
+A database name can contain characters `[0-9A-Za-z_.-]` without quoting. Names that contain other characters must be quoted with standard SQL identifier quoting:
+
+-   Enclose names in double quotes \(`" "`\).
+-   Represent a double-quote within an identifier with two consecutive double quote characters.
+
+The database name `*` is the fallback database. PgBouncer uses the value for this key as a connect string for the requested database. Automatically-created database entries such as these are cleaned up if they remain idle longer than the time specified in `autodb_idle_timeout` parameter.
+
+### <a id="dbconn"></a>Database Connection Parameters 
+
+The following parameters may be included in the `value` to specify the location of the database.
+
+dbname
+:   The destination database name.
+
+    Default: the client-specified database name
+
+host
+:   The name or IP address of the Greenplum master host. Host names are resolved at connect time. If DNS returns several results, they are used in a round-robin manner. The DNS result is cached and the `dns_max_ttl` parameter determines when the cache entry expires.
+
+:   If the value begins with `/`, then a Unix socket in the file-system namespace is used. If the value begins with `@`, then a Unix socket in the abstract namespace is used.
+
+:   Default: not set; the connection is made through a Unix socket
+
+port
+:   The Greenplum Database master port.
+
+:   Default: 5432
+
+user
+:   If `user=` is set, all connections to the destination database are initiated as the specified user, resulting in a single connection pool for the database.
+
+:   If the `user=` parameter is not set, PgBouncer attempts to log in to the destination database with the user name passed by the client. In this situation, there will be one pool for each user who connects to the database.
+
+password
+: If no password is specified here, the password from the `auth_file` or `auth_query` will be used.
+
+auth\_user
+:   Override of the global `auth_user` setting, if specified.
+
+client\_encoding
+:   Ask for specific `client_encoding` from server.
+
+datestyle
+:   Ask for specific `datestyle` from server.
+
+timezone
+:   Ask for specific `timezone` from server.
+
+### <a id="poolconfig"></a>Pool Configuration 
+
+You can use the following parameters for database-specific pool configuration.
+
+pool\_size
+:   Set the maximum size of pools for this database. If not set, the `default_pool_size` is used.
+
+min\_pool\_size
+:   Set the minimum pool size for this database. If not set, the global `min_pool_size` is used.
+
+reserve\_pool
+:   Set additional connections for this database. If not set, `reserve_pool_size` is used.
+
+connect\_query
+:   Query to be run after a connection is established, but before allowing the connection to be used by any clients. If the query raises errors, they are logged but ignored otherwise.
+
+pool\_mode
+:   Set the pool mode specific to this database. If not set, the default `pool_mode` is used.
+
+max\_db\_connections
+:   Set a database-wide maximum number of PgBouncer connections for this database. The total number of connections for all pools for this database will not exceed this value.
+
+## <a id="topic_orc_gkd_gs"></a>\[pgbouncer\] Section 
+
+### <a id="genset"></a>Generic Settings 
+
+logfile
+:   The location of the log file. For daemonization (`-d`), either this or `syslog` need to be set. The log file is kept open. After log rotation, run `kill -HUP pgbouncer` or run the `RELOAD` command in the PgBouncer Administration Console.
+
+:   Note that setting `logfile` does not by itself turn off logging to `stderr`. Use the command-line option `-q` or `-d` for that.
+
+    Default: not set
+
+pidfile
+:   The name of the pid file. Without a `pidfile`, you cannot run PgBouncer as a background \(daemon\) process.
+
+    Default: not set
+
+listen\_addr
+:   Specifies a list of interface addresses where PgBouncer listens for TCP connections. You may also use `*`, which means to listen on all interfaces. If not set, only Unix socket connections are accepted.
+
+    Specify addresses numerically \(IPv4/IPv6\) or by name.
+
+    Default: not set
+
+listen\_port
+:   The port PgBouncer listens on. Applies to both TCP and Unix sockets.
+
+    Default: 6432
+
+unix\_socket\_dir
+:   Specifies the location for the Unix sockets. Applies to both listening socket and server connections. If set to an empty string, Unix sockets are deactivated. A value that starts with @ specifies that a Unix socket in the abstract namespace should be created.
+
+:   For online reboot (`-R`) to work, a Unix socket needs to be configured, and it needs to be in the file-system namespace.
+
+    Default: `/tmp`
+
+unix\_socket\_mode
+:   Filesystem mode for the Unix socket. Ignored for sockets in the abstract namespace.
+
+    Default: 0777
+
+unix\_socket\_group
+:   Group name to use for Unix socket. Ignored for sockets in the abstract namespace.
+
+    Default: not set
+
+user
+:   If set, specifies the Unix user to change to after startup. This works only if PgBouncer is started as root or if it is already running as the given user.
+
+    Default: not set
+
+auth\_file
+:   The name of the file containing the user names and passwords to load. The file format is the same as the Greenplum Database pg\_auth file. Refer to the [PgBouncer Authentication File Format](../../admin_guide/access_db/topics/pgbouncer.html#pgb_auth) for more information.
+
+    Default: not set
+
+auth\_hba\_file
+:   HBA configuration file to use when `auth_type` is `hba`. Refer to the [Configuring HBA-based Authentication for PgBouncer](../../admin_guide/access_db/topics/pgbouncer.html#pgb_hba) and [Configuring LDAP-based Authentication for PgBouncer](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap) for more information.
+
+    Default: not set
+
+auth\_type
+:   How to authenticate users.
+
+    - `pam`: Use PAM to authenticate users. `auth_file` is ignored. This method is not compatible with databases using the `auth_user` option. The service name reported to PAM is `pgbouncer`. PAM is not supported in the HBA configuration file.
+    - `hba`:  The actual authentication type is loaded from the `auth_hba_file`. This setting allows different authentication methods for different access paths, for example: connections over Unix socket use the `peer` auth method, connections over TCP must use TLS.
+    - `cert`:  Clients must connect with TLS using a valid client certificate. The client's username is taken from CommonName field in the certificate.
+    - `md5`: Use MD5-based password check. `auth_file` may contain both MD5-encrypted or plain-text passwords. If `md5` is configured and a user has a SCRAM secret, then SCRAM authentication is used automatically instead. This is the default authentication method.
+    - `scram-sha-256`: Use password check with SCRAM-SHA-256. `auth_file` has to contain SCRAM secrets or plain-text passwords.
+    - `plain`:  Clear-text password is sent over wire. *Deprecated*.
+    - `trust`: No authentication is performed. The username must still exist in the `auth_file`.
+    - `any`: Like the `trust` method, but the username supplied is ignored. Requires that all databases are configured to log in with a specific user. Additionally, the console database allows any user to log in as admin.
+
+auth\_query
+:   Query to load a user's password from the database.
+
+:   Direct access to pg_shadow requires admin rights. It's preferable to use a non-superuser that calls a `SECURITY DEFINER` function instead.
+
+:   Note that the query is run inside target database, so if a function is used it needs to be installed into each database.
+
+    Default: `SELECT usename, passwd FROM pg_shadow WHERE usename=$1`
+
+auth\_user
+:   If `auth_user` is set, any user who is not specified in `auth_file` is authenticated through the `auth_query` query from the `pg_shadow` database view. PgBouncer performs this query as the `auth_user` Greenplum Database user. `auth_user`'s password must be set in the `auth_file`. (If the `auth_user` does not require a password then it does not need to be defined in `auth_file`.)
+
+:   Direct access to `pg_shadow` requires Greenplum Database administrative privileges. It is preferable to use a non-admin user that calls `SECURITY DEFINER` function instead.
+
+:    Default: not set
+
+pool\_mode
+:   Specifies when a server connection can be reused by other clients.
+
+    - `session`: Connection is returned to the pool when the client disconnects. Default.
+    - `transaction`: Connection is returned to the pool when the transaction finishes.
+    - `statement`: Connection is returned to the pool when the current query finishes. Transactions spanning multiple statements are disallowed in this mode.
+
+max\_client\_conn
+:   Maximum number of client connections allowed. When increased, you should also increase the file descriptor limits. The actual number of file descriptors used is more than `max_client_conn`. The theoretical maximum used, when each user connects with its own username to the server is:
+
+    ```
+    max_client_conn + (max pool_size * total databases * total users)
+    ```
+
+:   If a database user is specified in the connect string, all users connect using the same username. Then the theoretical maximum connections is:
+
+    ```
+    max_client_conn + (max pool_size * total databases)
+    ```
+
+    The theoretical maximum should be never reached, unless someone deliberately crafts a special load for it. Still, it means you should set the number of file descriptors to a safely high number. Search for `ulimit` in your operating system documentation.
+
+    Default: 100
+
+default\_pool\_size
+:   The number of server connections to allow per user/database pair. This can be overridden in the per-database configuration.
+
+    Default: 20
+
+min\_pool\_size
+:   Add more server connections to the pool when it is lower than this number. This improves behavior when the usual load drops and then returns suddenly after a period of total inactivity. The value is effectively capped at the pool size.
+
+    Default: 0 \(deactivated\)
+
+reserve\_pool\_size
+:   The number of additional connections to allow for a pool (see `reserve_pool_timeout`). `0` deactivates.
+
+    Default: 0 \(deactivated\)
+
+reserve\_pool\_timeout
+:   If a client has not been serviced in this many seconds, PgBouncer enables use of additional connections from the reserve pool. `0` deactivates.
+
+    Default: 5.0
+
+max\_db\_connections
+:   Do not allow more than this many server connections per database (regardless of user). This considers the PgBouncer database that the client has connected to, not the PostgreSQL database of the outgoing connection.
+
+:   This can also be set per database in the `[databases]` section.
+
+:   Note that when you hit the limit, closing a client connection to one pool will not immediately allow a server connection to be established for another pool, because the server connection for the first pool is still open. Once the server connection closes (due to idle timeout), a new server connection will immediately be opened for the waiting pool.
+
+:   Default: 0 (unlimited)
+
+max\_user\_connections
+:   Do not allow more than this many server connections per user (regardless of database). This considers the PgBouncer user that is associated with a pool, which is either the user specified for the server connection or in absence of that the user the client has connected as.
+
+:   This can also be set per user in the `[users]` section.
+
+:   Note that when you hit the limit, closing a client connection to one pool will not immediately allow a server connection to be established for another pool, because the server connection for the first pool is still open. Once the server connection closes (due to idle timeout), a new server connection will immediately be opened for the waiting pool.
+
+:   Default: 0 (unlimited)
+
+server\_round\_robin
+:   By default, PgBouncer reuses server connections in LIFO \(last-in, first-out\) order, so that a few connections get the most load. This provides the best performance when a single server serves a database. But if there is TCP round-robin behind a database IP, then it is better if PgBouncer also uses connections in that manner to achieve uniform load.
+
+    Default: 0
+
+ignore\_startup\_parameters
+:   By default, PgBouncer allows only parameters it can keep track of in startup packets: `client_encoding`, `datestyle`, `timezone`, and `standard_conforming_strings`. All others parameters raise an error. To allow other parameters, specify them here so that PgBouncer knows that they are handled by the admin and it can ignore them.
+
+    Default: empty
+
+disable\_pqexec
+:   Deactivates Simple Query protocol \(PQexec\). Unlike Extended Query protocol, Simple Query protocol allows multiple queries in one packet, which allows some classes of SQL-injection attacks. Deactivating it can improve security. This means that only clients that exclusively use Extended Query protocol will work.
+
+    Default: 0
+
+application\_name\_add\_host
+:   Add the client host address and port to the application name setting set on connection start. This helps in identifying the source of bad queries. This logic applies only on start of connection. If `application_name` is later changed with `SET`, PgBouncer does not change it again.
+
+    Default: 0
+
+conffile
+:   Show location of the current configuration file. Changing this parameter will result in PgBouncer using another config file for next `RELOAD` / `SIGHUP`.
+
+    Default: file from command line
+
+service\_name
+:   Used during win32 service registration.
+
+    Default: pgbouncer
+
+job\_name
+:   Alias for `service_name`.
+
+stats\_period
+:   Sets how often the averages shown in various `SHOW` commands are updated and how often aggregated statistics are written to the log (but see `log_stats`). [seconds]
+
+    Default: 60
+
+### <a id="logset"></a>Log Settings 
+
+syslog
+:   Toggles syslog on and off.
+
+    Default: 0
+
+syslog\_ident
+:   Under what name to send logs to syslog.
+
+    Default: `pgbouncer` (program name)
+
+syslog\_facility
+:   Under what facility to send logs to syslog. Some possibilities are: `auth`, `authpriv`, `daemon`, `user`, `local0-7`.
+
+    Default: `daemon`
+
+log\_connections
+:   Log successful logins.
+
+    Default: 1
+
+log\_disconnections
+:   Log disconnections, with reasons.
+
+    Default: 1
+
+log\_pooler\_errors
+:   Log error messages that the pooler sends to clients.
+
+    Default: 1
+
+log\_stats
+:   Write aggregated statistics into the log, every `stats_period`. This can be deactivated if external monitoring tools are used to grab the same data from `SHOW` commands.
+
+    Default: 1
+
+verbose
+:   Increase verbosity. Mirrors the `-v` switch on the command line. Using `-v -v` on the command line is the same as `verbose=2`.
+
+    Default: 0
+
+### <a id="consaccess"></a>Console Access Control 
+
+admin\_users
+:   Comma-separated list of database users that are allowed to connect and run all commands on the PgBouncer Administration Console. Ignored when `auth_type=any`, in which case any username is allowed in as admin.
+
+    Default: empty
+
+stats\_users
+:   Comma-separated list of database users that are allowed to connect and run read-only queries on the console. This includes all `SHOW` commands except `SHOW FDS`.
+
+    Default: empty
+
+### <a id="connsan"></a>Connection Sanity Checks, Timeouts 
+
+server\_reset\_query
+:   Query sent to server on connection release, before making it available to other clients. At that moment no transaction is in progress so it should not include `ABORT` or `ROLLBACK`.
+
+    The query should clean any changes made to a database session so that the next client gets a connection in a well-defined state. Default is `DISCARD ALL` which cleans everything, but that leaves the next client no pre-cached state. It can be made lighter, e.g. `DEALLOCATE ALL` to just drop prepared statements, if the application does not break when some state is kept around.
+
+    > **Note** Greenplum Database does not support `DISCARD ALL`.
+
+    When transaction pooling is used, the `server_reset_query` is not used, as clients must not use any session-based features as each transaction ends up in a different connection and thus gets a different session state.
+
+    Default: `DISCARD ALL;` \(Not supported by Greenplum Database.\)
+
+server\_reset\_query\_always
+:   Whether `server_reset_query` should be run in all pooling modes. When this setting is off \(default\), the `server_reset_query` will be run only in pools that are in sessions-pooling mode. Connections in transaction-pooling mode should not have any need for reset query.
+
+    This setting is for working around broken setups that run applications that use session features over a transaction-pooled PgBouncer. It changes non-deterministic breakage to deterministic breakage: Clients always lose their state after each transaction.
+
+    Default: 0
+
+server\_check\_delay
+:   How long to keep released connections available for immediate re-use, without running sanity-check queries on it. If `0`, then the query is run always.
+
+    Default: 30.0
+
+server\_check\_query
+:   A simple do-nothing query to test the server connection.
+
+    If an empty string, then sanity checking is deactivated.
+
+    Default: SELECT 1;
+
+server\_fast\_close
+:   Disconnect a server in session pooling mode immediately or after the end of the current transaction if it is in “close\_needed” mode \(set by `RECONNECT`, `RELOAD` that changes connection settings, or DNS change\), rather than waiting for the session end. In statement or transaction pooling mode, this has no effect since that is the default behavior there.
+
+    If because of this setting a server connection is closed before the end of the client session, the client connection is also closed. This ensures that the client notices that the session has been interrupted.
+
+    This setting makes connection configuration changes take effect sooner if session pooling and long-running sessions are used. The downside is that client sessions are liable to be interrupted by a configuration change, so client applications will need logic to reconnect and reestablish session state. But note that no transactions will be lost, because running transactions are not interrupted, only idle sessions.
+
+    Default: 0
+
+server\_lifetime
+:   The pooler will close an unused server connections that has been connected longer than this number of seconds. Setting it to `0` means the connection is to be used only once, then closed. \[seconds\]
+
+    Default: 3600.0
+
+server\_idle\_timeout
+:   If a server connection has been idle more than this many seconds it is dropped. If this parameter is set to `0`, timeout is deactivated. \[seconds\]
+
+    Default: 600.0
+
+server\_connect\_timeout
+:   If connection and login will not finish in this amount of time, the connection will be closed. \[seconds\]
+
+    Default: 15.0
+
+server\_login\_retry
+:   If a login fails due to failure from `connect()` or authentication, that pooler waits this much before retrying to connect. \[seconds\]
+
+    Default: 15.0
+
+client\_login\_timeout
+:   If a client connects but does not manage to login in this amount of time, it is disconnected. This is needed to avoid dead connections stalling `SUSPEND` and thus online restart. \[seconds\]
+
+    Default: 60.0
+
+autodb\_idle\_timeout
+:   If database pools created automatically \(via `*`\) have been unused this many seconds, they are freed. Their statistics are also forgotten. \[seconds\]
+
+    Default: 3600.0
+
+dns\_max\_ttl
+:   How long to cache DNS lookups, in seconds. If a DNS lookup returns several answers, PgBouncer round-robins between them in the meantime. The actual DNS TTL is ignored. \[seconds\]
+
+    Default: 15.0
+
+dns\_nxdomain\_ttl
+:   How long error and NXDOMAIN DNS lookups can be cached. \[seconds\]
+
+    Default: 15.0
+
+dns\_zone\_check\_period
+:   Period to check if zone serial numbers have changed.
+
+    PgBouncer can collect DNS zones from hostnames \(everything after first dot\) and then periodically check if the zone serial numbers change. If changes are detected, all hostnames in that zone are looked up again. If any host IP changes, its connections are invalidated.
+
+    Works only with UDNS and c-ares backend \(`--with-udns` or `--with-cares` to configure\).
+
+    Default: 0.0 \(deactivated\)
+
+resolv\_conf
+:   The location of a custom `resolv.conf` file. This is to allow specifying custom DNS servers and perhaps other name resolution options, independent of the global operating system configuration.
+
+    Requires evdns (>= 2.0.3) or c-ares (>= 1.15.0) backend.
+
+    The parsing of the file is done by the DNS backend library, not PgBouncer, so see the library's documentation for details on allowed syntax and directives.
+
+    Default: empty (use operating system defaults)
+
+
+### <a id="tlsset"></a>TLS settings 
+
+client\_tls\_sslmode
+:   TLS mode to use for connections from clients. TLS connections are deactivated by default. When enabled, `client_tls_key_file` and `client_tls_cert_file` must be also configured to set up the key and certificate PgBouncer uses to accept client connections.
+
+    -   `disable`: Plain TCP. If client requests TLS, it’s ignored. Default.
+    -   `allow`: If client requests TLS, it is used. If not, plain TCP is used. If client uses client-certificate, it is not validated.
+    -   `prefer`: Same as `allow`.
+    -   `require`: Client must use TLS. If not, client connection is rejected. If client presents a client-certificate, it is not validated.
+    -   `verify-ca`: Client must use TLS with valid client certificate.
+    -   `verify-full`: Same as `verify-ca`.
+
+client\_tls\_key\_file
+:   Private key for PgBouncer to accept client connections.
+
+:   Default: not set
+
+client\_tls\_cert\_file
+:   Certificate for private key. CLients can validate it.
+
+:   Default: unset
+
+client\_tls\_ca\_file
+:   Root certificate to validate client certificates.
+
+:   Default: unset
+
+client\_tls\_protocols
+:   Which TLS protocol versions are allowed.
+
+:   Valid values: are `tlsv1.0`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3`.
+
+:   Shortcuts: `all` \(`tlsv1.0`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3`\), `secure` \(`tlsv1.2`, `tlsv1.3`\), `legacy` \(`all`\).
+
+:   Default: `secure`
+
+client\_tls\_ciphers
+:   Allowed TLS ciphers, in OpenSSL syntax. Shortcuts: `default`/`secure`, `compat`/`legacy`, `insecure`/`all`, `normal`, `fast`.
+
+    Only connections using TLS version 1.2 and lower are affected. There is currently no setting that controls the cipher choices used by TLS version 1.3 connections.
+
+    Default: `fast`
+
+client\_tls\_ecdhcurve
+:   Elliptic Curve name to use for ECDH key exchanges.
+
+:   Allowed values: `none` \(DH is deactivated\), `auto` \(256-bit ECDH\), curve name.
+
+:   Default: `auto`
+
+client\_tls\_dheparams
+:   DHE key exchange type.
+
+:   Allowed values: `none` \(DH is deactivated\), `auto` \(2048-bit DH\), `legacy` \(1024-bit DH\).
+
+:   Default: `auto`
+
+server\_tls\_sslmode
+:   TLS mode to use for connections to Greenplum Database and PostgreSQL servers. TLS connections are deactivated by default.
+
+    -   `disable`: Plain TCP. TLS is not requested from the server. Default.
+    -   `allow`: If server rejects plain, try TLS. \(*PgBouncer Documentation is speculative on this.*\)
+    -   `prefer`: TLS connection is always requested first. When connection is refused, plain TPC is used. Server certificate is not validated.
+    -   `require`: Connection must use TLS. If server rejects it, plain TCP is not attempted. Server certificate is not validated.
+    -   `verify-ca`: Connection must use TLS and server certificate must be valid according to `server_tls_ca_file`. The server hostname is not verfied against the certificate.
+    -   `verify-full`: Connection must use TLS and the server certificate must be valid according to `server_tls_ca_file`. The server hostname must match the hostname in the certificate.
+
+server\_tls\_ca\_file
+:   Root certificate file used to validate Greenplum Database and PostgreSQL server certificates.
+
+:   Default: unset
+
+server\_tls\_key\_file
+:   Private key for PgBouncer to authenticate against Greenplum Database or PostgreSQL server.
+
+:   Default: not set
+
+server\_tls\_cert\_file
+:   Certificate for private key. Greenplum Database or PostgreSQL servers can validate it.
+
+:   Default: not set
+
+server\_tls\_protocols
+:   Which TLS protocol versions are allowed. Allowed values: `tlsv1.0`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3`. Shortcuts: `all` \(`tlsv1.0`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3`\); `secure` \(`tlsv1.2`, `tlsv1.3`\); `legacy` \(`all`\).
+
+:   Default: `secure`
+
+server\_tls\_ciphers
+:   Allowed TLS ciphers, in OpenSSL syntax. Shortcuts: `default`/`secure`, `compat`/`legacy`, `insecure`/`all`, `normal`, `fast`.
+
+    Only connections using TLS version 1.2 and lower are affected. There is currently no setting that controls the cipher choices used by TLS version 1.3 connections.
+
+    Default: `fast`
+
+### <a id="dangtimeouts"></a>Dangerous Timeouts 
+
+Setting the following timeouts can cause unexpected errors.
+
+query\_timeout
+:   Queries running longer than this \(seconds\) are canceled. This parameter should be used only with a slightly smaller server-side `statement_timeout`, to apply only for network problems. \[seconds\]
+
+    Default: 0.0 \(deactivated\)
+
+query\_wait\_timeout
+:   The maximum time, in seconds, queries are allowed to wait for execution. If the query is not assigned to a server during that time, the client is disconnected. This is used to prevent unresponsive servers from grabbing up connections. \[seconds\]
+
+    Default: 120
+
+client\_idle\_timeout
+:   Client connections idling longer than this many seconds are closed. This should be larger than the client-side connection lifetime settings, and only used for network problems. \[seconds\]
+
+    Default: 0.0 \(deactivated\)
+
+idle\_transaction\_timeout
+:   If client has been in "idle in transaction" state longer than this \(seconds\), it is disconnected. \[seconds\]
+
+    Default: 0.0 \(deactivated\)
+
+suspend\_timeout
+:   How many seconds to wait for buffer flush during `SUSPEND` or reboot (`-R`). A connection is dropped if the flush does not succeed.
+
+    Default: 10
+
+
+### <a id="llnet"></a>Low-level Network Settings 
+
+pkt\_buf
+:   Internal buffer size for packets. Affects the size of TCP packets sent and general memory usage. Actual `libpq` packets can be larger than this so there is no need to set it large.
+
+    Default: 4096
+
+max\_packet\_size
+:   Maximum size for packets that PgBouncer accepts. One packet is either one query or one result set row. A full result set can be larger.
+
+    Default: 2147483647
+
+listen\_backlog
+:   Backlog argument for the `listen(2)` system call. It determines how many new unanswered connection attempts are kept in queue. When the queue is full, further new connection attempts are dropped.
+
+    Default: 128
+
+sbuf\_loopcnt
+:   How many times to process data on one connection, before proceeding. Without this limit, one connection with a big result set can stall PgBouncer for a long time. One loop processes one `pkt_buf` amount of data. 0 means no limit.
+
+    Default: 5
+
+so\_reuseport
+:   Specifies whether to set the socket option `SO_REUSEPORT` on TCP listening sockets. On some operating systems, this allows running multiple PgBouncer instances on the same host listening on the same port and having the kernel distribute the connections automatically. This option is a way to get PgBouncer to use more CPU cores. \(PgBouncer is single-threaded and uses one CPU core per instance.\)
+
+    The behavior in detail depends on the operating system kernel. As of this writing, this setting has the desired effect on (sufficiently recent versions of) Linux, DragonFlyBSD, and FreeBSD. (On FreeBSD, it applies the socket option `SO_REUSEPORT_LB` instead.). Some other operating systems support the socket option but it won't have the desired effect: It will allow multiple processes to bind to the same port but only one of them will get the connections. See your operating system's `setsockopt()` documentation for details.
+
+    On systems that don’t support the socket option at all, turning this setting on will result in an error.
+
+    Each PgBouncer instance on the same host needs different settings for at least `unix_socket_dir` and `pidfile`, as well as `logfile` if that is used. Also note that if you make use of this option, you can no longer connect to a specific PgBouncer instance via TCP/IP, which might have implications for monitoring and metrics collection.
+
+    Default: 0
+
+tcp\_defer\_accept
+:   For details on this and other TCP options, please see the tcp\(7\) man page.
+
+    Default: 45 on Linux, otherwise 0
+
+tcp\_socket\_buffer
+:   Default: not set
+
+tcp\_keepalive
+:   Turns on basic keepalive with OS defaults.
+
+    On Linux, the system defaults are `tcp_keepidle=7200`, `tcp_keepintvl=75`, `tcp_keepcnt=9`. They are probably similar on other operating systems.
+
+    Default: 1
+
+tcp\_keepcnt
+:   Default: not set
+
+tcp\_keepidle
+:   Default: not set
+
+tcp\_keepintvl
+:   Default: not set
+
+tcp\_user\_timeout
+:   Sets the `TCP_USER_TIMEOUT` socket option. This specifies the maximum amount of time in milliseconds that transmitted data may remain unacknowledged before the TCP connection is forcibly closed. If set to `0`, then the operating system’s default is used.
+
+    Default: 0
+
+## <a id="topic_lzk_zjd_gs"></a>\[users\] Section 
+
+This section contains `key`=`value` pairs, where the `key` is a user name and the `value` is a `libpq` connect-string list of `key`=`value` pairs of configuration settings specific for this user. Only a few settings are available here.
+
+pool\_mode
+:   Set the pool mode for all connections from this user. If not set, the database or default `pool_mode` is used.
+
+max\_user\_connection
+:   Configure a maximum for the user (i.e. all pools with the user will not have more than this many server connections).
+
+For example:
+
+```
+[users]
+
+user1 = pool_mode=transaction max_user_connections=10
+```
+
+## <a id="topic_xw4_dtc_gs"></a>Example Configuration Files 
+
+**Minimal Configuration**
+
+```
+[databases]
+postgres = host=127.0.0.1 dbname=postgres auth_user=gpadmin
+
+[pgbouncer]
+pool_mode = session
+listen_port = 6543
+listen_addr = 127.0.0.1
+auth_type = md5
+auth_file = users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = someuser
+stats_users = stat_collector
+
+```
+
+Use connection parameters passed by the client:
+
+```
+[databases]
+* =
+
+[pgbouncer]
+listen_port = 6543
+listen_addr = 0.0.0.0
+auth_type = trust
+auth_file = bouncer/users.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+ignore_startup_parameters=options
+```
+
+**Database Defaults**
+
+```
+[databases]
+
+; foodb over unix socket
+foodb =
+
+; redirect bardb to bazdb on localhost
+bardb = host=127.0.0.1 dbname=bazdb
+
+; access to destination database will go with single user
+forcedb = host=127.0.0.1 port=300 user=baz password=foo client_encoding=UNICODE datestyle=ISO
+
+```
+
+Example of a secure function for auth_query:
+
+``` sql
+CREATE OR REPLACE FUNCTION pgbouncer.user_lookup(in i_username text, out uname text, out phash text)
+RETURNS record AS $$
+BEGIN
+    SELECT usename, passwd FROM pg_catalog.pg_shadow
+    WHERE usename = i_username INTO uname, phash;
+    RETURN;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+REVOKE ALL ON FUNCTION pgbouncer.user_lookup(text) FROM public, pgbouncer;
+GRANT EXECUTE ON FUNCTION pgbouncer.user_lookup(text) TO pgbouncer;
+```
+
+## <a id="seealso"></a>See Also 
+
+[pgbouncer](pgbouncer.html), [pgbouncer-admin](pgbouncer-admin.html), [PgBouncer Configuration Page](https://pgbouncer.github.io/config.html)
+

--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer.html.md
@@ -1,0 +1,72 @@
+---
+title: pgbouncer 
+---
+
+Manages database connection pools.
+
+## <a id="syn"></a>Synopsis 
+
+```
+pgbouncer [OPTION ...] <pgbouncer.ini>
+
+  OPTION
+   [ -d | --daemon ]
+   [ -R | --reboot ]
+   [ -q | --quiet ]
+   [ -v | --verbose ]
+   [ {-u | --user}=username ]
+
+pgbouncer [ -V | --version ] | [ -h | --help ]
+```
+
+## <a id="desc"></a>Description 
+
+PgBouncer is a light-weight connection pool manager for Greenplum and PostgreSQL databases. PgBouncer maintains a pool of connections for each database user and database combination. PgBouncer either creates a new database connection for the client or reuses an existing pooled connection for the same user and database. When the client disconnects, PgBouncer returns the connection to the pool for re-use.
+
+PgBouncer supports the standard connection interface shared by PostgreSQL and Greenplum Database. The Greenplum Database client application \(for example, `psql`\) should connect to the host and port on which PgBouncer is running rather than directly to the Greenplum Database master host and port.
+
+You configure PgBouncer and its access to Greenplum Database via a configuration file. You provide the configuration file name, usually `<pgbouncer.ini>`, when you run the `pgbouncer` command. This file provides location information for Greenplum databases. The `pgbouncer.ini` file also specifies process, connection pool, authorized users, and authentication configuration for PgBouncer, among other configuration options.
+
+By default, the `pgbouncer` process runs as a foreground process. You can optionally start `pgbouncer` as a background \(daemon\) process with the `-d` option.
+
+The `pgbouncer` process is owned by the operating system user that starts the process. You can optionally specify a different user name under which to start `pgbouncer`.
+
+PgBouncer includes a `psql`-like administration console. Authorized users can connect to a virtual database to monitor and manage PgBouncer. You can manage a PgBouncer daemon process via the admin console. You can also use the console to update and reload the PgBouncer configuration at runtime without stopping and restarting the process.
+
+For additional information about PgBouncer, refer to the [PgBouncer FAQ](https://pgbouncer.github.io/faq.html).
+
+## <a id="opt"></a>Options 
+
+-d \| --daemon
+:   Run PgBouncer as a daemon \(a background process\). The default start-up mode is to run as a foreground process. 
+
+:   In daemon mode, setting `pidfile` as well as `logfile` or `syslog` is required. No log messages will be written to `stderr` after going into the background.
+
+:   To stop a PgBouncer process that was started as a daemon, issue the `SHUTDOWN` command from the PgBouncer administration console.
+
+-R \| --reboot
+:   Restart PgBouncer using the specified command line arguments. That means connecting to the running process, loading the open sockets from it, and then using them. If there is no active process, boot normally. Non-TLS connections to databases are maintained during restart; TLS connections are dropped.
+
+:   To restart PgBouncer as a daemon, specify the options `-Rd`.
+
+    > **Note** Restart is available only if the operating system supports Unix sockets and the PgBouncer `unix_socket_dir` configuration is not deactivated.
+
+-q \| --quiet
+:   Run quietly. Do not log to `stderr`. This does not affect logging verbosity, only that `stderr` is not to be used. For use in `init.d` scripts.
+
+-v \| --verbose
+:   Increase message verbosity. Can be specified multiple times.
+
+\{-u \| --user\}=\<username\>
+:   Assume the identity of username on PgBouncer process start-up.
+
+-V \| --version
+:   Show the version and exit.
+
+-h \| --help
+:   Show the command help message and exit.
+
+## <a id="section7"></a>See Also 
+
+[pgbouncer.ini](pgbouncer-ini.html), [pgbouncer-admin](pgbouncer-admin.html)
+

--- a/gpdb-doc/markdown/utility_guide/utility-programs.html.md
+++ b/gpdb-doc/markdown/utility_guide/utility-programs.html.md
@@ -55,6 +55,9 @@ Greenplum Database provides the following utility programs. Superscripts identif
 - [pg\_dump](ref/pg_dump.html)<sup>3</sup>
 - [pg\_dumpall](ref/pg_dumpall.html)<sup>3</sup>
 - [pg\_restore](ref/pg_restore.html)
+- [pgbouncer](ref/pgbouncer.html)
+- [pgbouncer.ini](ref/pgbouncer-ini.html)
+- [pgbouncer-admin](ref/pgbouncer-admin.html)
 - [plcontainer](ref/plcontainer.html)
 - [plcontainer Configuration File](ref/plcontainer-configuration.html)
 - [psql](ref/psql.html)<sup>3</sup>


### PR DESCRIPTION
supercedes https://github.com/greenplum-db/gpdb/pull/16733.

pgbouncer docs were removed a while ago in commit 72e17f8f817ca6e252385e135e11b14c8cec1391.  add them back in (when source file exists) using current content from 6X_STABLE.

note: will apply updates from https://github.com/greenplum-db/gpdb/pull/16735 (6x, ldap encrypted password) after that PR is merged.

doc review site links (behind vpn):
- using topic - https://docs-staging.vmware.com/en/draft/VMware-Greenplum/pgb7/greenplum-database/admin_guide-access_db-topics-pgbouncer.html
- ports and protocols (scroll to the bottom of the table) - https://docs-staging.vmware.com/en/draft/VMware-Greenplum/pgb7/greenplum-database/security-guide-topics-ports_and_protocols.html
- utility ref pages - https://docs-staging.vmware.com/en/draft/VMware-Greenplum/pgb7/greenplum-database/utility_guide-ref-pgbouncer.html
