### PR TITLE
Fix view gp_toolkit.gp_stats_missing to only show tables missing stats

### DIFF
--- a/gpcontrib/gp_toolkit/expected/gp_toolkit.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit.out
@@ -180,7 +180,15 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
 -----------+----------+---------+---------+---------
 (0 rows)
 
+truncate toolkit_miss_stat;
 insert into toolkit_miss_stat select i,i from generate_series(1,10) i;
+-- table has not been analyzed, table should be returned
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
+ smischema |     smitable      | smisize | smicols | smirecs 
+-----------+-------------------+---------+---------+---------
+ public    | toolkit_miss_stat | f       |       2 |       0
+(1 row)
+
 analyze toolkit_miss_stat;
 -- after populating table and analyzing, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit.out
@@ -181,7 +181,49 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
 -----------+----------+---------+---------+---------
 (0 rows)
 
+-- ensure materialized view is displayed accordingly
+create materialized view toolkit_miss_stat_mv as select * from toolkit_miss_stat distributed by (a);
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
+ smischema |       smitable       | smisize | smicols | smirecs 
+-----------+----------------------+---------+---------+---------
+ public    | toolkit_miss_stat_mv | f       |       2 |       0
+(1 row)
+
+analyze toolkit_miss_stat_mv;
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
+ smischema | smitable | smisize | smicols | smirecs 
+-----------+----------+---------+---------+---------
+(0 rows)
+
+drop materialized view toolkit_miss_stat_mv;
 drop table toolkit_miss_stat;
