### PR TITLE
Resolve FIXME in create_ctescan_path()  in pathnode.c.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3139,8 +3139,7 @@ create_ctescan_path(PlannerInfo *root, RelOptInfo *rel,
 	 * We can't extract these two values from the subplan, so we simple set
 	 * them to their worst case here.
 	 *
-	 * GPDB_96_MERGE_FIXME: we do have the subpath, at least if it's not a
-	 * shared cte
+	 * GPDB: we do have the subpath, at least if it's not a shared cte.
 	 */
 	pathnode->motionHazard = true;
 	pathnode->rescannable = false;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3135,16 +3135,11 @@ create_ctescan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->pathkeys = pathkeys;
 	pathnode->locus = locus;
 
-	/*
-	 * We can't extract these two values from the subplan, so we simple set
-	 * them to their worst case here.
-	 *
-	 * GPDB: we do have the subpath, at least if it's not a shared cte.
-	 */
-	pathnode->motionHazard = true;
-	pathnode->rescannable = false;
 	pathnode->sameslice_relids = NULL;
 
+	/*
+	 * GPDB: we do have the subpath, at least if it's not a shared cte.
+	 */
 	if (subpath)
 	{
 		/* copy the cost estimates from the subpath */
@@ -3159,10 +3154,19 @@ create_ctescan_path(PlannerInfo *root, RelOptInfo *rel,
 		pathnode->startup_cost = subpath->startup_cost;
 		pathnode->total_cost = subpath->total_cost;
 
+		pathnode->motionHazard = subpath->motionHazard;
+		pathnode->rescannable = subpath->rescannable;
+
 		ctepath->subpath = subpath;
 	}
 	else
 	{
+		/*
+	 	 * We can't extract these two values from the subplan, so we simple set
+	 	 * them to their worst case here.
+		 */
+		pathnode->motionHazard = true;
+		pathnode->rescannable = false;
 		/* Shared scan. We'll use the cost estimates from the CTE rel. */
 		cost_ctescan(pathnode, root, rel, pathnode->param_info);
 	}

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1826,12 +1826,11 @@ select * from x;
          Join Filter: (length((x.a || x_1.a)) < 5)
          ->  WorkTable Scan on x
                Output: x.a
-         ->  Materialize
+         ->  WorkTable Scan on x x_1
                Output: x_1.a
-               ->  WorkTable Scan on x x_1
-                     Output: x_1.a
- Optimizer: Postgres query optimizer
-(13 rows)
+ Optimizer: Postgres-based planner
+ Settings: gp_cte_sharing = 'on'
+(12 rows)
 
 with recursive x(a) as
   ((values ('a'), ('b'))

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1902,13 +1902,11 @@ select * from x;
          Join Filter: (length((x.a || x_1.a)) < 5)
          ->  WorkTable Scan on x
                Output: x.a
-         ->  Materialize
+         ->  WorkTable Scan on x x_1
                Output: x_1.a
-               ->  WorkTable Scan on x x_1
-                     Output: x_1.a
  Optimizer: Postgres query optimizer
  Settings: gp_cte_sharing=on, optimizer=on
-(14 rows)
+(12 rows)
 
 with recursive x(a) as
   ((values ('a'), ('b'))


### PR DESCRIPTION
## We have our GPDB-specific processing for CTE queries in `set_cte_pathlist()` (Unlike upstream's work mostly in `SS_process_ctes()`):
* We decide whether to generate a new subplan for this CTE.
* We decide whether to enable plan sharing for this CTE.
* We decide whether to inline this CTE accroding to self references and if contains volatile functions.
* We decide whether to push down quals for this CTE.

## The Subquery planning also differs for shared / not shared CTEs:
* For CTEs shared, generate one Subquery plan as a singleton and store it in cteplaninfo. `sub_final_rel->pathlist` also only keeps the cheapest cost path, for sharing purpose.
* For CTEs not shared, generate different Subquery plans for each CTE. `sub_final_rel->pathlist` would have more than one cost paths, leaving upper callsite to decide the cheapest cost path.

## How do we `create_ctescan_path()` inside `set_cte_pathlist()`:
* Add a `CtePath` by: https://github.com/greenplum-db/gpdb/blob/7ef0db993d850268bc8c365f8d8728345ce1f11a/src/backend/optimizer/path/allpaths.c#L3105
* For shared CTE, we pass `Subpath` as `NULL` to `set_cte_pathlist()`.
* So for shared CTE scan, we'll use the cost estimates from the CTE rel, which is set by `set_cte_size_estimates()` before: https://github.com/greenplum-db/gpdb/blob/7ef0db993d850268bc8c365f8d8728345ce1f11a/src/backend/optimizer/path/allpaths.c#L3078 
* For not shared CTE, we pass the `Subpath` to `set_cte_pathlist()`.
* So for not shared CTE scan, we just copy the cost estimates from the subpath, which is produced by `subquery_planner()`.

## Conclusion
So it's safe to remove this fixme.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [x] Review a PR in return to support the community
