### PR TITLE
Keep partition child lock until end of select

### DIFF
--- a/.abi-check/6.26.2/postgres.symbols.ignore
+++ b/.abi-check/6.26.2/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -301,6 +301,9 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT(
 		 "Explore a nested loop join even if a hash join is possible")},
+	{EopttraceKeepPartitionChildrenLocks, &gp_keep_partition_children_locks,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT("Keep locks on partition children during planning")},
 
 };
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -30,6 +30,7 @@
 #include "naucrates/exception.h"
 extern "C" {
 #include "catalog/pg_collation.h"
+#include "catalog/pg_inherits_fn.h"
 #include "utils/memutils.h"
 }
 #define GP_WRAP_START                                            \
@@ -2733,6 +2734,49 @@ gpdb::IsTypeRange(Oid typid)
 	}
 	GP_WRAP_END;
 	return false;
+}
+
+RowMarkClause *
+gpdb::GetParseRowmark(Query *query, Index rtindex)
+{
+	GP_WRAP_START;
+	{
+		get_parse_rowmark(query, rtindex);
+	}
+	GP_WRAP_END;
+	return nullptr;
+}
+
+List *
+gpdb::FindAllInheritors(Oid parentrelId, LOCKMODE lockmode, List **numparents)
+{
+	GP_WRAP_START;
+	{
+		return find_all_inheritors(parentrelId, lockmode, numparents);
+	}
+	GP_WRAP_END;
+	return nullptr;
+}
+
+gpos::BOOL
+gpdb::WalkQueryTree(Query *query, bool (*walker)(), void *context, int flags)
+{
+	GP_WRAP_START;
+	{
+		return query_tree_walker(query, walker, context, flags);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
+void
+gpdb::GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode)
+{
+	GP_WRAP_START;
+	{
+		LockRelationOid(reloid, lockmode);
+	}
+	GP_WRAP_END;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -44,7 +44,7 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 	CMemoryPool *mp, CIdGenerator *plan_id_counter,
 	CIdGenerator *motion_id_counter, CIdGenerator *param_id_counter,
 	DistributionHashOpsKind distribution_hashops, List **rtable_entries_list,
-	List **subplan_entries_list)
+	List **subplan_entries_list, const Query *orig_query)
 	: m_mp(mp),
 	  m_plan_id_counter(plan_id_counter),
 	  m_motion_id_counter(motion_id_counter),
@@ -56,7 +56,8 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 	  m_subplan_entries_list(subplan_entries_list),
 	  m_result_relation_index(0),
 	  m_into_clause(NULL),
