### PR TITLE
Avoid extra motion from multiple self LOJ/ROJ

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
@@ -109,7 +109,7 @@ private:
 	// function properties
 	CFunctionProp *m_pfp;
 
-	CTableDescriptor *m_table_descriptor;
+	CTableDescriptorHashSet *m_table_descriptor{nullptr};
 
 	// helper for getting applicable FDs from child
 	static CFunctionalDependencyArray *DeriveChildFunctionalDependencies(
@@ -167,7 +167,7 @@ protected:
 	// function properties
 	CFunctionProp *DeriveFunctionProperties(CExpressionHandle &);
 
-	CTableDescriptor *DeriveTableDescriptor(CExpressionHandle &);
+	CTableDescriptorHashSet *DeriveTableDescriptor(CExpressionHandle &);
 
 public:
 	CDrvdPropRelational(const CDrvdPropRelational &) = delete;
@@ -228,7 +228,7 @@ public:
 	// function properties
 	CFunctionProp *GetFunctionProperties() const;
 
-	CTableDescriptor *GetTableDescriptor() const;
+	CTableDescriptorHashSet *GetTableDescriptor() const;
 
 	// shorthand for conversion
 	static CDrvdPropRelational *GetRelationalProperties(CDrvdProp *pdp);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1021,6 +1021,9 @@ public:
 	static BOOL FScalarConstOrBinaryCoercible(CExpression *pexpr);
 
 	static BOOL FScalarIdentNullTest(CExpression *pexpr);
+
+	static CTableDescriptorHashSet *RemoveDuplicateMdids(
+		CMemoryPool *mp, CTableDescriptorHashSet *tabdescs);
 };	// class CUtils
 
 // hash set from expressions

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -262,7 +262,21 @@ public:
 		return m_assigned_query_id_for_target_rel;
 	}
 
+	static ULONG HashValue(const CTableDescriptor *ptabdesc);
+
+	static BOOL Equals(const CTableDescriptor *ptabdescLeft,
+					   const CTableDescriptor *ptabdescRight);
+
 };	// class CTableDescriptor
+
+using CTableDescriptorHashSet =
+	CHashSet<CTableDescriptor, CTableDescriptor::HashValue,
+			 CTableDescriptor::Equals, CleanupRelease<CTableDescriptor>>;
+using CTableDescriptorHashSetIter =
+	CHashSetIter<CTableDescriptor, CTableDescriptor::HashValue,
+				 CTableDescriptor::Equals, CleanupRelease<CTableDescriptor>>;
+
+
 }  // namespace gpopt
 
 #endif	// !GPOPT_CTableDescriptor_H

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -292,7 +292,7 @@ public:
 	CFunctionProp *DeriveFunctionProperties();
 	CFunctionalDependencyArray *DeriveFunctionalDependencies();
 	CPartInfo *DerivePartitionInfo();
-	CTableDescriptor *DeriveTableDescriptor();
+	CTableDescriptorHashSet *DeriveTableDescriptor();
 
 	// Scalar property accessors - derived as needed
 	CColRefSet *DeriveDefinedColumns();

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -323,8 +323,8 @@ public:
 	CPartInfo *DerivePartitionInfo() const;
 	CPartInfo *DerivePartitionInfo(ULONG child_index) const;
 
