### PR TITLE
Do not throw error for INSERT into a table w/ foreign key constraint

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2710,9 +2710,6 @@ ExecARInsertTriggers(EState *estate, ResultRelInfo *relinfo,
 	if ((trigdesc && trigdesc->trig_insert_after_row) ||
 		(transition_capture && transition_capture->tcs_insert_new_table))
 	{
-		if(RelationIsAoCols(relinfo->ri_RelationDesc))
-			elog(ERROR, "Trigger is not supported on AOCS yet");
-
 		AfterTriggerSaveEvent(estate, relinfo, TRIGGER_EVENT_INSERT,
 							  true, NULL, slot,
 							  recheckIndexes, NULL,

--- a/src/test/regress/expected/foreign_key_gp.out
+++ b/src/test/regress/expected/foreign_key_gp.out
@@ -1,0 +1,12 @@
+--
+-- GPDB currently does not support foreign key constraints: table can be created
+-- with the constraints, but they won't be enforced. Tables operations will ignore
+-- the constraints. We should not see errors.
+--
+CREATE TABLE fk_ref(id int primary key);
+CREATE TABLE fk_heap(id int references fk_ref);
+CREATE TABLE fk_ao(id int references fk_ref) USING ao_row;
+CREATE TABLE fk_co(id int references fk_ref) USING ao_column;
+INSERT INTO fk_heap VALUES (1);
+INSERT INTO fk_ao VALUES (1);
+INSERT INTO fk_co VALUES (1);

--- a/src/test/regress/expected/triggers_gp.out
+++ b/src/test/regress/expected/triggers_gp.out
@@ -102,3 +102,15 @@ ERROR:  UPDATE on distributed key column not allowed on relation with update tri
 -- Should fire the DELETE trigger.
 delete from parted_trig where nonkey = 2;
 NOTICE:  delete trigger fired on parted_trig2 for DELETE  (seg0 127.0.0.1:40000 pid=10559)
+--
+-- Triggers on AO/CO table.
+-- Currently disabled.
+--
+create table trigtest_ao(a int) using ao_row;
+create table trigtest_co(a int) using ao_column;
+create trigger trig_ao after insert on trigtest_ao for each row execute function insert_notice_trig();
+create trigger trig_co after insert on trigtest_co for each row execute function insert_notice_trig();
+insert into trigtest_ao values(1);
+ERROR:  feature not supported on appendoptimized relations
+insert into trigtest_co values(1);
+ERROR:  feature not supported on appendoptimized relations

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -51,7 +51,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types combocid_gp gp_sort gp_prepared_xacts gp_backend_info gp_locale
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types combocid_gp gp_sort gp_prepared_xacts gp_backend_info gp_locale foreign_key_gp
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -134,6 +134,7 @@ test: select_views portals_p2 cluster dependency guc bitmapops combocid tsearch 
 
 # 'foreign_key' test is disabled, because it contains several tables with
 # multiple UNIQUE constraints, which is not supported in GPDB.
+# See the foreign_key_gp test in greenplum_schedule for the GPDB-specific behavior.
 #test: foreign_key
 
 # ----------

--- a/src/test/regress/sql/foreign_key_gp.sql
+++ b/src/test/regress/sql/foreign_key_gp.sql
@@ -1,0 +1,13 @@
+--
+-- GPDB currently does not support foreign key constraints: table can be created
+-- with the constraints, but they won't be enforced. Tables operations will ignore
+-- the constraints. We should not see errors.
+--
+CREATE TABLE fk_ref(id int primary key);
+CREATE TABLE fk_heap(id int references fk_ref);
+CREATE TABLE fk_ao(id int references fk_ref) USING ao_row;
+CREATE TABLE fk_co(id int references fk_ref) USING ao_column;
+INSERT INTO fk_heap VALUES (1);
+INSERT INTO fk_ao VALUES (1);
+INSERT INTO fk_co VALUES (1);
+

--- a/src/test/regress/sql/triggers_gp.sql
+++ b/src/test/regress/sql/triggers_gp.sql
@@ -104,3 +104,14 @@ update parted_trig set partkey = partkey + 1, distkey = distkey + 1;
 
 -- Should fire the DELETE trigger.
 delete from parted_trig where nonkey = 2;
+
+--
+-- Triggers on AO/CO table.
+-- Currently disabled.
+--
+create table trigtest_ao(a int) using ao_row;
+create table trigtest_co(a int) using ao_column;
+create trigger trig_ao after insert on trigtest_ao for each row execute function insert_notice_trig();
+create trigger trig_co after insert on trigtest_co for each row execute function insert_notice_trig();
+insert into trigtest_ao values(1);
+insert into trigtest_co values(1);


### PR DESCRIPTION
Foreign key constraint is not supported in GPDB. However, the expected behavior is that we should ignore the constraint and there shouldn't be errors.

But before this commit we would encounter an ERROR when performing INSERT on an AOCO table that has foreign key constraint:

```sql
CREATE TABLE a(id int primary key);
CREATE TABLE b(id int references a) WITH (appendonly=true, orientation=column); 
WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced

INSERT INTO b VALUES (1);
ERROR:  Trigger is not supported on AOCS yet (trigger.c:2714)  (seg4 #######:16004 pid=3948271) (trigger.c:2714)
```

The error message, which was for the purpose of disabling row trigger for AO/CO tables, got in the way of ignoring foreign key constraint. Further investigation in the code history reveals that the error message was an outdated one which is no longer needed due to other errors that disable row trigger for AO/CO tables. Delete the error message now and add test cases.

Fix #16770.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/insert-fail-fk

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