-	  m_distribution_policy(NULL)
+	  m_distribution_policy(NULL),
+	  m_orig_query(orig_query)
 {
 	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
 	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -301,7 +301,7 @@ COptTasks::ConvertToPlanStmtFromDXL(
 
 	CContextDXLToPlStmt dxl_to_plan_stmt_ctxt(
 		mp, &plan_id_generator, &motion_id_generator, &param_id_generator,
-		distribution_hashops, &table_list, &subplans_list);
+		distribution_hashops, &table_list, &subplans_list, orig_query);
 
 	// translate DXL -> PlannedStmt
 	CTranslatorDXLToPlStmt dxl_to_plan_stmt_translator(

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -228,6 +228,9 @@ enum EOptTraceFlag
 	// Discard HashJoin with RedistributeMotion nodes
 	EopttraceDiscardRedistributeHashJoin = 103044,
 
+	// Keep locks on partition children during planning
+	EopttraceKeepPartitionChildrenLocks = 103045,
+
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////
 	//////////////////////////////////////////////////////

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -57,7 +57,7 @@
 #include "cdb/cdbsetop.h"
 #include "cdb/cdbvars.h"
 #include "commands/tablecmds.h"
-
+#include "utils/guc.h"
 
 typedef struct
 {
@@ -1384,6 +1384,7 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 	List	   *appinfos;
 	ListCell   *l;
 	bool		parent_is_partitioned;
+	bool            parent_is_interior_partition;
 	Relids		child_relids = NULL;
 
 	/* Does RT entry allow inheritance? */
@@ -1405,6 +1406,7 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 	}
 
 	parent_is_partitioned = rel_is_partitioned(parentOID);
+	parent_is_interior_partition = rel_is_interior_partition(parentOID);
 
 	/*
 	 * The rewriter should already have obtained an appropriate lock on each
@@ -1556,9 +1558,36 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 			root->rowMarks = lappend(root->rowMarks, newrc);
 		}
 
-		/* Close child relations, but keep locks */
 		if (childOID != parentOID)
-			heap_close(newrelation, rel_needs_long_lock(childOID) ? NoLock: lockmode);
+		{
+			LOCKMODE	releaseLockMode;
+
+			/*
+			 * GPDB: Decide whether we should relinquish locks on children.
+			 *
+			 * If gp_keep_partition_children_locks is on, and we have an AO child,
+			 * then we keep the lock. This is the preferred behavior for strict
+			 * correctness for concurrent AO vacuums.
+			 *
+			 * Otherwise, we defer to rel_needs_long_lock(), which taps into the
+			 * GP specific optimization of locking only the parent in a partition
+			 * hierarchy, to save on memory and lock consumption inside a tx.
+			 * For example, if we didn't release the locks here, and we were
+			 * doing a join between two partition roots, with say P1 and P2
+			 * number of children, we would have (P1 + P2) locks being held till
+			 * end of command. Similarly, in the same transaction if we operate
+			 * on these 2 partition hierarchies in any way, we would be holding
+			 * (P1 + P2) locks till the end of the transaction.
+			 */
+			if (RelationIsAppendOptimized(newrelation) &&
+				(parent_is_partitioned || parent_is_interior_partition) &&
+				gp_keep_partition_children_locks)
+				releaseLockMode = NoLock;
+			else
+				releaseLockMode = rel_needs_long_lock(childOID) ? NoLock: lockmode;
+
+			heap_close(newrelation, releaseLockMode);
+		}
 	}
 
 	heap_close(oldrelation, NoLock);

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -666,6 +666,9 @@ PortalStart(Portal portal, ParamListInfo params,
 											params,
 											GP_INSTRUMENT_OPTS);
 				queryDesc->ddesc = ddesc;
+
+				/* Inject fault to check locks on table when select portal is created */
+				SIMPLE_FAULT_INJECTOR("locks_check_at_select_portal_create");
 				
 				if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
 				{			

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -161,6 +161,7 @@ bool		gp_log_suboverflow_statement = false;
 bool        gp_use_synchronize_seqscans_catalog_vacuum_full = false;
 
 bool		log_dispatch_stats = false;
+bool		gp_keep_partition_children_locks = false;
 
 int			explain_memory_verbosity = 0;
 char	   *memory_profiler_run_id = "none";
@@ -3341,6 +3342,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			&gp_detect_data_correctness,
 			false,
 			NULL, NULL, NULL
+	},
+
+	{
+		{"gp_keep_partition_children_locks", PGC_USERSET, QUERY_TUNING_METHOD,
+		 gettext_noop("Keep locks on partition children during planning"),
+		 NULL
+		},
+		&gp_keep_partition_children_locks,
+		false,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "access/attnum.h"
 #include "nodes/plannodes.h"
 #include "parser/parse_coerce.h"
+#include "storage/lmgr.h"
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 }
@@ -709,6 +710,15 @@ MemoryContext GPDBAllocSetContextCreate();
 void GPDBMemoryContextDelete(MemoryContext context);
 
 bool IsTypeRange(Oid typid);
+
+RowMarkClause *GetParseRowmark(Query *query, Index rtindex);
+
+List *FindAllInheritors(Oid parentrelId, LOCKMODE lockmode, List **numparents);
+
+gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
+						 int flags);
+
+void GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode);
 
 }  //namespace gpdb
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -128,14 +128,16 @@ private:
 	// CTAS distribution policy
 	GpPolicy *m_distribution_policy;
 
