### PR TITLE
gp_toolkit: partition maintenance UDFs and views

### DIFF
--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -3,12 +3,12 @@ DATA = gp_toolkit--1.1--1.2.sql gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql \
 		gp_toolkit--1.2--1.3.sql gp_toolkit--1.3.sql gp_toolkit--1.3--1.4.sql
 MODULE_big = gp_toolkit
 ifeq ($(shell uname -s), Linux)
-OBJS = resgroup.o
+OBJS = resgroup.o gp_partition_maint.o
 else
-OBJS = resgroup-dummy.o
+OBJS = resgroup-dummy.o gp_partition_maint.o
 endif
 
-REGRESS = resource_manager_restore_to_none gp_toolkit resource_manager_switch_to_queue gp_toolkit_resqueue gp_toolkit_ao_funcs
+REGRESS = resource_manager_restore_to_none gp_toolkit resource_manager_switch_to_queue gp_toolkit_resqueue gp_toolkit_ao_funcs gp_partition_maint
 EXTRA_REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file
 
 ifdef USE_PGXS

--- a/gpcontrib/gp_toolkit/expected/gp_partition_maint.out
+++ b/gpcontrib/gp_toolkit/expected/gp_partition_maint.out
@@ -1,0 +1,334 @@
+-- Classic Syntax
+-- Multi-level range-list partitioned table
+DROP TABLE IF EXISTS partrl;
+NOTICE:  table "partrl" does not exist, skipping
+CREATE TABLE partrl (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY list(c)
+(
+	PARTITION p1 START (10) END (20) EVERY (5)
+	(
+		SUBPARTITION sp1 VALUES (1, 2)
+	),
+	PARTITION p2 START (0) END (10)
+	(
+		SUBPARTITION sp2 VALUES (3, 4),
+		SUBPARTITION sp1 VALUES (1, 2),
+		DEFAULT SUBPARTITION others
+	)
+);
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+    from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+            relid             | level | rank |         relpartbound         | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+------------------------------+-------+------+------------------------------+------------+----------+---------------------------+----------------------------
+ partrl                       |     0 |      |                              |            |          | partrl_1_prt_p2           | partrl_1_prt_p1_2
+ partrl_1_prt_p1_1            |     1 |    2 | FOR VALUES FROM (10) TO (15) | 10         | 15       |                           | 
+ partrl_1_prt_p1_2            |     1 |    3 | FOR VALUES FROM (15) TO (20) | 15         | 20       |                           | 
+ partrl_1_prt_p2              |     1 |    1 | FOR VALUES FROM (0) TO (10)  | 0          | 10       |                           | 
+ partrl_1_prt_p1_1_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
+ partrl_1_prt_p1_2_2_prt_sp1  |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
+ partrl_1_prt_p2_2_prt_others |     2 |      | DEFAULT                      |            |          |                           | 
+ partrl_1_prt_p2_2_prt_sp2    |     2 |      | FOR VALUES IN (3, 4)         |            |          |                           | 
+ partrl_1_prt_p2_2_prt_sp1    |     2 |      | FOR VALUES IN (1, 2)         |            |          |                           | 
+(9 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrl' and partitionlevel = 1 order by partitionrank;
+ schemaname | tablename | partitionschemaname | partitiontablename | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |      partitionboundary       | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+--------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+------------------------------+------------------+---------------------
+ public     | partrl    | public              | partrl_1_prt_p2    | partrl                   | range         |              1 |             1 |                     | 0                   | 10                | f                  | FOR VALUES FROM (0) TO (10)  | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p1_1  | partrl                   | range         |              1 |             2 |                     | 10                  | 15                | f                  | FOR VALUES FROM (10) TO (15) | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p1_2  | partrl                   | range         |              1 |             3 |                     | 15                  | 20                | f                  | FOR VALUES FROM (15) TO (20) | pg_default       | pg_default
+(3 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrl' and partitionlevel = 2;
+ schemaname | tablename | partitionschemaname |      partitiontablename      | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |  partitionboundary   | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+------------------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+----------------------+------------------+---------------------
+ public     | partrl    | public              | partrl_1_prt_p2_2_prt_sp1    | partrl_1_prt_p2          | list          |              2 |               | 1, 2                |                     |                   | f                  | FOR VALUES IN (1, 2) | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p2_2_prt_sp2    | partrl_1_prt_p2          | list          |              2 |               | 3, 4                |                     |                   | f                  | FOR VALUES IN (3, 4) | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p2_2_prt_others | partrl_1_prt_p2          | list          |              2 |               |                     |                     |                   | t                  | DEFAULT              | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p1_1_2_prt_sp1  | partrl_1_prt_p1_1        | list          |              2 |               | 1, 2                |                     |                   | f                  | FOR VALUES IN (1, 2) | pg_default       | pg_default
+ public     | partrl    | public              | partrl_1_prt_p1_2_2_prt_sp1  | partrl_1_prt_p1_2        | list          |              2 |               | 1, 2                |                     |                   | f                  | FOR VALUES IN (1, 2) | pg_default       | pg_default
+(5 rows)
+
+-- Classic Syntax
+-- Multi-level range-range partitioned table
+CREATE TABLE partrr (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY range(c)
+(
+	PARTITION p1 START (0) END (10)
+	(
+		DEFAULT SUBPARTITION other_c
+	),
+	PARTITION p2 START (10) END (20)
+	(
+		SUBPARTITION sp2 START (300) END (600),
+		SUBPARTITION sp1 START (100) END (300),
+		DEFAULT SUBPARTITION other_c
+	)
+);
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+  from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+             relid             | level | rank |          relpartbound          | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+-------------------------------+-------+------+--------------------------------+------------+----------+---------------------------+----------------------------
+ partrr                        |     0 |      |                                |            |          | partrr_1_prt_p1           | partrr_1_prt_p2
+ partrr_1_prt_p1               |     1 |    1 | FOR VALUES FROM (0) TO (10)    | 0          | 10       |                           | 
+ partrr_1_prt_p2               |     1 |    2 | FOR VALUES FROM (10) TO (20)   | 10         | 20       | partrr_1_prt_p2_2_prt_sp1 | partrr_1_prt_p2_2_prt_sp2
+ partrr_1_prt_p1_2_prt_other_c |     2 |      | DEFAULT                        |            |          |                           | 
+ partrr_1_prt_p2_2_prt_other_c |     2 |      | DEFAULT                        |            |          |                           | 
+ partrr_1_prt_p2_2_prt_sp2     |     2 |    2 | FOR VALUES FROM (300) TO (600) | 300        | 600      |                           | 
+ partrr_1_prt_p2_2_prt_sp1     |     2 |    1 | FOR VALUES FROM (100) TO (300) | 100        | 300      |                           | 
+(7 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrr' and partitionlevel = 1 order by partitionrank;
+ schemaname | tablename | partitionschemaname | partitiontablename | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |      partitionboundary       | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+--------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+------------------------------+------------------+---------------------
+ public     | partrr    | public              | partrr_1_prt_p1    | partrr                   | range         |              1 |             1 |                     | 0                   | 10                | f                  | FOR VALUES FROM (0) TO (10)  | pg_default       | pg_default
+ public     | partrr    | public              | partrr_1_prt_p2    | partrr                   | range         |              1 |             2 |                     | 10                  | 20                | f                  | FOR VALUES FROM (10) TO (20) | pg_default       | pg_default
+(2 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrr' and partitionlevel = 2 order by partitionrank;
+ schemaname | tablename | partitionschemaname |      partitiontablename       | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |       partitionboundary        | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+-------------------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+--------------------------------+------------------+---------------------
+ public     | partrr    | public              | partrr_1_prt_p2_2_prt_sp1     | partrr_1_prt_p2          | range         |              2 |             1 |                     | 100                 | 300               | f                  | FOR VALUES FROM (100) TO (300) | pg_default       | pg_default
+ public     | partrr    | public              | partrr_1_prt_p2_2_prt_sp2     | partrr_1_prt_p2          | range         |              2 |             2 |                     | 300                 | 600               | f                  | FOR VALUES FROM (300) TO (600) | pg_default       | pg_default
+ public     | partrr    | public              | partrr_1_prt_p1_2_prt_other_c | partrr_1_prt_p1          | range         |              2 |               |                     |                     |                   | t                  | DEFAULT                        | pg_default       | pg_default
+ public     | partrr    | public              | partrr_1_prt_p2_2_prt_other_c | partrr_1_prt_p2          | range         |              2 |               |                     |                     |                   | t                  | DEFAULT                        | pg_default       | pg_default
+(4 rows)
+
+-- w/ minvalue and maxvalue
+CREATE TABLE range_parted2 (
+    a int
+) PARTITION BY RANGE (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE part1 PARTITION OF range_parted2 FOR VALUES FROM (1) TO (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part2 PARTITION OF range_parted2 FOR VALUES FROM (10) TO (20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part3 PARTITION OF range_parted2 FOR VALUES FROM (20) TO (30);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part4 PARTITION OF range_parted2 FOR VALUES FROM (30) TO (40);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part5 PARTITION OF range_parted2 FOR VALUES FROM (40) TO (50);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+     relid     | level | rank |            relpartbound            | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+---------------+-------+------+------------------------------------+------------+----------+---------------------------+----------------------------
+ range_parted2 |     0 |      |                                    |            |          | part7                     | part6
+ part1         |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10       |                           | 
+ part2         |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20       |                           | 
+ part3         |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30       |                           | 
+ part4         |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40       |                           | 
+ part5         |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50       |                           | 
+ part6         |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE |                           | 
+ part7         |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1        |                           | 
+(8 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'range_parted2' order by partitionrank;
+ schemaname |   tablename   | partitionschemaname | partitiontablename | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |         partitionboundary          | parenttablespace | partitiontablespace 
+------------+---------------+---------------------+--------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+------------------------------------+------------------+---------------------
+ public     | range_parted2 | public              | part7              | range_parted2            | range         |              1 |             1 |                     | MINVALUE            | 1                 | f                  | FOR VALUES FROM (MINVALUE) TO (1)  | pg_default       | pg_default
+ public     | range_parted2 | public              | part1              | range_parted2            | range         |              1 |             2 |                     | 1                   | 10                | f                  | FOR VALUES FROM (1) TO (10)        | pg_default       | pg_default
+ public     | range_parted2 | public              | part2              | range_parted2            | range         |              1 |             3 |                     | 10                  | 20                | f                  | FOR VALUES FROM (10) TO (20)       | pg_default       | pg_default
+ public     | range_parted2 | public              | part3              | range_parted2            | range         |              1 |             4 |                     | 20                  | 30                | f                  | FOR VALUES FROM (20) TO (30)       | pg_default       | pg_default
+ public     | range_parted2 | public              | part4              | range_parted2            | range         |              1 |             5 |                     | 30                  | 40                | f                  | FOR VALUES FROM (30) TO (40)       | pg_default       | pg_default
+ public     | range_parted2 | public              | part5              | range_parted2            | range         |              1 |             6 |                     | 40                  | 50                | f                  | FOR VALUES FROM (40) TO (50)       | pg_default       | pg_default
+ public     | range_parted2 | public              | part6              | range_parted2            | range         |              1 |             7 |                     | 60                  | MAXVALUE          | f                  | FOR VALUES FROM (60) TO (MAXVALUE) | pg_default       | pg_default
+(7 rows)
+
+-- w/ expressions
+CREATE TABLE range_parted3 (
+    a int,
+    b int
+) PARTITION BY RANGE (abs(a - b));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE range_parted3_part1 PARTITION OF range_parted3 FOR VALUES FROM (1) TO (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part2 PARTITION OF range_parted3 FOR VALUES FROM (10) TO (20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part3 PARTITION OF range_parted3 FOR VALUES FROM (20) TO (30);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part4 PARTITION OF range_parted3 FOR VALUES FROM (30) TO (40);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part5 PARTITION OF range_parted3 FOR VALUES FROM (40) TO (50);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60) TO (maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+        relid        | level | rank |            relpartbound            | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+---------------------+-------+------+------------------------------------+------------+----------+---------------------------+----------------------------
+ range_parted3       |     0 |      |                                    |            |          | range_parted3_part7       | range_parted3_part6
+ range_parted3_part1 |     1 |    2 | FOR VALUES FROM (1) TO (10)        | 1          | 10       |                           | 
+ range_parted3_part2 |     1 |    3 | FOR VALUES FROM (10) TO (20)       | 10         | 20       |                           | 
+ range_parted3_part3 |     1 |    4 | FOR VALUES FROM (20) TO (30)       | 20         | 30       |                           | 
+ range_parted3_part4 |     1 |    5 | FOR VALUES FROM (30) TO (40)       | 30         | 40       |                           | 
+ range_parted3_part5 |     1 |    6 | FOR VALUES FROM (40) TO (50)       | 40         | 50       |                           | 
+ range_parted3_part6 |     1 |    7 | FOR VALUES FROM (60) TO (MAXVALUE) | 60         | MAXVALUE |                           | 
+ range_parted3_part7 |     1 |    1 | FOR VALUES FROM (MINVALUE) TO (1)  | MINVALUE   | 1        |                           | 
+(8 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'range_parted3' order by partitionrank;
+ schemaname |   tablename   | partitionschemaname | partitiontablename  | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |         partitionboundary          | parenttablespace | partitiontablespace 
+------------+---------------+---------------------+---------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+------------------------------------+------------------+---------------------
+ public     | range_parted3 | public              | range_parted3_part7 | range_parted3            | range         |              1 |             1 |                     | MINVALUE            | 1                 | f                  | FOR VALUES FROM (MINVALUE) TO (1)  | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part1 | range_parted3            | range         |              1 |             2 |                     | 1                   | 10                | f                  | FOR VALUES FROM (1) TO (10)        | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part2 | range_parted3            | range         |              1 |             3 |                     | 10                  | 20                | f                  | FOR VALUES FROM (10) TO (20)       | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part3 | range_parted3            | range         |              1 |             4 |                     | 20                  | 30                | f                  | FOR VALUES FROM (20) TO (30)       | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part4 | range_parted3            | range         |              1 |             5 |                     | 30                  | 40                | f                  | FOR VALUES FROM (30) TO (40)       | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part5 | range_parted3            | range         |              1 |             6 |                     | 40                  | 50                | f                  | FOR VALUES FROM (40) TO (50)       | pg_default       | pg_default
+ public     | range_parted3 | public              | range_parted3_part6 | range_parted3            | range         |              1 |             7 |                     | 60                  | MAXVALUE          | f                  | FOR VALUES FROM (60) TO (MAXVALUE) | pg_default       | pg_default
+(7 rows)
+
+-- date partitioned table
+CREATE TABLE sales (trans_id int, date date, amount
+                             decimal(9,2), region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (date)
+        (START (date '2023-01-01')
+        END (date '2023-05-01') EVERY (INTERVAL '7 day'),
+        DEFAULT PARTITION other_date);
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid;
+         relid          | level | rank |                   relpartbound                   |  range_from  |   range_to   | pg_partition_lowest_child | pg_partition_highest_child 
+------------------------+-------+------+--------------------------------------------------+--------------+--------------+---------------------------+----------------------------
+ sales_1_prt_2          |     1 |    1 | FOR VALUES FROM ('01-01-2023') TO ('01-08-2023') | '01-01-2023' | '01-08-2023' |                           | 
+ sales_1_prt_3          |     1 |    2 | FOR VALUES FROM ('01-08-2023') TO ('01-15-2023') | '01-08-2023' | '01-15-2023' |                           | 
+ sales_1_prt_4          |     1 |    3 | FOR VALUES FROM ('01-15-2023') TO ('01-22-2023') | '01-15-2023' | '01-22-2023' |                           | 
+ sales_1_prt_5          |     1 |    4 | FOR VALUES FROM ('01-22-2023') TO ('01-29-2023') | '01-22-2023' | '01-29-2023' |                           | 
+ sales_1_prt_6          |     1 |    5 | FOR VALUES FROM ('01-29-2023') TO ('02-05-2023') | '01-29-2023' | '02-05-2023' |                           | 
+ sales_1_prt_7          |     1 |    6 | FOR VALUES FROM ('02-05-2023') TO ('02-12-2023') | '02-05-2023' | '02-12-2023' |                           | 
+ sales_1_prt_8          |     1 |    7 | FOR VALUES FROM ('02-12-2023') TO ('02-19-2023') | '02-12-2023' | '02-19-2023' |                           | 
+ sales_1_prt_9          |     1 |    8 | FOR VALUES FROM ('02-19-2023') TO ('02-26-2023') | '02-19-2023' | '02-26-2023' |                           | 
+ sales_1_prt_10         |     1 |    9 | FOR VALUES FROM ('02-26-2023') TO ('03-05-2023') | '02-26-2023' | '03-05-2023' |                           | 
+ sales_1_prt_11         |     1 |   10 | FOR VALUES FROM ('03-05-2023') TO ('03-12-2023') | '03-05-2023' | '03-12-2023' |                           | 
+ sales_1_prt_12         |     1 |   11 | FOR VALUES FROM ('03-12-2023') TO ('03-19-2023') | '03-12-2023' | '03-19-2023' |                           | 
+ sales_1_prt_13         |     1 |   12 | FOR VALUES FROM ('03-19-2023') TO ('03-26-2023') | '03-19-2023' | '03-26-2023' |                           | 
+ sales_1_prt_14         |     1 |   13 | FOR VALUES FROM ('03-26-2023') TO ('04-02-2023') | '03-26-2023' | '04-02-2023' |                           | 
+ sales_1_prt_15         |     1 |   14 | FOR VALUES FROM ('04-02-2023') TO ('04-09-2023') | '04-02-2023' | '04-09-2023' |                           | 
+ sales_1_prt_16         |     1 |   15 | FOR VALUES FROM ('04-09-2023') TO ('04-16-2023') | '04-09-2023' | '04-16-2023' |                           | 
+ sales_1_prt_17         |     1 |   16 | FOR VALUES FROM ('04-16-2023') TO ('04-23-2023') | '04-16-2023' | '04-23-2023' |                           | 
+ sales_1_prt_18         |     1 |   17 | FOR VALUES FROM ('04-23-2023') TO ('04-30-2023') | '04-23-2023' | '04-30-2023' |                           | 
+ sales_1_prt_19         |     1 |   18 | FOR VALUES FROM ('04-30-2023') TO ('05-01-2023') | '04-30-2023' | '05-01-2023' |                           | 
+ sales_1_prt_other_date |     1 |      | DEFAULT                                          |              |              |                           | 
+ sales                  |     0 |      |                                                  |              |              | sales_1_prt_2             | sales_1_prt_19
+(20 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'sales' order by partitionrank;
+ schemaname | tablename | partitionschemaname |   partitiontablename   | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues | partitionrangestart | partitionrangeend | partitionisdefault |                partitionboundary                 | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+------------------------+--------------------------+---------------+----------------+---------------+---------------------+---------------------+-------------------+--------------------+--------------------------------------------------+------------------+---------------------
+ public     | sales     | public              | sales_1_prt_2          | sales                    | range         |              1 |             1 |                     | '01-01-2023'        | '01-08-2023'      | f                  | FOR VALUES FROM ('01-01-2023') TO ('01-08-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_3          | sales                    | range         |              1 |             2 |                     | '01-08-2023'        | '01-15-2023'      | f                  | FOR VALUES FROM ('01-08-2023') TO ('01-15-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_4          | sales                    | range         |              1 |             3 |                     | '01-15-2023'        | '01-22-2023'      | f                  | FOR VALUES FROM ('01-15-2023') TO ('01-22-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_5          | sales                    | range         |              1 |             4 |                     | '01-22-2023'        | '01-29-2023'      | f                  | FOR VALUES FROM ('01-22-2023') TO ('01-29-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_6          | sales                    | range         |              1 |             5 |                     | '01-29-2023'        | '02-05-2023'      | f                  | FOR VALUES FROM ('01-29-2023') TO ('02-05-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_7          | sales                    | range         |              1 |             6 |                     | '02-05-2023'        | '02-12-2023'      | f                  | FOR VALUES FROM ('02-05-2023') TO ('02-12-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_8          | sales                    | range         |              1 |             7 |                     | '02-12-2023'        | '02-19-2023'      | f                  | FOR VALUES FROM ('02-12-2023') TO ('02-19-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_9          | sales                    | range         |              1 |             8 |                     | '02-19-2023'        | '02-26-2023'      | f                  | FOR VALUES FROM ('02-19-2023') TO ('02-26-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_10         | sales                    | range         |              1 |             9 |                     | '02-26-2023'        | '03-05-2023'      | f                  | FOR VALUES FROM ('02-26-2023') TO ('03-05-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_11         | sales                    | range         |              1 |            10 |                     | '03-05-2023'        | '03-12-2023'      | f                  | FOR VALUES FROM ('03-05-2023') TO ('03-12-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_12         | sales                    | range         |              1 |            11 |                     | '03-12-2023'        | '03-19-2023'      | f                  | FOR VALUES FROM ('03-12-2023') TO ('03-19-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_13         | sales                    | range         |              1 |            12 |                     | '03-19-2023'        | '03-26-2023'      | f                  | FOR VALUES FROM ('03-19-2023') TO ('03-26-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_14         | sales                    | range         |              1 |            13 |                     | '03-26-2023'        | '04-02-2023'      | f                  | FOR VALUES FROM ('03-26-2023') TO ('04-02-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_15         | sales                    | range         |              1 |            14 |                     | '04-02-2023'        | '04-09-2023'      | f                  | FOR VALUES FROM ('04-02-2023') TO ('04-09-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_16         | sales                    | range         |              1 |            15 |                     | '04-09-2023'        | '04-16-2023'      | f                  | FOR VALUES FROM ('04-09-2023') TO ('04-16-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_17         | sales                    | range         |              1 |            16 |                     | '04-16-2023'        | '04-23-2023'      | f                  | FOR VALUES FROM ('04-16-2023') TO ('04-23-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_18         | sales                    | range         |              1 |            17 |                     | '04-23-2023'        | '04-30-2023'      | f                  | FOR VALUES FROM ('04-23-2023') TO ('04-30-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_19         | sales                    | range         |              1 |            18 |                     | '04-30-2023'        | '05-01-2023'      | f                  | FOR VALUES FROM ('04-30-2023') TO ('05-01-2023') | pg_default       | pg_default
+ public     | sales     | public              | sales_1_prt_other_date | sales                    | range         |              1 |               |                     |                     |                   | t                  | DEFAULT                                          | pg_default       | pg_default
+(19 rows)
+
+-- Multi-column range partitioned table
+-- multi-column keys
+create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table mc3p_default partition of mc3p default;
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p0 partition of mc3p for values from (minvalue, minvalue, minvalue) to (1, 1, 1);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p1 partition of mc3p for values from (1, 1, 1) to (10, 5, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p2 partition of mc3p for values from (10, 5, 10) to (10, 10, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p3 partition of mc3p for values from (10, 10, 10) to (10, 10, 20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p4 partition of mc3p for values from (10, 10, 20) to (10, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
+    relid     | level | rank |                          relpartbound                          | range_from | range_to | pg_partition_lowest_child | pg_partition_highest_child 
+--------------+-------+------+----------------------------------------------------------------+------------+----------+---------------------------+----------------------------
+ mc3p         |     0 |      |                                                                |            |          | mc3p0                     | mc3p7
+ mc3p_default |     1 |      | DEFAULT                                                        |            |          |                           | 
+ mc3p0        |     1 |    1 | FOR VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (1, 1, 1)    |            |          |                           | 
+ mc3p1        |     1 |    2 | FOR VALUES FROM (1, 1, 1) TO (10, 5, 10)                       |            |          |                           | 
+ mc3p2        |     1 |    3 | FOR VALUES FROM (10, 5, 10) TO (10, 10, 10)                    |            |          |                           | 
+ mc3p3        |     1 |    4 | FOR VALUES FROM (10, 10, 10) TO (10, 10, 20)                   |            |          |                           | 
+ mc3p4        |     1 |    5 | FOR VALUES FROM (10, 10, 20) TO (10, MAXVALUE, MAXVALUE)       |            |          |                           | 
+ mc3p5        |     1 |    6 | FOR VALUES FROM (11, 1, 1) TO (20, 10, 10)                     |            |          |                           | 
+ mc3p6        |     1 |    7 | FOR VALUES FROM (20, 10, 10) TO (20, 20, 20)                   |            |          |                           | 
+ mc3p7        |     1 |    8 | FOR VALUES FROM (20, 20, 20) TO (MAXVALUE, MAXVALUE, MAXVALUE) |            |          |                           | 
+(10 rows)
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'mc3p' order by partitionrank;
+ schemaname | tablename | partitionschemaname | partitiontablename | parentpartitiontablename | partitiontype | partitionlevel | partitionrank | partitionlistvalues |     partitionrangestart      |      partitionrangeend       | partitionisdefault |                       partitionboundary                        | parenttablespace | partitiontablespace 
+------------+-----------+---------------------+--------------------+--------------------------+---------------+----------------+---------------+---------------------+------------------------------+------------------------------+--------------------+----------------------------------------------------------------+------------------+---------------------
+ public     | mc3p      | public              | mc3p0              | mc3p                     | range         |              1 |             1 |                     | MINVALUE, MINVALUE, MINVALUE | 1, 1, 1                      | f                  | FOR VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (1, 1, 1)    | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p1              | mc3p                     | range         |              1 |             2 |                     | 1, 1, 1                      | 10, 5, 10                    | f                  | FOR VALUES FROM (1, 1, 1) TO (10, 5, 10)                       | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p2              | mc3p                     | range         |              1 |             3 |                     | 10, 5, 10                    | 10, 10, 10                   | f                  | FOR VALUES FROM (10, 5, 10) TO (10, 10, 10)                    | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p3              | mc3p                     | range         |              1 |             4 |                     | 10, 10, 10                   | 10, 10, 20                   | f                  | FOR VALUES FROM (10, 10, 10) TO (10, 10, 20)                   | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p4              | mc3p                     | range         |              1 |             5 |                     | 10, 10, 20                   | 10, MAXVALUE, MAXVALUE       | f                  | FOR VALUES FROM (10, 10, 20) TO (10, MAXVALUE, MAXVALUE)       | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p5              | mc3p                     | range         |              1 |             6 |                     | 11, 1, 1                     | 20, 10, 10                   | f                  | FOR VALUES FROM (11, 1, 1) TO (20, 10, 10)                     | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p6              | mc3p                     | range         |              1 |             7 |                     | 20, 10, 10                   | 20, 20, 20                   | f                  | FOR VALUES FROM (20, 10, 10) TO (20, 20, 20)                   | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p7              | mc3p                     | range         |              1 |             8 |                     | 20, 20, 20                   | MAXVALUE, MAXVALUE, MAXVALUE | f                  | FOR VALUES FROM (20, 20, 20) TO (MAXVALUE, MAXVALUE, MAXVALUE) | pg_default       | pg_default
+ public     | mc3p      | public              | mc3p_default       | mc3p                     | range         |              1 |               |                     |                              |                              | t                  | DEFAULT                                                        | pg_default       | pg_default
+(9 rows)
+

--- a/gpcontrib/gp_toolkit/gp_partition_maint.c
+++ b/gpcontrib/gp_toolkit/gp_partition_maint.c
@@ -1,0 +1,342 @@
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/relation.h"
+#include "catalog/pg_inherits.h"
+#include "catalog/partition.h"
+#include "funcapi.h"
+#include "partitioning/partbounds.h"
+#include "partitioning/partdesc.h"
+#include "storage/lmgr.h"
+#include "utils/builtins.h"
+#include "utils/partcache.h"
+
+typedef struct GetPartitionsQueueItem
+{
+	Oid 		relid;
+	Oid 		parent_relid;
+	bool		isleaf;
+	int 		level;
+	char 		strategy;
+	int 		rank;
+	bool		isdefault;
+} GetPartitionsQueueItem;
+
+typedef struct GetPartitionsContext
+{
+	List 		*queue;
+} GetPartitionsContext;
+
+static void add_partition_children(List **queue, Relation parent, int level);
+
+extern Datum pg_partition_rank(PG_FUNCTION_ARGS);
+extern Datum pg_partition_lowest_child(PG_FUNCTION_ARGS);
+extern Datum pg_partition_highest_child(PG_FUNCTION_ARGS);
+extern Datum gp_get_partitions(PG_FUNCTION_ARGS);
+
+/*
+ * Calculate the rank (1-based) of a non-default range partition. We return
+ * NULL for any other relation type.
+ */
+PG_FUNCTION_INFO_V1(pg_partition_rank);
+Datum
+pg_partition_rank(PG_FUNCTION_ARGS)
+{
+	Oid					relid = PG_GETARG_OID(0);
+	Oid					parentrelid = InvalidOid;
+	Relation			parentrel = NULL;
+	PartitionDesc		parentpartdesc = NULL;
+
+	if (!rel_is_range_part_nondefault(relid))
+		PG_RETURN_NULL();
+
+	parentrelid = get_partition_parent(relid);
+	parentrel = relation_open(parentrelid, AccessShareLock);
+	parentpartdesc = RelationRetrievePartitionDesc(parentrel);
+
+	/* Child oids are already sorted by range bounds in ascending order. */
+	for (int i = 0; i < parentpartdesc->nparts; i++)
+	{
+		if (relid == parentpartdesc->oids[i])
+		{
+			relation_close(parentrel, AccessShareLock);
+			PG_RETURN_INT32(i + 1);
+		}
+	}
+
+	PG_RETURN_NULL(); /* unreachable, keep compiler happy */
+}
+
+/*
+ * Find the lowest child with respect to range bounds for a range partition.
+ * Default partitions are not considered in this calculation.
+ */
+PG_FUNCTION_INFO_V1(pg_partition_lowest_child);
+Datum
+pg_partition_lowest_child(PG_FUNCTION_ARGS)
+{
+	Oid					relid = PG_GETARG_OID(0);
+	Relation			rel = NULL;
+	PartitionDesc		partdesc = NULL;
+	PartitionKey		partkey = NULL;
+	Oid					childrelid = InvalidOid;
+
+	rel = relation_open(relid, AccessShareLock);
+	partkey = RelationRetrievePartitionKey(rel);
+	partdesc = RelationRetrievePartitionDesc(rel);
+	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE &&
+		partkey->strategy == PARTITION_STRATEGY_RANGE &&
+		partdesc->nparts > 0)
+	{
+		/*
+		 * Child oids are already sorted by range bounds in ascending order.
+		 * If default partition exists, it is the last partition.
+		 */
+		if (partdesc->nparts > 1 || !OidIsValid(get_default_partition_oid(relid)))
+			childrelid = partdesc->oids[0];
+	}
+
+	relation_close(rel, AccessShareLock);
+	if (OidIsValid(childrelid))
+		PG_RETURN_OID(childrelid);
+	else
+		PG_RETURN_NULL();
+}
+
+/*
+ * Find the highest child with respect to range bounds for a range partition.
+ * Default partitions are not considered in this calculation.
+ */
+PG_FUNCTION_INFO_V1(pg_partition_highest_child);
+Datum
+pg_partition_highest_child(PG_FUNCTION_ARGS)
+{
+	Oid					relid = PG_GETARG_OID(0);
+	Relation			rel = NULL;
+	PartitionDesc		partdesc = NULL;
+	PartitionKey		partkey = NULL;
+	Oid					default_relid = InvalidOid;
+	Oid					highest_relid = InvalidOid;
+
+	rel = relation_open(relid, AccessShareLock);
+	partkey = RelationRetrievePartitionKey(rel);
+	partdesc = RelationRetrievePartitionDesc(rel);
+	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE &&
+		partkey->strategy == PARTITION_STRATEGY_RANGE &&
+		partdesc->nparts > 0)
+	{
+		/*
+		 * Child oids are already sorted by range bounds in ascending order.
+		 * If default partition exists, it is the last partition.
+		 */
+		default_relid = get_default_partition_oid(relid);
+		if (!OidIsValid(default_relid))
+			highest_relid = partdesc->oids[partdesc->nparts - 1];
+		else if (partdesc->nparts > 1)
+		{
+			Assert (default_relid == partdesc->oids[partdesc->nparts - 1]);
+			highest_relid = partdesc->oids[partdesc->nparts - 2];
+		}
+	}
+
+	relation_close(rel, AccessShareLock);
+	if (OidIsValid(highest_relid))
+		PG_RETURN_OID(highest_relid);
+	else
+		PG_RETURN_NULL();
+}
+
+/*
+ * gp_get_partitions
+ *
+ * Main driver for the gp_partitions view.
+ *
+ * Given the root (or interior node) of a partition hierarchy, return a result
+ * set akin to pg_partition_tree(), complete with rank, level etc. There will be
+ * 1 row per member (the root of the hierarchy isn't included, unlike
+ * pg_partition_tree()).
+ *
+ * To obtain this set, we perform a level-order traversal of the partition
+ * hierarchy.
+ */
+PG_FUNCTION_INFO_V1(gp_get_partitions);
+Datum
+gp_get_partitions(PG_FUNCTION_ARGS)
+{
+#define GP_GET_PARTITION_COLS	7
+	Oid						rootrelid = PG_GETARG_OID(0);
+	FuncCallContext 		*funcctx;
+	GetPartitionsContext	*context;
+
+	/* stuff done only on the first call of the function */
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext 			oldcxt;
+		TupleDesc				tupdesc;
+		Relation 				rootrel;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		rootrel = relation_open(rootrelid, AccessShareLock);
+
+		if (rootrel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
+		{
+			relation_close(rootrel, AccessShareLock);
+			SRF_RETURN_DONE(funcctx);
+		}
+
+		/*
+		 * Grab access share locks on hierarchy, they will be implicitly
+		 * released at transaction end. This is similar to pg_partition_tree().
+		 */
+		find_all_inheritors(rootrelid, AccessShareLock, NULL);
+
+		/* switch to memory context appropriate for multiple function calls */
+		oldcxt = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		tupdesc = CreateTemplateTupleDesc(GP_GET_PARTITION_COLS);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "relid",
+						   REGCLASSOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "parentid",
+						   REGCLASSOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "isleaf",
+						   BOOLOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "partitionlevel",
+						   INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "partitiontype",
+						   TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "partitionrank",
+						   INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "is_default",
+						   BOOLOID, -1, 0);
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		/* Add initial entries into the queue */
+		context = palloc0(sizeof(GetPartitionsContext));
+		add_partition_children(&context->queue, rootrel, 0);
+		funcctx->user_fctx = context;
+
+		MemoryContextSwitchTo(oldcxt);
+	}
+
+	/* stuff done on every call of the function */
+	funcctx = SRF_PERCALL_SETUP();
+	context = (GetPartitionsContext *) funcctx->user_fctx;
+
+	if (list_length(context->queue) > 0)
+	{
+		Datum					result;
+		Datum					values[GP_GET_PARTITION_COLS];
+		bool					nulls[GP_GET_PARTITION_COLS];
+		HeapTuple				tuple;
+		GetPartitionsQueueItem 	*next;
+		MemoryContext 			oldcxt;
+
+		next = (GetPartitionsQueueItem *) linitial(context->queue);
+
+		/*
+		 * Form tuple with appropriate data.
+		 */
+		MemSet(nulls, 0, sizeof(nulls));
+		MemSet(values, 0, sizeof(values));
+
+		/* relid */
+		values[0] = ObjectIdGetDatum(next->relid);
+
+		/* parentid */
+		values[1] = ObjectIdGetDatum(next->parent_relid);
+
+		/* isleaf */
+		values[2] = BoolGetDatum(next->isleaf);
+
+		/* partitionlevel */
+		values[3] = Int32GetDatum(next->level);
+
+		/* partitiontype */
+		values[4] = CStringGetTextDatum(PartitionStrategyGetName(next->strategy));
+
+		/*
+		 * partitionrank:
+		 * -1 signifies that partition rank here is N/A. See
+		 * add_partition_children().
+		 */
+		if (next->rank != -1)
+			values[5] = Int32GetDatum(next->rank);
+		else
+			nulls[5] = true;
+
+		/* isdefault */
+		values[6] = next->isdefault;
+
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tuple);
+
+		/* switch to memory context appropriate for multiple function calls */
+		oldcxt = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		if (!next->isleaf)
+		{
+			/* add children to the level-order-traversal queue */
+			add_partition_children(&context->queue,
+								   relation_open(next->relid, NoLock),
+								   next->level);
+		}
+
+		/* de-queue */
+		context->queue = list_delete_first(context->queue);
+
+		MemoryContextSwitchTo(oldcxt);
+
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+	/* done when there are no more elements left */
+	SRF_RETURN_DONE(funcctx);
+}
+
+/*
+ * For a given partition parent, add all its children to the
+ * level-order-traversal queue. Assumes that the parent relation is already open
+ * and locks have been taken earlier. We also close the parent relation at the
+ * end of this function, since we no longer need the parent's Relation object.
+ */
+static void
+add_partition_children(List **queue, Relation parent, int level)
+{
+	PartitionDesc 	pdesc;
+
+	Assert(RelationIsValid(parent));
+	Assert(parent->rd_rel->relkind == RELKIND_PARTITIONED_TABLE);
+	Assert(level >= 0);
+
+	/*
+	 * Building the partition descriptor guarantees that its children are sorted
+	 * in order of their partition boundaries.
+	 */
+	pdesc = RelationRetrievePartitionDesc(parent);
+
+	for (int i = 0; i < pdesc->nparts; i++)
+	{
+		GetPartitionsQueueItem *item = palloc0(sizeof(GetPartitionsQueueItem));
+		bool isdefault = (pdesc->boundinfo->default_index == i);
+
+		item->relid = pdesc->oids[i];
+		item->parent_relid = RelationGetRelid(parent);
+		item->isleaf = pdesc->is_leaf[i];
+		item->level = level + 1;
+		item->strategy = pdesc->boundinfo->strategy;
+
+		if (pdesc->boundinfo->strategy == PARTITION_STRATEGY_RANGE && !isdefault)
+			item->rank = i + 1; /* since oids array is sorted by part bounds */
+		else
+			item->rank = -1; /* doesn't have a rank */
+
+		item->isdefault = isdefault;
+
+		*queue = lappend(*queue, item);
+	}
+
+	/* now close the relation */
+	relation_close(parent, NoLock);
+}

--- a/gpcontrib/gp_toolkit/sql/gp_partition_maint.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_partition_maint.sql
@@ -1,0 +1,141 @@
+-- Classic Syntax
+-- Multi-level range-list partitioned table
+DROP TABLE IF EXISTS partrl;
+CREATE TABLE partrl (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY list(c)
+(
+	PARTITION p1 START (10) END (20) EVERY (5)
+	(
+		SUBPARTITION sp1 VALUES (1, 2)
+	),
+	PARTITION p2 START (0) END (10)
+	(
+		SUBPARTITION sp2 VALUES (3, 4),
+		SUBPARTITION sp1 VALUES (1, 2),
+		DEFAULT SUBPARTITION others
+	)
+);
+
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+    from pg_partition_tree('partrl') pt join pg_class c on pt.relid = c.oid;
+
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrl' and partitionlevel = 1 order by partitionrank;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrl' and partitionlevel = 2;
+
+-- Classic Syntax
+-- Multi-level range-range partitioned table
+CREATE TABLE partrr (a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY range(b)
+SUBPARTITION BY range(c)
+(
+	PARTITION p1 START (0) END (10)
+	(
+		DEFAULT SUBPARTITION other_c
+	),
+	PARTITION p2 START (10) END (20)
+	(
+		SUBPARTITION sp2 START (300) END (600),
+		SUBPARTITION sp1 START (100) END (300),
+		DEFAULT SUBPARTITION other_c
+	)
+);
+
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+  from pg_partition_tree('partrr') pt join pg_class c on pt.relid = c.oid;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrr' and partitionlevel = 1 order by partitionrank;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'partrr' and partitionlevel = 2 order by partitionrank;
+
+-- w/ minvalue and maxvalue
+CREATE TABLE range_parted2 (
+    a int
+) PARTITION BY RANGE (a);
+CREATE TABLE part1 PARTITION OF range_parted2 FOR VALUES FROM (1) TO (10);
+CREATE TABLE part2 PARTITION OF range_parted2 FOR VALUES FROM (10) TO (20);
+CREATE TABLE part3 PARTITION OF range_parted2 FOR VALUES FROM (20) TO (30);
+CREATE TABLE part4 PARTITION OF range_parted2 FOR VALUES FROM (30) TO (40);
+CREATE TABLE part5 PARTITION OF range_parted2 FOR VALUES FROM (40) TO (50);
+CREATE TABLE part6 PARTITION OF range_parted2 FOR VALUES FROM (60) TO (maxvalue);
+CREATE TABLE part7 PARTITION OF range_parted2 FOR VALUES FROM (minvalue) TO (1);
+
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('range_parted2') pt join pg_class c on pt.relid = c.oid;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'range_parted2' order by partitionrank;
+
+-- w/ expressions
+CREATE TABLE range_parted3 (
+    a int,
+    b int
+) PARTITION BY RANGE (abs(a - b));
+CREATE TABLE range_parted3_part1 PARTITION OF range_parted3 FOR VALUES FROM (1) TO (10);
+CREATE TABLE range_parted3_part2 PARTITION OF range_parted3 FOR VALUES FROM (10) TO (20);
+CREATE TABLE range_parted3_part3 PARTITION OF range_parted3 FOR VALUES FROM (20) TO (30);
+CREATE TABLE range_parted3_part4 PARTITION OF range_parted3 FOR VALUES FROM (30) TO (40);
+CREATE TABLE range_parted3_part5 PARTITION OF range_parted3 FOR VALUES FROM (40) TO (50);
+CREATE TABLE range_parted3_part6 PARTITION OF range_parted3 FOR VALUES FROM (60) TO (maxvalue);
+CREATE TABLE range_parted3_part7 PARTITION OF range_parted3 FOR VALUES FROM (minvalue) TO (1);
+
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('range_parted3') pt join pg_class c on pt.relid = c.oid;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'range_parted3' order by partitionrank;
+
+-- date partitioned table
+CREATE TABLE sales (trans_id int, date date, amount
+                             decimal(9,2), region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (date)
+        (START (date '2023-01-01')
+        END (date '2023-05-01') EVERY (INTERVAL '7 day'),
+        DEFAULT PARTITION other_date);
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('sales') pt join pg_class c on pt.relid = c.oid;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'sales' order by partitionrank;
+
+-- Multi-column range partitioned table
+-- multi-column keys
+create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
+create table mc3p_default partition of mc3p default;
+create table mc3p0 partition of mc3p for values from (minvalue, minvalue, minvalue) to (1, 1, 1);
+create table mc3p1 partition of mc3p for values from (1, 1, 1) to (10, 5, 10);
+create table mc3p2 partition of mc3p for values from (10, 5, 10) to (10, 10, 10);
+create table mc3p3 partition of mc3p for values from (10, 10, 10) to (10, 10, 20);
+create table mc3p4 partition of mc3p for values from (10, 10, 20) to (10, maxvalue, maxvalue);
+create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
+create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
+create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
+
+SELECT relid, level, gp_toolkit.pg_partition_rank(relid) as rank,
+       pg_get_expr(relpartbound, c.oid) as relpartbound,
+       gp_toolkit.pg_partition_range_from(c.oid) as range_from,
+       gp_toolkit.pg_partition_range_to(c.oid) as range_to,
+       gp_toolkit.pg_partition_lowest_child(c.oid),
+       gp_toolkit.pg_partition_highest_child(c.oid)
+from pg_partition_tree('mc3p') pt join pg_class c on pt.relid = c.oid;
+SELECT * from gp_toolkit.gp_partitions where schemaname = 'public' and tablename = 'mc3p' order by partitionrank;

--- a/src/backend/catalog/partition.c
+++ b/src/backend/catalog/partition.c
@@ -27,11 +27,11 @@
 #include "optimizer/optimizer.h"
 #include "partitioning/partbounds.h"
 #include "rewrite/rewriteManip.h"
+#include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/partcache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
-
 
 static Oid	get_partition_parent_worker(Relation inhRel, Oid relid);
 static void get_partition_ancestors_worker(Relation inhRel, Oid relid,
@@ -394,4 +394,48 @@ get_proposed_default_constraint(List *new_part_constraints)
 	defPartConstraint = canonicalize_qual(defPartConstraint, true);
 
 	return make_ands_implicit(defPartConstraint);
+}
+
+/*
+ * Is this a non-default range partition?
+ */
+bool
+rel_is_range_part_nondefault(Oid relid)
+{
+	HeapTuple			tuple;
+	Form_pg_class		classForm;
+	bool				retval = false;
+
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for relation %u", relid);
+
+	/* check if the relation is a partition */
+	classForm = (Form_pg_class) GETSTRUCT(tuple);
+	if ((classForm->relkind == RELKIND_RELATION ||
+		classForm->relkind == RELKIND_PARTITIONED_TABLE) &&
+		classForm->relispartition)
+	{
+		PartitionBoundSpec *boundspec = NULL;
+		Datum				datum;
+		bool				isnull;
+
+		datum = SysCacheGetAttr(RELOID, tuple, Anum_pg_class_relpartbound, &isnull);
+		if (!isnull)
+		{
+			boundspec = stringToNode(TextDatumGetCString(datum));
+			if (boundspec->strategy == PARTITION_STRATEGY_RANGE &&
+				!boundspec->is_default)
+				retval = true;
+		}
+
+		/* Sanity checks. */
+		if (!boundspec)
+			elog(ERROR, "missing relpartbound for relation %u", relid);
+		if (!IsA(boundspec, PartitionBoundSpec))
+			elog(ERROR, "invalid relpartbound for relation %u", relid);
+	}
+
+	ReleaseSysCache(tuple);
+	return retval;
 }

--- a/src/include/catalog/partition.h
+++ b/src/include/catalog/partition.h
@@ -32,5 +32,6 @@ extern bool has_partition_attrs(Relation rel, Bitmapset *attnums,
 extern Oid	get_default_partition_oid(Oid parentId);
 extern void update_default_partition_oid(Oid parentId, Oid defaultPartId);
 extern List *get_proposed_default_constraint(List *new_part_constraints);
+extern bool rel_is_range_part_nondefault(Oid relid);
 
 #endif							/* PARTITION_H */

--- a/src/include/partitioning/partbounds.h
+++ b/src/include/partitioning/partbounds.h
@@ -115,5 +115,20 @@ extern int	partition_range_datum_bsearch(FmgrInfo *partsupfunc,
 										  int nvalues, Datum *values, bool *is_equal);
 extern int	partition_hash_bsearch(PartitionBoundInfo boundinfo,
 								   int modulus, int remainder);
+static inline const char *
+PartitionStrategyGetName(char strategy)
+{
+	switch (strategy)
+	{
+		case PARTITION_STRATEGY_LIST:
+			return "list";
+		case PARTITION_STRATEGY_HASH:
+			return "hash";
+		case PARTITION_STRATEGY_RANGE:
+			return "range";
+		default:
+			ereport(ERROR, (errmsg("unrecognized partitioning strategy")));
+	}
+}
 
 #endif							/* PARTBOUNDS_H */


### PR DESCRIPTION
This commit introduces the following UDFs and view to help users tackle
various partition maintenance tasks.

```
Helper UDFs:

pg_partition_rank()
   - Rank of a non-default range partition among siblings (position of
     partition in a hypothetical sorted array of siblings)
pg_partition_range_from()
   - Lower range bound of a range partition
pg_partition_range_to()
   - Higher range bound of a range partition
pg_partition_bound_value()
   - Textual representation of the range bounds of a partition
pg_partition_isdefault()
   - Checks if given partition is a default partition
pg_partition_lowest_child()
   - Finds the lowest ranked child of given partition
pg_partition_highest_child()
   - Finds the highest ranked child of a given partition
```


```
View:

gp_partitions: Equivalent of legacy view pg_partitions from older major
versions of GPDB, minus some columns (which don't really apply to the
current world view anymore):

partitionname
partitionposition
partitionstartinclusive
partitionendinclusive
partitioneveryclause

```

Notable differences from 6X for this view:
(1) The root is level = 0, its immediate children are level 1 and so on.
(2) Immediate children of the root have parentpartitiontablename equal
    to that of the root (instead of being null).

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Reviewed-by: Huansong Fu <fuhuansong@gmail.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/part_maint?group=all
