### PR TITLE
Improve DPv2 algorithm to include distribution spec information with partition selectors

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -64,11 +64,6 @@ public:
 		EspHigh		// operator has high priority for stat derivation
 	};
 
-private:
-	// private copy ctor
-	CLogical(const CLogical &);
-
-
 protected:
 	// set of locally used columns
 	CColRefSet *m_pcrsLocalUsed;
@@ -176,6 +171,8 @@ protected:
 											 CColRefSet *pcrsUsedAdditional);
 
 public:
+	CLogical(const CLogical &) = delete;
+
 	// ctor
 	explicit CLogical(CMemoryPool *mp);
 
@@ -329,9 +326,6 @@ public:
 
 	// returns the table descriptor for (Dynamic)(BitmapTable)Get operators
 	static CTableDescriptor *PtabdescFromTableGet(COperator *pop);
-
-	// returns the output columns for selected operator
-	static CColRefArray *PoutputColsFromTableGet(COperator *pop);
 
 	// extract the output columns descriptor from a logical get or dynamic get operator
 	static CColRefArray *PdrgpcrOutputFromLogicalGet(CLogical *pop);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -34,7 +34,7 @@ using namespace gpos;
 //		Helper class for creating compact join orders
 //
 //---------------------------------------------------------------------------
-class CJoinOrder : public DbgPrintMixin<CJoinOrder>
+class CJoinOrder
 {
 public:
 	enum EPosition

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -516,6 +516,10 @@ private:
 
 	void FinalizeDPLevel(ULONG level);
 
+	CDouble CostJoinWithPartitionSelection(
+		SExpressionInfo *join_expr_info, SExpressionInfo *atom_ps,
+		SGroupInfo *pt_atom, SGroupInfo *part_selector_group_info);
+
 	SGroupInfoArray *
 	GetGroupsForLevel(ULONG level) const
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -27,7 +27,9 @@
 #include "gpopt/operators/CLogicalApply.h"
 #include "gpopt/operators/CLogicalBitmapTableGet.h"
 #include "gpopt/operators/CLogicalDynamicBitmapTableGet.h"
+#include "gpopt/operators/CLogicalDynamicForeignGet.h"
 #include "gpopt/operators/CLogicalDynamicGet.h"
+#include "gpopt/operators/CLogicalForeignGet.h"
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CLogicalNAryJoin.h"
 #include "gpopt/operators/CLogicalSelect.h"
@@ -1263,6 +1265,10 @@ CLogical::PtabdescFromTableGet(COperator *pop)
 			return CLogicalDynamicGet::PopConvert(pop)->Ptabdesc();
 		case CLogical::EopLogicalBitmapTableGet:
 			return CLogicalBitmapTableGet::PopConvert(pop)->Ptabdesc();
+		case CLogical::EopLogicalForeignGet:
+			return CLogicalForeignGet::PopConvert(pop)->Ptabdesc();
+		case CLogical::EopLogicalDynamicForeignGet:
+			return CLogicalDynamicForeignGet::PopConvert(pop)->Ptabdesc();
 		case CLogical::EopLogicalDynamicBitmapTableGet:
 			return CLogicalDynamicBitmapTableGet::PopConvert(pop)->Ptabdesc();
 		case CLogical::EopLogicalSelect:

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -27,7 +27,6 @@
 
 using namespace gpopt;
 
-FORCE_GENERATE_DBGSTR(CJoinOrder);
 FORCE_GENERATE_DBGSTR(CJoinOrder::SEdge);
 FORCE_GENERATE_DBGSTR(CJoinOrder::SComponent);
 


### PR DESCRIPTION
DPv2 produces a few different join order alternatives. One of these
alternatives, stored in m_top_k_part_expressions, attempts to produce a
plan while considering the effects of partition selection. This was
initially added in 9c44532. However, when considering a partition
selector's effect, we also need to consider the distribution spec.
Otherwise we may choose a particular join order that may appear to be a
valid join order with a partition selector, but it actually isn't due to
a mismatch of distribution specs. In many cases, the DPv2 algorithm's
partition selection logic wasn't producing a valid join order.

Consider the tables P1, P2, T1, T2 all inner joined together. We
currently produce the join order:

```
      PS2
    PT2
  PT1
PS1
```

This occurs in the hope that PS1 is a partition selector for PT1, and PS2 is a partition selector for PT2. That is, the join tree ideally would look like the following after the commutative xform is applied in the final plan:

```
     HJ3
  HJ2    PS2
PT2  HJ1
   PT1 PS1
```

However, if PT2 has a distribution spec that is not in HJ2's condition,
it will have a redistribute. At this point, PS2 is in a different slice
and a partition selector here isn't valid.

Now, we check that the distribution cols of PT2 is included in the hash
condition of HJ2. More generally, when checking whether a partition
selector will have any effect, we check if the outer child's (HJ2) join
condition contains the distribution columns of the partition table we're
impacting.

This heavily improves the performance of some complex queries (Q25) due to the
added partition selector by ~50%, and in one case (Q72) has a slight decrease in performance.
However, that regression is due to a join tree with more
than 10 joins, and the performance decrease is ~10%. Increasing the join
threshold to 11 restores most of the performance.

Adding a test case for this is difficult, since this will only have an effect
for more complex queries with specific statistics. If we set
`GPOPT_DPV2_JOIN_ORDERING_TOPK` to 0 in `CJoinOrderDPv2.cpp`, we can see that
we generate a better plan from `m_top_k_part_expressions`


See individual commits for details