+	const Query *m_orig_query;
+
 public:
 	// ctor/dtor
 	CContextDXLToPlStmt(CMemoryPool *mp, CIdGenerator *plan_id_counter,
 						CIdGenerator *motion_id_counter,
 						CIdGenerator *param_id_counter,
 						DistributionHashOpsKind distribution_hashops,
-						List **rtable_entries_list,
-						List **subplan_entries_list);
+						List **rtable_entries_list, List **subplan_entries_list,
+						const Query *orig_query);
 
 	// dtor
 	~CContextDXLToPlStmt();
@@ -215,6 +217,12 @@ public:
 	// based on decision made by DetermineDistributionHashOpclasses()
 	Oid GetDistributionHashOpclassForType(Oid typid);
 	Oid GetDistributionHashFuncForType(Oid typid);
+
+	const Query *
+	GetQuery() const
+	{
+		return m_orig_query;
+	}
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -160,6 +160,10 @@ private:
 	static BOOL SetIndexVarAttnoWalker(
 		Node *node, SContextIndexVarAttno *ctxt_index_var_attno_walker);
 
+	static BOOL AcquireLocksOnChildAORelations(Query *parsetree, OID oidRel);
+
+	static BOOL AcquireLocksOnChildAORelationsWalker(Node *node, OID *oidRel);
+
 public:
 	// ctor
 	CTranslatorDXLToPlStmt(CMemoryPool *mp, CMDAccessor *md_accessor,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -354,6 +354,7 @@ extern int gp_max_partition_level;
 extern bool gp_perfmon_print_packet_info;
 
 extern bool gp_enable_relsize_collection;
+extern bool gp_keep_partition_children_locks;
 
 /* Debug DTM Action */
 typedef enum

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -211,6 +211,7 @@
 		"gp_interconnect_cache_future_packets",
 		"gp_is_writer",
 		"gp_keep_all_xlog",
+		"gp_keep_partition_children_locks",
 		"gp_local_distributed_cache_stats",
 		"gp_log_dynamic_partition_pruning",
 		"gp_log_format",

--- a/src/test/isolation2/expected/concurrent_select_vacuum_ao_partitioned_table.out
+++ b/src/test/isolation2/expected/concurrent_select_vacuum_ao_partitioned_table.out
@@ -1,0 +1,235 @@
+-- Ensure that a SELECT tx on a partition hierarchy comprised of AO tables, that
+-- predates a concurrent vacuum doesn't error out, because the tuples have moved
+-- to a new segfile and it doesn't know about it.
+
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM foo_part;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- Test for Dynamic Bitmap Heap Scan
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+create index ind1 on foo_part using btree(a);
+CREATE
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+1: SET enable_seqscan to off;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM foo_part where a>=1;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- RTE inside CTE
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: WITH cte AS (SELECT * FROM foo_part) SELECT * FROM cte;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- RTE inside SUBLINK
+CREATE TABLE bar ( p int);
+CREATE
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+INSERT INTO bar SELECT 1;
+INSERT 1
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT bar.p FROM bar WHERE bar.p IN (SELECT a FROM foo_part);  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ p 
+---
+ 1 
+(1 row)
+DROP TABLE foo_part;
+DROP
+DROP TABLE bar;
+DROP
+
+-- Testing multilevel partitions
+CREATE TABLE foo_part(a int, b int, c int) WITH (APPENDONLY = true) DISTRIBUTED BY (a) PARTITION BY RANGE (b) SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE ( start (1) inclusive end (2) inclusive every (1)) ( start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+INSERT INTO foo_part SELECT 1, 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 1, 2;
+INSERT 1
+DELETE FROM foo_part WHERE c = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * from foo_part_1_prt_1;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1_2_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b | c 
+---+---+---
+ 1 | 1 | 2 
+(1 row)
+DROP TABLE foo_part;

--- a/src/test/isolation2/expected/concurrent_select_vacuum_ao_partitioned_table_optimizer.out
+++ b/src/test/isolation2/expected/concurrent_select_vacuum_ao_partitioned_table_optimizer.out
@@ -1,0 +1,235 @@
+-- Ensure that a SELECT tx on a partition hierarchy comprised of AO tables, that
+-- predates a concurrent vacuum doesn't error out, because the tuples have moved
+-- to a new segfile and it doesn't know about it.
+
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM foo_part;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- Test for Dynamic Bitmap Heap Scan
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+create index ind1 on foo_part using btree(a);
+CREATE
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+1: SET enable_seqscan to off;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM foo_part where a>=1;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- RTE inside CTE
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: WITH cte AS (SELECT * FROM foo_part) SELECT * FROM cte;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+DROP TABLE foo_part;
+DROP
+
+-- RTE inside SUBLINK
+CREATE TABLE bar ( p int);
+CREATE
+CREATE TABLE foo_part (a int, b int) WITH (appendonly=true) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+INSERT INTO bar SELECT 1;
+INSERT 1
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT bar.p FROM bar WHERE bar.p IN (SELECT a FROM foo_part);  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ p 
+---
+ 1 
+(1 row)
+DROP TABLE foo_part;
+DROP
+DROP TABLE bar;
+DROP
+
+-- Testing multilevel partitions
+CREATE TABLE foo_part(a int, b int, c int) WITH (APPENDONLY = true) DISTRIBUTED BY (a) PARTITION BY RANGE (b) SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE ( start (1) inclusive end (2) inclusive every (1)) ( start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+INSERT INTO foo_part SELECT 1, 1, 1;
+INSERT 1
+INSERT INTO foo_part SELECT 1, 1, 2;
+INSERT 1
+DELETE FROM foo_part WHERE c = 1;
+DELETE 1
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * from foo_part_1_prt_1;  <waiting ...>
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1_2_prt_1;
+VACUUM
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b | c 
+---+---+---
+ 1 | 1 | 2 
+(1 row)
+DROP TABLE foo_part;

--- a/src/test/isolation2/input/uao/select_while_vacuum.source
+++ b/src/test/isolation2/input/uao/select_while_vacuum.source
@@ -30,3 +30,46 @@ DELETE FROM ao WHERE a < 128;
 2: VACUUM ao;
 1<:
 3: INSERT INTO ao VALUES (0);
+
+-- Ensure that a SELECT tx on a partition hierarchy comprised of AO tables, that
+-- predates a concurrent vacuum doesn't error out, because the tuples have moved
+-- to a new segfile and it doesn't know about it.
+
+CREATE TABLE ao_vacuum_drop_@orientation@ (a int, b int)
+    WITH (appendonly=true, orientation=@orientation@) PARTITION BY range(a)
+    (start (1) inclusive end (2) inclusive every (1));
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 1;
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 2;
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM ao_vacuum_drop_@orientation@ WHERE b = 1;
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+
+1: SET gp_keep_partition_children_locks TO on;
+SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+    FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: SELECT * FROM ao_vacuum_drop_@orientation@;
+SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE ao_vacuum_drop_@orientation@_1_prt_1;
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+
+SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+    FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+
+-- Smoke test: check to see if insert still works.
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 3;
+SELECT * FROM ao_vacuum_drop_@orientation@;
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+
+-- VACUUM now should be able to drop the sefile pending drop.
+VACUUM ao_vacuum_drop_@orientation@_1_prt_1;
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -308,6 +308,9 @@ test: standby_replay_dtx_info
 # Test for concurrent vacuum with delete
 test: concurrent_vacuum_with_delete
 
+# Test for concurrent vacuum with select
+test: concurrent_select_vacuum_ao_partitioned_table
+
 # test if GUC is synchronized from the QD to QEs.
 test: sync_guc
 

--- a/src/test/isolation2/output/uao/select_while_vacuum.source
+++ b/src/test/isolation2/output/uao/select_while_vacuum.source
@@ -58,3 +58,90 @@ VACUUM
 SELECT
 3: INSERT INTO ao VALUES (0);
 INSERT 1
+
+-- Ensure that a SELECT tx on a partition hierarchy comprised of AO tables, that
+-- predates a concurrent vacuum doesn't error out, because the tuples have moved
+-- to a new segfile and it doesn't know about it.
+
+CREATE TABLE ao_vacuum_drop_@orientation@ (a int, b int) WITH (appendonly=true, orientation=@orientation@) PARTITION BY range(a) (start (1) inclusive end (2) inclusive every (1));
+CREATE
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 1;
+INSERT 1
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 2;
+INSERT 1
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM ao_vacuum_drop_@orientation@ WHERE b = 1;
+DELETE 1
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 2        | 1     
+(1 row)
+
+1: SET gp_keep_partition_children_locks TO on;
+SET
+SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM ao_vacuum_drop_@orientation@;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE ao_vacuum_drop_@orientation@_1_prt_1;
+VACUUM
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 2        | 2     
+ 2     | 1        | 1     
+(2 rows)
+
+SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid) FROM gp_segment_configuration c WHERE role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a | b 
+---+---
+ 1 | 2 
+(1 row)
+
+-- Smoke test: check to see if insert still works.
+INSERT INTO ao_vacuum_drop_@orientation@ SELECT 1, 3;
+INSERT 1
+SELECT * FROM ao_vacuum_drop_@orientation@;
+ a | b 
+---+---
+ 1 | 2 
+ 1 | 3 
+(2 rows)
+
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 2        | 2     
+ 2     | 2        | 1     
+(2 rows)
+
+-- VACUUM now should be able to drop the sefile pending drop.
+VACUUM ao_vacuum_drop_@orientation@_1_prt_1;
+VACUUM
+1U: SELECT segno, tupcount,state FROM gp_ao_or_aocs_seg('ao_vacuum_drop_@orientation@_1_prt_1');
+ segno | tupcount | state 
+-------+----------+-------
+ 1     | 0        | 1     
+ 2     | 2        | 1     
+ 3     | 0        | 1     
+(3 rows)

--- a/src/test/isolation2/sql/concurrent_select_vacuum_ao_partitioned_table.sql
+++ b/src/test/isolation2/sql/concurrent_select_vacuum_ao_partitioned_table.sql
@@ -1,0 +1,146 @@
+-- Ensure that a SELECT tx on a partition hierarchy comprised of AO tables, that
+-- predates a concurrent vacuum doesn't error out, because the tuples have moved
+-- to a new segfile and it doesn't know about it.
+
+CREATE TABLE foo_part (a int, b int)
+    WITH (appendonly=true) PARTITION BY range(a)
+(start (1) inclusive end (2) inclusive every (1));
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT INTO foo_part SELECT 1, 2;
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+
+1: SET gp_keep_partition_children_locks TO on;
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: SELECT * FROM foo_part;
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+   FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+DROP TABLE foo_part;
+
+-- Test for Dynamic Bitmap Heap Scan
+CREATE TABLE foo_part (a int, b int)
+    WITH (appendonly=true) PARTITION BY range(a)
+(start (1) inclusive end (2) inclusive every (1));
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT INTO foo_part SELECT 1, 2;
+create index ind1 on foo_part using btree(a);
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+
+
+1: SET gp_keep_partition_children_locks TO on;
+1: SET enable_seqscan to off;
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: SELECT * FROM foo_part where a>=1;
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+   FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+DROP TABLE foo_part;
+
+-- RTE inside CTE
+CREATE TABLE foo_part (a int, b int)
+    WITH (appendonly=true) PARTITION BY range(a)
+(start (1) inclusive end (2) inclusive every (1));
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT INTO foo_part SELECT 1, 2;
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+
+1: SET gp_keep_partition_children_locks TO on;
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: WITH cte AS (SELECT * FROM foo_part) SELECT * FROM cte;
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+   FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+DROP TABLE foo_part;
+
+-- RTE inside SUBLINK
+CREATE TABLE bar ( p int);
+CREATE TABLE foo_part (a int, b int)
+    WITH (appendonly=true) PARTITION BY range(a)
+(start (1) inclusive end (2) inclusive every (1));
+INSERT INTO bar SELECT 1;
+
+-- Insert 2 rows into the 1st partition on a single QE.
+INSERT INTO foo_part SELECT 1, 1;
+INSERT INTO foo_part SELECT 1, 2;
+-- Delete 1 row from the first partition on a single QE.
+DELETE FROM foo_part WHERE b = 1;
+
+1: SET gp_keep_partition_children_locks TO on;
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: SELECT bar.p FROM bar WHERE bar.p IN (SELECT a FROM foo_part);
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+   FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1;
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+DROP TABLE foo_part;
+DROP TABLE bar;
+
+-- Testing multilevel partitions
+CREATE TABLE foo_part(a int, b int, c int)
+WITH (APPENDONLY = true)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+SUBPARTITION BY RANGE (c)
+SUBPARTITION TEMPLATE (
+start (1) inclusive end (2) inclusive every (1))
+( start (1) inclusive end (2) inclusive every (1));
+
+INSERT INTO foo_part SELECT 1, 1, 1;
+INSERT INTO foo_part SELECT 1, 1, 2;
+DELETE FROM foo_part WHERE c = 1;
+
+1: SET gp_keep_partition_children_locks TO on;
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'suspend', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+1&: SELECT * from foo_part_1_prt_1;
+2: SELECT gp_wait_until_triggered_fault('locks_check_at_select_portal_create', 1, dbid)
+   FROM gp_segment_configuration WHERE role='p' AND content = -1;
+
+-- VACUUM shouldn't drop the files and SELECT should complete fine
+VACUUM ANALYZE foo_part_1_prt_1_2_prt_1;
+
+2: SELECT gp_inject_fault('locks_check_at_select_portal_create', 'reset', c.dbid)
+   FROM gp_segment_configuration c WHERE role='p' and content=-1;
+
+1<:
+DROP TABLE foo_part;


### PR DESCRIPTION
Introduce a new GUC gp_keep_partition_children_locks that preserves
relation locks on AO partition leaves, that are taken during planning.

This fixes concurrency issues such as #16545, where a SELECT pre-dating
a concurrent lazy vacuum can read past eof of a segfile, since the
vacuum would "drop" the segment. Adequate locking during planning is one
way to ensure that vacuumStatement_Relation() can't acquire the
AccessExclusiveLock on the coordinator. This would cause it to give up
on the drop, and the concurrent SELECT isn't compromised.

Unfortunately, we can't quite mark this GUC on by default, as it has
consequences on the amount of locks consumed:

Setting this GUC on means that we keep the acquired locks in
expand_inherited_rtentry() around longer now, up until the end of the
transaction. This can have consequences for transactions dealing with a
large number of partitions, leading us to inch closer to the
max_locks_per_transaction limit. Joins/unions etc with large partition
tables now consume more locks than before.

Notes:
(0) This conforms locking behavior to upstream behavior, that we have
in 7X (for append-optimized relations).

(1) For ORCA, we take the locks during DXL to planned statement
translation, borrowing from expand_inherited_rtentry().

(2) Unlike 7X, neither ORCA nor planner considers the statically pruned
list of partitions for locking.

(3) Currently these locks are taken only for append-optimized leaves,
but the GUC can easily be extended to cover heap tables as well, as
similar concurrency issues do exist.

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Dev Chattopadhyay <cdev@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_vacuum_select
