### PR TITLE
Fix a test failure in distributed_transactions

### DIFF
--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -912,6 +912,8 @@ set optimizer=false;
 -- that they are not supposed to see.
 select dtx_set_bug();
 INFO:  (slice 0) Dispatch command to SINGLE content
+CONTEXT:  SQL statement "update tbl_dtx set b = 1 where a = 1;"
+PL/pgSQL function dtx_set_bug() line 3 at EXECUTE statement
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
  dtx_set_bug 
 -------------


### PR DESCRIPTION
The test was added in https://github.com/greenplum-db/gpdb/commit/b055a88584fcc503ce8f5a85e7e4b49f04edfd53. Some query CONTEXT output is missing the output. Added now. (I don't remember exactly why it's missed, but definitely should've flown a pipeline for that PR).

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6x-dtx-test-failure

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
