### PR TITLE
Reuse BrinDesc and BrinRevmap in brininsert

### DIFF
--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -212,7 +212,7 @@ index_insert_cleanup(Relation indexRelation,
 	if (indexRelation->rd_rel->relam == BRIN_AM_OID && indexInfo->ii_AmCache)
 		brininsertcleanup(indexInfo);
 #if 0
-	if (indexRelation->rd_indam->aminsertcleanup)
+	if (indexRelation->rd_indam->aminsertcleanup && indexInfo->ii_AmCache)
 		indexRelation->rd_indam->aminsertcleanup(indexInfo);
 #endif
 }

--- a/src/backend/executor/execIndexing.c
+++ b/src/backend/executor/execIndexing.c
@@ -228,14 +228,19 @@ ExecCloseIndices(ResultRelInfo *resultRelInfo)
 	int			i;
 	int			numIndices;
 	RelationPtr indexDescs;
+	IndexInfo **indexInfos;
 
 	numIndices = resultRelInfo->ri_NumIndices;
 	indexDescs = resultRelInfo->ri_IndexRelationDescs;
+	indexInfos = resultRelInfo->ri_IndexRelationInfo;
 
 	for (i = 0; i < numIndices; i++)
 	{
 		if (indexDescs[i] == NULL)
 			continue;			/* shouldn't happen? */
+
+		/* Give the index a chance to do some post-insert cleanup */
+		index_insert_cleanup(indexDescs[i], indexInfos[i]);
 
 		/* Drop lock acquired by ExecOpenIndices */
 		index_close(indexDescs[i], RowExclusiveLock);

--- a/src/include/access/brin_internal.h
+++ b/src/include/access/brin_internal.h
@@ -91,6 +91,7 @@ extern bool brininsert(Relation idxRel, Datum *values, bool *nulls,
 					   ItemPointer heaptid, Relation heapRel,
 					   IndexUniqueCheck checkUnique,
 					   struct IndexInfo *indexInfo);
+extern void brininsertcleanup(struct IndexInfo *indexInfo);
 extern IndexScanDesc brinbeginscan(Relation r, int nkeys, int norderbys);
 extern int64 bringetbitmap(IndexScanDesc scan, Node **bmNodeP);
 extern void brinrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -144,6 +144,8 @@ extern bool index_insert(Relation indexRelation,
 						 Relation heapRelation,
 						 IndexUniqueCheck checkUnique,
 						 struct IndexInfo *indexInfo);
+extern void index_insert_cleanup(Relation indexRelation,
+								 struct IndexInfo *indexInfo);
 
 extern IndexScanDesc index_beginscan(Relation heapRelation,
 									 Relation indexRelation,

--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -601,3 +601,14 @@ SELECT * FROM brintest_3 WHERE b < '0';
 
 DROP TABLE brintest_3;
 RESET enable_seqscan;
+-- test an unlogged table, mostly to get coverage of brinbuildempty
+CREATE UNLOGGED TABLE brintest_unlogged (n numrange);
+CREATE INDEX brinidx_unlogged ON brintest_unlogged USING brin (n);
+INSERT INTO brintest_unlogged VALUES (numrange(0, 2^1000::numeric));
+DROP TABLE brintest_unlogged;
+-- test that the insert optimization works if no rows end up inserted
+CREATE TABLE brin_insert_optimization (a int);
+INSERT INTO brin_insert_optimization VALUES (1);
+CREATE INDEX ON brin_insert_optimization USING brin (a);
+UPDATE brin_insert_optimization SET a = a;
+DROP TABLE brin_insert_optimization;

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -623,3 +623,14 @@ SELECT * FROM brintest_3 WHERE b < '0';
 
 DROP TABLE brintest_3;
 RESET enable_seqscan;
+-- test an unlogged table, mostly to get coverage of brinbuildempty
+CREATE UNLOGGED TABLE brintest_unlogged (n numrange);
+CREATE INDEX brinidx_unlogged ON brintest_unlogged USING brin (n);
+INSERT INTO brintest_unlogged VALUES (numrange(0, 2^1000::numeric));
+DROP TABLE brintest_unlogged;
+-- test that the insert optimization works if no rows end up inserted
+CREATE TABLE brin_insert_optimization (a int);
+INSERT INTO brin_insert_optimization VALUES (1);
+CREATE INDEX ON brin_insert_optimization USING brin (a);
+UPDATE brin_insert_optimization SET a = a;
+DROP TABLE brin_insert_optimization;

--- a/src/test/regress/sql/brin.sql
+++ b/src/test/regress/sql/brin.sql
@@ -550,3 +550,16 @@ SELECT * FROM brintest_3 WHERE b < '0';
 
 DROP TABLE brintest_3;
 RESET enable_seqscan;
+
+-- test an unlogged table, mostly to get coverage of brinbuildempty
+CREATE UNLOGGED TABLE brintest_unlogged (n numrange);
+CREATE INDEX brinidx_unlogged ON brintest_unlogged USING brin (n);
+INSERT INTO brintest_unlogged VALUES (numrange(0, 2^1000::numeric));
+DROP TABLE brintest_unlogged;
+
+-- test that the insert optimization works if no rows end up inserted
+CREATE TABLE brin_insert_optimization (a int);
+INSERT INTO brin_insert_optimization VALUES (1);
+CREATE INDEX ON brin_insert_optimization USING brin (a);
+UPDATE brin_insert_optimization SET a = a;
+DROP TABLE brin_insert_optimization;


### PR DESCRIPTION
This is a backport of upstream commit c1ec02be1d7 with some notable
adjustments:

(1) We don't backport the aminsertcleanup() AM routine, as that will
break ABI. Left merge fixmes with instructions for when that becomes
available.

~(2) Since we don't have REL14 commit c5b7ba4e67a, ExecOpenIndices() can
be called, even if ExecInsert() is never called (e.g. on QD or IIS with
no insert set). This means that ii_AmCache can be NULL, which means we
have to early return from index_insert_cleanup() if that is the case.
Left merge fixme with instructions for when that commit is absorbed.~

~(3) initialize_brin_insertstate() takes an isAO argument, like many
other BRIN routines. This avoids having to open the base relation to
figure out if this index is on an AO table or not.~

Note: the benefits of this patch is even more for GPDB, due to the added
AO specific fields in the structs involved.

Original commit message follows:

The brininsert code used to initialize (and destroy) BrinDesc and
BrinRevmap for each tuple, which is not free. This patch initializes
these structures only once, and reuses them for all inserts in the same
command. The data is passed through indexInfo->ii_AmCache.

This also introduces an optional AM callback "aminsertcleanup" that
allows performing custom cleanup in case simply pfree-ing ii_AmCache is
not sufficient (which is the case when the cache contains TupleDesc,
Buffers, and so on).

Author: Soumyadeep Chakraborty
Reviewed-by: Alvaro Herrera, Matthias van de Meent, Tomas Vondra
Discussion: https://postgr.es/m/CAE-ML%2B9r2%3DaO1wwji1sBN9gvPz2xRAtFUGfnffpd0ZqyuzjamA%40mail.gmail.com

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/backport_brininsert?group=all