### PR TITLE
pg_upgrade: rewrite data type check sql in plpgsql to run on GPDB6

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -1319,7 +1319,7 @@ check_for_appendonly_materialized_view_with_relfrozenxid(ClusterInfo *cluster)
 	char		output_path[MAXPGPATH];
 	bool		found = false;
 
-	prep_status("Checking for appendonly materialized view with relfrozenxid\n");
+	prep_status("Checking for appendonly materialized view with relfrozenxid");
 
 	snprintf(output_path,
 				sizeof(output_path),

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -100,6 +100,8 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 
 	get_loadable_libraries();
 
+	setup_GPDB6_data_type_checks(&old_cluster);
+
 	/*
 	 * Check for various failure cases
 	 */
@@ -172,6 +174,8 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	{
 		check_for_appendonly_materialized_view_with_relfrozenxid(&old_cluster);
 	}
+
+	teardown_GPDB6_data_type_checks(&old_cluster);
 
 dump_old_cluster:
 	/*

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -86,6 +86,8 @@ void new_gpdb_invalidate_bitmap_indexes(void);
 /* check_gp.c */
 
 void check_greenplum(void);
+void setup_GPDB6_data_type_checks(ClusterInfo *cluster);
+void teardown_GPDB6_data_type_checks(ClusterInfo *cluster);
 
 /* reporting.c */
 


### PR DESCRIPTION
pg_upgrade has a few checks that look for specific data types. The SQL
used to look for data types does not run on GPDB6 because it is a
recursive CTE that contains a self-reference in a subquery. This
specific type of query works on GPDB7, but is broken on GPDB6 and
therefore doesn't work for GPDB6 > GPDB7 upgrade. To get type of query
working on GPDB6 would require a non trivial amount of backports. As a
workaround, the query was rewritten in plpgsql so it can run on GPDB6.
    
This fixes the following pg_upgrade checks:
 - check_for_composite_data_type_usage
 - check_for_reg_data_type_usage
 - old_11_check_for_sql_identifier_data_type_usage
 - old_9_6_check_for_unknown_data_type_usage

performance numbers using `\timing` against the icw regression db on a demo clusters.
plpgsql on 6X regression
Time: 653.903 ms

CTE on 7X regression
Time: 206.348 ms