-	CTableDescriptor *DeriveTableDescriptor() const;
-	CTableDescriptor *DeriveTableDescriptor(ULONG child_index) const;
+	CTableDescriptorHashSet *DeriveTableDescriptor() const;
+	CTableDescriptorHashSet *DeriveTableDescriptor(ULONG child_index) const;
 
 	// Scalar property accessors
 	CColRefSet *DeriveDefinedColumns(ULONG child_index) const;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -255,7 +255,7 @@ public:
 	virtual CFunctionProp *DeriveFunctionProperties(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
-	virtual CTableDescriptor *DeriveTableDescriptor(
+	virtual CTableDescriptorHashSet *DeriveTableDescriptor(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
@@ -40,7 +40,7 @@ class CLogicalBitmapTableGet : public CLogical
 {
 private:
 	// table descriptor
-	CTableDescriptor *m_ptabdesc;
+	CTableDescriptorHashSet *m_ptabdesc;
 
 	// origin operator id -- gpos::ulong_max if operator was not generated via a transformation
 	ULONG m_ulOriginOpId;
@@ -70,7 +70,7 @@ public:
 	CTableDescriptor *
 	Ptabdesc() const
 	{
-		return m_ptabdesc;
+		return m_ptabdesc->First();
 	}
 
 	// table alias
@@ -157,11 +157,12 @@ public:
 	}
 
 	// derive table descriptor
-	CTableDescriptor *
-	DeriveTableDescriptor(CMemoryPool *,	   // mp
-						  CExpressionHandle &  // exprhdl
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *mp GPOS_UNUSED,	// mp
+						  CExpressionHandle &			// exprhdl
 	) const override
 	{
+		m_ptabdesc->AddRef();
 		return m_ptabdesc;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
@@ -146,7 +146,7 @@ public:
 								   CExpressionHandle &exprhdl) const override;
 
 	// derive table descriptor
-	CTableDescriptor *DeriveTableDescriptor(
+	CTableDescriptorHashSet *DeriveTableDescriptor(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
 
 	// compute required stats columns of the n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
@@ -138,7 +138,7 @@ public:
 		return PpartinfoPassThruOuter(exprhdl);
 	}
 
-	CTableDescriptor *DeriveTableDescriptor(
+	CTableDescriptorHashSet *DeriveTableDescriptor(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
 	// compute required stats columns of the n-th child
 	CColRefSet *

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
@@ -131,11 +131,12 @@ public:
 	}
 
 	// derive table descriptor
-	CTableDescriptor *
-	DeriveTableDescriptor(CMemoryPool *,	   // mp
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *mp GPOS_UNUSED,
 						  CExpressionHandle &  // exprhdl
 	) const override
 	{
+		m_ptabdesc->AddRef();
 		return m_ptabdesc;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -37,7 +37,7 @@ protected:
 	const CName *m_pnameAlias;
 
 	// table descriptor
-	CTableDescriptor *m_ptabdesc;
+	CTableDescriptorHashSet *m_ptabdesc;
 
 	// dynamic scan id
 	ULONG m_scan_id;
@@ -117,7 +117,7 @@ public:
 	virtual CTableDescriptor *
 	Ptabdesc() const
 	{
-		return m_ptabdesc;
+		return m_ptabdesc->First();
 	}
 
 	// return scan id
@@ -164,11 +164,12 @@ public:
 	}
 
 	// derive table descriptor
-	CTableDescriptor *
-	DeriveTableDescriptor(CMemoryPool *,	   // mp
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *mp GPOS_UNUSED,
 						  CExpressionHandle &  // exprhdl
 	) const override
 	{
+		m_ptabdesc->AddRef();
 		return m_ptabdesc;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGbAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGbAgg.h
@@ -261,6 +261,16 @@ public:
 	static IOstream &OsPrintGbAggType(IOstream &os,
 									  COperator::EGbAggType egbaggtype);
 
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *,
+						  CExpressionHandle &exprhdl) const override
+	{
+		CTableDescriptorHashSet *table_descriptor_set =
+			exprhdl.DeriveTableDescriptor(0);
+		table_descriptor_set->AddRef();
+		return table_descriptor_set;
+	}
+
 private:
 	// array of grouping columns
 	CColRefArray *m_pdrgpcr;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
@@ -37,7 +37,7 @@ private:
 	const CName *m_pnameAlias;
 
 	// table descriptor
-	CTableDescriptor *m_ptabdesc;
+	CTableDescriptorHashSet *m_ptabdesc;
 
 	// output columns
 	CColRefArray *m_pdrgpcrOutput;
@@ -105,7 +105,7 @@ public:
 	CTableDescriptor *
 	Ptabdesc() const
 	{
-		return m_ptabdesc;
+		return m_ptabdesc->First();
 	}
 
 	// partition columns
@@ -156,7 +156,8 @@ public:
 							 CExpressionHandle &  // exprhdl
 	) const override
 	{
-		return PpcDeriveConstraintFromTable(mp, m_ptabdesc, m_pdrgpcrOutput);
+		return PpcDeriveConstraintFromTable(mp, m_ptabdesc->First(),
+											m_pdrgpcrOutput);
 	}
 
 	// derive join depth
@@ -169,11 +170,12 @@ public:
 	}
 
 	// derive table descriptor
-	CTableDescriptor *
-	DeriveTableDescriptor(CMemoryPool *,	   // mp
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *mp GPOS_UNUSED,
 						  CExpressionHandle &  // exprhdl
 	) const override
 	{
+		m_ptabdesc->AddRef();
 		return m_ptabdesc;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalNAryJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalNAryJoin.h
@@ -86,6 +86,10 @@ public:
 	CPropConstraint *DerivePropertyConstraint(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
 
+	// derive table descriptor
+	CTableDescriptorHashSet *DeriveTableDescriptor(
+		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
+
 	//-------------------------------------------------------------------------------------
 	// Derived Stats
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalProject.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalProject.h
@@ -109,6 +109,16 @@ public:
 		return dynamic_cast<CLogicalProject *>(pop);
 	}
 
+	CTableDescriptorHashSet *
+	DeriveTableDescriptor(CMemoryPool *,
+						  CExpressionHandle &exprhdl) const override
+	{
+		CTableDescriptorHashSet *table_descriptor_set =
+			exprhdl.DeriveTableDescriptor(0);
+		table_descriptor_set->AddRef();
+		return table_descriptor_set;
+	}
+
 };	// class CLogicalProject
 
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -95,11 +95,14 @@ public:
 	}
 
 	// derive table descriptor
-	CTableDescriptor *
+	CTableDescriptorHashSet *
 	DeriveTableDescriptor(CMemoryPool *,  // mp
 						  CExpressionHandle &exprhdl) const override
 	{
-		return exprhdl.DeriveTableDescriptor(0);
+		CTableDescriptorHashSet *table_descriptor_set =
+			exprhdl.DeriveTableDescriptor(0);
+		table_descriptor_set->AddRef();
+		return table_descriptor_set;
 	}
 
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -55,6 +55,15 @@ private:
 	CDistributionSpec *PdsMatch(CMemoryPool *mp, CDistributionSpec *pds,
 								ULONG ulSourceChildIndex) const;
 
+	// helper for deriving hash join distribution from hashed children
+	CDistributionSpec *PdsDeriveFromHashedChildren(
+		CMemoryPool *mp, CExpressionHandle &exprhdl,
+		CDistributionSpec *pdsOuter, CDistributionSpec *pdsInner) const;
+
+	BOOL FSelfJoinWithMatchingJoinKeys(CMemoryPool *mp,
+									   CExpressionHandle &exprhdl) const;
+
+
 protected:
 	// compute required hashed distribution from the n-th child
 	CDistributionSpecHashed *PdshashedRequired(CMemoryPool *mp,
@@ -126,6 +135,9 @@ protected:
 
 	CPartitionPropagationSpec *PppsDeriveForJoins(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
+	CDistributionSpec *PdsDeriveForOuterJoin(CMemoryPool *mp,
+											 CExpressionHandle &exprhdl) const;
 
 public:
 	CPhysicalHashJoin(const CPhysicalHashJoin &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -27,12 +27,6 @@ namespace gpopt
 //---------------------------------------------------------------------------
 class CPhysicalLeftOuterHashJoin : public CPhysicalHashJoin
 {
-private:
-	// helper for deriving hash join distribution from hashed children
-	CDistributionSpec *PdsDeriveFromHashedChildren(
-		CMemoryPool *mp, CDistributionSpec *pdsOuter,
-		CDistributionSpec *pdsInner) const;
-
 public:
 	CPhysicalLeftOuterHashJoin(const CPhysicalLeftOuterHashJoin &) = delete;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
@@ -28,6 +28,11 @@ namespace gpopt
 class CPhysicalRightOuterHashJoin : public CPhysicalHashJoin
 {
 private:
+	// helper for deriving hash join distribution from hashed children
+	CDistributionSpec *PdsDeriveFromHashedChildren(
+		CMemoryPool *mp, CDistributionSpec *pdsOuter,
+		CDistributionSpec *pdsInner) const;
+
 protected:
 	// create optimization requests
 	void CreateOptRequests(CMemoryPool *mp) override;
@@ -44,6 +49,9 @@ public:
 
 	// dtor
 	~CPhysicalRightOuterHashJoin() override;
+
+	CDistributionSpec *PdsDerive(CMemoryPool *mp,
+								 CExpressionHandle &exprhdl) const override;
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -962,10 +962,7 @@ CDistributionSpecHashed *
 CDistributionSpecHashed::Combine(CMemoryPool *mp,
 								 CDistributionSpecHashed *other_spec)
 {
-	if (nullptr == other_spec)
-	{
-		return this;
-	}
+	GPOS_ASSERT(nullptr != other_spec);
 
 	CDistributionSpecHashed *combined_spec = other_spec->Copy(mp);
 	CDistributionSpecHashed *prev = nullptr, *next = nullptr;

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2193,7 +2193,7 @@ CUtils::PexprLogicalSelect(CMemoryPool *mp, CExpression *pexpr,
 		pexpr->Pop()->Eopid() == CLogical::EopLogicalGet ||
 		pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
 	{
-		ptabdesc = pexpr->DeriveTableDescriptor();
+		ptabdesc = pexpr->DeriveTableDescriptor()->First();
 		// there are some cases where we don't populate LogicalSelect currently
 		GPOS_ASSERT_IMP(pexpr->Pop()->Eopid() != CLogical::EopLogicalSelect,
 						nullptr != ptabdesc);

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -5034,4 +5034,33 @@ CUtils::AddExprs(CExpressionArrays *results_exprs,
 	}
 	GPOS_ASSERT(results_exprs->Size() >= input_exprs->Size());
 }
+
+
+// Given a table desriptor set, return a new table descriptor set without
+// duplicate mdids. This can happen if there is more than one table desriptor
+// for the same table, but using different alias names.
+CTableDescriptorHashSet *
+CUtils::RemoveDuplicateMdids(CMemoryPool *mp, CTableDescriptorHashSet *tabdescs)
+{
+	GPOS_ASSERT(nullptr != tabdescs);
+	CTableDescriptorHashSet *result = GPOS_NEW(mp) CTableDescriptorHashSet(mp);
+
+	MdidHashSet *mdids = GPOS_NEW(mp) MdidHashSet(mp);
+	CTableDescriptorHashSetIter hsiter(tabdescs);
+	while (hsiter.Advance())
+	{
+		CTableDescriptor *tabdesc =
+			const_cast<CTableDescriptor *>(hsiter.Get());
+		if (mdids->Insert(tabdesc->MDId()))
+		{
+			tabdesc->MDId()->AddRef();
+			if (result->Insert(tabdesc))
+			{
+				tabdesc->AddRef();
+			}
+		}
+	}
+	mdids->Release();
+	return result;
+}
 // EOF

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -309,5 +309,33 @@ CTableDescriptor::IndexCount()
 	return ulIndices;
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CTableDescriptor::HashValue
+//
+//	@doc:
+//		Returns hash value of the relation. The value is unique by MDId and
+//		relation name (or alias).
+//
+//
+//---------------------------------------------------------------------------
+ULONG
+CTableDescriptor::HashValue(const CTableDescriptor *ptabdesc)
+{
+	ULONG ulHash =
+		gpos::CombineHashes(ptabdesc->MDId()->HashValue(),
+							CWStringConst::HashValue(ptabdesc->Name().Pstr()));
+
+	return ulHash;
+}
+
+BOOL
+CTableDescriptor::Equals(const CTableDescriptor *ptabdescLeft,
+						 const CTableDescriptor *ptabdescRight)
+{
+	return ptabdescLeft->MDId()->Equals(ptabdescRight->MDId()) &&
+		   ptabdescLeft->Name().Equals(ptabdescRight->Name());
+}
+
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1417,7 +1417,7 @@ CExpression::DerivePartitionInfo()
 	return m_pdprel->DerivePartitionInfo(exprhdl);
 }
 
-CTableDescriptor *
+CTableDescriptorHashSet *
 CExpression::DeriveTableDescriptor()
 {
 	CExpressionHandle exprhdl(m_mp);

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -1983,7 +1983,7 @@ CExpressionHandle::DerivePartitionInfo() const
 	return GetRelationalProperties()->GetPartitionInfo();
 }
 
-CTableDescriptor *
+CTableDescriptorHashSet *
 CExpressionHandle::DeriveTableDescriptor() const
 {
 	if (nullptr != Pexpr())
@@ -1994,7 +1994,7 @@ CExpressionHandle::DeriveTableDescriptor() const
 	return GetRelationalProperties()->GetTableDescriptor();
 }
 
-CTableDescriptor *
+CTableDescriptorHashSet *
 CExpressionHandle::DeriveTableDescriptor(ULONG child_index) const
 {
 	if (nullptr != Pexpr())

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -938,12 +938,10 @@ CLogical::DeriveFunctionProperties(CMemoryPool *mp,
 //		Derive table descriptor for tables used by operator
 //
 //---------------------------------------------------------------------------
-CTableDescriptor *
-CLogical::DeriveTableDescriptor(CMemoryPool *, CExpressionHandle &) const
+CTableDescriptorHashSet *
+CLogical::DeriveTableDescriptor(CMemoryPool *mp, CExpressionHandle &) const
 {
-	//currently return null unless there is a single table being used. Later we may want
-	//to make this return a set of table descriptors and pass them up all operators
-	return nullptr;
+	return GPOS_NEW(mp) CTableDescriptorHashSet(mp);
 }
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
@@ -238,7 +238,7 @@ CLogicalCTEConsumer::DeriveJoinDepth(CMemoryPool *,		  //mp,
 }
 
 // derive table descriptor
-CTableDescriptor *
+CTableDescriptorHashSet *
 CLogicalCTEConsumer::DeriveTableDescriptor(CMemoryPool *,		//mp
 										   CExpressionHandle &	//exprhdl
 ) const
@@ -246,7 +246,11 @@ CLogicalCTEConsumer::DeriveTableDescriptor(CMemoryPool *,		//mp
 	CExpression *pexpr =
 		COptCtxt::PoctxtFromTLS()->Pcteinfo()->PexprCTEProducer(m_id);
 	GPOS_ASSERT(nullptr != pexpr);
-	return pexpr->DeriveTableDescriptor();
+
+	CTableDescriptorHashSet *table_descriptor_set =
+		pexpr->DeriveTableDescriptor();
+	table_descriptor_set->AddRef();
+	return table_descriptor_set;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
@@ -132,12 +132,15 @@ CLogicalCTEProducer::DeriveMaxCard(CMemoryPool *,  // mp
 	return exprhdl.DeriveMaxCard(0);
 }
 
-CTableDescriptor *
-CLogicalCTEProducer::DeriveTableDescriptor(CMemoryPool *,  // mp
+CTableDescriptorHashSet *
+CLogicalCTEProducer::DeriveTableDescriptor(CMemoryPool *,
 										   CExpressionHandle &exprhdl) const
 {
 	// pass on table descriptor of first child
-	return exprhdl.DeriveTableDescriptor(0);
+	CTableDescriptorHashSet *child_table_descriptor_set =
+		exprhdl.DeriveTableDescriptor(0);
+	child_table_descriptor_set->AddRef();
+	return child_table_descriptor_set;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicBitmapTableGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicBitmapTableGet.cpp
@@ -82,7 +82,7 @@ ULONG
 CLogicalDynamicBitmapTableGet::HashValue() const
 {
 	ULONG ulHash = gpos::CombineHashes(COperator::HashValue(),
-									   m_ptabdesc->MDId()->HashValue());
+									   Ptabdesc()->MDId()->HashValue());
 	ulHash = gpos::CombineHashes(ulHash, gpos::HashValue(&m_scan_id));
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
@@ -118,7 +118,7 @@ CPropConstraint *
 CLogicalDynamicBitmapTableGet::DerivePropertyConstraint(
 	CMemoryPool *mp, CExpressionHandle &exprhdl) const
 {
-	return PpcDeriveConstraintFromTableWithPredicates(mp, exprhdl, m_ptabdesc,
+	return PpcDeriveConstraintFromTableWithPredicates(mp, exprhdl, Ptabdesc(),
 													  m_pdrgpcrOutput);
 }
 
@@ -167,7 +167,7 @@ CLogicalDynamicBitmapTableGet::OsPrint(IOstream &os) const
 {
 	os << SzId() << " ";
 	os << ", Table Name: (";
-	m_ptabdesc->Name().OsPrint(os);
+	Ptabdesc()->Name().OsPrint(os);
 	os << ") Scan Id: " << m_scan_id;
 	os << ", Columns: [";
 	CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
@@ -201,14 +201,14 @@ CLogicalDynamicBitmapTableGet::PopCopyWithRemappedColumns(
 	}
 	CName *pnameAlias = GPOS_NEW(mp) CName(mp, *m_pnameAlias);
 
-	m_ptabdesc->AddRef();
+	Ptabdesc()->AddRef();
 	m_partition_mdids->AddRef();
 
 	CColRef2dArray *pdrgpdrgpcrPart = CUtils::PdrgpdrgpcrRemap(
 		mp, m_pdrgpdrgpcrPart, colref_mapping, must_exist);
 
 	return GPOS_NEW(mp) CLogicalDynamicBitmapTableGet(
-		mp, m_ptabdesc, m_ulOriginOpId, pnameAlias, m_scan_id, pdrgpcrOutput,
+		mp, Ptabdesc(), m_ulOriginOpId, pnameAlias, m_scan_id, pdrgpcrOutput,
 		pdrgpdrgpcrPart, m_partition_mdids);
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
@@ -107,13 +107,13 @@ CLogicalDynamicForeignGet::PopCopyWithRemappedColumns(
 											 colref_mapping, must_exist);
 	}
 	CColRef2dArray *pdrgpdrgpcrPart =
-		PdrgpdrgpcrCreatePartCols(mp, pdrgpcrOutput, m_ptabdesc->PdrgpulPart());
+		PdrgpdrgpcrCreatePartCols(mp, pdrgpcrOutput, Ptabdesc()->PdrgpulPart());
 	CName *pnameAlias = GPOS_NEW(mp) CName(mp, *m_pnameAlias);
-	m_ptabdesc->AddRef();
+	Ptabdesc()->AddRef();
 	m_partition_mdids->AddRef();
 
 	return GPOS_NEW(mp) CLogicalDynamicForeignGet(
-		mp, pnameAlias, m_ptabdesc, m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
+		mp, pnameAlias, Ptabdesc(), m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
 		m_partition_mdids, m_foreign_server_oid, m_exec_location);
 }
 
@@ -143,7 +143,7 @@ CLogicalDynamicForeignGet::PstatsDerive(CMemoryPool *mp,
 {
 	// requesting stats on distribution columns to estimate data skew
 	IStatistics *pstatsTable =
-		PstatsBaseTable(mp, exprhdl, m_ptabdesc, m_pcrsDist);
+		PstatsBaseTable(mp, exprhdl, Ptabdesc(), m_pcrsDist);
 
 	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp, m_pdrgpcrOutput);
 	CUpperBoundNDVs *upper_bound_NDVs =

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
@@ -115,7 +115,7 @@ ULONG
 CLogicalDynamicGet::HashValue() const
 {
 	ULONG ulHash = gpos::CombineHashes(COperator::HashValue(),
-									   m_ptabdesc->MDId()->HashValue());
+									   Ptabdesc()->MDId()->HashValue());
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
 
@@ -162,9 +162,9 @@ CLogicalDynamicGet::PopCopyWithRemappedColumns(CMemoryPool *mp,
 											 colref_mapping, must_exist);
 	}
 	CColRef2dArray *pdrgpdrgpcrPart =
-		PdrgpdrgpcrCreatePartCols(mp, pdrgpcrOutput, m_ptabdesc->PdrgpulPart());
+		PdrgpdrgpcrCreatePartCols(mp, pdrgpcrOutput, Ptabdesc()->PdrgpulPart());
 	CName *pnameAlias = GPOS_NEW(mp) CName(mp, *m_pnameAlias);
-	m_ptabdesc->AddRef();
+	Ptabdesc()->AddRef();
 	m_partition_mdids->AddRef();
 
 	CConstraint *partition_cnstrs_disj = nullptr;
@@ -182,7 +182,7 @@ CLogicalDynamicGet::PopCopyWithRemappedColumns(CMemoryPool *mp,
 	}
 
 	return GPOS_NEW(mp) CLogicalDynamicGet(
-		mp, pnameAlias, m_ptabdesc, m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
+		mp, pnameAlias, Ptabdesc(), m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
 		m_partition_mdids, partition_cnstrs_disj, m_static_pruned,
 		m_foreign_server_mdids);
 }
@@ -257,7 +257,7 @@ CLogicalDynamicGet::OsPrint(IOstream &os) const
 
 		// actual name of table in catalog and columns
 		os << " (";
-		m_ptabdesc->Name().OsPrint(os);
+		Ptabdesc()->Name().OsPrint(os);
 		os << "), ";
 		os << "Columns: [";
 		CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
@@ -327,7 +327,7 @@ CLogicalDynamicGet::PstatsDeriveFilter(CMemoryPool *mp,
 	}
 
 	CStatistics *pstatsFullTable = dynamic_cast<CStatistics *>(
-		PstatsBaseTable(mp, exprhdl, m_ptabdesc, pcrsStat));
+		PstatsBaseTable(mp, exprhdl, Ptabdesc(), pcrsStat));
 
 	pcrsStat->Release();
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicIndexGet.cpp
@@ -166,11 +166,11 @@ CLogicalDynamicIndexGet::PopCopyWithRemappedColumns(
 	CColRef2dArray *pdrgpdrgpcrPart = CUtils::PdrgpdrgpcrRemap(
 		mp, m_pdrgpdrgpcrPart, colref_mapping, must_exist);
 
-	m_ptabdesc->AddRef();
+	Ptabdesc()->AddRef();
 	m_partition_mdids->AddRef();
 
 	return GPOS_NEW(mp) CLogicalDynamicIndexGet(
-		mp, pmdindex, m_ptabdesc, m_ulOriginOpId, pnameAlias, m_scan_id,
+		mp, pmdindex, Ptabdesc(), m_ulOriginOpId, pnameAlias, m_scan_id,
 		pdrgpcrOutput, pdrgpdrgpcrPart, m_partition_mdids,
 		m_ulUnindexedPredColCount);
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
@@ -40,7 +40,7 @@ using namespace gpopt;
 CLogicalGet::CLogicalGet(CMemoryPool *mp)
 	: CLogical(mp),
 	  m_pnameAlias(nullptr),
-	  m_ptabdesc(nullptr),
+	  m_ptabdesc(GPOS_NEW(mp) CTableDescriptorHashSet(mp)),
 	  m_pdrgpcrOutput(nullptr),
 	  m_pdrgpdrgpcrPart(nullptr),
 	  m_pcrsDist(nullptr)
@@ -60,7 +60,7 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 						 CTableDescriptor *ptabdesc)
 	: CLogical(mp),
 	  m_pnameAlias(pnameAlias),
-	  m_ptabdesc(ptabdesc),
+	  m_ptabdesc(GPOS_NEW(mp) CTableDescriptorHashSet(mp)),
 	  m_pdrgpcrOutput(nullptr),
 	  m_pdrgpdrgpcrPart(nullptr),
 	  m_pcrsDist(nullptr)
@@ -68,17 +68,19 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 	GPOS_ASSERT(nullptr != ptabdesc);
 	GPOS_ASSERT(nullptr != pnameAlias);
 
-	// generate a default column set for the table descriptor
-	m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, m_ptabdesc->Pdrgpcoldesc(),
-										   UlOpId(), m_ptabdesc->MDId());
+	m_ptabdesc->Insert(ptabdesc);
 
-	if (m_ptabdesc->IsPartitioned())
+	// generate a default column set for the table descriptor
+	m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, Ptabdesc()->Pdrgpcoldesc(),
+										   UlOpId(), Ptabdesc()->MDId());
+
+	if (Ptabdesc()->IsPartitioned())
 	{
 		m_pdrgpdrgpcrPart = PdrgpdrgpcrCreatePartCols(
-			mp, m_pdrgpcrOutput, m_ptabdesc->PdrgpulPart());
+			mp, m_pdrgpcrOutput, Ptabdesc()->PdrgpulPart());
 	}
 
-	m_pcrsDist = CLogical::PcrsDist(mp, m_ptabdesc, m_pdrgpcrOutput);
+	m_pcrsDist = CLogical::PcrsDist(mp, Ptabdesc(), m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -94,20 +96,22 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 						 CColRefArray *pdrgpcrOutput)
 	: CLogical(mp),
 	  m_pnameAlias(pnameAlias),
-	  m_ptabdesc(ptabdesc),
+	  m_ptabdesc(GPOS_NEW(mp) CTableDescriptorHashSet(mp)),
 	  m_pdrgpcrOutput(pdrgpcrOutput),
 	  m_pdrgpdrgpcrPart(nullptr)
 {
 	GPOS_ASSERT(nullptr != ptabdesc);
 	GPOS_ASSERT(nullptr != pnameAlias);
 
-	if (m_ptabdesc->IsPartitioned())
+	m_ptabdesc->Insert(ptabdesc);
+
+	if (Ptabdesc()->IsPartitioned())
 	{
 		m_pdrgpdrgpcrPart = PdrgpdrgpcrCreatePartCols(
-			mp, m_pdrgpcrOutput, m_ptabdesc->PdrgpulPart());
+			mp, m_pdrgpcrOutput, Ptabdesc()->PdrgpulPart());
 	}
 
-	m_pcrsDist = CLogical::PcrsDist(mp, m_ptabdesc, m_pdrgpcrOutput);
+	m_pcrsDist = CLogical::PcrsDist(mp, Ptabdesc(), m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -141,7 +145,7 @@ ULONG
 CLogicalGet::HashValue() const
 {
 	ULONG ulHash = gpos::CombineHashes(COperator::HashValue(),
-									   m_ptabdesc->MDId()->HashValue());
+									   Ptabdesc()->MDId()->HashValue());
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
 
@@ -166,7 +170,7 @@ CLogicalGet::Matches(COperator *pop) const
 	}
 	CLogicalGet *popGet = CLogicalGet::PopConvert(pop);
 
-	return m_ptabdesc->MDId()->Equals(popGet->m_ptabdesc->MDId()) &&
+	return Ptabdesc()->MDId()->Equals(popGet->Ptabdesc()->MDId()) &&
 		   m_pdrgpcrOutput->Equals(popGet->PdrgpcrOutput());
 }
 
@@ -195,9 +199,9 @@ CLogicalGet::PopCopyWithRemappedColumns(CMemoryPool *mp,
 											 colref_mapping, must_exist);
 	}
 	CName *pnameAlias = GPOS_NEW(mp) CName(mp, *m_pnameAlias);
-	m_ptabdesc->AddRef();
+	Ptabdesc()->AddRef();
 
-	return GPOS_NEW(mp) CLogicalGet(mp, pnameAlias, m_ptabdesc, pdrgpcrOutput);
+	return GPOS_NEW(mp) CLogicalGet(mp, pnameAlias, Ptabdesc(), pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------
@@ -291,7 +295,7 @@ CLogicalGet::DeriveKeyCollection(CMemoryPool *mp,
 								 CExpressionHandle &  // exprhdl
 ) const
 {
-	const CBitSetArray *pdrgpbs = m_ptabdesc->PdrgpbsKeys();
+	const CBitSetArray *pdrgpbs = Ptabdesc()->PdrgpbsKeys();
 
 	return CLogical::PkcKeysBaseTable(mp, pdrgpbs, m_pdrgpcrOutput);
 }
@@ -330,7 +334,7 @@ CLogicalGet::PstatsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl,
 {
 	// requesting stats on distribution columns to estimate data skew
 	IStatistics *pstatsTable =
-		PstatsBaseTable(mp, exprhdl, m_ptabdesc, m_pcrsDist);
+		PstatsBaseTable(mp, exprhdl, Ptabdesc(), m_pcrsDist);
 
 	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp, m_pdrgpcrOutput);
 	CUpperBoundNDVs *upper_bound_NDVs =
@@ -364,13 +368,13 @@ CLogicalGet::OsPrint(IOstream &os) const
 
 		// actual name of table in catalog and columns
 		os << " (";
-		m_ptabdesc->Name().OsPrint(os);
+		Ptabdesc()->Name().OsPrint(os);
 		os << "), Columns: [";
 		CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
 		os << "] Key sets: {";
 
 		const ULONG ulColumns = m_pdrgpcrOutput->Size();
-		const CBitSetArray *pdrgpbsKeys = m_ptabdesc->PdrgpbsKeys();
+		const CBitSetArray *pdrgpbsKeys = Ptabdesc()->PdrgpbsKeys();
 		for (ULONG ul = 0; ul < pdrgpbsKeys->Size(); ul++)
 		{
 			CBitSet *pbs = (*pdrgpbsKeys)[ul];

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
@@ -52,6 +52,14 @@ CPhysicalRightOuterHashJoin::CPhysicalRightOuterHashJoin(
 //---------------------------------------------------------------------------
 CPhysicalRightOuterHashJoin::~CPhysicalRightOuterHashJoin() = default;
 
+CDistributionSpec *
+CPhysicalRightOuterHashJoin::PdsDerive(CMemoryPool *mp,
+									   CExpressionHandle &exprhdl) const
+{
+	return PdsDeriveForOuterJoin(mp, exprhdl);
+}
+
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPhysicalRightOuterHashJoin::PdsRequired

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1475,10 +1475,12 @@ CJoinOrderDPv2::PexprExpand()
 		// We need the underlying partition and table row information to properly estimate cardinality for
 		// partition selection. If this is a logical expr that is more complex (eg: cte, nary join), we
 		// will use a default estimate
-		CTableDescriptor *table_desc = pexpr_atom->DeriveTableDescriptor();
+		CTableDescriptorHashSet *table_desc_set =
+			pexpr_atom->DeriveTableDescriptor();
 
-		if (table_desc != nullptr)
+		if (table_desc_set->Size() > 0)
 		{
+			CTableDescriptor *table_desc = table_desc_set->First();
 			IMDId *rel_mdid = table_desc->MDId();
 			rel_mdid->AddRef();
 			CMDIdRelStats *rel_stats_mdid =

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2430,8 +2430,10 @@ CXformUtils::PexprBuildBtreeIndexPlan(CMemoryPool *mp, CMDAccessor *md_accessor,
 
 	BOOL fDynamicGet = (COperator::EopLogicalDynamicGet == op_id);
 
-	CTableDescriptor *ptabdesc = pexprGet->DeriveTableDescriptor();
-	GPOS_ASSERT(nullptr != ptabdesc);
+	CTableDescriptorHashSet *ptabdescset = pexprGet->DeriveTableDescriptor();
+	GPOS_ASSERT(1 == ptabdescset->Size());
+	CTableDescriptor *ptabdesc = ptabdescset->First();
+
 	CColRefArray *pdrgpcrOutput = nullptr;
 	CWStringConst *alias = nullptr;
 	ULONG ulPartIndex = gpos::ulong_max;
@@ -3363,7 +3365,11 @@ CXformUtils::PexprSelect2BitmapBoolOp(CMemoryPool *mp, CExpression *pexpr)
 	CExpression *pexprScalar = (*pexpr)[1];
 	CLogical *popGet = CLogical::PopConvert(pexprRelational->Pop());
 
-	CTableDescriptor *ptabdesc = pexprRelational->DeriveTableDescriptor();
+	CTableDescriptorHashSet *ptabdescset =
+		pexprRelational->DeriveTableDescriptor();
+	GPOS_ASSERT(1 == ptabdescset->Size());
+	CTableDescriptor *ptabdesc = ptabdescset->First();
+
 	GPOS_ASSERT(nullptr != ptabdesc);
 	const ULONG ulIndices = ptabdesc->IndexCount();
 	if (0 == ulIndices)

--- a/src/backend/gporca/libgpos/include/gpos/common/CHashSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashSet.h
@@ -236,6 +236,17 @@ public:
 		return m_size;
 	}
 
+	T *
+	First()
+	{
+		if (m_elements->Size() == 0 || m_size == 0)
+		{
+			return nullptr;
+		}
+
+		return (*m_elements)[0];
+	}
+
 };	// class CHashSet
 
 }  // namespace gpos

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1249,7 +1249,10 @@ CStatisticsUtils::DeriveStatsForBitmapTableGet(CMemoryPool *mp,
 					expr_handle.Pop()->Eopid() ||
 				CLogical::EopLogicalDynamicBitmapTableGet ==
 					expr_handle.Pop()->Eopid());
-	CTableDescriptor *table_descriptor = expr_handle.DeriveTableDescriptor();
+
+	CTableDescriptorHashSet *table_descriptor_set =
+		expr_handle.DeriveTableDescriptor();
+	CTableDescriptor *table_descriptor = table_descriptor_set->First();
 
 	// the index of the condition
 	ULONG child_cond_index = 0;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3807,6 +3807,183 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
  Optimizer: Postgres query optimizer
 (18 rows)
 
+-- Test hashed distribution spec derived from a self join
+truncate o1;
+truncate o2;
+insert into o1 select i, i from generate_series(1,9) i;
+insert into o1 values (NULL, NULL);
+insert into o2 select i, NULL from generate_series(11,100) i;
+insert into o2 values (NULL, NULL);
+analyze o1;
+analyze o2;
+-- Self join maintains the distribution keys from both children (i.e. the join
+-- result produces a combine hash distribution spec)
+--
+-- Expect no redistribute under the joins
+explain select t2.b1 from (select distinct a1 from o1) t1
+left outer join (select a1, b1 from o1) t2 on t1.a1 = t2.a1
+left outer join o1 t3 on t2.a1 = t3.a1
+left outer join o1 t4 on t2.a1 = t4.a1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.29..4.57 rows=9 width=4)
+   ->  Hash Right Join  (cost=3.29..4.45 rows=3 width=4)
+         Hash Cond: (o1.a1 = o1_1.a1)
+         ->  Hash Left Join  (cost=2.15..3.27 rows=3 width=8)
+               Hash Cond: (o1.a1 = t4.a1)
+               ->  Hash Left Join  (cost=1.08..2.15 rows=3 width=8)
+                     Hash Cond: (o1.a1 = t3.a1)
+                     ->  Seq Scan on o1  (cost=0.00..1.03 rows=3 width=8)
+                     ->  Hash  (cost=1.03..1.03 rows=3 width=4)
+                           ->  Seq Scan on o1 t3  (cost=0.00..1.03 rows=3 width=4)
+               ->  Hash  (cost=1.03..1.03 rows=3 width=4)
+                     ->  Seq Scan on o1 t4  (cost=0.00..1.03 rows=3 width=4)
+         ->  Hash  (cost=1.10..1.10 rows=3 width=4)
+               ->  HashAggregate  (cost=1.04..1.07 rows=3 width=4)
+                     Group Key: o1_1.a1
+                     ->  Seq Scan on o1 o1_1  (cost=0.00..1.03 rows=3 width=4)
+ Optimizer: Postgres-based planner
+(17 rows)
+
+select t2.b1 from (select distinct a1 from o1) t1
+left outer join (select a1, b1 from o1) t2 on t1.a1 = t2.a1
+left outer join o1 t3 on t2.a1 = t3.a1
+left outer join o1 t4 on t2.a1 = t4.a1;
+ b1 
+----
+  2
+  3
+  4
+  7
+  8
+   
+  1
+  5
+  6
+  9
+(10 rows)
+
+-- Self join maintains the distribution keys from both children (i.e. the join
+-- result produces a combine hash distribution spec)
+--
+-- Expect no redistribute under the joins
+explain (costs off) select t2.b1 from o1 t3
+right outer join (select a1, b1 from o1) t2 on t2.a1 = t3.a1
+right outer join o1 t4 on t2.a1 = t4.a1
+right outer join (select distinct a1 from o1) t1 on t1.a1 = t2.a1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: (o1.a1 = o1_1.a1)
+         ->  Hash Left Join
+               Hash Cond: (o1.a1 = t3.a1)
+               ->  Hash Join
+                     Hash Cond: (o1.a1 = t4.a1)
+                     ->  Seq Scan on o1
+                     ->  Hash
+                           ->  Seq Scan on o1 t4
+               ->  Hash
+                     ->  Seq Scan on o1 t3
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: o1_1.a1
+                     ->  Seq Scan on o1 o1_1
+ Optimizer: Postgres-based planner
+(17 rows)
+
+select t2.b1 from o1 t3
+right outer join (select a1, b1 from o1) t2 on t2.a1 = t3.a1
+right outer join o1 t4 on t2.a1 = t4.a1
+right outer join (select distinct a1 from o1) t1 on t1.a1 = t2.a1;
+ b1 
+----
+  1
+  5
+  6
+  9
+  2
+  3
+  4
+  7
+  8
+   
+(10 rows)
+
+-- Self join, but the projected distribution key value is changed
+--
+-- Expect redistribute under the joins
+explain select t2.b1 from (select distinct a1+1 as a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.22..2.41 rows=9 width=4)
+   ->  Hash Right Join  (cost=1.22..2.29 rows=3 width=4)
+         Hash Cond: (t2.a1 = ((o1.a1 + 1)))
+         ->  Seq Scan on o1 t2  (cost=0.00..1.03 rows=3 width=8)
+         ->  Hash  (cost=1.18..1.18 rows=3 width=4)
+               ->  Unique  (cost=1.14..1.15 rows=3 width=4)
+                     Group Key: ((o1.a1 + 1))
+                     ->  Sort  (cost=1.14..1.15 rows=3 width=4)
+                           Sort Key: ((o1.a1 + 1))
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.11 rows=3 width=4)
+                                 Hash Key: ((o1.a1 + 1))
+                                 ->  Seq Scan on o1  (cost=0.00..1.04 rows=3 width=4)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+select t2.b1 from (select distinct a1+1 as a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1;
+ b1 
+----
+  5
+  6
+  9
+   
+  2
+  3
+  4
+  7
+  8
+   
+(10 rows)
+
+-- Self join, but the joined distribution key value is changed
+--
+-- Expect redistribute under the joins
+explain select t2.b1 from (select distinct a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1+1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.20..2.40 rows=9 width=4)
+   ->  Hash Right Join  (cost=1.20..2.28 rows=3 width=4)
+         Hash Cond: (t2.a1 = (o1.a1 + 1))
+         ->  Seq Scan on o1 t2  (cost=0.00..1.03 rows=3 width=8)
+         ->  Hash  (cost=1.16..1.16 rows=3 width=4)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.04..1.16 rows=3 width=4)
+                     Hash Key: (o1.a1 + 1)
+                     ->  HashAggregate  (cost=1.04..1.07 rows=3 width=4)
+                           Group Key: o1.a1
+                           ->  Seq Scan on o1  (cost=0.00..1.03 rows=3 width=4)
+ Optimizer: Postgres-based planner
+(11 rows)
+
+select t2.b1 from (select distinct a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1+1;
+ b1 
+----
+  5
+  6
+  9
+   
+  2
+  3
+  4
+  7
+  8
+   
+(10 rows)
+
 -- Test case from community Github PR 13722
 create table t_13722(id int, tt timestamp)
   distributed by (id);

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3818,8 +3818,191 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
 (13 rows)
+
+-- Test hashed distribution spec derived from a self join
+truncate o1;
+truncate o2;
+insert into o1 select i, i from generate_series(1,9) i;
+insert into o1 values (NULL, NULL);
+insert into o2 select i, NULL from generate_series(11,100) i;
+insert into o2 values (NULL, NULL);
+analyze o1;
+analyze o2;
+-- Self join maintains the distribution keys from both children (i.e. the join
+-- result produces a combine hash distribution spec)
+--
+-- Expect no redistribute under the joins
+explain select t2.b1 from (select distinct a1 from o1) t1
+left outer join (select a1, b1 from o1) t2 on t1.a1 = t2.a1
+left outer join o1 t3 on t2.a1 = t3.a1
+left outer join o1 t4 on t2.a1 = t4.a1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=13 width=4)
+   ->  Hash Left Join  (cost=0.00..1724.00 rows=5 width=4)
+         Hash Cond: (o1.a1 = o1_3.a1)
+         ->  Hash Left Join  (cost=0.00..1293.00 rows=4 width=8)
+               Hash Cond: (o1.a1 = o1_2.a1)
+               ->  Hash Right Join  (cost=0.00..862.00 rows=4 width=8)
+                     Hash Cond: (o1.a1 = o1_1.a1)
+                     ->  Seq Scan on o1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=4)
+                                 Group Key: o1_1.a1
+                                 ->  Sort  (cost=0.00..431.00 rows=4 width=4)
+                                       Sort Key: o1_1.a1
+                                       ->  Seq Scan on o1 o1_1  (cost=0.00..431.00 rows=4 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on o1 o1_2  (cost=0.00..431.00 rows=4 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+               ->  Seq Scan on o1 o1_3  (cost=0.00..431.00 rows=4 width=4)
+ Optimizer: GPORCA
+(19 rows)
+
+select t2.b1 from (select distinct a1 from o1) t1
+left outer join (select a1, b1 from o1) t2 on t1.a1 = t2.a1
+left outer join o1 t3 on t2.a1 = t3.a1
+left outer join o1 t4 on t2.a1 = t4.a1;
+ b1 
+----
+  1
+  5
+  6
+  9
+  2
+  3
+  4
+  7
+  8
+   
+(10 rows)
+
+-- Self join maintains the distribution keys from both children (i.e. the join
+-- result produces a combine hash distribution spec)
+--
+-- Expect no redistribute under the joins
+explain (costs off) select t2.b1 from o1 t3
+right outer join (select a1, b1 from o1) t2 on t2.a1 = t3.a1
+right outer join o1 t4 on t2.a1 = t4.a1
+right outer join (select distinct a1 from o1) t1 on t1.a1 = t2.a1;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: (o1.a1 = o1_3.a1)
+         ->  Hash Right Join
+               Hash Cond: (o1.a1 = o1_2.a1)
+               ->  Hash Left Join
+                     Hash Cond: (o1.a1 = o1_1.a1)
+                     ->  Seq Scan on o1
+                     ->  Hash
+                           ->  Seq Scan on o1 o1_1
+               ->  Hash
+                     ->  Seq Scan on o1 o1_2
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: o1_3.a1
+                     ->  Sort
+                           Sort Key: o1_3.a1
+                           ->  Seq Scan on o1 o1_3
+ Optimizer: GPORCA
+(19 rows)
+
+select t2.b1 from o1 t3
+right outer join (select a1, b1 from o1) t2 on t2.a1 = t3.a1
+right outer join o1 t4 on t2.a1 = t4.a1
+right outer join (select distinct a1 from o1) t1 on t1.a1 = t2.a1;
+ b1 
+----
+  1
+  5
+  6
+  9
+  2
+  3
+  4
+  7
+  8
+   
+(10 rows)
+
+-- Self join, but the projected distribution key value is changed
+--
+-- Expect redistribute under the joins
+explain select t2.b1 from (select distinct a1+1 as a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=11 width=4)
+   ->  Hash Right Join  (cost=0.00..862.00 rows=4 width=4)
+         Hash Cond: (o1.a1 = ((o1_1.a1 + 1)))
+         ->  Seq Scan on o1  (cost=0.00..431.00 rows=4 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=4)
+                     Group Key: ((o1_1.a1 + 1))
+                     ->  Sort  (cost=0.00..431.00 rows=4 width=4)
+                           Sort Key: ((o1_1.a1 + 1))
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                 Hash Key: ((o1_1.a1 + 1))
+                                 ->  Seq Scan on o1 o1_1  (cost=0.00..431.00 rows=4 width=4)
+ Optimizer: GPORCA
+(13 rows)
+
+select t2.b1 from (select distinct a1+1 as a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1;
+ b1 
+----
+  2
+  3
+  4
+  7
+  8
+   
+  5
+  6
+  9
+   
+(10 rows)
+
+-- Self join, but the joined distribution key value is changed
+--
+-- Expect redistribute under the joins
+explain select t2.b1 from (select distinct a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1+1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=14 width=4)
+   ->  Hash Right Join  (cost=0.00..862.00 rows=5 width=4)
+         Hash Cond: (o1.a1 = (o1_1.a1 + 1))
+         ->  Seq Scan on o1  (cost=0.00..431.00 rows=4 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     Hash Key: (o1_1.a1 + 1)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=4 width=4)
+                           Group Key: o1_1.a1
+                           ->  Sort  (cost=0.00..431.00 rows=4 width=4)
+                                 Sort Key: o1_1.a1
+                                 ->  Seq Scan on o1 o1_1  (cost=0.00..431.00 rows=4 width=4)
+ Optimizer: GPORCA
+(13 rows)
+
+select t2.b1 from (select distinct a1 from o1) t1
+left outer join o1 t2 on t2.a1 = t1.a1+1;
+ b1 
+----
+  2
+  3
+  4
+  7
+  8
+   
+  5
+  6
+  9
+   
+(10 rows)
 
 -- Test case from community Github PR 13722
 create table t_13722(id int, tt timestamp)


### PR DESCRIPTION
In order to perform a join, a motion is required to shuffle the input
data when a join condition doesn't cover the distribution columns. If it
does cover the distribution columns then we can avoid the motion because
the matching data is already collocated on the segment and (for INNER
JOINS) the result set continues to be distributed by the distribution
columns.

Left-outer-join (LOJ) and right-outer-join (ROJ) may have NULLs in the
result set. That means that the result may not be distributed by the
distribution columns. However, if it's a self join, then there shouldn't
be non-collocated NULLs. That means that it is still distributed by the
distribution columns, too. This commit handles aforementioned special
case as demonstrated by following scenario:

```sql
  CREATE TABLE o1 (a1 int, b1 int) DISTRIBUTED BY (a1);

  EXPLAIN (COSTS OFF)
  SELECT * FROM (SELECT DISTINCT a1 FROM o1) t1
                 LEFT OUTER JOIN o1 t2 ON t1.a1 = t2.a1
                 LEFT OUTER JOIN o1 t3 ON t2.a1 = t3.a1;
```