### PR TITLE
Fix gpcheckcat 'oid does not exist' error for catalog tables

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3356,6 +3356,10 @@ TableMainColumn['pg_type_encoding'] = ['typid', 'pg_type']
 TableMainColumn['pg_window'] = ['winfnoid', 'pg_proc']
 TableMainColumn['gp_distribution_policy'] = ['localoid', 'pg_class']
 TableMainColumn['pg_description'] = ['objoid', 'pg_description']
+TableMainColumn['pg_shdescription'] = ['objoid', 'pg_shdescription']
+TableMainColumn['pg_seclabel'] = ['objoid', 'pg_seclabel']
+TableMainColumn['pg_shseclabel'] = ['objoid', 'pg_shseclabel']
+TableMainColumn['pg_seclabels'] = ['objoid', 'pg_seclabels']
 
 # Table with OID (special case), these OIDs are known to be inconsistent
 TableMainColumn['pg_attrdef'] = ['adrelid', 'pg_class']

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -568,17 +568,23 @@ Feature: gpcheckcat tests
         And the user runs "dropdb check_dependency_error"
         And the user runs "psql -c "DROP ROLE foo""
 
-    Scenario: gpcheckcat should discover missing attributes of pg_description catalogue table
-        Given there is a "heap" table "public.heap_table" in "miss_attr_db5" with data and description
-        When the user runs "gpcheckcat -v miss_attr_db5"
-        And gpcheckcat should return a return code of 0
-        Then gpcheckcat should not print "Missing" to stdout
-        And the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_description where objoid='heap_table'::regclass::oid;""
+    Scenario: gpcheckcat should discover missing attributes of pg_description and pg_shdescription catalogue table without errors
+        Given database "miss_attr_db5" is dropped and recreated
+        And there is a "heap" table "public.heap_table" in "miss_attr_db5" with data and description
+        And a tablespace is created with data and description
+        When the user runs "gpcheckcat miss_attr_db5"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "Missing" to stdout
+        When the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_description where objoid='heap_table'::regclass::oid;""
         Then psql should return a return code of 0
-        When the user runs "gpcheckcat -v miss_attr_db5"
+        When the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_shdescription where objoid=(SELECT oid from pg_tablespace where spcname='outerspace');""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat miss_attr_db5"
         Then gpcheckcat should print "Missing description metadata of {.*} on content -1" to stdout
         And gpcheckcat should not print "Execution error:" to stdout
         And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_description" to stdout
+        Then gpcheckcat should print "Missing shdescription metadata of {.*} on content -1" to stdout
+        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_shdescription" to stdout
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
**Issue:**
gpcheckcat reports `column "oid" does not exist` error while running ‘missing_extraneous’ test on pg_shdescription catalogue table

```
[~/workspace/gpdb6: {6x_error_gpcheckcat} ?]$ gpcheckcat postgres
Truncated batch size to number of primaries: 4
Connected as user 'sshirisha' to database 'postgres', port '6000', gpdb version '6.24'
-------------------------------------------------------------------
Batch size: 4
Performing test 'unique_index_violation'
Total runtime for test 'unique_index_violation': 0:00:02.50
Performing test 'duplicate'
Total runtime for test 'duplicate': 0:00:04.49
Performing test 'missing_extraneous'
  Execution error: ERROR:  column "oid" does not exist
LINE 4:                 SELECT oid FROM pg_shdescription
                               ^
          SELECT oid
          FROM (
                SELECT oid FROM pg_shdescription
                WHERE classoid='1213' and objoid='17346'
                UNION ALL
                SELECT oid FROM gp_dist_random('pg_shdescription')
                WHERE classoid='1213' and objoid='17346'
          ) alloids
          GROUP BY oid
          ORDER BY count(*) desc, oid
```
This is because internally 'missing_extraneous' test of gpcheckcat tries to fetch the oid of all the catalogue tables present in the database.
For pg_shdescription table, the oid was changed to objoid in 6x and 7x.
So there is no attribute as oid in pg_shdescription table.
Similar issue will be seen for other catalogue tables wherever the 'attname' field of pg_attribute table is objoid.
```
postgres=# select relname from pg_class where oid in (select attrelid from pg_attribute where attname='objoid') and relname not like '%index%';
     relname
------------------
 pg_seclabels
 pg_description
 pg_shdescription
 pg_seclabel
 pg_shseclabel
(5 rows)
```
Issue with pg_description table is fixed as part of [#16140 ](https://github.com/greenplum-db/gpdb/pull/16140)
This PR is used to track the fix for other catalog tables listed above.

**Fix:**
Catalog tables which do not have a OID column are stored in a dictionary 'TableMainColumn' and are mapped an existing OID type attribute. An entry for the required catalog tables is added to dictionary so that objoid is used instead of oid while running SQL queries.

**Test:**
A behave test is added for pg_shdescription table.
