### PR TITLE
[6X] Printing const-folder expression in ruleutils.c

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -45,6 +45,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/tlist.h"
+#include "optimizer/planner.h"
 #include "parser/keywords.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_func.h"
@@ -98,6 +99,9 @@
 #define PRETTY_INDENT(context)	((context)->prettyFlags & PRETTYFLAG_INDENT)
 #define PRETTY_SCHEMA(context)	((context)->prettyFlags & PRETTYFLAG_SCHEMA)
 
+/* macros for negative operator only used in current file */
+#define	Int4NegOperator			558
+#define	NumericNegOperator		1751
 
 /* ----------
  * Local data types
@@ -5437,6 +5441,31 @@ get_rule_sortgroupclause(SortGroupClause *srt, List *tlist, bool force_colno,
 	}
 	else if (expr && IsA(expr, Const))
 		get_const_expr((Const *) expr, context, 1);
+	else if (expr && IsA(expr, OpExpr))
+	{
+		OpExpr		*opexpr = (OpExpr *)expr;
+		List		*args = opexpr->args;
+
+		/*
+		 * Const-folder the expression(opexpr plus const) to negative const,
+		 * mainly there are two operators we need to worried about, namely
+		 * in4um(Int4NegOperator) and numeric_uminus(NumericNegOperator),
+		 * and get_const_expr() is responsible for end up getting labeled
+		 * with a typecast.
+		 */
+		if (list_length(args) == 1)
+		{
+			Node	   *arg = (Node *) linitial(args);
+			Oid			opno = opexpr->opno;
+
+			if ((opno == Int4NegOperator ||
+				 opno == NumericNegOperator) &&
+				 IsA(arg, Const))
+				expr = (Node *)expression_planner((Expr *)expr);
+		}
+
+		get_rule_expr(expr, context, true);
+	}
 	else
 		get_rule_expr(expr, context, true);
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5458,10 +5458,9 @@ get_rule_sortgroupclause(SortGroupClause *srt, List *tlist, bool force_colno,
 			Node	   *arg = (Node *) linitial(args);
 			Oid			opno = opexpr->opno;
 
-			if ((opno == Int4NegOperator ||
-				 opno == NumericNegOperator) &&
+			if ((opno == Int4NegOperator || opno == NumericNegOperator) &&
 				 IsA(arg, Const))
-				expr = (Node *)expression_planner((Expr *)expr);
+				expr = (Node *) expression_planner((Expr *)expr);
 		}
 
 		get_rule_expr(expr, context, true);

--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1703,6 +1703,22 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+                  pg_get_viewdef                   
+---------------------------------------------------
+  SELECT tdis.a,                                  +
+     tdis.b,                                      +
+     tdis.c,                                      +
+     - 1                                          +
+    FROM tdis                                     +
+   GROUP BY tdis.a, tdis.b, tdis.c, '-1'::integer;
+(1 row)
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1703,6 +1703,22 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+                  pg_get_viewdef                   
+---------------------------------------------------
+  SELECT tdis.a,                                  +
+     tdis.b,                                      +
+     tdis.c,                                      +
+     - 1                                          +
+    FROM tdis                                     +
+   GROUP BY tdis.a, tdis.b, tdis.c, '-1'::integer;
+(1 row)
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/sql/create_view.sql
+++ b/src/test/regress/sql/create_view.sql
@@ -584,6 +584,12 @@ select pg_get_viewdef('tt23v', true);
 select pg_get_ruledef(oid, true) from pg_rewrite
   where ev_class = 'tt23v'::regclass and ev_type = '1';
 
+
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
+select pg_get_viewdef('tdis_v1', true);
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;


### PR DESCRIPTION
Previous coding in get_const_expr() has handled with negative number, opexpr plus number is an exception. 
(ex. -1 could be a negative const and also could be a opexpr '-' plus number 1). So we needed to hacking up
in get_rule_sortgroupclause() for Opexpr cases and pre-calculate opexpr plus number to real const by expression_planner(). 

More Discussions: https://www.postgresql.org/message-id/KL1PR03MB728644D79999D6BBF65E4D6FA482A%40KL1PR03MB7286.apcprd03.prod.outlook.com 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
