### PR TITLE
ignore CreateDir in abi-check

### DIFF
--- a/.abi-check/7.0.0/postgres.symbols.ignore
+++ b/.abi-check/7.0.0/postgres.symbols.ignore
@@ -2,3 +2,4 @@ ConfigureNamesInt_gp
 ConfigureNamesBool_gp
 ConfigureNamesEnum_gp
 UpdateOrAddAttributeEncodings
+createDir


### PR DESCRIPTION
The signature of `CreateDir` has been changed in #16732  which is unlikely expected to be used by the outside world. Just add it to the ABI ignore list.
