### PR TITLE
Fix flaky test autovacuum-temp-table

### DIFF
--- a/src/test/isolation2/expected/autovacuum-temp-table.out
+++ b/src/test/isolation2/expected/autovacuum-temp-table.out
@@ -21,14 +21,14 @@ CREATE TABLE
 1U: create temp table ttu_av1(a int);
 CREATE TABLE
 
--- PANIC
-1: select gp_inject_fault('exec_mpp_query_start', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+-- Inject a PANIC on one of the segment. Use something that's not going to be hit by background worker (including autovacuum).
+1: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: select * from tt_av1;
-ERROR:  fault triggered, fault name:'exec_mpp_query_start' fault type:'panic'  (seg0 slice1 127.0.1.1:7002 pid=21899)
+1: create function my_function() returns void as $$ begin end; $$ language plpgsql;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (seg0 127.0.1.1:7002 pid=19244)
 
 0Uq: ... <quitting>
 1q: ... <quitting>
@@ -37,6 +37,13 @@ ERROR:  fault triggered, fault name:'exec_mpp_query_start' fault type:'panic'  (
 -- also served as a third test case.
 1: create temp table tt_av3(a int);
 CREATE TABLE
+
+-- clear the fault
+1: select gp_inject_fault('create_function_fail', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 
 -- make sure the autovacuum is run at least once,
 -- it might've been run already, which is fine.

--- a/src/test/isolation2/sql/autovacuum-temp-table.sql
+++ b/src/test/isolation2/sql/autovacuum-temp-table.sql
@@ -14,9 +14,9 @@
 0U: create temp table ttu_av0(a int);
 1U: create temp table ttu_av1(a int);
 
--- PANIC
-1: select gp_inject_fault('exec_mpp_query_start', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
-1: select * from tt_av1;
+-- Inject a PANIC on one of the segment. Use something that's not going to be hit by background worker (including autovacuum).
+1: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+1: create function my_function() returns void as $$ begin end; $$ language plpgsql;
 
 0Uq:
 1q:
@@ -24,6 +24,9 @@
 -- make sure the segment restarted,
 -- also served as a third test case.
 1: create temp table tt_av3(a int);
+
+-- clear the fault
+1: select gp_inject_fault('create_function_fail', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
 
 -- make sure the autovacuum is run at least once,
 -- it might've been run already, which is fine.


### PR DESCRIPTION
Failure diff:
```
--- /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/expected/autovacuum-temp-table.out	2023-12-07 10:40:29.583957111 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/results/autovacuum-temp-table.out	2023-12-07 10:40:29.591957823 +0000
@@ -29,7 +38,9 @@
  Success:
 (1 row)
 1: select * from tt_av1;
-ERROR:  fault triggered, fault name:'exec_mpp_query_start' fault type:'panic'
+ a
+---
+(0 rows)

 0Uq: ... <quitting>
 1q: ... <quitting>
```

The fault was not hit by the expected "select * from tt_av1" query. From the log it's hit by a query dispatched by the autovacuum on QD:
```
2023-12-07 10:40:26.973550 UTC,"gpadmin","isolation2test",p206008,th-1346017152,"[local]",,2023-12-07 10:40:26 UTC,0,con147,cmd5,seg-1,,dx268381,,sx1,"LOG","00000","statement: create table bloat_tbl(i int, j int, k int, l int, m int, n int, o int, p int) distributed by (i) partition by range (j) (start (0) end (1000) every (1));",,,,,,,0,,"postgres.c",1730,
2023-12-07 10:40:27.127327 UTC,,,p205954,th-1346017152,,,,0,con140,cmd6,seg-1,,,,sx1,"ERROR","XX009","fault triggered, fault name:'exec_mpp_query_start' fault type:'panic'  (seg0 slice1 10.80.0.2:7002 pid=205963)",,,,,"automatic analyze of table ""isolation2test.public.aoco_index_build_progress""",,0,,"faultinjector.c",430,"Stack trace:
```

Obviously we cannot run the test with autovacuum disabled because it's dependent on autovacuum. So use a different fault and query to trigger the panic.

P.S. we have guard against background worker from hitting unexpected fault: https://github.com/greenplum-db/gpdb/blob/61de7b3bb63c45a18ea3c90c2e14e8e4bc829120/src/backend/utils/misc/faultinjector.c#L254-L267
But that doesn't work for this case because autovacuum process just dispatched a query and it is a normal backend on QE who hits the fault.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/flake-autovacuum-temp-table

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
