### PR TITLE
Enable MPP support for pg_buffercache and build by default

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -30,6 +30,8 @@ all:
 	$(MAKE) -C contrib/isn all
 	$(MAKE) -C contrib/tsm_system_rows all
 	$(MAKE) -C contrib/tsm_system_time all
+	$(MAKE) -C contrib/pg_buffercache all
+
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo all
 endif
@@ -77,6 +79,8 @@ install:
 	$(MAKE) -C contrib/btree_gin $@
 	$(MAKE) -C contrib/pg_trgm $@
 	$(MAKE) -C contrib/isn $@
+	$(MAKE) -C contrib/pg_buffercache $@
+
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo $@
 endif
@@ -181,6 +185,7 @@ ICW_TARGETS += contrib/auto_explain contrib/citext contrib/btree_gin
 ICW_TARGETS += contrib/file_fdw contrib/postgres_fdw contrib/formatter_fixedwidth
 ICW_TARGETS += contrib/extprotocol contrib/dblink contrib/pg_trgm
 ICW_TARGETS += contrib/indexscan contrib/hstore contrib/ltree contrib/pgcrypto contrib/isn
+ICW_TARGETS += contrib/pg_buffercache
 # sslinfo depends on openssl
 ifeq ($(with_openssl), yes)
 ICW_TARGETS += contrib/sslinfo

--- a/contrib/pg_buffercache/.gitignore
+++ b/contrib/pg_buffercache/.gitignore
@@ -1,1 +1,4 @@
-/pg_buffercache.sql
+# Generated subdirectories
+/log/
+/results/
+/tmp_check/

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -6,7 +6,8 @@ OBJS = pg_buffercache_pages.o $(WIN32RES)
 EXTENSION = pg_buffercache
 DATA = pg_buffercache--1.2.sql pg_buffercache--1.2--1.3.sql \
 	pg_buffercache--1.1--1.2.sql pg_buffercache--1.0--1.1.sql \
-	pg_buffercache--unpackaged--1.0.sql
+	pg_buffercache--unpackaged--1.0.sql \
+	pg_buffercache--1.3--1.4.sql
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
 REGRESS = pg_buffercache

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -9,6 +9,8 @@ DATA = pg_buffercache--1.2.sql pg_buffercache--1.2--1.3.sql \
 	pg_buffercache--unpackaged--1.0.sql
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
+REGRESS = pg_buffercache
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -7,7 +7,9 @@ EXTENSION = pg_buffercache
 DATA = pg_buffercache--1.2.sql pg_buffercache--1.2--1.3.sql \
 	pg_buffercache--1.1--1.2.sql pg_buffercache--1.0--1.1.sql \
 	pg_buffercache--unpackaged--1.0.sql \
-	pg_buffercache--1.3--1.4.sql
+	pg_buffercache--1.3--1.4.sql \
+	pg_buffercache--1.4--1.4.1.sql
+
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
 REGRESS = pg_buffercache

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -17,6 +17,12 @@ from pg_buffercache_summary();
  t        | t        | t
 (1 row)
 
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts() WHERE buffers >= 0;
+ ?column? 
+----------
+ t
+(1 row)
+
 -- Check that the functions / views can't be accessed by default. To avoid
 -- having to create a dedicated user, use the pg_database_owner pseudo-role.
 SET ROLE pg_database_owner;
@@ -26,6 +32,8 @@ SELECT * FROM pg_buffercache_pages() AS p (wrong int);
 ERROR:  permission denied for function pg_buffercache_pages
 SELECT * FROM pg_buffercache_summary();
 ERROR:  permission denied for function pg_buffercache_summary
+SELECT * FROM pg_buffercache_usage_counts();
+ERROR:  permission denied for function pg_buffercache_usage_counts
 RESET role;
 -- Check that pg_monitor is allowed to query view / function
 SET ROLE pg_monitor;
