### PR TITLE
Fix AO table fsync memory leak

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1430,6 +1430,8 @@ aosyncfiletag(const FileTag *ftag, char *path)
 {
 	SMgrRelation reln = smgropen(ftag->rnode, InvalidBackendId, 1);
 	char	   *p;
+	int			result,
+				save_errno;
 
 	/* Provide the path for informational messages. */
 	p = _mdfd_segpath(reln, ftag->forknum, ftag->segno);
@@ -1441,7 +1443,13 @@ aosyncfiletag(const FileTag *ftag, char *path)
 		elog(ERROR, "could not open file %s: %m", path);
 
 	/* Try to fsync the file. */
-	return FileSync(fd, WAIT_EVENT_DATA_FILE_SYNC);
+	result = FileSync(fd, WAIT_EVENT_DATA_FILE_SYNC);
+	save_errno = errno;
+
+	FileClose(fd);
+
+	errno = save_errno;
+	return result;
 }
 
 /*


### PR DESCRIPTION
AO table has its own fsync function `aosyncfiletag`, but it didn't call `FileClose` at the end, which will cause mirror segment's checkpointer process memory leak.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
