### PR TITLE
Docs: add gppkg option to specify package to migrate

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -31,16 +31,16 @@ Examples of database extensions and packages software that are delivered using t
 
 ## <a id="commands"></a>Commands
 
-help 
+`help` 
 :   Display the help for the command.
 
-install <package_name> [<command_options>]
+`install <package_name> [<command_options>]`
 :   Install or upgrade the specified package in the cluster. This includes any pre/post installation steps and installation of any dependencies.
 
-migrate --source <source_path> --destination <destination_path> [--pkglibs <pkglibs_path>] [<command_options>]
-:   Migrate all packages from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
+`migrate --source <source_path> --destination <destination_path> [<package_name>] [--pkglibs <pkglibs_path>] [<command_options>]`
+:   Migrate all packages or a specific package from one minor version of Greenplum Database to another. The option `--source <source_path>` specifies the path of the source `$GPHOME`, and the option `--destination <destination_path>` specifies the path of the destination `$GPHOME`. The option `[<package_name>]`, if used, indicates the name of a specific package to migrate. You may use `[<package_name>]` as a keyword, so all available packages matching the specific keyword will be migrated. If you do not use the option `[<package_name>]`, all packages are migrated. Additionally, the option `--pkglibs <pkglibs_path>` allows you to point to a location where you may place newer version packages for the destination Greenplum version; `gppkg` will upgrade these packages automatically. 
 
-query [<package_name_string>] [<query_option>] [<command_options>]
+`query [<package_name_string>] [<query_option>] [<command_options>]`
 :   Display information about the extensions installed in the cluster. `<package_name_string>` is a string that specifies the package name. If it is an empty string, it will match all packages. If it is a simple word, it will match all packages with the word included in the name. Use `–-exact` to specify the exact package name.
 
     |query_option|Returns|
@@ -50,40 +50,40 @@ query [<package_name_string>] [<query_option>] [<command_options>]
     |`--verify`|Verify the package installation|
     |`--local`|Do not query at cluster level|
 
-remove <package_name> [<command_options>]
+`remove <package_name> [<command_options>]`
 :    Uninstall the specified package from the cluster. 
 
-sync [<command_options>]
+`sync [<command_options>]`
 :    Reconcile the package state of the cluster to match the state of the master host. Running this option after a failed or partial install/uninstall ensures that the package installation state is consistent across the cluster.
 
 ## <a id="options"></a>Global Options 
 
---cluster_info <cluster_info>
+`--cluster_info <cluster_info>`
 :   Use this option when Greenplum Database is not running. The input file `<cluster_info>` contains information about the database cluster. You may generate the file by running the following command:
 
     ```
     psql postgres -Xc 'select dbid, content, role, preferred_role, mode, status, hostname, address, port, datadir from gp_segment_configuration order by content, preferred_role desc;' | head -n-2 | tail -n+3 | tr -d " " > cluster_info
     ```
 
--a | --accept 
+`-a | --accept` 
 :   Do not prompt the user for confirmation.
 
--d | --dryrun     
+`-d | --dryrun`     
 :   Run a simulation for the command, without modifying anything.
 
--f | --force
+`-f | --force`
 :   Skip all requirement checks and overwrite existing files.
 
--h | --help
+`-h | --help`
 :   Display the online help.
 
---tmpdir
+`--tmpdir`
 :   Specify the directory to which `gppkg` should write temporary files. If not specified, `gppkg` writes temporary files to the directory specified in the `TMPDIR` environment variable.
 
--V | --version
+`-V | --version`
 :   Display the version of this utility.
 
--v | --verbose
+`-v | --verbose`
 :   Set the logging level to verbose.
 
 ## <a id="examples"></a>Examples


### PR DESCRIPTION
This PR documents the option to specify a package name when migrating with `gppkg`.
Also introduces some formatting changes in order to correctly render the command options.
