### PR TITLE
pg_dumpall: dump 6x resource groups correctly for 6 > 7 upgrade

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -778,16 +778,31 @@ dumpResGroups(PGconn *conn)
 			i_cpu_weight,
 			i_cpuset;
 
-	printfPQExpBuffer(buf, "SELECT g.rsgname AS groupname, "
-					  "t1.value AS concurrency, "
-					  "t2.value AS cpu_max_percent, "
-					  "t3.value AS cpu_weight, "
-					  "t4.value AS cpuset "
-					  "FROM pg_resgroup g "
-					  "     JOIN pg_resgroupcapability t1 ON g.oid = t1.resgroupid AND t1.reslimittype = 1 "
-					  "     JOIN pg_resgroupcapability t2 ON g.oid = t2.resgroupid AND t2.reslimittype = 2 "
-					  "     JOIN pg_resgroupcapability t3 ON g.oid = t3.resgroupid AND t3.reslimittype = 3 "
-					  "LEFT JOIN pg_resgroupcapability t4 ON g.oid = t4.resgroupid AND t4.reslimittype = 4;");
+	if (server_version >= GPDB7_MAJOR_PGVERSION)
+	{
+		printfPQExpBuffer(buf, "SELECT g.rsgname AS groupname, "
+						  "t1.value AS concurrency, "
+						  "t2.value AS cpu_max_percent, "
+						  "t3.value AS cpu_weight, "
+						  "t4.value AS cpuset "
+						  "FROM pg_resgroup g "
+						  "     JOIN pg_resgroupcapability t1 ON g.oid = t1.resgroupid AND t1.reslimittype = 1 "
+						  "     JOIN pg_resgroupcapability t2 ON g.oid = t2.resgroupid AND t2.reslimittype = 2 "
+						  "     JOIN pg_resgroupcapability t3 ON g.oid = t3.resgroupid AND t3.reslimittype = 3 "
+						  "LEFT JOIN pg_resgroupcapability t4 ON g.oid = t4.resgroupid AND t4.reslimittype = 4;");
+	}
+	else
+	{
+		printfPQExpBuffer(buf, "SELECT g.rsgname AS groupname, "
+						  "t1.value AS concurrency, "
+						  "t2.value AS cpu_max_percent, "
+						  "     100 AS cpu_weight, "
+						  "t7.value AS cpuset "
+						  "FROM pg_resgroup g "
+						  "     JOIN pg_resgroupcapability t1 ON g.oid = t1.resgroupid AND t1.reslimittype = 1 "
+						  "     JOIN pg_resgroupcapability t2 ON g.oid = t2.resgroupid AND t2.reslimittype = 2 "
+						  "LEFT JOIN pg_resgroupcapability t7 ON g.oid = t7.resgroupid AND t7.reslimittype = 7;");
+	}
 
 	res = executeQuery(conn, buf->data);
 


### PR DESCRIPTION
In order to support 6 > 7 upgrade using pg_upgrade. 7x pg_dumpall needs to be able to dump 6x resource groups correctly. Supporting the dumping of 6x resource group resolves the following error with trying to upgrade from 6 > 7.

```
ALTER RESOURCE GROUP "default_group" SET cpu_weight 0;
psql:pg_upgrade_dump_globals.sql:27: ERROR:  cpu_weight range is [1, 500]
```

This happens because some of the attribute ordering in pg_resgroupcapability changed from 6x to 7x. To resolve this issue, the following mapping was done based on 6x and 7x resource group docs. New attribute cpu_weight is set to 7x default value of 100.

```
6x             |  7x
---------------+-----------------
concurrency    | concurrency
cpu_rate_limit | cpu_max_percent
100            | cpu_weight
cpuset         | cputset
```
reference resource group docs:
https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-workload_mgmt_resgroups.html
