### PR TITLE
Fix memory leak in Dynamic Index/IndexOnly/BitmapIndex Scan during execution (#16797)

### DIFF
--- a/src/backend/executor/execDynamicIndexes.c
+++ b/src/backend/executor/execDynamicIndexes.c
@@ -206,12 +206,26 @@ endCurrentIndexScan(DynamicIndexScanState *node)
 {
 	if (node->indexScanState)
 	{
+		/* Free ExprContext allocated in beginCurrentIndexScan */
+		if (node->indexScanState->ss.ps.ps_ExprContext)
+		{
+			FreeExprContext(node->indexScanState->ss.ps.ps_ExprContext, true);
+			node->indexScanState->ss.ps.ps_ExprContext = NULL;
+		}
+
 		ExecEndIndexScan(node->indexScanState);
 		node->indexScanState = NULL;
 		table_close(node->ss.ss_currentRelation, NoLock);
 	}
 	else if (node->indexOnlyScanState)
 	{
+		/* Free ExprContext allocated in beginCurrentIndexScan */
+		if (node->indexOnlyScanState->ss.ps.ps_ExprContext)
+		{
+			FreeExprContext(node->indexOnlyScanState->ss.ps.ps_ExprContext, true);
+			node->indexOnlyScanState->ss.ps.ps_ExprContext = NULL;
+		}
+
 		ExecEndIndexOnlyScan(node->indexOnlyScanState);
 		node->indexOnlyScanState = NULL;
 		table_close(node->ss.ss_currentRelation, NoLock);

--- a/src/backend/executor/nodeDynamicBitmapIndexscan.c
+++ b/src/backend/executor/nodeDynamicBitmapIndexscan.c
@@ -206,6 +206,13 @@ endCurrentBitmapIndexScan(DynamicBitmapIndexScanState *node)
 {
 	if (node->bitmapIndexScanState)
 	{
+		/* Free ExprContext allocated in beginCurrentBitmapIndexScan */
+		if (node->bitmapIndexScanState->ss.ps.ps_ExprContext)
+		{
+			FreeExprContext(node->bitmapIndexScanState->ss.ps.ps_ExprContext, true);
+			node->bitmapIndexScanState->ss.ps.ps_ExprContext = NULL;
+		}
+
 		ExecEndBitmapIndexScan(node->bitmapIndexScanState);
 		node->bitmapIndexScanState = NULL;
 	}


### PR DESCRIPTION
This fix addresses a memory leak that occurs during the execution of DynamicIndexScan, DynamicIndexOnlyScan, and DynamicBitmapIndexScan. Each partition of the DynamicIndexScan creates an IndexScanState for execution usage. Within each IndexScanState, an ExprContext is allocated but not freed in ExecFreeExprContext(). This ExprContext includes a MemoryContext, resulting in a memory leak of the initial context space during each iteration of the DynamicIndexScan partition loop. Which will lead to a significant accumulation of leaked memory if the partition loop is extensive.
The same issue is observed in the execution of DynamicIndexOnlyScan and DynamicBitmapIndexScan.

This fix ensures that the allocated MemoryContext within the ExprContext is properly freed during the execution of each partition in Dynamic Index/IndexOnly/BitmapIndex Scan.

Fix #16797
