### PR TITLE
Fix gpcheckcat 'oid does not exist' error for catalog tables

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2423,6 +2423,10 @@ TableMainColumn['pg_statistic_ext_data'] = ['stxoid', 'pg_statistic_ext']
 TableMainColumn['pg_type_encoding'] = ['typid', 'pg_type']
 TableMainColumn['pg_window'] = ['winfnoid', 'pg_proc']
 TableMainColumn['pg_description'] = ['objoid', 'pg_description']
+TableMainColumn['pg_shdescription'] = ['objoid', 'pg_shdescription']
+TableMainColumn['pg_seclabel'] = ['objoid', 'pg_seclabel']
+TableMainColumn['pg_shseclabel'] = ['objoid', 'pg_shseclabel']
+TableMainColumn['pg_seclabels'] = ['objoid', 'pg_seclabels']
 
 # Table with OID (special case), these OIDs are known to be inconsistent
 TableMainColumn['pg_attrdef'] = ['adrelid', 'pg_class']

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -730,18 +730,23 @@ Feature: gpcheckcat tests
             | attrname   | tablename          |
             | relname    | pg_class           |
 
-    Scenario: gpcheckcat should discover missing attributes of pg_description catalogue table
-        Given there is a "heap" table "public.heap_table" in "miss_attr_db5" with data and description
-        When the user runs "gpcheckcat -v miss_attr_db5"
-        And gpcheckcat should return a return code of 0
-        Then gpcheckcat should not print "Missing" to stdout
-        And the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_description where objoid='heap_table'::regclass::oid;""
+    Scenario: gpcheckcat should discover missing attributes of pg_description and pg_shdescription catalogue table without errors
+        Given database "miss_attr_db5" is dropped and recreated
+        And there is a "heap" table "public.heap_table" in "miss_attr_db5" with data and description
+        And a tablespace is created with data and description
+        When the user runs "gpcheckcat miss_attr_db5"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "Missing" to stdout
+        When the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_description where objoid='heap_table'::regclass::oid;""
         Then psql should return a return code of 0
-        When the user runs "gpcheckcat -v miss_attr_db5"
+        When the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_shdescription where objoid=(SELECT oid from pg_tablespace where spcname='outerspace');""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat miss_attr_db5"
         Then gpcheckcat should print "Missing description metadata of {.*} on content -1" to stdout
         And gpcheckcat should not print "Execution error:" to stdout
         And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_description" to stdout
-
+        Then gpcheckcat should print "Missing shdescription metadata of {.*} on content -1" to stdout
+        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_shdescription" to stdout
 
     Scenario: set multiple GUC at session level in gpcheckcat
         Given database "all_good" is dropped and recreated

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -13,7 +13,7 @@ from gppylib.commands.base import Command, REMOTE
 from gppylib.commands.unix import get_remote_link_path
 
 class Tablespace:
-    def __init__(self, name):
+    def __init__(self, name, with_desc=False):
         self.name = name
         self.path = tempfile.mkdtemp()
         self.dbname = 'tablespace_db_%s' % name
@@ -32,6 +32,9 @@ class Tablespace:
         conn = dbconn.connect(dbconn.DbURL(dbname=self.dbname), unsetSearchPath=False)
         dbconn.execSQL(conn, "CREATE TABLE tbl (i int) DISTRIBUTED RANDOMLY")
         dbconn.execSQL(conn, "INSERT INTO tbl VALUES (GENERATE_SERIES(0, 25))")
+
+        if with_desc:
+            dbconn.execSQL(conn, "COMMENT on TABLESPACE %s IS 'This is a tablespace'" % (self.name))
 
         # save the distributed data for later verification
         self.initial_data = dbconn.query(conn, "SELECT gp_segment_id, i FROM tbl").fetchall()
@@ -214,11 +217,14 @@ def impl(context):
 def impl(context):
     _create_tablespace_with_data(context, "myspace")
 
+@given('a tablespace is created with data and description')
+def impl(context):
+    _create_tablespace_with_data(context, "outerspace", with_desc=True)
 
-def _create_tablespace_with_data(context, name):
+def _create_tablespace_with_data(context, name, with_desc=False):
     if 'tablespaces' not in context:
         context.tablespaces = {}
-    context.tablespaces[name] = Tablespace(name)
+    context.tablespaces[name] = Tablespace(name, with_desc=with_desc)
 
 
 @then('the tablespace is valid')


### PR DESCRIPTION

**Issue:**
gpcheckcat reports column "oid" does not exist error while running ‘missing_extraneous’ test on pg_shdescription catalogue table.

```
Connected as user 'sshirisha' to database 'miss_attr_db5', port '7000', gpdb version '7.0'
      -------------------------------------------------------------------
      Batch size: 4
      Performing test 'unique_index_violation'
      Total runtime for test 'unique_index_violation': 0:00:01.62
      Performing test 'duplicate'
      Total runtime for test 'duplicate': 0:00:16.29
      Performing test 'missing_extraneous'
        Execution error: column "oid" does not exist
      LINE 4:                 SELECT oid FROM pg_shdescription
                                     ^


                SELECT oid
                FROM (
                      SELECT oid FROM pg_shdescription
                      WHERE objoid='18362' and classoid='1213'
                      UNION ALL
                      SELECT oid FROM gp_dist_random('pg_shdescription')
                      WHERE objoid='18362' and classoid='1213'
                ) alloids
                GROUP BY oid
                ORDER BY count(*) desc, oid

      Total runtime for test 'missing_extraneous': 0:00:00.54
      Performing test 'inconsistent'
      Total runtime for test 'inconsistent': 0:00:15.63
      Performing test 'foreign_key'
      Total runtime for test 'foreign_key': 0:00:02.67
      Performing test 'pgclass'
      Total runtime for test 'pgclass': 0:00:00.21
      Performing test 'namespace'
      Total runtime for test 'namespace': 0:00:00.04
      Performing test 'distribution_policy'
      Total runtime for test 'distribution_policy': 0:00:00.01
      Performing test 'dependency'
      Total runtime for test 'dependency': 0:00:00.16
      Performing test 'part_integrity'
      Total runtime for test 'part_integrity': 0:00:00.05
      Performing test 'orphaned_toast_tables'
      Total runtime for test 'orphaned_toast_tables': 0:00:00.36
      Performing test 'aoseg_table'
      Total runtime for test 'aoseg_table': 0:00:00.00
      Performing test 'ao_lastrownums'
      Total runtime for test 'ao_lastrownums': 0:00:00.00
```
**RCA:**
Internally missing_extraneous test of gpcheckcat tries to fetch the oid from all the catalogue tables present in the database. For pg_description table, the oid is changed to objoid in 6x and 7x. As there is no column as oid currently in pg_description table, hence an error is reported.

```
sshirisha=# \d+ pg_description;
                               Table "pg_catalog.pg_description"
   Column    |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description
-------------+---------+-----------+----------+---------+----------+--------------+-------------
 objoid      | oid     |           | not null |         | plain    |              |
 classoid    | oid     |           | not null |         | plain    |              |
 objsubid    | integer |           | not null |         | plain    |              |
 description | text    | C         | not null |         | extended |              |
Indexes:
    "pg_description_o_c_o_index" UNIQUE, btree (objoid, classoid, objsubid)
Access method: heap
```
**Fix:**
Catalogue tables which do not have a OID column are stored in a dictionary 'TableMainColumn' and are mapped an existing OID type attribute. For fixing this issue an entry is added to dictionary so that objoid is used instead of oid while running SQL queries.

Additionally, a behave test is also added to catch any further inconsistencies with pg_description tabl
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
