### PR TITLE
Improve sampling algorithm for AO/CO table

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -2704,7 +2704,7 @@ aoco_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
 			aoscan->targrow = currblk * AO_MAX_TUPLES_PER_HEAP_BLOCK + targetoffset - 1;
 			Assert(aoscan->targrow < totalrows);
 
-			if (aocs_get_target_tuple(aoscan, aoscan->targrow, slot))
+			if (aocs_get_target_tuple(aoscan, aoscan->targrow, slot, false))
 				return true;
 
 			/* tuple was deleted, loop around to try the next one */

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1696,14 +1696,6 @@ aoco_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
  * forward by n live tuples (ignoring all dead tuples in the scanning).
  * When RowSampler selected a tuple which is dead, continue to move globalOffset
  * till getting a live tuple.
- *
- * Peformance improvement:
- *
- * For now we use aocs_get_target_tuple() to walk through the table, which is
- * unnecessary because we need just to fetch live tuples. A visimap scan
- * without table scan will have better performance. However, it is not easy
- * to implement since the code of visimap scan ties to table scan heavily.
- * We can consider it for performance improvement in future.
  */
 static int
 aoco_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -133,6 +133,7 @@ bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
 bool		Debug_bitmap_print_insert = false;
+bool		Debug_aocotbl_sampling_notablescan = false;
 bool		Test_print_direct_dispatch_info = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
@@ -1468,6 +1469,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_bitmap_print_insert,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"debug_aocotbl_sampling_notablescan", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Don't perform table scan for aoco table sampling, may cause incorrect sampling result"),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_aocotbl_sampling_notablescan,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -416,7 +416,10 @@ extern void aocs_delete_finish(AOCSDeleteDesc desc);
 
 extern AOCSHeaderScanDesc aocs_begin_headerscan(
 		Relation rel, int colno);
-extern bool aocs_get_target_tuple(AOCSScanDesc aoscan, int64 targrow, TupleTableSlot *slot);
+extern bool aocs_get_target_tuple(AOCSScanDesc aoscan,
+								  int64 targrow,
+								  TupleTableSlot *slot,
+								  bool checkVisiOnly);
 extern AOCSWriteColumnDesc aocs_writecol_init(Relation rel, List *newvals, AOCSWriteColumnOperation op);
 extern void aocs_writecol_add(Oid relid, List *newvals, List *constraints, TupleDesc oldDesc);
 extern void aocs_writecol_rewrite(Oid relid, List *newvals, TupleDesc oldDesc);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -282,6 +282,7 @@ extern bool Debug_appendonly_print_datumstream;
 extern bool Debug_appendonly_print_visimap;
 extern bool Debug_appendonly_print_compaction;
 extern bool Debug_bitmap_print_insert;
+extern bool Debug_aocotbl_sampling_notablescan;
 extern bool enable_checksum_on_tables;
 extern int  gp_max_local_distributed_cache;
 extern bool gp_local_distributed_cache_stats;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -26,6 +26,7 @@
 		"debug_appendonly_print_verify_write_block",
 		"debug_appendonly_print_visimap",
 		"debug_appendonly_use_no_toast",
+		"debug_aocotbl_sampling_notablescan",
 		"default_table_access_method",
 		"default_tablespace",
 		"dml_ignore_target_partition_check",


### PR DESCRIPTION
The PR is from this issue: https://github.com/greenplum-db/gpdb/issues/15655

### Issue

When sampling tuples in ANALYZE an AO/CO table, if the sample row number was pointing to a dead tuple, we count this dead row as the current sample slot, instead of skipping it and continuing to get the next live row for this sample slot like Heap. We need to improve the sampling algorithm to select only live tuples.

The PR is for aoco table code path only. There is another code path (`appendonly_acquire_sample_rows()`) for append-only table, and I will open another PR to handle it.

### Basic algorithm

Let `RowSampler` works in the scope of a "filtered" table which includes only live tuples. e.g. there is a table with 100 tuples including 30 live tuples and 70 dead tuples. `RowSampler` can "see" a table with only 30 tuples.

Use a global cursor (`globalOffset`) to remember the actual position. When `RowSampler` skipped `n` tuples before a selecting, move `globalOffset` forward by `n` live tuples (ignoring all dead tuples in the scanning). When `RowSampler` selected a tuple which is dead, continue to move `globalOffset` till getting a live tuple.

### Peformance improvement

The new algorithm can guarantee that all selected tuples are live, and the algorithm of `RowSampler` works as design regardless of layout of live tuples. However, it causes performance regression because we have to perform table scan to read all the live and dead tuples.

For now we use `aocs_get_target_tuple()` to walk through the table, which is unnecessary because we need just to fetch live tuples. **A visimap scan without table scan** will have better performance. However, it is not easy to implement since the code of visimap scan ties to table scan heavily. I tried for a couple of hours and gave up finally because too much effort is needed. We can consider it for performance improvement in future.

### Performance test

Script:

```
drop table aoco1;
create table aoco1 (a int, b int, c int) with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=3);
insert into aoco1 select i,i,i from generate_series(1,10000000)i;
create index on aoco1(a);
delete from aoco1 where a % 4 = 0; -- generate a table with 3/4 live tuples
delete from aoco1 where (a % 4 = 1) or (a % 4 = 2); -- generate a table with 1/4 live tuples
analyze aoco1;
```

Performance:

Old code:

Full table: 468.623 ms
1/4 live tuples: 120.299 ms

New code:

Full table: 1053.901 ms
1/4 live tuples: 910.012 ms

New code is much slower than old code, because new code reads more than 3.3m tuples (on each seg), but old code reads only 10000 tuples.