### PR TITLE
[ORCA] Fix boolean testing when the child is not an ident but an expression

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-Boolean2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-Boolean2.mdp
@@ -164,6 +164,30 @@
           <dxl:Partition Mdid="6.112489.1.0"/>
         </dxl:Partitions>
       </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.1694.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1691.1.0"/>
+        <dxl:Commutator Mdid="0.1695.1.0"/>
+        <dxl:InverseOp Mdid="0.59.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.1695.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1692.1.0"/>
+        <dxl:Commutator Mdid="0.1694.1.0"/>
+        <dxl:InverseOp Mdid="0.58.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.58.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.16.1.0"/>
         <dxl:RightType Mdid="0.16.1.0"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -109,8 +109,8 @@ private:
 		BOOL infer_nulls_as = false,
 		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
-	// create interval from scalar null test
-	static CConstraintInterval *PciIntervalFromScalarNullTest(
+	// create interval from scalar null test & unknown test
+	static CConstraintInterval *PciIntervalFromScalarNullAndUnknownTest(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref);
 
 	// create interval from scalar boolean test

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -1227,7 +1227,7 @@ explain (costs off) select * from boolpart where a is unknown;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a IS UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1237,7 +1237,7 @@ explain (costs off) select * from boolpart where a is not unknown;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 2 (out of 3)
          Filter: (a IS NOT UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -4098,6 +4098,162 @@ SELECT * FROM pt_bool_tab WHERE col2 IS NOT NULL;
     3 | t
 (5 rows)
 
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000000694.14 rows=187 width=5)
+   ->  Append  (cost=10000000000.00..20000000691.65 rows=62 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+(0 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000000694.14 rows=187 width=5)
+   ->  Append  (cost=10000000000.00..20000000691.65 rows=62 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+(0 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000003493.53 rows=186813 width=5)
+   ->  Append  (cost=10000000000.00..20000001002.69 rows=62271 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000003493.53 rows=186813 width=5)
+   ->  Append  (cost=10000000000.00..20000001002.69 rows=62271 width=5)
+         ->  Seq Scan on pt_bool_tab_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+         ->  Seq Scan on pt_bool_tab_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
 CREATE TABLE pt_bool_tab_df
 (
   col1 int,
@@ -4253,6 +4409,182 @@ EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
 (9 rows)
 
 SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
+ col1 | col2 
+------+------
+    2 | f
+    2 | t
+    3 | t
+    1 | f
+    1 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    1 | f
+    2 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    1 | t
+    2 | t
+    3 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000001041.21 rows=280 width=5)
+   ->  Append  (cost=10000000000.00..30000001037.47 rows=94 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000001041.21 rows=280 width=5)
+   ->  Append  (cost=10000000000.00..30000001037.47 rows=94 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+    1 | 
+(4 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+    1 | 
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000005240.29 rows=280220 width=5)
+   ->  Append  (cost=10000000000.00..30000001504.03 rows=93406 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000005240.29 rows=280220 width=5)
+   ->  Append  (cost=10000000000.00..30000001504.03 rows=93406 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
  col1 | col2 
 ------+------
     2 | f
@@ -4422,6 +4754,182 @@ SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT NULL;
     3 | t
     1 | f
     1 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS TRUE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS FALSE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000001041.21 rows=280 width=5)
+   ->  Append  (cost=10000000000.00..30000001037.47 rows=94 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS NULL)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000001041.21 rows=280 width=5)
+   ->  Append  (cost=10000000000.00..30000001037.47 rows=94 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=31 width=5)
+               Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    1 | t
+    1 | 
+    2 | t
+    3 | t
+(4 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000003140.75 rows=140250 width=5)
+   ->  Append  (cost=10000000000.00..30000001270.75 rows=46750 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    1 | f
+    1 | 
+    2 | f
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000005240.29 rows=280220 width=5)
+   ->  Append  (cost=10000000000.00..30000001504.03 rows=93406 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..30000005240.29 rows=280220 width=5)
+   ->  Append  (cost=10000000000.00..30000001504.03 rows=93406 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=31136 width=5)
+               Filter: ((NOT col2) IS NOT NULL)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
 (5 rows)
 
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3442,14 +3442,12 @@ SELECT * FROM pt_bool_tab WHERE col2 IS NULL;
 (0 rows)
 
 EXPLAIN SELECT * FROM pt_bool_tab WHERE col2 IS unknown;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
-   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 2 (out of 2)
-         Filter: (col2 IS UNKNOWN)
- Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=5)
+   One-Time Filter: false
+ Optimizer: GPORCA
+(3 rows)
 
 SELECT * FROM pt_bool_tab WHERE col2 IS unknown;
  col1 | col2 
@@ -3531,6 +3529,146 @@ SELECT * FROM pt_bool_tab WHERE col2 IS NOT NULL;
     3 | t
 (5 rows)
 
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 2)
+         Filter: ((NOT col2) IS TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 2)
+         Filter: ((NOT col2) IS FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 2)
+         Filter: ((NOT col2) IS NULL)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+(0 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 2)
+         Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+(0 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 2)
+         Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 2)
+         Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 2)
+         Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 2)
+         Filter: (NOT ((NOT col2) IS NULL))
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
 CREATE TABLE pt_bool_tab_df
 (
   col1 int,
@@ -3602,7 +3740,7 @@ EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS unknown;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
    ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 1 (out of 3)
          Filter: (col2 IS UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3655,7 +3793,7 @@ EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT unknown;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
    ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 2 (out of 3)
          Filter: (col2 IS NOT UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3675,12 +3813,156 @@ EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
    ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 2 (out of 3)
          Filter: (NOT (col2 IS NULL))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
+ col1 | col2 
+------+------
+    2 | f
+    2 | t
+    3 | t
+    1 | f
+    1 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 3)
+         Filter: ((NOT col2) IS TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 3)
+         Filter: ((NOT col2) IS FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS NULL)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 3)
+         Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    2 | t
+    3 | t
+    1 | t
+    1 | 
+(4 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 3)
+         Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    2 | f
+    1 | f
+    1 | 
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    2 | f
+    2 | t
+    3 | t
+    1 | f
+    1 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_df  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: (NOT ((NOT col2) IS NULL))
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
  col1 | col2 
 ------+------
     2 | f
@@ -3761,7 +4043,7 @@ EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS unknown;
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
    ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 1 (out of 3)
          Filter: (col2 IS UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3814,7 +4096,7 @@ EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT unknown;
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
    ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
-         Number of partitions to scan: 3 (out of 3)
+         Number of partitions to scan: 2 (out of 3)
          Filter: (col2 IS NOT UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3847,6 +4129,150 @@ SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT NULL;
     3 | t
     1 | f
     1 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 3)
+         Filter: ((NOT col2) IS TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+ col1 | col2 
+------+------
+    1 | f
+    2 | f
+(2 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 1 (out of 3)
+         Filter: ((NOT col2) IS FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+ col1 | col2 
+------+------
+    1 | t
+    2 | t
+    3 | t
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS NULL)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+ col1 | col2 
+------+------
+    1 | 
+(1 row)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 3)
+         Filter: ((NOT col2) IS NOT TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+ col1 | col2 
+------+------
+    1 | t
+    1 | 
+    2 | t
+    3 | t
+(4 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 2 (out of 3)
+         Filter: ((NOT col2) IS NOT FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+ col1 | col2 
+------+------
+    1 | f
+    1 | 
+    2 | f
+(3 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: ((NOT col2) IS NOT UNKNOWN)
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
+(5 rows)
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+   ->  Dynamic Seq Scan on pt_bool_tab_null  (cost=0.00..431.00 rows=1 width=5)
+         Number of partitions to scan: 3 (out of 3)
+         Filter: (NOT ((NOT col2) IS NULL))
+ Optimizer: GPORCA
+(5 rows)
+
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
+ col1 | col2 
+------+------
+    1 | f
+    1 | t
+    2 | f
+    2 | t
+    3 | t
 (5 rows)
 
 RESET ALL;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -882,6 +882,23 @@ SELECT * FROM pt_bool_tab WHERE col2 IS NOT unknown;
 EXPLAIN SELECT * FROM pt_bool_tab WHERE col2 IS NOT NULL;
 SELECT * FROM pt_bool_tab WHERE col2 IS NOT NULL;
 
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS true;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS false;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NULL;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS unknown;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT true;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT false;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT unknown;
+EXPLAIN SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+SELECT * FROM pt_bool_tab WHERE (not col2) IS NOT NULL;
+
 CREATE TABLE pt_bool_tab_df
 (
   col1 int,
@@ -916,6 +933,23 @@ SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT unknown;
 EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
 SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT NULL;
 
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS true;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS false;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NULL;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS unknown;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT true;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT false;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT unknown;
+EXPLAIN SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
+SELECT * FROM pt_bool_tab_df WHERE (not col2) IS NOT NULL;
+
 
 CREATE TABLE pt_bool_tab_null
 (
@@ -949,5 +983,22 @@ EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT unknown;
 SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT unknown;
 EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT NULL;
 SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT NULL;
+
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS true;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS false;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NULL;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS unknown;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT true;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT false;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT unknown;
+EXPLAIN SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
+SELECT * FROM pt_bool_tab_null WHERE (not col2) IS NOT NULL;
 
 RESET ALL;


### PR DESCRIPTION
After the commit "[ORCA] Support boolean static partition pruning (#15348)", we added support for boolean testing in partition pruning or other condition pruning. However, currently, we only treated it as a parent of ident. When its child is an expression, errors may occur.

For example 1, this query will lead to a "One-Time Filter: false" because we treated it as "b is true and (not b)".

create table test (a int, b boolean);
explain select * from test where (not b) is true and (not b);

For example 2, this query will have no results because partition pruning will prune the current part as we treated it as "col2 IS true".

CREATE TABLE pt_bool_tab (
  col1 int,
  col2 bool
)
distributed by (col1)
partition by list(col2)
(
  partition part1 values(true),
  partition part2 values(false)
);
INSERT INTO pt_bool_tab SELECT i, true FROM generate_series(1,3)i;
INSERT INTO pt_bool_tab SELECT i, false FROM generate_series(1,2)i;
SELECT * FROM pt_bool_tab WHERE (not col2) IS true;

To fix this issue, we can use the following approaches to replace boolean testing: "expr (with infer_nulls_as)", "not (with infer_nulls_as)", "is null", and "is not null". 
This is the table about results of boolean tests & some other boolean operators

Parameter		T	F	NULL
----------------------------
is true			T	F	F
is not false		T	F	T
is false			F	T	F
is not true		F	T	T
is unknown		F	F	T
is not unknown	T	T	F
----------------------------
expr				T	F	infer_nulls_as
not				F	T	infer_nulls_as
is null			F	F	T
is not null		T	T	F

So, we treat
(is true / is not false)	as	expr with infer_nulls_as
(is false / is not true)	as	not with infer_nulls_as
is unknown 					as	is null
is not unknown 				as	is not null

TODO: After this fix, there is also one optimization remaining. The way of "is null" cannot process pruning when its child is an expression. It is difficult to differentiate between ((ident is true) is null) and (ident is null) when ident is null. We may consider adding a null_is_null flag in CConstraintInterval in the future.
