### PR TITLE
remove ereport()/elog() from signal handler

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3876,8 +3876,6 @@ ProcessInterrupts(const char* filename, int lineno)
 		bool		lock_timeout_occurred;
 		bool		stmt_timeout_occurred;
 
-		elog(LOG,"Process interrupt for 'query cancel pending' (%s:%d)", filename, lineno);
-
 		/*
 		 * Don't allow query cancel interrupts while reading input from the
 		 * client, because we might lose sync in the FE/BE protocol.  (Die

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3517,13 +3517,7 @@ StatementCancelHandler(SIGNAL_ARGS)
 		 * interrupt, service the interrupt immediately
 		 */
 		if (ImmediateInterruptOK)
-		{
-			/* Print out stack for immediate interruption */
-			ereport(LOG,
-					(errmsg("immediate interruption"),
-					errprintstack(true)));
 			ProcessInterrupts(__FILE__, __LINE__);
-		}
 	}
 
 	/* If we're still here, waken anything waiting on the process latch */

--- a/src/backend/tcop/test/postgres_test.c
+++ b/src/backend/tcop/test/postgres_test.c
@@ -142,15 +142,6 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	QueryCancelPending = true;
 	DoingCommandRead = true;
 
-	/* Mock up elog_start and elog_finish */
-	expect_any(elog_start, filename);
-	expect_any(elog_start, lineno);
-	expect_any(elog_start, funcname);
-	will_be_called(elog_start);
-	expect_value(elog_finish, elevel, LOG);
-	expect_any(elog_finish, fmt);
-	will_be_called(elog_finish);
-
 	ProcessInterrupts(__FILE__, __LINE__);
 
 	assert_false(QueryCancelPending);
@@ -161,15 +152,6 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	 */
 	QueryCancelPending = true;
 	DoingCommandRead = false;
-
-	/* Mock up elog_start and elog_finish */
-	expect_any(elog_start, filename);
-	expect_any(elog_start, lineno);
-	expect_any(elog_start, funcname);
-	will_be_called(elog_start);
-	expect_value(elog_finish, elevel, LOG);
-	expect_any(elog_finish, fmt);
-	will_be_called(elog_finish);
 
 	will_be_called(DisableNotifyInterrupt);
 	will_be_called(DisableCatchupInterrupt);


### PR DESCRIPTION
### Brief

The commit https://github.com/greenplum-db/gpdb/commit/be97c73d7131d57abf0178f2cf981f1895af9d2f added calling of `ereport()` to `StatementCancelHandler()` to print out more info. However, we need to avoid calling `ereport()`/`elog()` in signal handler. See the discussion: https://www.postgresql.org/message-id/flat/7E3165DE-601D-4930-A85F-35BD6318E1C2%40arenadata.io

### Error

With the calling, it's possible to hit deadlock in a corner case. See the scenario:

1. QE was waiting for message from QD.
2. QE received signal SIGINT from cancellation, and `StatementCancelHandler()` was called.
3. In `errstart()`,  `backtrace()` was called.
4. At the time, another signal SIGTERM was received, and `die()` was called. 
5. In `die()`, `backtrace()` was called again and we hit a hung because of re-entry of `backtrace()`.

### Fix

The fix is to simply remove the calling of `ereport()` in `StatementCancelHandler()`. After that, we suppose that there is no any other signal handler (except `die()`) calling `ereport()`, so the deadlock will not happen.

It's still better to print out the stack info when signal SIGINT is received, because in the scenario of https://github.com/greenplum-db/gpdb/pull/14351 we need the info when current process is interrupted. But since we cannot call `ereport()`/`elog()` in signal handler, I have not got good idea by now (maybe beyond this PR). Please let me know if you have any idea. Thanks!

### About 7X forward-port

The PR includes two changes:

1. Removing `ereport()` from `StatementCancelHandler()`. It doesn't exist on 7X and nothing is needed to do.
2. Removing `elog()` from `ProcessInterrupts()`. We need to forward-port it to 7X.