### PR TITLE
[ORCA] Avoid unnecessary redistribute from self LOJ

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -31,7 +31,7 @@ private:
 	// helper for deriving hash join distribution from hashed children
 	CDistributionSpec *PdsDeriveFromHashedChildren(
 		CMemoryPool *mp, CDistributionSpec *pdsOuter,
-		CDistributionSpec *pdsInner) const;
+		CDistributionSpec *pdsInner, BOOL isselfjoin = false) const;
 
 public:
 	CPhysicalLeftOuterHashJoin(const CPhysicalLeftOuterHashJoin &) = delete;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3807,6 +3807,49 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
  Optimizer: Postgres query optimizer
 (18 rows)
 
+-- Test hashed distribution spec derived from a self join
+truncate o1;
+truncate o2;
+insert into o1 select i, i from generate_series(1,9) i;
+insert into o1 values (NULL, NULL);
+insert into o2 select i, NULL from generate_series(11,100) i;
+analyze o1;
+analyze o2;
+-- Self LOJ on distribution keys of null colocated children produces a null
+-- colocated result. If the join result is joined against another table on
+-- distribution keys then an additional redistribute motion is not needed
+-- because the null values are already colocated.
+explain select * from o1 t1 left outer join o1 on t1.a1=o1.a1 left outer join o2 on o1.a1=o2.a2;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.15..3.74 rows=10 width=24)
+   ->  Hash Right Join  (cost=2.15..3.61 rows=3 width=24)
+         Hash Cond: (o1.a1 = t1.a1)
+         ->  Hash Right Join  (cost=1.08..2.49 rows=3 width=16)
+               Hash Cond: (o2.a2 = o1.a1)
+               ->  Seq Scan on o2  (cost=0.00..1.30 rows=30 width=8)
+               ->  Hash  (cost=1.03..1.03 rows=3 width=8)
+                     ->  Seq Scan on o1  (cost=0.00..1.03 rows=3 width=8)
+         ->  Hash  (cost=1.03..1.03 rows=3 width=8)
+               ->  Seq Scan on o1 t1  (cost=0.00..1.03 rows=3 width=8)
+ Optimizer: Postgres-based planner
+(11 rows)
+
+select * from o1 t1 left outer join o1 on t1.a1=o1.a1 left outer join o2 on o1.a1=o2.a2;
+ a1 | b1 | a1 | b1 | a2 | b2 
+----+----+----+----+----+----
+  1 |  1 |  1 |  1 |    |   
+  6 |  6 |  6 |  6 |    |   
+  5 |  5 |  5 |  5 |    |   
+  9 |  9 |  9 |  9 |    |   
+  8 |  8 |  8 |  8 |    |   
+  4 |  4 |  4 |  4 |    |   
+  7 |  7 |  7 |  7 |    |   
+  2 |  2 |  2 |  2 |    |   
+  3 |  3 |  3 |  3 |    |   
+    |    |    |    |    |   
+(10 rows)
+
 -- Test case from community Github PR 13722
 create table t_13722(id int, tt timestamp)
   distributed by (id);

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3818,8 +3818,51 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (13 rows)
+
+-- Test hashed distribution spec derived from a self join
+truncate o1;
+truncate o2;
+insert into o1 select i, i from generate_series(1,9) i;
+insert into o1 values (NULL, NULL);
+insert into o2 select i, NULL from generate_series(11,100) i;
+analyze o1;
+analyze o2;
+-- Self LOJ on distribution keys of null colocated children produces a null
+-- colocated result. If the join result is joined against another table on
+-- distribution keys then an additional redistribute motion is not needed
+-- because the null values are already colocated.
+explain select * from o1 t1 left outer join o1 on t1.a1=o1.a1 left outer join o2 on o1.a1=o2.a2;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.01 rows=12 width=24)
+   ->  Hash Right Join  (cost=0.00..1293.01 rows=4 width=24)
+         Hash Cond: (o2.a2 = o1_1.a1)
+         ->  Seq Scan on o2  (cost=0.00..431.00 rows=30 width=8)
+         ->  Hash  (cost=862.00..862.00 rows=4 width=16)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=4 width=16)
+                     Hash Cond: (o1.a1 = o1_1.a1)
+                     ->  Seq Scan on o1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=8)
+                           ->  Seq Scan on o1 o1_1  (cost=0.00..431.00 rows=4 width=8)
+ Optimizer: GPORCA
+(11 rows)
+
+select * from o1 t1 left outer join o1 on t1.a1=o1.a1 left outer join o2 on o1.a1=o2.a2;
+ a1 | b1 | a1 | b1 | a2 | b2 
+----+----+----+----+----+----
+  1 |  1 |  1 |  1 |    |   
+  6 |  6 |  6 |  6 |    |   
+  5 |  5 |  5 |  5 |    |   
+  9 |  9 |  9 |  9 |    |   
+    |    |    |    |    |   
+  8 |  8 |  8 |  8 |    |   
+  4 |  4 |  4 |  4 |    |   
+  7 |  7 |  7 |  7 |    |   
+  2 |  2 |  2 |  2 |    |   
+  3 |  3 |  3 |  3 |    |   
+(10 rows)
 
 -- Test case from community Github PR 13722
 create table t_13722(id int, tt timestamp)


### PR DESCRIPTION
Commit https://github.com/greenplum-db/gpdb/commit/f8264ad6f171de0587af15a28efd1d2fca6cc9d3 added support to avoid unnecessary motions from outer
joins by considering distribution specs from both left and right side.
It chose to be conservative for deciding null colocation because the
risk of getting it wrong could lead to wrong results.

However, a self outer join with children that are null colocated seems
to be a safe scenario to assume the result is null colocated. The
advantage of this optimization is that we can potentially avoid a costly
redistribute motion.