### PR TITLE
delete cgroup leaf dir only when use group-v2

### DIFF
--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -543,9 +543,8 @@ deleteDir(Oid group, CGroupComponentType component, const char *filename, bool u
 					 pathes[i].path, strerror(err));
 			}
 
-			if (retry <= MAX_RETRY)
-				elog(DEBUG1, "cgroup dir '%s' removed", pathes[i].path);
 			pathes[i].deleted = true;
+			elog(DEBUG1, "cgroup dir '%s' removed", pathes[i].path);
 		}
 		break;
 	}


### PR DESCRIPTION
There is no leaf directory in gpdb cgroup when use cgroup v1, so the `rmdir(leaf_path)` will always return non-zero values, then the `rmdir(path)` will be ignored.
When drop some resource groups, when corresponding cgroup dir cannot be removed because the `rmdire(path)` is not executed, this behavior will cause the failure of CI.

This commit add some logic to check resource group version in `deleteDir`, when use `group-v1`, `rmdir(leaf_path)` will be ignored.