+create table deep_part ( i int, j int, k int, s char(5))
+distributed by (i)
+partition by list(s)
+subpartition by range (j) subpartition template (start(1)  end(3) every(1))
+(partition female values('F'), partition male values('M'));
+insert into deep_part values (1, 1, 1, 'M');
+insert into deep_part values (1, 1, 1, 'F');
+insert into deep_part values (2, 2, 2, 'M');
+-- should return all partitions and root, but not intermediate
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+ smischema |            smitable            | smisize | smicols | smirecs 
+-----------+--------------------------------+---------+---------+---------
+ public    | deep_part_1_prt_female_2_prt_1 | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_1   | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_2   | f       |       4 |       0
+ public    | deep_part_1_prt_female_2_prt_2 | f       |       4 |       0
+ public    | deep_part                      | f       |       4 |       0
+(5 rows)
+
+analyze deep_part;
+-- should return no partitions, since they've all been analyzed
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+ smischema | smitable | smisize | smicols | smirecs 
+-----------+----------+---------+---------+---------
+(0 rows)
+
+reset gp_autostats_mode;
 -- Test the gp_skew_idle_fractions view
 create table toolkit_skew (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit.out
@@ -162,10 +162,9 @@ from gp_toolkit.gp_disk_free where dfsegment=0;
 (1 row)
 
 -- GP Missing Stats
--- New table or without any data will not have any stats
+-- New table that hasn't been analyzed will not have any stats
 -- After analyze or with auto-stats, then we will not have any table in gp_stats_missing
-set gp_autostats_mode='none';
-create table toolkit_miss_stat (a int, b int);
+create table toolkit_miss_stat (a int, b int) with (autovacuum_enabled=false);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
@@ -174,15 +173,23 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
  public    | toolkit_miss_stat | f       |       2 |       0
 (1 row)
 
-insert into toolkit_miss_stat select i,i from generate_series(1,10) i;
 analyze toolkit_miss_stat;
+-- after analyzing empty table, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
  smischema | smitable | smisize | smicols | smirecs 
 -----------+----------+---------+---------+---------
 (0 rows)
 
--- ensure materialized view is displayed accordingly
-create materialized view toolkit_miss_stat_mv as select * from toolkit_miss_stat distributed by (a);
+insert into toolkit_miss_stat select i,i from generate_series(1,10) i;
+analyze toolkit_miss_stat;
+-- after populating table and analyzing, table should not be returned
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
+ smischema | smitable | smisize | smicols | smirecs 
+-----------+----------+---------+---------+---------
+(0 rows)
+
+-- ensure materialized view is shown when stats are missing
+create materialized view toolkit_miss_stat_mv with (autovacuum_enabled=false) as select * from toolkit_miss_stat distributed by (a);
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
  smischema |       smitable       | smisize | smicols | smirecs 
 -----------+----------------------+---------+---------+---------
@@ -190,6 +197,7 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
 (1 row)
 
 analyze toolkit_miss_stat_mv;
+-- after analyze, table will have stats and should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
  smischema | smitable | smisize | smicols | smirecs 
 -----------+----------+---------+---------+---------
@@ -197,11 +205,33 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
 
 drop materialized view toolkit_miss_stat_mv;
 drop table toolkit_miss_stat;
-create table deep_part ( i int, j int, k int, s char(5))
+-- test partitioned table. Intermediate parittions should never be shown, root partition should be shown
+-- if any leaf hasn't been analyzed, OR all leaves are empty and have been analyzed
+create table deep_part ( i int, j int, k int, s char(5)) with (autovacuum_enabled=false)
 distributed by (i)
 partition by list(s)
 subpartition by range (j) subpartition template (start(1)  end(3) every(1))
 (partition female values('F'), partition male values('M'));
+-- all leaf partitions and root partition should be returned
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+ smischema |            smitable            | smisize | smicols | smirecs 
+-----------+--------------------------------+---------+---------+---------
+ public    | deep_part                      | f       |       4 |       0
+ public    | deep_part_1_prt_female_2_prt_2 | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_2   | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_1   | f       |       4 |       0
+ public    | deep_part_1_prt_female_2_prt_1 | f       |       4 |       0
+(5 rows)
+
+analyze deep_part;
+-- only root partition should be returned
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+ smischema | smitable  | smisize | smicols | smirecs 
+-----------+-----------+---------+---------+---------
+ public    | deep_part | f       |       4 |       0
+(1 row)
+
+truncate deep_part; -- remove stats
 insert into deep_part values (1, 1, 1, 'M');
 insert into deep_part values (1, 1, 1, 'F');
 insert into deep_part values (2, 2, 2, 'M');
@@ -209,11 +239,11 @@ insert into deep_part values (2, 2, 2, 'M');
 select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
  smischema |            smitable            | smisize | smicols | smirecs 
 -----------+--------------------------------+---------+---------+---------
- public    | deep_part_1_prt_female_2_prt_1 | f       |       4 |       0
- public    | deep_part_1_prt_male_2_prt_1   | f       |       4 |       0
- public    | deep_part_1_prt_male_2_prt_2   | f       |       4 |       0
- public    | deep_part_1_prt_female_2_prt_2 | f       |       4 |       0
  public    | deep_part                      | f       |       4 |       0
+ public    | deep_part_1_prt_female_2_prt_2 | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_2   | f       |       4 |       0
+ public    | deep_part_1_prt_male_2_prt_1   | f       |       4 |       0
+ public    | deep_part_1_prt_female_2_prt_1 | f       |       4 |       0
 (5 rows)
 
 analyze deep_part;
@@ -223,7 +253,6 @@ select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
 -----------+----------+---------+---------+---------
 (0 rows)
 
-reset gp_autostats_mode;
 -- Test the gp_skew_idle_fractions view
 create table toolkit_skew (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.3.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.3.sql
@@ -868,8 +868,11 @@ GRANT SELECT ON TABLE gp_toolkit.gp_skew_idle_fractions TO public;
 --        gp_toolkit.gp_stats_missing
 --
 -- @doc:
---        List all tables with no or insufficient stats. Always skip interior partitions, as stats are never collected
---        and this would add noise.
+--        List all tables with no or insufficient stats. For partitioned
+--        tables, always skip interior partitions, as stats are never collected
+--        and this would add noise. If all leaves are empty and table is
+--        analyzed, the root will still be displayed as we can't differentiate
+--        between an analyzed and unanalyzed root based on relpages.
 --        GPDB_14_MERGE_FIXME: Change this to relpages > -1 after 3d351d9
 --
 --------------------------------------------------------------------------------

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.3.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.3.sql
@@ -868,7 +868,9 @@ GRANT SELECT ON TABLE gp_toolkit.gp_skew_idle_fractions TO public;
 --        gp_toolkit.gp_stats_missing
 --
 -- @doc:
---        List all tables with no or insufficient stats
+--        List all tables with no or insufficient stats. Always skip interior partitions, as stats are never collected
+--        and this would add noise.
+--        GPDB_14_MERGE_FIXME: Change this to relpages > -1 after 3d351d9
 --
 --------------------------------------------------------------------------------
 CREATE VIEW gp_toolkit.gp_stats_missing
@@ -898,7 +900,7 @@ AS
             GROUP BY starelid
         ) bar
         ON aut.autoid = starelid
-    WHERE (aut.autrelkind in ('r', 'p', 'm')
+    WHERE aut.autrelkind in ('r', 'p', 'm')
     AND NOT (pgc.relispartition AND aut.autrelkind = 'p')
     AND (aut.autrelpages = 0 AND (stacnt IS NULL OR attcnt > stacnt));
 

--- a/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
@@ -87,7 +87,11 @@ select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
 analyze toolkit_miss_stat;
 -- after analyzing empty table, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
+truncate toolkit_miss_stat;
+
 insert into toolkit_miss_stat select i,i from generate_series(1,10) i;
+-- table has not been analyzed, table should be returned
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
 analyze toolkit_miss_stat;
 -- after populating table and analyzing, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';

--- a/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_toolkit.sql
@@ -80,27 +80,41 @@ from gp_toolkit.gp_disk_free where dfsegment=0;
 
 
 -- GP Missing Stats
--- New table or without any data will not have any stats
+-- New table that hasn't been analyzed will not have any stats
 -- After analyze or with auto-stats, then we will not have any table in gp_stats_missing
-set gp_autostats_mode='none';
-create table toolkit_miss_stat (a int, b int);
+create table toolkit_miss_stat (a int, b int) with (autovacuum_enabled=false);
+select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
+analyze toolkit_miss_stat;
+-- after analyzing empty table, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
 insert into toolkit_miss_stat select i,i from generate_series(1,10) i;
 analyze toolkit_miss_stat;
+-- after populating table and analyzing, table should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat';
--- ensure materialized view is displayed accordingly
-create materialized view toolkit_miss_stat_mv as select * from toolkit_miss_stat distributed by (a);
+
+-- ensure materialized view is shown when stats are missing
+create materialized view toolkit_miss_stat_mv with (autovacuum_enabled=false) as select * from toolkit_miss_stat distributed by (a);
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
 analyze toolkit_miss_stat_mv;
+-- after analyze, table will have stats and should not be returned
 select * from gp_toolkit.gp_stats_missing where smitable='toolkit_miss_stat_mv';
 drop materialized view toolkit_miss_stat_mv;
 drop table toolkit_miss_stat;
 
-create table deep_part ( i int, j int, k int, s char(5))
+-- test partitioned table. Intermediate parittions should never be shown, root partition should be shown
+-- if any leaf hasn't been analyzed, OR all leaves are empty and have been analyzed
+create table deep_part ( i int, j int, k int, s char(5)) with (autovacuum_enabled=false)
 distributed by (i)
 partition by list(s)
 subpartition by range (j) subpartition template (start(1)  end(3) every(1))
 (partition female values('F'), partition male values('M'));
+-- all leaf partitions and root partition should be returned
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+analyze deep_part;
+-- only root partition should be returned
+select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
+
+truncate deep_part; -- remove stats
 insert into deep_part values (1, 1, 1, 'M');
 insert into deep_part values (1, 1, 1, 'F');
 insert into deep_part values (2, 2, 2, 'M');
@@ -109,7 +123,6 @@ select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
 analyze deep_part;
 -- should return no partitions, since they've all been analyzed
 select * from gp_toolkit.gp_stats_missing where smitable LIKE 'deep_part%';
-reset gp_autostats_mode;
 
 -- Test the gp_skew_idle_fractions view
 create table toolkit_skew (a int);


### PR DESCRIPTION
The view gp_toolkit.gp_stats_missing is used by users to show which tables/partitioned tables do not have stats--and therefore which tables should be analyzed. 

The current behavior has a few shortcomings:

1) it shows tables that have been analyzed but have no data 
2) it shows intermediate partitions (which can't be analyzed, but displaying them is noisy)
3) it never shows root partitioned tables
4) it never shows materialized views

Now, the above behavior is fixed. Note that it will still show root partitioned tables as having no stats if none of the leaves have data--we can't differentiate between a root table that has no stats and a root table that has no data but has been analyzed.

The goal with this is to show users which tables may not be being analyzed in their workflow or need to be analyzed in order to populate root stats via incremental analyze.

Note: I haven't added tests yet as I want to get consensus first on the goals of this view. Additionally, I believe this needs to be added this as a separate extension upgrade file? 