### PR TITLE
Restore field name to pass API compatibility check

### DIFF
--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -139,6 +139,14 @@ typedef struct AppendOnlyBlockDirectory
 	ScanKey scanKeys;
 	StrategyNumber *strategyNumbers;
 
+	/*
+	 * GP_ABI_BUMP_FIXME
+	 *
+	 * Not used, just for ABI compatibility, remove this when we decide to bump
+	 * the ABI version.
+	 */
+	int cached_mpentry_num;
+
 }	AppendOnlyBlockDirectory;
 
 

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -416,7 +416,7 @@ typedef struct HashJoinTableData
 	 * Not used, just for ABI compatibility, remove this when we decide to bump
 	 * the ABI version.
 	 */
-	uint64		workset_abi_reserved;
+	uint64		workset_min_file_size;
 	uint64		workset_compression_buf_total;
 }			HashJoinTableData;
 

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -97,7 +97,7 @@ typedef struct workfile_set
 	 * Not used, just for ABI compatibility, remove this when we decide to bump
 	 * the ABI version.
 	 */
-	uint64		abi_reserved;
+	uint64		min_file_size;
 
 	/* Total memory usage by compression buffer */
 	uint64		compression_buf_total;


### PR DESCRIPTION
Keep the field name the same as gpdb 7.0.0. This can help to pass the Source Compatibility check of abi-compliance-checker

There is an example failed report
https://github.com/greenplum-db/gpdb/suites/18409133263/artifacts/1066766916

But there are two places that can not be solved:
1. In struct `HashJoinTableData`, Field workset_max_file_size has been renamed to  workset_avg_file_size.
2. In struct `workfile_set`, Field max_file_size has been renamed to avg_file_size.

I think their meanings have been changed and we cannot restore the field names.

The only way to pass the Source Compatibility is to ignore these two structs.

This is the draft PR to add the ABI check to the main branch: https://github.com/greenplum-db/gpdb/pull/16763

Related PRs that remove struct fields:
- https://github.com/greenplum-db/gpdb/pull/16456
- https://github.com/greenplum-db/gpdb/pull/16577

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
