### PR TITLE
fix resource group reserve memory

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -37,6 +37,7 @@
 #include "cdb/cdbpq.h"
 #include "miscadmin.h"
 #include "commands/sequence.h"
+#include "utils/vmem_tracker.h"
 #include "access/xact.h"
 #include "utils/timestamp.h"
 #define DISPATCH_WAIT_TIMEOUT_MSEC 2000
@@ -456,6 +457,9 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 
 	db_count = pParms->dispatchCount;
 	fds = (struct pollfd *) palloc(db_count * sizeof(struct pollfd));
+
+	if (SIMPLE_FAULT_INJECTOR("alloc_chunk_during_dispatch") == FaultInjectorTypeSkip)
+		palloc(1 << VmemTracker_GetChunkSizeInBits());
 
 	/*
 	 * OK, we are finished submitting the command to the segdbs. Now, we have

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -458,8 +458,10 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	db_count = pParms->dispatchCount;
 	fds = (struct pollfd *) palloc(db_count * sizeof(struct pollfd));
 
+#ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("alloc_chunk_during_dispatch") == FaultInjectorTypeSkip)
 		palloc(1 << VmemTracker_GetChunkSizeInBits());
+#endif
 
 	/*
 	 * OK, we are finished submitting the command to the segdbs. Now, we have

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1436,11 +1436,13 @@ groupIncMemUsage(ResGroupData *group, ResGroupSlotData *slot, int32 chunks)
 	pg_atomic_add_fetch_u32((pg_atomic_uint32 *) &group->memUsage,
 							chunks);
 
+#ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("group_set_overused_freechunk") == FaultInjectorTypeSkip)
 	{
 		pg_atomic_write_u32(&pResGroupControl->freeChunks, -5);
 		SIMPLE_FAULT_INJECTOR("group_overused_freechunks");
 	}
+#endif
 
 	return globalOveruse;
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1417,11 +1417,14 @@ groupIncMemUsage(ResGroupData *group, ResGroupSlotData *slot, int32 chunks)
 		/* Calculate the global over used chunks */
 		int32 deltaGlobalSharedMemUsage = Max(0, deltaSharedMemUsage - oldSharedFree);
 
-		/* freeChunks -= deltaGlobalSharedMemUsage and get the new value */
-		int32 newFreeChunks = pg_atomic_sub_fetch_u32(&pResGroupControl->freeChunks,
+		if (deltaGlobalSharedMemUsage > 0)
+		{
+			/* freeChunks -= deltaGlobalSharedMemUsage and get the new value */
+			int32 newFreeChunks = pg_atomic_sub_fetch_u32(&pResGroupControl->freeChunks,
 													  deltaGlobalSharedMemUsage);
-		/* calculate the total over used chunks of global share */
-		globalOveruse = Max(0, 0 - newFreeChunks);
+			/* calculate the total over used chunks of global share */
+			globalOveruse = Max(0, 0 - newFreeChunks);
+		}
 	}
 
 	/* Add the chunks to memUsage in group */
@@ -1502,11 +1505,14 @@ groupIncSlotMemUsage(ResGroupData *group, ResGroupSlotData *slot)
 		/* Calculate the global over used chunks */
 		int32 deltaGlobalSharedMemUsage = Max(0, slotSharedMemUsage - oldSharedFree);
 
-		/* freeChunks -= deltaGlobalSharedMemUsage and get the new value */
-		int32 newFreeChunks = pg_atomic_sub_fetch_u32(&pResGroupControl->freeChunks,
+		if (deltaGlobalSharedMemUsage > 0)
+		{
+			/* freeChunks -= deltaGlobalSharedMemUsage and get the new value */
+			int32 newFreeChunks = pg_atomic_sub_fetch_u32(&pResGroupControl->freeChunks,
 													  deltaGlobalSharedMemUsage);
-		/* calculate the total over used chunks of global share */
-		globalOveruse = Max(0, 0 - newFreeChunks);
+			/* calculate the total over used chunks of global share */
+			globalOveruse = Max(0, 0 - newFreeChunks);
+		}
 	}
 
 	/* Add the chunks to memUsage in group */

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -78,7 +78,7 @@ $$;
 0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
 0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;
 
