### PR TITLE
Disallow SUBPARTITION BY clause when creating empty partition hierarchy

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5461,6 +5461,10 @@ OptFirstPartitionSpec: PartitionSpec opt_list_subparts OptTabPartitionSpec
 					if ($1->gpPartDef)
 						check_expressions_in_partition_key($1, yyscanner);
 					$$ = $1;
+					/* Do not allow SUBPARTITION BY clause for empty partition hierarchy */
+					if (!$1->gpPartDef && $1->subPartSpec)
+						ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("SUBPARTITION BY clause is not allowed when no partitions specified at depth 1")));
 
 					pg_yyget_extra(yyscanner)->tail_partition_magic = true;
 				}
@@ -5488,6 +5492,12 @@ OptSecondPartitionSpec:
 					 */
 					if (n->gpPartDef)
 						check_expressions_in_partition_key(n, yyscanner);
+
+					/* Do not allow SUBPARTITION BY clause for empty partition hierarchy */
+					if (!n->gpPartDef && n->subPartSpec)
+						ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("SUBPARTITION BY clause is not allowed when no partitions specified at depth 1")));
+
 					$$ = n;
 
 					pg_yyget_extra(yyscanner)->tail_partition_magic = false;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6572,3 +6572,18 @@ SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHER
 (1 row)
 
 DROP TABLE public.logs_issue_16558;
+-- We should not allow subpartition by clause when creating empty partition hierarchy
+-- Should error out
+CREATE TABLE empty_partition_disallow_subpartition(i int, j int)
+PARTITION BY range(i) SUBPARTITION BY range(j);
+ERROR:  SUBPARTITION BY clause is not allowed when no partitions specified at depth 1
+-- Check with other Partition syntax
+CREATE TABLE empty_partition_disallow_subpartition_2(i int, j int)
+    DISTRIBUTED BY (i) PARTITION BY range(i) SUBPARTITION BY range(j);
+ERROR:  SUBPARTITION BY clause is not allowed when no partitions specified at depth 1
+-- Should work fine for empty hierarchy when subpartition is not specified
+CREATE TABLE empty_partition(i int, j int) PARTITION BY range(i);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check with other Partition syntax
+CREATE TABLE empty_partition2(i int, j int) DISTRIBUTED BY (i) PARTITION BY range(i);

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6543,3 +6543,18 @@ SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHER
 (1 row)
 
 DROP TABLE public.logs_issue_16558;
+-- We should not allow subpartition by clause when creating empty partition hierarchy
+-- Should error out
+CREATE TABLE empty_partition_disallow_subpartition(i int, j int)
+PARTITION BY range(i) SUBPARTITION BY range(j);
+ERROR:  SUBPARTITION BY clause is not allowed when no partitions specified at depth 1
+-- Check with other Partition syntax
+CREATE TABLE empty_partition_disallow_subpartition_2(i int, j int)
+    DISTRIBUTED BY (i) PARTITION BY range(i) SUBPARTITION BY range(j);
+ERROR:  SUBPARTITION BY clause is not allowed when no partitions specified at depth 1
+-- Should work fine for empty hierarchy when subpartition is not specified
+CREATE TABLE empty_partition(i int, j int) PARTITION BY range(i);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check with other Partition syntax
+CREATE TABLE empty_partition2(i int, j int) DISTRIBUTED BY (i) PARTITION BY range(i);

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4174,3 +4174,17 @@ ALTER TABLE public.logs_issue_16558 SET SUBPARTITION TEMPLATE
 SELECT level, pg_get_expr(template, relid, true) FROM gp_partition_template WHERE relid = 'public.logs_issue_16558'::regclass ORDER BY 1 DESC;
 DROP TABLE public.logs_issue_16558;
 
+-- We should not allow subpartition by clause when creating empty partition hierarchy
+-- Should error out
+CREATE TABLE empty_partition_disallow_subpartition(i int, j int)
+PARTITION BY range(i) SUBPARTITION BY range(j);
+
+-- Check with other Partition syntax
+CREATE TABLE empty_partition_disallow_subpartition_2(i int, j int)
+    DISTRIBUTED BY (i) PARTITION BY range(i) SUBPARTITION BY range(j);
+
+-- Should work fine for empty hierarchy when subpartition is not specified
+CREATE TABLE empty_partition(i int, j int) PARTITION BY range(i);
+
+-- Check with other Partition syntax
+CREATE TABLE empty_partition2(i int, j int) DISTRIBUTED BY (i) PARTITION BY range(i);


### PR DESCRIPTION
We should not allow subpartition by clause when creating empty partition hierarchy with modern syntax (`CREATE PARTITION BY` ... without creating any partitions and then later on adding partitions by `CREATE TABLE PARTITION OF`...).

Example:

`CREATE TABLE foo(i int, j int) PARTITION BY range(i) SUBPARTITION BY range(j);`
Here the info about subpart by j is lost.

This is because the info in the subpartition by clause is currently lost. Partitions attached henceforth don't obey the partition policy of the top level. So, ban it outright - it is a bad mixture of upstream and legacy syntax.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
