### PR TITLE
Don't emit critical error message when gppkg is missing.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -642,7 +642,7 @@ class CommandNotFoundException(Exception):
         return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd, repr(self.paths))
 
 
-def findCmdInPath(cmd):
+def findCmdInPath(cmd, missing_ok=False):
     # ---------------command path--------------------
     CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/usr/local/bin', '/bin',
                '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
@@ -662,7 +662,11 @@ def findCmdInPath(cmd):
                 CMD_CACHE[cmd] = f
                 return f
 
-        logger.critical('Command %s not found' % cmd)
+        # missing_ok is just suppressing the critical log message. This function
+        # still raises an exception and leaves the client to decide whether to
+        # consume the error.
+        if not missing_ok:
+            logger.critical('Command %s not found' % cmd)
         search_path = CMDPATH[:]
         raise CommandNotFoundException(cmd, search_path)
     else:

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -27,7 +27,7 @@ class SyncPackages(Operation):
     def __init__(self):
         self.gppkg_path = None
         try:
-            self.gppkg_path = findCmdInPath('gppkg')
+            self.gppkg_path = findCmdInPath('gppkg', missing_ok=True)
         except CommandNotFoundException:
             pass
 


### PR DESCRIPTION
Gppkg for Greenplum 7 is closed source and we don't ship it for OSS users. This patch helps suppress the error message when gppkg is missing.