--- session 1 set global freechunks to -5 and suapend
+-- session 1 set global freechunks to -5 and suspend
 1: create extension gp_inject_fault;
 1: create table overuse_table(a int);
 1: select gp_inject_fault('group_overused_freechunks','suspend','', '', '', 1, -1, 0, dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where role = 'p' and content = -1;

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -77,3 +77,30 @@ $$;
 -- to verify that it can be correctly loaded even for bypassed commands
 0: ALTER RESOURCE GROUP admin_group SET memory_spill_ratio 10;
 0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;
+
+-- session 1 set global freechunks to -5 and suapend
+1: create extension gp_inject_fault;
+1: create table overuse_table(a int);
+1: select gp_inject_fault('group_overused_freechunks','suspend','', '', '', 1, -1, 0, dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where role = 'p' and content = -1;
+1: select gp_inject_fault('group_set_overused_freechunk','skip', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where role = 'p' and content = -1;
+1&: select * from overuse_table;
+
+-- session 2: alloc 1 chunk when checkDispatchResult
+2: select gp_inject_fault_infinite('alloc_chunk_during_dispatch', 'skip', dbid) from gp_segment_configuration
+ where role = 'p' and content = -1;
+-- execute 'set' statement to bypass query so it will use shared mem
+2: SET SESSION AUTHORIZATION DEFAULT;
+
+-- reset all injected fault
+2: select gp_inject_fault('alloc_chunk_during_dispatch', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+2: select gp_inject_fault('group_set_overused_freechunk', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+2: select gp_inject_fault('group_overused_freechunks', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+1<:
+
+2: drop table overuse_table;
+
+-- start_ignore
+! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -98,7 +98,7 @@ ALTER
 0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;
 ALTER
 
--- session 1 set global freechunks to -5 and suapend
+-- session 1 set global freechunks to -5 and suspend
 1: create extension gp_inject_fault;
 CREATE
 1: create table overuse_table(a int);

--- a/src/test/isolation2/output/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/output/resgroup/enable_resgroup.source
@@ -97,3 +97,60 @@ ALTER
 ALTER
 0: ALTER RESOURCE GROUP default_group SET memory_spill_ratio 10;
 ALTER
+
+-- session 1 set global freechunks to -5 and suapend
+1: create extension gp_inject_fault;
+CREATE
+1: create table overuse_table(a int);
+CREATE
+1: select gp_inject_fault('group_overused_freechunks','suspend','', '', '', 1, -1, 0, dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('group_set_overused_freechunk','skip', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: select * from overuse_table;  <waiting ...>
+
+-- session 2: alloc 1 chunk when checkDispatchResult
+2: select gp_inject_fault_infinite('alloc_chunk_during_dispatch', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- execute 'set' statement to bypass query so it will use shared mem
+2: SET SESSION AUTHORIZATION DEFAULT;
+SET
+
+-- reset all injected fault
+2: select gp_inject_fault('alloc_chunk_during_dispatch', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2: select gp_inject_fault('group_set_overused_freechunk', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: select gp_inject_fault('group_overused_freechunks', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a 
+---
+(0 rows)
+
+2: drop table overuse_table;
+DROP
+
+-- start_ignore
+! gpstop -rai;
+-- end_ignore


### PR DESCRIPTION
Current check order of reserve memory for resource group: 1. reserve memory from the resource group slot 2. if the slot quota exceeded, reserve memory from the group shared 3. then reserve memory from the global free chunk.

If group 2 over use the global freeChunks, even group 1 has enough group share free space to alloc, it will still check global freeChunks value and get MemoryFailure_ResourceGroupMemoryExhausted error.

Check global freeChunks only when group shared memory are over used.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