@@ -36,6 +44,12 @@ SELECT count(*) > 0 FROM pg_buffercache;
 (1 row)
 
 SELECT buffers_used + buffers_unused > 0 FROM pg_buffercache_summary();
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts();
  ?column? 
 ----------
  t

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -1,0 +1,10 @@
+CREATE EXTENSION pg_buffercache;
+select count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers')
+from pg_buffercache;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -23,9 +23,54 @@ SELECT count(*) > 0 FROM pg_buffercache_usage_counts() WHERE buffers >= 0;
  t
 (1 row)
 
--- Check that the functions / views can't be accessed by default. To avoid
--- having to create a dedicated user, use the pg_database_owner pseudo-role.
-SET ROLE pg_database_owner;
+-- Test GPDB functions/views
+SELECT count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers') *
+                   (select count(*) from gp_segment_configuration where role='p')
+                   as buffers
+FROM gp_buffercache;
+ buffers 
+---------
+ t
+(1 row)
+
+SELECT buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+FROM gp_buffercache_summary;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+ t        | t        | t
+ t        | t        | t
+ t        | t        | t
+(4 rows)
+
+SELECT buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+FROM gp_buffercache_summary_aggregated;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+(1 row)
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts WHERE buffers >= 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts_aggregated WHERE buffers >= 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Check that the functions / views can't be accessed by default.
+CREATE ROLE buffercache_test;
+SET ROLE buffercache_test;
 SELECT * FROM pg_buffercache;
 ERROR:  permission denied for view pg_buffercache
 SELECT * FROM pg_buffercache_pages() AS p (wrong int);
@@ -34,7 +79,22 @@ SELECT * FROM pg_buffercache_summary();
 ERROR:  permission denied for function pg_buffercache_summary
 SELECT * FROM pg_buffercache_usage_counts();
 ERROR:  permission denied for function pg_buffercache_usage_counts
-RESET role;
+-- GPDB
+SELECT * FROM pg_buffercache_summary;
+ERROR:  permission denied for view pg_buffercache_summary
+SELECT * FROM pg_buffercache_usage_counts;
+ERROR:  permission denied for view pg_buffercache_usage_counts
+SELECT * FROM gp_buffercache;
+ERROR:  permission denied for view gp_buffercache
+SELECT * FROM gp_buffercache_summary;
+ERROR:  permission denied for view gp_buffercache_summary
+SELECT * FROM gp_buffercache_usage_counts;
+ERROR:  permission denied for view gp_buffercache_usage_counts
+SELECT * FROM gp_buffercache_summary_aggregated;
+ERROR:  permission denied for view gp_buffercache_summary_aggregated
+SELECT * FROM gp_buffercache_usage_counts_aggregated;
+ERROR:  permission denied for view gp_buffercache_usage_counts_aggregated
+RESET ROLE;
 -- Check that pg_monitor is allowed to query view / function
 SET ROLE pg_monitor;
 SELECT count(*) > 0 FROM pg_buffercache;
@@ -55,3 +115,51 @@ SELECT count(*) > 0 FROM pg_buffercache_usage_counts();
  t
 (1 row)
 
+-- GPDB
+SELECT count(*) > 0 FROM pg_buffercache_summary;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM gp_buffercache;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT buffers_used + buffers_unused > 0 FROM gp_buffercache_summary;
+ ?column? 
+----------
+ t
+ t
+ t
+ t
+(4 rows)
+
+SELECT buffers_used + buffers_unused > 0 FROM gp_buffercache_summary_aggregated;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts_aggregated;
+ ?column? 
+----------
+ t
+(1 row)
+
+RESET ROLE;
+DROP ROLE buffercache_test;

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -8,3 +8,36 @@ from pg_buffercache;
  t
 (1 row)
 
