### PR TITLE
7X: remove ereport()/elog() from signal handler

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3960,8 +3960,6 @@ ProcessInterrupts(const char* filename, int lineno)
 		bool		lock_timeout_occurred;
 		bool		stmt_timeout_occurred;
 
-		elog(LOG,"Process interrupt for 'query cancel pending' (%s:%d)", filename, lineno);
-
 		QueryCancelPending = false;
 
 		/*

--- a/src/backend/tcop/test/postgres_test.c
+++ b/src/backend/tcop/test/postgres_test.c
@@ -115,8 +115,6 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	QueryCancelPending = true;
 	DoingCommandRead = true;
 
-	EXPECT_EREPORT(LOG);
-
 	ProcessInterrupts(__FILE__, __LINE__);
 
 	assert_false(QueryCancelPending);
@@ -128,7 +126,6 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	QueryCancelPending = true;
 	DoingCommandRead = false;
 
-	EXPECT_EREPORT(LOG);
 	EXPECT_EREPORT(ERROR);
 
 	PG_TRY();


### PR DESCRIPTION
It's a forward-port of https://github.com/greenplum-db/gpdb/pull/16750

It doesn't include "Removing ereport() from StatementCancelHandler()" since the code doesn't exist on 7X.
