### PR TITLE
Fix deadlock between coordinator and segments

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -144,8 +144,26 @@ cdb_sync_indcheckxmin_with_segments(Oid indexRelationId)
 	int			i;
 	char		cmd[100];
 	bool		indcheckxmin_set_in_any_segment;
+	Relation	pg_index_rel;
 
 	Assert(Gp_role == GP_ROLE_DISPATCH && !IsBootstrapProcessingMode());
+
+	/*
+	 * The query to check on indcheckxmin on segments will acquire AccessShareLock
+	 * on pg_index table, and wouldn't release until the end of the transaction.
+	 * To avoid deadlock between coordinator and segments, we should acquire the
+	 * lock on coordinator in advance, and shouldn't release until the end of the
+	 * transaction.
+	 *
+	 * A typical deadlock case without acquiring the lock is:
+	 *
+	 *   T1: CREATE TABLE t1 (c1 int);
+	 *   T1: BEGIN;
+	 *   T1: CREATE INDEX idx on t1(c1);
+	 *   T2: VACUUM FULL pg_index;
+	 *   T1: SELECT * FROM t1;
+	 */
+	pg_index_rel = heap_open(IndexRelationId, AccessShareLock);
 
 	/*
 	 * Query all the segments, for their indcheckxmin value for this index.
@@ -209,6 +227,12 @@ cdb_sync_indcheckxmin_with_segments(Oid indexRelationId)
 		heap_freetuple(indexTuple);
 		heap_close(pg_index, RowExclusiveLock);
 	}
+
+	/*
+	 * Keep consistent with segments, don't release the lock until the end of
+	 * the transaction.
+	 */
+	heap_close(pg_index_rel, NoLock);
 }
 
 /*

--- a/src/test/isolation2/expected/create_index_deadlock.out
+++ b/src/test/isolation2/expected/create_index_deadlock.out
@@ -1,0 +1,22 @@
+-- This test is used to check if there is a deadlock between coordinator and segments
+-- when creating index.
+
+1: CREATE TABLE test_create_index_deadlock_tbl (c1 int);
+CREATE TABLE
+
+1: BEGIN;
+BEGIN
+1: CREATE INDEX test_create_index_deadlock_idx on test_create_index_deadlock_tbl (c1);
+CREATE INDEX
+2&: VACUUM FULL pg_index;  <waiting ...>
+1: SELECT * FROM test_create_index_deadlock_tbl;
+ c1 
+----
+(0 rows)
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+VACUUM
+
+1: DROP TABLE test_create_index_deadlock_tbl;
+DROP TABLE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -70,6 +70,7 @@ test: misc
 
 test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock bitmap_index_ao_sparse
 
+test: create_index_deadlock
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend

--- a/src/test/isolation2/sql/create_index_deadlock.sql
+++ b/src/test/isolation2/sql/create_index_deadlock.sql
@@ -1,0 +1,13 @@
+-- This test is used to check if there is a deadlock between coordinator and segments
+-- when creating index.
+
+1: CREATE TABLE test_create_index_deadlock_tbl (c1 int);
+
+1: BEGIN;
+1: CREATE INDEX test_create_index_deadlock_idx on test_create_index_deadlock_tbl (c1);
+2&: VACUUM FULL pg_index;
+1: SELECT * FROM test_create_index_deadlock_tbl;
+1: COMMIT;
+2<:
+
+1: DROP TABLE test_create_index_deadlock_tbl;


### PR DESCRIPTION
Create index will dispatch query `select indcheckxmin from pg_catalog.pg_index where indexrelid = 'xxx'` to segments to sync `indcheckxmin` on coordinator. This query will acquire `AccessShareLock` on `pg_index` in segments, and wouldn't release until the end of the transaction, since coordinator won't acquire the lock for now, deadlock between coordinator and segment may be occurred in some scenarios, what's worse, this kind of deadlock couldn't be resolved by GDD.

To avoid that, before dispatching the query, coordinator should also grab the `AccessShareLock` on `pg_index`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
