### PR TITLE
ao/co: Manage array type during AM changes

### DIFF
--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -56,5 +56,7 @@ extern Oid AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 									  bool errorOnTableType,
 									  ObjectAddresses *objsMoved);
 extern void AlterType(AlterTypeStmt *stmt);
+extern void AlterAMAddArrayType(Form_pg_class oldRelForm);
+extern void AlterAMRemoveArrayType(Form_pg_class oldRelForm);
 
 #endif							/* TYPECMDS_H */

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -821,6 +821,8 @@ CREATE TEMP TABLE relfilebeforeco2heap AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname LIKE 'co2heap%'
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname LIKE 'co2heap%' ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Various cases of altering AOCO to AO:
 -- 1. Basic ATSETAMs:
 ALTER TABLE co2heap SET ACCESS METHOD heap;
@@ -1951,3 +1953,163 @@ EXECUTE attribute_encoding_check ('at_with_addedcols');
 (0 rows)
 
 DROP TABLE at_with_addedcols;
+--
+-- Ensure that the array type of the base table type is removed when moving from
+-- heap -> ao_row | ao_column
+--
+CREATE TABLE at_array_type_heap_to_ao(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_ao';
+         typname          | typnamespace | typcategory |          typarray          
+--------------------------+--------------+-------------+----------------------------
+ at_array_type_heap_to_ao | public       | C           | at_array_type_heap_to_ao[]
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_ao';
+          typname          | typnamespace | typcategory |         typelem          
+---------------------------+--------------+-------------+--------------------------
+ _at_array_type_heap_to_ao | public       | A           | at_array_type_heap_to_ao
+(1 row)
+
+ALTER TABLE at_array_type_heap_to_ao SET ACCESS METHOD ao_row;
+-- The array type should be gone.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_ao';
+         typname          | typnamespace | typcategory | typarray 
+--------------------------+--------------+-------------+----------
+ at_array_type_heap_to_ao | public       | C           | -
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_ao';
+ typname | typnamespace | typcategory | typelem 
+---------+--------------+-------------+---------
+(0 rows)
+
+-- A successful drop indicates that the array type -> base type dependency
+-- should have been removed successfully by the ALTER TABLE SET AM above.
+DROP TABLE at_array_type_heap_to_ao;
+CREATE TABLE at_array_type_heap_to_co(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_co';
+         typname          | typnamespace | typcategory |          typarray          
+--------------------------+--------------+-------------+----------------------------
+ at_array_type_heap_to_co | public       | C           | at_array_type_heap_to_co[]
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_co';
+          typname          | typnamespace | typcategory |         typelem          
+---------------------------+--------------+-------------+--------------------------
+ _at_array_type_heap_to_co | public       | A           | at_array_type_heap_to_co
+(1 row)
+
+ALTER TABLE at_array_type_heap_to_co SET ACCESS METHOD ao_column;
+-- The array type should be gone.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_co';
+         typname          | typnamespace | typcategory | typarray 
+--------------------------+--------------+-------------+----------
+ at_array_type_heap_to_co | public       | C           | -
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_co';
+ typname | typnamespace | typcategory | typelem 
+---------+--------------+-------------+---------
+(0 rows)
+
+-- A successful drop indicates that the array type -> base type dependency
+-- should have been removed successfully by the ALTER TABLE SET AM above.
+DROP TABLE at_array_type_heap_to_co;
+--
+-- Ensure that the array type of the base table type is created when moving from
+-- ao_row | ao_column -> heap
+--
+CREATE TABLE at_array_type_ao_to_heap(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_ao_to_heap';
+         typname          | typnamespace | typcategory | typarray 
+--------------------------+--------------+-------------+----------
+ at_array_type_ao_to_heap | public       | C           | -
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_ao_to_heap';
+ typname | typnamespace | typcategory | typelem 
+---------+--------------+-------------+---------
+(0 rows)
+
+ALTER TABLE at_array_type_ao_to_heap SET ACCESS METHOD heap;
+-- The array type should have been created and linked.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_ao_to_heap';
+         typname          | typnamespace | typcategory |          typarray          
+--------------------------+--------------+-------------+----------------------------
+ at_array_type_ao_to_heap | public       | C           | at_array_type_ao_to_heap[]
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_ao_to_heap';
+          typname          | typnamespace | typcategory |         typelem          
+---------------------------+--------------+-------------+--------------------------
+ _at_array_type_ao_to_heap | public       | A           | at_array_type_ao_to_heap
+(1 row)
+
+SELECT objid::regtype, refobjid::regtype FROM pg_depend
+    WHERE objid = '_at_array_type_ao_to_heap'::regtype AND refobjid = 'at_array_type_ao_to_heap'::regtype;
+           objid            |         refobjid         
+----------------------------+--------------------------
+ at_array_type_ao_to_heap[] | at_array_type_ao_to_heap
+(1 row)
+
+-- Alter it back to ao_row so that we test the upgrade path
+ALTER TABLE at_array_type_ao_to_heap SET ACCESS METHOD ao_row;
+CREATE TABLE at_array_type_co_to_heap(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_co_to_heap';
+         typname          | typnamespace | typcategory | typarray 
+--------------------------+--------------+-------------+----------
+ at_array_type_co_to_heap | public       | C           | -
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_co_to_heap';
+ typname | typnamespace | typcategory | typelem 
+---------+--------------+-------------+---------
+(0 rows)
+
+ALTER TABLE at_array_type_co_to_heap SET ACCESS METHOD heap;
+-- The array type should have been created and linked.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_co_to_heap';
+         typname          | typnamespace | typcategory |          typarray          
+--------------------------+--------------+-------------+----------------------------
+ at_array_type_co_to_heap | public       | C           | at_array_type_co_to_heap[]
+(1 row)
+
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_co_to_heap';
+          typname          | typnamespace | typcategory |         typelem          
+---------------------------+--------------+-------------+--------------------------
+ _at_array_type_co_to_heap | public       | A           | at_array_type_co_to_heap
+(1 row)
+
+SELECT objid::regtype, refobjid::regtype FROM pg_depend
+    WHERE objid = '_at_array_type_co_to_heap'::regtype AND refobjid = 'at_array_type_co_to_heap'::regtype;
+           objid            |         refobjid         
+----------------------------+--------------------------
+ at_array_type_co_to_heap[] | at_array_type_co_to_heap
+(1 row)
+
+-- Alter it back to ao_column so that we test the upgrade path
+ALTER TABLE at_array_type_co_to_heap SET ACCESS METHOD ao_column;

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -57,7 +57,6 @@ CREATE TEMP TABLE relfilebeforeao AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
-
 -- Set default storage options for the table to inherit from
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
 
@@ -86,7 +85,6 @@ CREATE TEMP TABLE relfileafterao AS
     WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
 
 SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
-
 -- aux tables are created, pg_appendonly row is created
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
 SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heap2ao')).* FROM gp_dist_random('gp_id');
@@ -185,7 +183,6 @@ CREATE TEMP TABLE relfilebeforeao2heap AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'ao2heap2', 'aoi')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname in ('ao2heap', 'ao2heap2', 'aoi') ORDER BY segid;
-
 -- Altering AO to heap
 ALTER TABLE ao2heap SET ACCESS METHOD heap;
 ALTER TABLE ao2heap2 SET WITH (appendoptimized=false);
@@ -936,3 +933,91 @@ SELECT * FROM at_with_addedcols;
 -- pg_attribute_encoding should not have any entries
 EXECUTE attribute_encoding_check ('at_with_addedcols');
 DROP TABLE at_with_addedcols;
+
+--
+-- Ensure that the array type of the base table type is removed when moving from
+-- heap -> ao_row | ao_column
+--
+
+CREATE TABLE at_array_type_heap_to_ao(i int);
+
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_ao';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_ao';
+
+ALTER TABLE at_array_type_heap_to_ao SET ACCESS METHOD ao_row;
+
+-- The array type should be gone.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_ao';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_ao';
+
+-- A successful drop indicates that the array type -> base type dependency
+-- should have been removed successfully by the ALTER TABLE SET AM above.
+DROP TABLE at_array_type_heap_to_ao;
+
+CREATE TABLE at_array_type_heap_to_co(i int);
+
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_co';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_co';
+
+ALTER TABLE at_array_type_heap_to_co SET ACCESS METHOD ao_column;
+
+-- The array type should be gone.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_heap_to_co';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_heap_to_co';
+
+-- A successful drop indicates that the array type -> base type dependency
+-- should have been removed successfully by the ALTER TABLE SET AM above.
+DROP TABLE at_array_type_heap_to_co;
+
+--
+-- Ensure that the array type of the base table type is created when moving from
+-- ao_row | ao_column -> heap
+--
+
+CREATE TABLE at_array_type_ao_to_heap(i int) USING ao_row;
+
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_ao_to_heap';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_ao_to_heap';
+
+ALTER TABLE at_array_type_ao_to_heap SET ACCESS METHOD heap;
+
+-- The array type should have been created and linked.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_ao_to_heap';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_ao_to_heap';
+SELECT objid::regtype, refobjid::regtype FROM pg_depend
+    WHERE objid = '_at_array_type_ao_to_heap'::regtype AND refobjid = 'at_array_type_ao_to_heap'::regtype;
+
+-- Alter it back to ao_row so that we test the upgrade path
+ALTER TABLE at_array_type_ao_to_heap SET ACCESS METHOD ao_row;
+
+CREATE TABLE at_array_type_co_to_heap(i int) USING ao_column;
+
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_co_to_heap';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_co_to_heap';
+
+ALTER TABLE at_array_type_co_to_heap SET ACCESS METHOD heap;
+
+-- The array type should have been created and linked.
+SELECT typname, typnamespace::regnamespace, typcategory, typarray::regtype FROM pg_type
+    WHERE typname = 'at_array_type_co_to_heap';
+SELECT typname, typnamespace::regnamespace, typcategory, typelem::regtype FROM pg_type
+    WHERE typname = '_at_array_type_co_to_heap';
+SELECT objid::regtype, refobjid::regtype FROM pg_depend
+    WHERE objid = '_at_array_type_co_to_heap'::regtype AND refobjid = 'at_array_type_co_to_heap'::regtype;
+
+-- Alter it back to ao_column so that we test the upgrade path
+ALTER TABLE at_array_type_co_to_heap SET ACCESS METHOD ao_column;


### PR DESCRIPTION
Unlike heap tables, append-optimized tables do not have an array type of
their base type created in the catalog. This is done to avoid catalog
bloat.

When changing AM from heap -> ao_row|ao_column, we weren't removing
this array type. Also, when changing AM from ao_row|ao_column -> heap,
we weren't adding this type into the catalog. This commit fixes that.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/setam_heap_fix_typearray
