### PR TITLE
Remove quote_identifier in function list_join()

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -593,7 +593,7 @@ list_join(List *list, char delimiter)
 		const char *cellval;
 
 		cellval = strVal(lfirst(cell));
-		appendStringInfo(&buf, "%s%c", quote_identifier(cellval), delimiter);
+		appendStringInfo(&buf, "%s%c", cellval, delimiter);
 	}
 
 	/*

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -1190,6 +1190,27 @@ CREATE EXTERNAL TABLE gz_multi_chunk_2(
 LOCATION('gpfdist://@hostname@:7070/gpfdist2/gz_multi_chunk_2.tbl.gz') FORMAT 'csv';
 SELECT count(*) FROM gz_multi_chunk_2;
 
+-- test the bug of auto-quote for key words
+-- please refer to issue-16753
+CREATE TABLE test_quote (id bigint, item text, price int);
+CREATE TABLE test_quote_input AS (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+INSERT INTO test_quote values(1, 'xyz', 1);
+CREATE WRITABLE EXTERNAL TABLE test_quote_ext (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
+INSERT INTO test_quote_ext (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+DROP TABLE test_quote;
+DROP TABLE test_quote_input;
+DROP EXTERNAL TABLE test_quote_ext;
+
 -- start_ignore
 select * from gpfdist2_stop;
 -- end_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -1199,17 +1199,22 @@ CREATE TABLE test_quote_input AS (
         current_timestamp as time 
         from test_quote order by id);
 INSERT INTO test_quote values(1, 'xyz', 1);
-CREATE WRITABLE EXTERNAL TABLE test_quote_ext (LIKE test_quote_input) 
+CREATE WRITABLE EXTERNAL TABLE test_quote_writable (LIKE test_quote_input) 
 LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
 FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
-INSERT INTO test_quote_ext (
+INSERT INTO test_quote_writable (
         select id, item, price, 
         gp_segment_id as segment,
         current_timestamp as time 
         from test_quote order by id);
+CREATE READABLE EXTERNAL TABLE test_quote_readable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE NOT NULL id, item, price, segment, time);
+SELECT count(*) FROM test_quote_readable;
 DROP TABLE test_quote;
 DROP TABLE test_quote_input;
-DROP EXTERNAL TABLE test_quote_ext;
+DROP EXTERNAL TABLE test_quote_writable;
+DROP EXTERNAL TABLE test_quote_readable;
 
 -- start_ignore
 select * from gpfdist2_stop;

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -1307,7 +1307,7 @@ CREATE TABLE test_quote_input AS (
         from test_quote order by id);
 INSERT INTO test_quote values(1, 'xyz', 1);
 CREATE WRITABLE EXTERNAL TABLE test_quote_ext (LIKE test_quote_input) 
-LOCATION('gpfdist://d3551cfb-3aa4-4406-76ed-52f6067c1774:7070/gpfdist2/test_quote.csv') 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
 FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
 INSERT INTO test_quote_ext (
         select id, item, price, 

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -1297,6 +1297,26 @@ LOCATION('gpfdist://@hostname@:7070/gpfdist2/gz_multi_chunk_2.tbl.gz') FORMAT 'c
 SELECT count(*) FROM gz_multi_chunk_2;
      2
 
+-- test the bug of auto-quote for key words
+-- please refer to issue-16753
+CREATE TABLE test_quote (id bigint, item text, price int);
+CREATE TABLE test_quote_input AS (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+INSERT INTO test_quote values(1, 'xyz', 1);
+CREATE WRITABLE EXTERNAL TABLE test_quote_ext (LIKE test_quote_input) 
+LOCATION('gpfdist://d3551cfb-3aa4-4406-76ed-52f6067c1774:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
+INSERT INTO test_quote_ext (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+DROP TABLE test_quote;
+DROP TABLE test_quote_input;
+DROP EXTERNAL TABLE test_quote_ext;
 -- start_ignore
 select * from gpfdist2_stop;
  stopping...

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -1306,17 +1306,24 @@ CREATE TABLE test_quote_input AS (
         current_timestamp as time 
         from test_quote order by id);
 INSERT INTO test_quote values(1, 'xyz', 1);
-CREATE WRITABLE EXTERNAL TABLE test_quote_ext (LIKE test_quote_input) 
+CREATE WRITABLE EXTERNAL TABLE test_quote_writable (LIKE test_quote_input) 
 LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
 FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
-INSERT INTO test_quote_ext (
+INSERT INTO test_quote_writable (
         select id, item, price, 
         gp_segment_id as segment,
         current_timestamp as time 
         from test_quote order by id);
+CREATE READABLE EXTERNAL TABLE test_quote_readable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE NOT NULL id, item, price, segment, time);
+SELECT count(*) FROM test_quote_readable;
+     1
+
 DROP TABLE test_quote;
 DROP TABLE test_quote_input;
-DROP EXTERNAL TABLE test_quote_ext;
+DROP EXTERNAL TABLE test_quote_writable;
+DROP EXTERNAL TABLE test_quote_readable;
 -- start_ignore
 select * from gpfdist2_stop;
  stopping...


### PR DESCRIPTION
Long log:

This commit can fix the bug reported in #16753 

### Error
Without this commit, the last column name `time` and its name in FDW options `"time"` are different, shown as below, which leads to this error `column ""time"" of relation "test_quote_ext" does not exist`. 
``` sql
gpadmin=# \d test_quote_ext
                       Foreign table "public.test_quote_ext"
 Column  |           Type           | Collation | Nullable | Default | FDW options 
---------+--------------------------+-----------+----------+---------+-------------
 id      | bigint                   |           |          |         | 
 item    | text                     |           |          |         | 
 price   | integer                  |           |          |         | 
 segment | integer                  |           |          |         | 
 time    | timestamp with time zone |           |          |         | 
FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', 
force_quote 'id,item,price,segment,"time"', 
location_uris 'gpfdist://@hostname@:7070/gpfdist2/test_quote.csv', 
execute_on 'ALL_SEGMENTS', log_errors 'disable', 
encoding 'UTF8', is_writable 'true')
Distributed by: (id)
```

### Analyse
`quote_identifier()` will call `ScanKeywordLookup()`, which scans keywords in the file `kwlist.h`. Of course, `time` is a keyword, so becomes `"time"` after `quote_identifier()` in the function `list_join()`. Now, the same column has different names. So it will hit `if (attnum == InvalidAttrNumber)` and error out at function `CopyGetAttnums()` in `copy.c`.

### Solution
The solution is simple, remove `quote_identifier()` in function `list_join()` to keep the column name with keywords unchanged.

Bug catcher: Wenkang Zhang <zwenkang@vmware.com> and Rui Wang <ruiw2@vmware.com>
