### PR TITLE
Rocky8/oel8/rhel8 needs zstd 1.4.4 to be vendored

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -96,10 +96,13 @@ function include_dependencies() {
 	header_search_path=( /usr/local/include/ /usr/include/ )
 	vendored_headers=(zstd*.h uv.h uv )
 	pkgconfigs=(libzstd.pc libuv.pc quicklz.pc)
-	# rocky9/oel9/rhel9 won't vendor zstd because of rsync on these platofrm does not work libzstd 1.3.7
+	# rocky9/oel9/rhel9 won't vendor zstd because of rsync on these platform does not work libzstd 1.3.7
 	if [[ ${BLD_ARCH} == "rhel9"* ]]; then
 	  vendored_libs=(libquicklz.so{,.1,.1.5.0} libuv.so{,.1,.1.0.0} libxerces-c{,-3.1}.so)
-	else
+	# rocky8/oel8/rhel8 needs zstd 1.4.4 to be vendor because these platform support system libzstd 1.4.4
+	elif [[ ${BLD_ARCH} == "rhel8"* ]]; then
+	  vendored_libs=(libquicklz.so{,.1,.1.5.0} libzstd.so{,.1,.1.4.4} libuv.so{,.1,.1.0.0} libxerces-c{,-3.1}.so)
+  else
 	vendored_libs=(libquicklz.so{,.1,.1.5.0} libzstd.so{,.1,.1.3.7} libuv.so{,.1,.1.0.0} libxerces-c{,-3.1}.so)
 	fi
 


### PR DESCRIPTION
because these platform support system libzstd 1.4.4

[GPR-1624]

Authored-by: Anusha Shakarad <shakarada@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
