### PR TITLE
Checking interrupt more frequently in HashJoin

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -808,6 +808,8 @@ process_ordered_aggregate_multi(AggState *aggstate,
 
 	while (tuplesort_gettupleslot(peraggstate->sortstate, true, slot1))
 	{
+		CHECK_FOR_INTERRUPTS();
+
 		/*
 		 * Extract the first numTransInputs columns as datums to pass to the
 		 * transfn.  (This will help execTuplesMatch too, so we do it
@@ -1120,6 +1122,8 @@ hash_agg_entry_size(int numAggs)
 TupleTableSlot *
 ExecAgg(AggState *node)
 {
+	CHECK_FOR_INTERRUPTS();
+
 	/*
 	 * Check to see if we're still projecting out tuples from a previous agg
 	 * tuple (because there is a function-returning-set in the projection
@@ -1186,6 +1190,8 @@ ExecAgg(AggState *node)
 		 */
 		for (;;)
 		{
+			CHECK_FOR_INTERRUPTS();
+
 			if (!node->hhashtable->is_spilling)
 			{
 				tuple = agg_retrieve_hash_table(node);

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -59,6 +59,7 @@
 
 #include "executor/execdebug.h"
 #include "executor/nodeAppend.h"
+#include "miscadmin.h"
 
 static bool exec_append_initialize_next(AppendState *appendstate);
 
@@ -199,6 +200,8 @@ ExecAppend(AppendState *node)
 	{
 		PlanState  *subnode;
 		TupleTableSlot *result;
+
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * figure out which subplan we are currently processing

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -314,6 +314,8 @@ BitmapHeapNext(BitmapHeapScanState *node)
 		Page		dp;
 		ItemId		lp;
 
+		CHECK_FOR_INTERRUPTS();
+
 		if (tbmres == NULL || tbmres->ntuples == 0)
 		{
 			CHECK_FOR_INTERRUPTS();

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -24,6 +24,7 @@
 
 #include "executor/executor.h"
 #include "executor/nodeGroup.h"
+#include "miscadmin.h"
 
 
 /*
@@ -39,6 +40,8 @@ ExecGroup(GroupState *node)
 	AttrNumber *grpColIdx;
 	TupleTableSlot *firsttupleslot;
 	TupleTableSlot *outerslot;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/*
 	 * get state info from node

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -1197,6 +1197,9 @@ ExecScanHashBucket(HashState *hashState, HashJoinState *hjstate,
 		}
 
 		hashTuple = hashTuple->next;
+
+		/* allow this loop to be cancellable */
+		CHECK_FOR_INTERRUPTS();
 	}
 	}
 	END_MEMORY_ACCOUNT();

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -29,6 +29,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeIndexonlyscan.h"
 #include "executor/nodeIndexscan.h"
+#include "miscadmin.h"
 #include "storage/bufmgr.h"
 #include "storage/predicate.h"
 #include "utils/memutils.h"
@@ -79,6 +80,8 @@ IndexOnlyNext(IndexOnlyScanState *node)
 	while ((tid = index_getnext_tid(scandesc, direction)) != NULL)
 	{
 		HeapTuple	tuple = NULL;
+
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * We can skip the heap fetch if the TID references a heap page on

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -29,6 +29,7 @@
 #include "access/relscan.h"
 #include "executor/execdebug.h"
 #include "executor/nodeIndexscan.h"
+#include "miscadmin.h"
 #include "optimizer/clauses.h"
 #include "utils/array.h"
 #include "utils/lsyscache.h"
@@ -78,6 +79,8 @@ IndexNext(IndexScanState *node)
 	 */
 	while ((tuple = index_getnext(scandesc, direction)) != NULL)
 	{
+		CHECK_FOR_INTERRUPTS();
+
 		/*
 		 * Store the scanned tuple in the scan tuple slot of the scan state.
 		 * Note: we pass 'false' because tuples returned by amgetnext are

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -26,6 +26,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/executor.h"
 #include "executor/nodeLimit.h"
+#include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
 
 static void recompute_limits(LimitState *node);
@@ -45,6 +46,8 @@ ExecLimit_guts(LimitState *node)
 	ScanDirection direction;
 	TupleTableSlot *slot;
 	PlanState  *outerPlan;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -25,6 +25,7 @@
 #include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeLockRows.h"
+#include "miscadmin.h"
 #include "storage/bufmgr.h"
 #include "utils/rel.h"
 #include "utils/tqual.h"
@@ -42,6 +43,8 @@ ExecLockRows(LockRowsState *node)
 	PlanState  *outerPlan;
 	bool		epq_started;
 	ListCell   *lc;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -62,6 +62,8 @@ ExecMaterial(MaterialState *node)
 	TupleTableSlot *slot;
 	Material *ma;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/*
 	 * get state info from node
 	 */

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -42,6 +42,7 @@
 #include "executor/nodeMergeAppend.h"
 
 #include "lib/binaryheap.h"
+#include "miscadmin.h"
 
 /*
  * We have one slot for each item in the heap array.  We use SlotNumber
@@ -159,6 +160,8 @@ ExecMergeAppend(MergeAppendState *node)
 {
 	TupleTableSlot *result;
 	SlotNumber	i;
+
+	CHECK_FOR_INTERRUPTS();
 
 	if (!node->ms_initialized)
 	{

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -640,6 +640,8 @@ ExecMergeJoin_guts(MergeJoinState *node)
 	bool		doFillOuter;
 	bool		doFillInner;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/*
 	 * get information from node
 	 */

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1784,6 +1784,8 @@ ExecModifyTable(ModifyTableState *node)
 	HeapTupleData oldtupdata;
 	HeapTuple	oldtuple;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/*
 	 * This should NOT get called during EvalPlanQual; we should have passed a
 	 * subplan tree to EvalPlanQual, instead.  Use a runtime test not just

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -26,6 +26,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/execdebug.h"
 #include "executor/nodeNestloop.h"
+#include "miscadmin.h"
 #include "optimizer/clauses.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
@@ -77,6 +78,8 @@ ExecNestLoop_guts(NestLoopState *node)
 	List	   *otherqual;
 	ExprContext *econtext;
 	ListCell   *lc;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -81,6 +81,8 @@ ExecRecursiveUnion(RecursiveUnionState *node)
 	TupleTableSlot *slot;
 	bool		isnew;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/* 1. Evaluate non-recursive term */
 	if (!node->recursing)
 	{

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -49,6 +49,7 @@
 
 #include "executor/executor.h"
 #include "executor/nodeResult.h"
+#include "miscadmin.h"
 #include "utils/memutils.h"
 
 #include "catalog/pg_type.h"
@@ -131,6 +132,8 @@ ExecResult(ResultState *node)
 {
 	ExprContext *econtext;
 
+	CHECK_FOR_INTERRUPTS();
+
 	econtext = node->ps.ps_ExprContext;
 
 	/*
@@ -151,6 +154,8 @@ ExecResult(ResultState *node)
 
 	while (!outputSlot)
 	{
+		CHECK_FOR_INTERRUPTS();
+
 		TupleTableSlot *candidateOutputSlot = NULL;
 
 		/*

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -26,6 +26,7 @@
 #include "access/htup_details.h"
 #include "executor/executor.h"
 #include "executor/nodeSubplan.h"
+#include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
 #include "utils/array.h"
@@ -71,6 +72,8 @@ ExecSubPlan(SubPlanState *node,
 	EState	   *estate = node->planstate->state;
 	ScanDirection dir = estate->es_direction;
 	Datum		retval;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/* Set default values for result flags: non-null, not a set result */
 	*isNull = false;
@@ -619,6 +622,8 @@ findPartialMatch(TupleHashTable hashtable, TupleTableSlot *slot,
 	InitTupleHashIterator(hashtable, &hashiter);
 	while ((entry = ScanTupleHashTable(&hashiter)) != NULL)
 	{
+		CHECK_FOR_INTERRUPTS();
+
 		ExecStoreMinimalTuple(entry->firstTuple, hashtable->tableslot, false);
 		if (!execTuplesUnequal(slot, hashtable->tableslot,
 							   numCols, keyColIdx,

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -29,6 +29,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/execdebug.h"
 #include "executor/nodeTidscan.h"
+#include "miscadmin.h"
 #include "optimizer/clauses.h"
 #include "storage/bufmgr.h"
 #include "utils/array.h"
@@ -349,6 +350,8 @@ TidNext(TidScanState *node)
 			node->tss_TidPtr--;
 		else
 			node->tss_TidPtr++;
+
+		CHECK_FOR_INTERRUPTS();
 	}
 
 	/*

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -36,6 +36,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/executor.h"
 #include "executor/nodeUnique.h"
+#include "miscadmin.h"
 #include "utils/memutils.h"
 
 
@@ -50,6 +51,8 @@ ExecUnique(UniqueState *node)
 	TupleTableSlot *resultTupleSlot;
 	TupleTableSlot *slot;
 	PlanState  *outerPlan;
+
+	CHECK_FOR_INTERRUPTS();
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -1998,6 +1998,8 @@ ExecWindowAgg(WindowAggState *winstate)
 	int			i;
 	int			numfuncs;
 
+	CHECK_FOR_INTERRUPTS();
+
 	if (winstate->all_done)
 		return NULL;
 
@@ -3163,6 +3165,9 @@ window_gettupleslot(WindowObject winobj, int64 pos, TupleTableSlot *slot)
 {
 	WindowAggState *winstate = winobj->winstate;
 	MemoryContext oldcontext;
+
+	/* often called repeatedly in a row */
+	CHECK_FOR_INTERRUPTS();
 
 	/* Don't allow passing -1 to spool_tuples here */
 	if (pos < 0)


### PR DESCRIPTION
Backport this commit to fix a hung case in cancellation of request.

    commit d47cfef7116fb36349949f5c757aa2112c249804
    Author: Andres Freund <andres@anarazel.de>
    Date:   Tue Jul 25 17:37:17 2017 -0700

        Move interrupt checking from ExecProcNode() to executor nodes.

        In a followup commit ExecProcNode(), and especially the large switch
        it contains, will largely be replaced by a function pointer directly
        to the correct node. The node functions will then get invoked by a
        thin inline function wrapper. To avoid having to include miscadmin.h
        in headers - CHECK_FOR_INTERRUPTS() - move the interrupt checks into
        the individual executor routines.

        While looking through all executor nodes, I noticed a number of
        arguably missing interrupt checks, add these too.

        Author: Andres Freund, Tom Lane
        Reviewed-By: Tom Lane
        Discussion:
            https://postgr.es/m/22833.1490390175@sss.pgh.pa.us

Fixes https://github.com/greenplum-db/gpdb/issues/15226

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
