### PR TITLE
[6X] Remove quote_identifier() in transformFormatOpts() 

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -820,8 +820,7 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 			{
 				const char *col_name = strVal(lfirst(l));
 
-				appendStringInfo(&cfbuf, (is_first_col ? " %s" : ",%s"),
-								 quote_identifier(col_name));
+				appendStringInfo(&cfbuf, (is_first_col ? " %s" : ",%s"), col_name);
 				is_first_col = false;
 			}
 		}
@@ -840,8 +839,7 @@ transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswrita
 			{
 				const char *col_name = strVal(lfirst(l));
 
-				appendStringInfo(&cfbuf, (is_first_col ? " %s" : ",%s"),
-								 quote_identifier(col_name));
+				appendStringInfo(&cfbuf, (is_first_col ? " %s" : ",%s"), col_name);
 				is_first_col = false;
 			}
 		}

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -1193,6 +1193,32 @@ DROP EXTERNAL TABLE ext_lineitem_in;
 DROP EXTERNAL TABLE ext_lineitem_out;
 DROP EXTERNAL TABLE ext_lineitem;
 
+-- test the bug of auto-quote for key words
+-- please refer to issue-16753
+CREATE TABLE test_quote (id bigint, item text, price int);
+CREATE TABLE test_quote_input AS (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+INSERT INTO test_quote values(1, 'xyz', 1);
+CREATE WRITABLE EXTERNAL TABLE test_quote_writable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
+INSERT INTO test_quote_writable (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+CREATE READABLE EXTERNAL TABLE test_quote_readable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE NOT NULL id, item, price, segment, time);
+SELECT count(*) FROM test_quote_readable;
+DROP TABLE test_quote;
+DROP TABLE test_quote_input;
+DROP EXTERNAL TABLE test_quote_writable;
+DROP EXTERNAL TABLE test_quote_readable;
+
 -- start_ignore
 select * from gpfdist2_stop;
 -- end_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -1304,6 +1304,33 @@ select count(*) from ext_lineitem_in;
 DROP EXTERNAL TABLE ext_lineitem_in;
 DROP EXTERNAL TABLE ext_lineitem_out;
 DROP EXTERNAL TABLE ext_lineitem;
+-- test the bug of auto-quote for key words
+-- please refer to issue-16753
+CREATE TABLE test_quote (id bigint, item text, price int);
+CREATE TABLE test_quote_input AS (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+INSERT INTO test_quote values(1, 'xyz', 1);
+CREATE WRITABLE EXTERNAL TABLE test_quote_writable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE QUOTE id, item, price, segment, time);
+INSERT INTO test_quote_writable (
+        select id, item, price, 
+        gp_segment_id as segment,
+        current_timestamp as time 
+        from test_quote order by id);
+CREATE READABLE EXTERNAL TABLE test_quote_readable (LIKE test_quote_input) 
+LOCATION('gpfdist://@hostname@:7070/gpfdist2/test_quote.csv') 
+FORMAT 'CSV' (FORCE NOT NULL id, item, price, segment, time);
+SELECT count(*) FROM test_quote_readable;
+     1
+
+DROP TABLE test_quote;
+DROP TABLE test_quote_input;
+DROP EXTERNAL TABLE test_quote_writable;
+DROP EXTERNAL TABLE test_quote_readable;
 -- start_ignore
 select * from gpfdist2_stop;
  stopping...


### PR DESCRIPTION
Cherry-pick from #16754.
Fix the bug about #16753 in 6X.

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-hyt-gpdb6-centos6/jobs/icw_planner_centos6/builds/1 (turns green now)

Signed-off-by: Yongtao Huang <yongtaoh@vmwware.com>