### PR TITLE
Docs: added note for gppkg remove force option

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -72,7 +72,7 @@ Examples of database extensions and packages software that are delivered using t
 :   Run a simulation for the command, without modifying anything.
 
 `-f | --force`
-:   Skip all requirement checks and overwrite existing files. If using it with `gppkg remove`, the utility removes package files which have incomplete or missing files.
+:   Skip all requirement checks and overwrite existing files. If using it with `gppkg remove`, the utility removes packages which have incomplete or missing files.
 
 `-h | --help`
 :   Display the online help.

--- a/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gppkg.html.md
@@ -72,7 +72,7 @@ Examples of database extensions and packages software that are delivered using t
 :   Run a simulation for the command, without modifying anything.
 
 `-f | --force`
-:   Skip all requirement checks and overwrite existing files.
+:   Skip all requirement checks and overwrite existing files. If using it with `gppkg remove`, the utility removes package files which have incomplete or missing files.
 
 `-h | --help`
 :   Display the online help.


### PR DESCRIPTION
This PR adds a note for the `-f` option for `gppkg` utility, based on the changes introduced by https://github.com/pivotal/gp-pkg/pull/150