+select buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+from pg_buffercache_summary();
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+(1 row)
+
+-- Check that the functions / views can't be accessed by default. To avoid
+-- having to create a dedicated user, use the pg_database_owner pseudo-role.
+SET ROLE pg_database_owner;
+SELECT * FROM pg_buffercache;
+ERROR:  permission denied for view pg_buffercache
+SELECT * FROM pg_buffercache_pages() AS p (wrong int);
+ERROR:  permission denied for function pg_buffercache_pages
+SELECT * FROM pg_buffercache_summary();
+ERROR:  permission denied for function pg_buffercache_summary
+RESET role;
+-- Check that pg_monitor is allowed to query view / function
+SET ROLE pg_monitor;
+SELECT count(*) > 0 FROM pg_buffercache;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT buffers_used + buffers_unused > 0 FROM pg_buffercache_summary();
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/contrib/pg_buffercache/pg_buffercache--1.3--1.4.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.3--1.4.sql
@@ -12,6 +12,17 @@ CREATE FUNCTION pg_buffercache_summary(
 AS 'MODULE_PATHNAME', 'pg_buffercache_summary'
 LANGUAGE C PARALLEL SAFE;
 
+CREATE FUNCTION pg_buffercache_usage_counts(
+    OUT usage_count int4,
+    OUT buffers int4,
+    OUT dirty int4,
+    OUT pinned int4)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_buffercache_usage_counts'
+LANGUAGE C PARALLEL SAFE;
+
 -- Don't want these to be available to public.
 REVOKE ALL ON FUNCTION pg_buffercache_summary() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION pg_buffercache_summary() TO pg_monitor;
+REVOKE ALL ON FUNCTION pg_buffercache_usage_counts() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_buffercache_usage_counts() TO pg_monitor;

--- a/contrib/pg_buffercache/pg_buffercache--1.3--1.4.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.3--1.4.sql
@@ -1,0 +1,17 @@
+/* contrib/pg_buffercache/pg_buffercache--1.3--1.4.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_buffercache UPDATE TO '1.4'" to load this file. \quit
+
+CREATE FUNCTION pg_buffercache_summary(
+    OUT buffers_used int4,
+    OUT buffers_unused int4,
+    OUT buffers_dirty int4,
+    OUT buffers_pinned int4,
+    OUT usagecount_avg float8)
+AS 'MODULE_PATHNAME', 'pg_buffercache_summary'
+LANGUAGE C PARALLEL SAFE;
+
+-- Don't want these to be available to public.
+REVOKE ALL ON FUNCTION pg_buffercache_summary() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_buffercache_summary() TO pg_monitor;

--- a/contrib/pg_buffercache/pg_buffercache--1.4--1.4.1.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.4--1.4.1.sql
@@ -1,0 +1,77 @@
+/* contrib/pg_buffercache/pg_buffercache--1.4--1.4.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_buffercache UPDATE TO '1.4.1'" to load this file. \quit
+
+
+-- Wrap the functions in a view for convenience.
+CREATE VIEW pg_buffercache_summary AS
+	SELECT * FROM pg_buffercache_summary();
+
+CREATE VIEW pg_buffercache_usage_counts AS
+	SELECT * FROM pg_buffercache_usage_counts();
+
+-- Create MPP views to gather results from coordinator and all segments.
+CREATE VIEW gp_buffercache AS
+	SELECT gp_execution_segment() AS gp_segment_id, *
+	FROM gp_dist_random('pg_buffercache')
+	UNION ALL
+	SELECT -1 AS gp_segment_id, *
+  FROM pg_buffercache
+  ORDER BY 1,2;
+
+CREATE VIEW gp_buffercache_summary AS
+	SELECT gp_execution_segment() AS gp_segment_id, *
+	FROM gp_dist_random('pg_buffercache_summary')
+	UNION ALL
+	SELECT -1 AS gp_segment_id, *
+	FROM pg_buffercache_summary
+	ORDER BY 1;
+
+CREATE VIEW gp_buffercache_usage_counts AS
+	SELECT gp_execution_segment() AS gp_segment_id, *
+	FROM gp_dist_random('pg_buffercache_usage_counts')
+	UNION ALL
+	SELECT -1 AS gp_segment_id, *
+	FROM pg_buffercache_usage_counts
+	ORDER BY 1,2;
+
+-- Create aggregate views.
+CREATE VIEW gp_buffercache_summary_aggregated AS
+  SELECT
+    sum(buffers_used) AS buffers_used,
+    sum(buffers_unused) AS buffers_unused,
+    sum(buffers_dirty) AS buffers_dirty,
+    sum(buffers_pinned) AS buffers_pinned,
+    avg(usagecount_avg) AS usagecount_avg
+  FROM gp_buffercache_summary;
+
+CREATE VIEW gp_buffercache_usage_counts_aggregated AS
+	SELECT
+    sum(usage_count) AS usage_count,
+    sum(buffers) AS buffers,
+    sum(dirty) AS dirty,
+    sum(pinned) AS pinned
+	FROM gp_buffercache_usage_counts;
+
+
+REVOKE ALL ON pg_buffercache_summary FROM PUBLIC;
+GRANT SELECT ON pg_buffercache_summary TO pg_monitor;
+
+REVOKE ALL ON pg_buffercache_usage_counts FROM PUBLIC;
+GRANT SELECT ON pg_buffercache_usage_counts TO pg_monitor;
+
+REVOKE ALL ON gp_buffercache FROM PUBLIC;
+GRANT SELECT ON gp_buffercache TO pg_monitor;
+
+REVOKE ALL ON gp_buffercache_summary FROM PUBLIC;
+GRANT SELECT ON gp_buffercache_summary TO pg_monitor;
+
+REVOKE ALL ON gp_buffercache_usage_counts FROM PUBLIC;
+GRANT SELECT ON gp_buffercache_usage_counts TO pg_monitor;
+
+REVOKE ALL ON gp_buffercache_summary_aggregated FROM PUBLIC;
+GRANT SELECT ON gp_buffercache_summary_aggregated TO pg_monitor;
+
+REVOKE ALL ON gp_buffercache_usage_counts_aggregated FROM PUBLIC;
+GRANT SELECT ON gp_buffercache_usage_counts_aggregated TO pg_monitor;

--- a/contrib/pg_buffercache/pg_buffercache.control
+++ b/contrib/pg_buffercache/pg_buffercache.control
@@ -1,5 +1,5 @@
 # pg_buffercache extension
 comment = 'examine the shared buffer cache'
-default_version = '1.3'
+default_version = '1.4'
 module_pathname = '$libdir/pg_buffercache'
 relocatable = true

--- a/contrib/pg_buffercache/pg_buffercache.control
+++ b/contrib/pg_buffercache/pg_buffercache.control
@@ -1,5 +1,5 @@
 # pg_buffercache extension
 comment = 'examine the shared buffer cache'
-default_version = '1.4'
+default_version = '1.4.1'
 module_pathname = '$libdir/pg_buffercache'
 relocatable = true

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -10,15 +10,19 @@ select buffers_used + buffers_unused > 0,
         buffers_pinned <= buffers_used
 from pg_buffercache_summary();
 
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts() WHERE buffers >= 0;
+
 -- Check that the functions / views can't be accessed by default. To avoid
 -- having to create a dedicated user, use the pg_database_owner pseudo-role.
 SET ROLE pg_database_owner;
 SELECT * FROM pg_buffercache;
 SELECT * FROM pg_buffercache_pages() AS p (wrong int);
 SELECT * FROM pg_buffercache_summary();
+SELECT * FROM pg_buffercache_usage_counts();
 RESET role;
 
 -- Check that pg_monitor is allowed to query view / function
 SET ROLE pg_monitor;
 SELECT count(*) > 0 FROM pg_buffercache;
 SELECT buffers_used + buffers_unused > 0 FROM pg_buffercache_summary();
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts();

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -1,0 +1,6 @@
+CREATE EXTENSION pg_buffercache;
+
+select count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers')
+from pg_buffercache;

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -4,3 +4,21 @@ select count(*) = (select setting::bigint
                    from pg_settings
                    where name = 'shared_buffers')
 from pg_buffercache;
+
+select buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+from pg_buffercache_summary();
+
+-- Check that the functions / views can't be accessed by default. To avoid
+-- having to create a dedicated user, use the pg_database_owner pseudo-role.
+SET ROLE pg_database_owner;
+SELECT * FROM pg_buffercache;
+SELECT * FROM pg_buffercache_pages() AS p (wrong int);
+SELECT * FROM pg_buffercache_summary();
+RESET role;
+
+-- Check that pg_monitor is allowed to query view / function
+SET ROLE pg_monitor;
+SELECT count(*) > 0 FROM pg_buffercache;
+SELECT buffers_used + buffers_unused > 0 FROM pg_buffercache_summary();

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -12,17 +12,59 @@ from pg_buffercache_summary();
 
 SELECT count(*) > 0 FROM pg_buffercache_usage_counts() WHERE buffers >= 0;
 
--- Check that the functions / views can't be accessed by default. To avoid
--- having to create a dedicated user, use the pg_database_owner pseudo-role.
-SET ROLE pg_database_owner;
+-- Test GPDB functions/views
+SELECT count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers') *
+                   (select count(*) from gp_segment_configuration where role='p')
+                   as buffers
+FROM gp_buffercache;
+
+SELECT buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+FROM gp_buffercache_summary;
+
+SELECT buffers_used + buffers_unused > 0,
+        buffers_dirty <= buffers_used,
+        buffers_pinned <= buffers_used
+FROM gp_buffercache_summary_aggregated;
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts WHERE buffers >= 0;
+
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts_aggregated WHERE buffers >= 0;
+
+-- Check that the functions / views can't be accessed by default.
+CREATE ROLE buffercache_test;
+SET ROLE buffercache_test;
 SELECT * FROM pg_buffercache;
 SELECT * FROM pg_buffercache_pages() AS p (wrong int);
 SELECT * FROM pg_buffercache_summary();
 SELECT * FROM pg_buffercache_usage_counts();
-RESET role;
+-- GPDB
+SELECT * FROM pg_buffercache_summary;
+SELECT * FROM pg_buffercache_usage_counts;
+SELECT * FROM gp_buffercache;
+SELECT * FROM gp_buffercache_summary;
+SELECT * FROM gp_buffercache_usage_counts;
+SELECT * FROM gp_buffercache_summary_aggregated;
+SELECT * FROM gp_buffercache_usage_counts_aggregated;
+RESET ROLE;
 
 -- Check that pg_monitor is allowed to query view / function
 SET ROLE pg_monitor;
 SELECT count(*) > 0 FROM pg_buffercache;
 SELECT buffers_used + buffers_unused > 0 FROM pg_buffercache_summary();
 SELECT count(*) > 0 FROM pg_buffercache_usage_counts();
+
+-- GPDB
+SELECT count(*) > 0 FROM pg_buffercache_summary;
+SELECT count(*) > 0 FROM pg_buffercache_usage_counts;
+SELECT count(*) > 0 FROM gp_buffercache;
+SELECT buffers_used + buffers_unused > 0 FROM gp_buffercache_summary;
+SELECT buffers_used + buffers_unused > 0 FROM gp_buffercache_summary_aggregated;
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts;
+SELECT count(*) > 0 FROM gp_buffercache_usage_counts_aggregated;
+RESET ROLE;
+
+DROP ROLE buffercache_test;

--- a/doc/src/sgml/pgbuffercache.sgml
+++ b/doc/src/sgml/pgbuffercache.sgml
@@ -21,9 +21,10 @@
  </indexterm>
 
  <para>
-  The module provides the <function>pg_buffercache_pages()</function>
-  function, wrapped in the <structname>pg_buffercache</structname> view, and
-  the <function>pg_buffercache_summary()</function> function.
+  This module provides the <function>pg_buffercache_pages()</function>
+  function (wrapped in the <structname>pg_buffercache</structname> view),
+  the <function>pg_buffercache_summary()</function> function, and the
+  <function>pg_buffercache_usage_counts()</function> function.
  </para>
 
  <para>
@@ -36,6 +37,12 @@
  <para>
   The <function>pg_buffercache_summary()</function> function returns a single
   row summarizing the state of the shared buffer cache.
+ </para>
+
+ <para>
+  The <function>pg_buffercache_usage_counts()</function> function returns a set
+  of records, each row describing the number of buffers with a given usage
+  count.
  </para>
 
  <para>
@@ -242,7 +249,7 @@
        <structfield>usagecount_avg</structfield> <type>float8</type>
       </para>
       <para>
-       Average usagecount of used shared buffers
+       Average usage count of used shared buffers
       </para></entry>
      </row>
     </tbody>
@@ -266,6 +273,84 @@
  </sect2>
 
  <sect2>
+  <title>The <function>pg_buffercache_usage_counts()</function> Function</title>
+
+  <para>
+   The definitions of the columns exposed by the function are shown in
+   <xref linkend="pgbuffercache_usage_counts-columns"/>.
+  </para>
+
+  <table id="pgbuffercache_usage_counts-columns">
+   <title><function>pg_buffercache_usage_counts()</function> Output Columns</title>
+   <tgroup cols="1">
+    <thead>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       Column Type
+      </para>
+      <para>
+       Description
+      </para></entry>
+     </row>
+    </thead>
+
+    <tbody>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>usage_count</structfield> <type>int4</type>
+      </para>
+      <para>
+       A possible buffer usage count
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>buffers</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of buffers with the usage count
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>dirty</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of dirty buffers with the usage count
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>pinned</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of pinned buffers with the usage count
+      </para></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <para>
+   The <function>pg_buffercache_usage_counts()</function> function returns a
+   set of rows summarizing the states of all shared buffers, aggregated over
+   the possible usage count values.  Similar and more detailed information is
+   provided by the <structname>pg_buffercache</structname> view, but
+   <function>pg_buffercache_usage_counts()</function> is significantly cheaper.
+  </para>
+
+  <para>
+   Like the <structname>pg_buffercache</structname> view,
+   <function>pg_buffercache_usage_counts()</function> does not acquire buffer
+   manager locks. Therefore concurrent activity can lead to minor inaccuracies
+   in the result.
+  </para>
+ </sect2>
+
+ <sect2 id="pgbuffercache-sample-output">
   <title>Sample Output</title>
 
 <screen>
@@ -299,6 +384,18 @@ regression=# SELECT * FROM pg_buffercache_summary();
 --------------+----------------+---------------+----------------+----------------
           248 |        2096904 |            39 |              0 |       3.141129
 (1 row)
+
+
+regression=# SELECT * FROM pg_buffercache_usage_counts();
+ usage_count | buffers | dirty | pinned
+-------------+---------+-------+--------
+           0 |   14650 |     0 |      0
+           1 |    1436 |   671 |      0
+           2 |     102 |    88 |      0
+           3 |      23 |    21 |      0
+           4 |       9 |     7 |      0
+           5 |     164 |   106 |      0
+(6 rows)
 </screen>
  </sect2>
 

--- a/doc/src/sgml/pgbuffercache.sgml
+++ b/doc/src/sgml/pgbuffercache.sgml
@@ -1,0 +1,321 @@
+<!-- doc/src/sgml/pgbuffercache.sgml -->
+
+<sect1 id="pgbuffercache" xreflabel="pg_buffercache">
+ <title>pg_buffercache</title>
+
+ <indexterm zone="pgbuffercache">
+  <primary>pg_buffercache</primary>
+ </indexterm>
+
+ <para>
+  The <filename>pg_buffercache</filename> module provides a means for
+  examining what's happening in the shared buffer cache in real time.
+ </para>
+
+ <indexterm>
+  <primary>pg_buffercache_pages</primary>
+ </indexterm>
+
+ <indexterm>
+  <primary>pg_buffercache_summary</primary>
+ </indexterm>
+
+ <para>
+  The module provides the <function>pg_buffercache_pages()</function>
+  function, wrapped in the <structname>pg_buffercache</structname> view, and
+  the <function>pg_buffercache_summary()</function> function.
+ </para>
+
+ <para>
+  The <function>pg_buffercache_pages()</function> function returns a set of
+  records, each row describing the state of one shared buffer entry. The
+  <structname>pg_buffercache</structname> view wraps the function for
+  convenient use.
+ </para>
+
+ <para>
+  The <function>pg_buffercache_summary()</function> function returns a single
+  row summarizing the state of the shared buffer cache.
+ </para>
+
+ <para>
+  By default, use is restricted to superusers and roles with privileges of the
+  <literal>pg_monitor</literal> role. Access may be granted to others
+  using <command>GRANT</command>.
+ </para>
+
+ <sect2>
+  <title>The <structname>pg_buffercache</structname> View</title>
+
+  <para>
+   The definitions of the columns exposed by the view are shown in <xref linkend="pgbuffercache-columns"/>.
+  </para>
+
+  <table id="pgbuffercache-columns">
+   <title><structname>pg_buffercache</structname> Columns</title>
+   <tgroup cols="1">
+    <thead>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       Column Type
+      </para>
+      <para>
+       Description
+      </para></entry>
+     </row>
+    </thead>
+
+    <tbody>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>bufferid</structfield> <type>integer</type>
+      </para>
+      <para>
+       ID, in the range 1..<varname>shared_buffers</varname>
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>relfilenode</structfield> <type>oid</type>
+       (references <link linkend="catalog-pg-class"><structname>pg_class</structname></link>.<structfield>relfilenode</structfield>)
+      </para>
+      <para>
+       Filenode number of the relation
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>reltablespace</structfield> <type>oid</type>
+       (references <link linkend="catalog-pg-tablespace"><structname>pg_tablespace</structname></link>.<structfield>oid</structfield>)
+      </para>
+      <para>
+       Tablespace OID of the relation
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>reldatabase</structfield> <type>oid</type>
+       (references <link linkend="catalog-pg-database"><structname>pg_database</structname></link>.<structfield>oid</structfield>)
+      </para>
+      <para>
+       Database OID of the relation
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>relforknumber</structfield> <type>smallint</type>
+      </para>
+      <para>
+       Fork number within the relation;  see
+       <filename>common/relpath.h</filename>
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>relblocknumber</structfield> <type>bigint</type>
+      </para>
+      <para>
+       Page number within the relation
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>isdirty</structfield> <type>boolean</type>
+      </para>
+      <para>
+       Is the page dirty?
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>usagecount</structfield> <type>smallint</type>
+      </para>
+      <para>
+       Clock-sweep access count
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>pinning_backends</structfield> <type>integer</type>
+      </para>
+      <para>
+       Number of backends pinning this buffer
+      </para></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <para>
+   There is one row for each buffer in the shared cache. Unused buffers are
+   shown with all fields null except <structfield>bufferid</structfield>.  Shared system
+   catalogs are shown as belonging to database zero.
+  </para>
+
+  <para>
+   Because the cache is shared by all the databases, there will normally be
+   pages from relations not belonging to the current database.  This means
+   that there may not be matching join rows in <structname>pg_class</structname> for
+   some rows, or that there could even be incorrect joins.  If you are
+   trying to join against <structname>pg_class</structname>, it's a good idea to
+   restrict the join to rows having <structfield>reldatabase</structfield> equal to
+   the current database's OID or zero.
+  </para>
+
+  <para>
+   Since buffer manager locks are not taken to copy the buffer state data that
+   the view will display, accessing <structname>pg_buffercache</structname> view
+   has less impact on normal buffer activity but it doesn't provide a consistent
+   set of results across all buffers.  However, we ensure that the information of
+   each buffer is self-consistent.
+  </para>
+ </sect2>
+
+ <sect2>
+  <title>The <function>pg_buffercache_summary()</function> Function</title>
+
+  <para>
+   The definitions of the columns exposed by the function are shown in <xref linkend="pgbuffercache_summary-columns"/>.
+  </para>
+
+  <table id="pgbuffercache_summary-columns">
+   <title><function>pg_buffercache_summary()</function> Output Columns</title>
+   <tgroup cols="1">
+    <thead>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       Column Type
+      </para>
+      <para>
+       Description
+      </para></entry>
+     </row>
+    </thead>
+
+    <tbody>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>buffers_used</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of unused shared buffers
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>buffers_unused</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of unused shared buffers
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>buffers_dirty</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of dirty shared buffers
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>buffers_pinned</structfield> <type>int4</type>
+      </para>
+      <para>
+       Number of pinned shared buffers
+      </para></entry>
+     </row>
+
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>usagecount_avg</structfield> <type>float8</type>
+      </para>
+      <para>
+       Average usagecount of used shared buffers
+      </para></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <para>
+   The <function>pg_buffercache_summary()</function> function returns a
+   single row summarizing the state of all shared buffers. Similar and more
+   detailed information is provided by the
+   <structname>pg_buffercache</structname> view, but
+   <function>pg_buffercache_summary()</function> is significantly cheaper.
+  </para>
+
+  <para>
+   Like the <structname>pg_buffercache</structname> view,
+   <function>pg_buffercache_summary()</function> does not acquire buffer
+   manager locks. Therefore concurrent activity can lead to minor inaccuracies
+   in the result.
+  </para>
+ </sect2>
+
+ <sect2>
+  <title>Sample Output</title>
+
+<screen>
+regression=# SELECT n.nspname, c.relname, count(*) AS buffers
+             FROM pg_buffercache b JOIN pg_class c
+             ON b.relfilenode = pg_relation_filenode(c.oid) AND
+                b.reldatabase IN (0, (SELECT oid FROM pg_database
+                                      WHERE datname = current_database()))
+             JOIN pg_namespace n ON n.oid = c.relnamespace
+             GROUP BY n.nspname, c.relname
+             ORDER BY 3 DESC
+             LIMIT 10;
+
+  nspname   |        relname         | buffers
+------------+------------------------+---------
+ public     | delete_test_table      |     593
+ public     | delete_test_table_pkey |     494
+ pg_catalog | pg_attribute           |     472
+ public     | quad_poly_tbl          |     353
+ public     | tenk2                  |     349
+ public     | tenk1                  |     349
+ public     | gin_test_idx           |     306
+ pg_catalog | pg_largeobject         |     206
+ public     | gin_test_tbl           |     188
+ public     | spgist_text_tbl        |     182
+(10 rows)
+
+
+regression=# SELECT * FROM pg_buffercache_summary();
+ buffers_used | buffers_unused | buffers_dirty | buffers_pinned | usagecount_avg
+--------------+----------------+---------------+----------------+----------------
+          248 |        2096904 |            39 |              0 |       3.141129
+(1 row)
+</screen>
+ </sect2>
+
+ <sect2>
+  <title>Authors</title>
+
+  <para>
+   Mark Kirkwood <email>markir@paradise.net.nz</email>
+  </para>
+
+  <para>
+   Design suggestions: Neil Conway <email>neilc@samurai.com</email>
+  </para>
+
+  <para>
+   Debugging advice: Tom Lane <email>tgl@sss.pgh.pa.us</email>
+  </para>
+ </sect2>
+
+</sect1>


### PR DESCRIPTION
Enable MPP support for pg_buffercache and build by default

This PR first backports the following upstream commits for `pg_buffercache`
https://github.com/postgres/postgres/commit/be39d88934331c47c43d8c51500305e928f06240
https://github.com/postgres/postgres/commit/2589434ae0fbfe08e46b6a4ffba400140b636074
https://github.com/postgres/postgres/commit/f3fa31327ecba75ee0e946abaa56dbf471ba704b

The final commit:

* Adds wrapper views around pg_buffercache_summary() and
  pg_buffercache_usage_counts() for convenience.

* Adds three MPP views displaying results from the coordinator and all segments
  - gp_buffercache
  - gp_buffercache_summary
  - gp_buffercache_usage_counts

* Adds two views displaying aggregated cluster-wide results
  - gp_buffercache_summary_aggregated
  - gp_buffercache_usage_counts_aggregated

Adds basic tests for the new functions/views.