### PR TITLE
Remove duplicated function definitions in builtins.h

### DIFF
--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -75,13 +75,6 @@ extern char *regexp_fixed_prefix(text *text_re, bool case_insensitive,
 /* ruleutils.c */
 extern bool quote_all_identifiers;
 extern char *pg_get_constraintexpr_string(Oid constraintId);
-extern const char *quote_identifier(const char *ident);
-extern char *quote_qualified_identifier(const char *qualifier,
-						   const char *ident);
-extern void generate_operator_clause(fmStringInfo buf,
-						 const char *leftop, Oid leftoptype,
-						 Oid opoid,
-						 const char *rightop, Oid rightoptype);
 
 extern const char *quote_identifier(const char *ident);
 extern char *quote_qualified_identifier(const char *qualifier,


### PR DESCRIPTION
There are some duplicated definitions, some exist
since commit Initial Greenplum code dump.
Remove that for clean codes.

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
