### PR TITLE
Printing const-folder expression in ruleutils.c 

### DIFF
--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1783,6 +1783,22 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select a,b,c, -1::int from tdis group by 1,2,3,4;
+select pg_get_viewdef('tdis_v1', true);
+                   pg_get_viewdef                    
+-----------------------------------------------------
+  SELECT tdis.a,                                    +
+     tdis.b,                                        +
+     tdis.c,                                        +
+     - 1 AS "?column?"                              +
+    FROM tdis                                       +
+   GROUP BY tdis.a, tdis.b, tdis.c, ('-1'::integer);
+(1 row)
+
 -- clean up all the random objects we made above
 DROP SCHEMA temp_view_test CASCADE;
 NOTICE:  drop cascades to 27 other objects
@@ -1814,7 +1830,7 @@ drop cascades to view aliased_view_2
 drop cascades to view aliased_view_3
 drop cascades to view aliased_view_4
 DROP SCHEMA testviewschm2 CASCADE;
-NOTICE:  drop cascades to 64 other objects
+NOTICE:  drop cascades to 66 other objects
 DETAIL:  drop cascades to table t1
 drop cascades to view temporal1
 drop cascades to view temporal2
@@ -1879,3 +1895,5 @@ drop cascades to view tt20v
 drop cascades to view tt21v
 drop cascades to view tt22v
 drop cascades to view tt23v
+drop cascades to table tdis
+drop cascades to view tdis_v1

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1786,6 +1786,22 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tdis_v1 as select a,b,c, -1::int from tdis group by 1,2,3,4;
+select pg_get_viewdef('tdis_v1', true);
+                   pg_get_viewdef                    
+-----------------------------------------------------
+  SELECT tdis.a,                                    +
+     tdis.b,                                        +
+     tdis.c,                                        +
+     - 1 AS "?column?"                              +
+    FROM tdis                                       +
+   GROUP BY tdis.a, tdis.b, tdis.c, ('-1'::integer);
+(1 row)
+
 -- clean up all the random objects we made above
 DROP SCHEMA temp_view_test CASCADE;
 NOTICE:  drop cascades to 27 other objects
@@ -1817,7 +1833,7 @@ drop cascades to view aliased_view_2
 drop cascades to view aliased_view_3
 drop cascades to view aliased_view_4
 DROP SCHEMA testviewschm2 CASCADE;
-NOTICE:  drop cascades to 64 other objects
+NOTICE:  drop cascades to 66 other objects
 DETAIL:  drop cascades to table t1
 drop cascades to view temporal1
 drop cascades to view temporal2
@@ -1882,3 +1898,5 @@ drop cascades to view tt20v
 drop cascades to view tt21v
 drop cascades to view tt22v
 drop cascades to view tt23v
+drop cascades to table tdis
+drop cascades to view tdis_v1

--- a/src/test/regress/sql/create_view.sql
+++ b/src/test/regress/sql/create_view.sql
@@ -615,6 +615,12 @@ select pg_get_viewdef('tt23v', true);
 select pg_get_ruledef(oid, true) from pg_rewrite
   where ev_class = 'tt23v'::regclass and ev_type = '1';
 
+
+-- test display negative operator of const-folder expression
+create table tdis(a int, b int, c int);
+create view tdis_v1 as select a,b,c, -1::int from tdis group by 1,2,3,4;
+select pg_get_viewdef('tdis_v1', true);
+
 -- clean up all the random objects we made above
 DROP SCHEMA temp_view_test CASCADE;
 DROP SCHEMA testviewschm2 CASCADE;


### PR DESCRIPTION
Previous coding in get_const_expr() has handled with negative number, opexpr plus number is an exception. 
(ex. -1 could be a negative const and also could be a opexpr '-' plus number 1). So we needed to hacking up
in get_rule_sortgroupclause() for Opexpr cases and pre-calculate opexpr plus number to real const by expression_planner(). 

More Discussions: https://www.postgresql.org/message-id/KL1PR03MB728644D79999D6BBF65E4D6FA482A%40KL1PR03MB7286.apcprd03.prod.outlook.com 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
