### PR TITLE
Produce stable explain_format test output

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,38 +1,50 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes \(seg\d+\)\./Executor memory: ####K bytes (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Memory wanted:  \d+\w?kB/
--- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- end_matchsubs
---
+-- Tests EXPLAIN format output
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -41,248 +53,210 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3577.00..11272.25 rows=77900 width=84)
-   ->  Hash Left Join  (cost=3577.00..9714.25 rows=25967 width=84)
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                             explain_filter                                             
+--------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+   ->  Hash Left Join  (cost=N.N..N.N rows=N width=N)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2361.00..7427.12 rows=25967 width=48)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=2361.00..5869.12 rows=25967 width=48)
+               ->  Hash Left Join  (cost=N.N..N.N rows=N width=N)
                      Hash Cond: (boxes.apple_id = apples.id)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
-                     ->  Hash  (cost=1111.00..1111.00 rows=33334 width=36)
-                           ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36)
-         ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N)
+                     ->  Hash  (cost=N.N..N.N rows=N width=N)
+                           ->  Seq Scan on apples  (cost=N.N..N.N rows=N width=N)
+         ->  Hash  (cost=N.N..N.N rows=N width=N)
+               ->  Seq Scan on box_locations  (cost=N.N..N.N rows=N width=N)
  Optimizer: Postgres-based planner
 (15 rows)
 
--- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                                QUERY PLAN                                                                 
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=812.00..3838.66 rows=77900 width=84) (actual time=13.602..13.602 rows=0 loops=1)
-   ->  Hash Left Join  (cost=812.00..2799.99 rows=25967 width=84) (actual time=0.000..13.242 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                                explain_filter                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+   ->  Hash Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=406.00..2066.16 rows=25967 width=48) (actual time=0.000..12.303 rows=0 loops=1)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=406.00..1546.83 rows=25967 width=48) (actual time=0.000..12.138 rows=0 loops=1)
+               ->  Hash Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                      Hash Cond: (boxes.apple_id = apples.id)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..813.00 rows=25967 width=12) (actual time=0.000..0.005 rows=0 loops=1)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.007 rows=0 loops=1)
-                     ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=9.989..9.989 rows=33462 loops=1)
-                           Buckets: 131072  Batches: 1  Memory Usage: 2201kB
-                           ->  Seq Scan on apples  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.024..3.215 rows=33462 loops=1)
-         ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
-               Buckets: 131072  Batches: 1  Memory Usage: 1024kB
-               ->  Seq Scan on box_locations  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                     ->  Hash  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                           Buckets: N  Batches: N  Memory Usage: NkB
+                           ->  Seq Scan on apples  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+         ->  Hash  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+               Buckets: N  Batches: N  Memory Usage: NkB
+               ->  Seq Scan on box_locations  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
  Optimizer: Postgres-based planner
- Planning Time: 0.893 ms
-   (slice0)    Executor memory: 64K bytes.
-   (slice1)    Executor memory: 1051K bytes avg x 3 workers, 1051K bytes max (seg0).  Work_mem: 1024K bytes max.
-   (slice2)    Executor memory: 2364K bytes avg x 3 workers, 2364K bytes max (seg0).  Work_mem: 2201K bytes max.
-   (slice3)    Executor memory: 41K bytes avg x 3 workers, 44K bytes max (seg1).
- Memory used:  128000kB
- Execution Time: 29.877 ms
+ Planning Time: N.N ms
+   (sliceN)    Executor memory: NK bytes.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+ Memory used:  NkB
+ Execution Time: N.N ms
 (24 rows)
 
--- explain_processing_on
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
 -- and its position depends on the longest line. If the width changes, all
 -- lines need to be adjusted for the moved end-of-line-marker.
 \a
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
--- start_matchignore
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 3577.00
-    Total Cost: 11272.25
-    Plan Rows: 77900
-    Plan Width: 84
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Plans: 
       - Node Type: "Hash Join"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 3577.00
-        Total Cost: 9714.25
-        Plan Rows: 77900
-        Plan Width: 84
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Inner Unique: true
         Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 2361.00
-            Total Cost: 7427.12
-            Plan Rows: 77900
-            Plan Width: 48
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Hash Key: "boxes.location_id"
             Plans: 
               - Node Type: "Hash Join"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 2361.00
-                Total Cost: 5869.12
-                Plan Rows: 77900
-                Plan Width: 48
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
                 Inner Unique: true
                 Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 2437.00
-                    Plan Rows: 77900
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Hash Key: "boxes.apple_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 879.00
-                        Plan Rows: 77900
-                        Plan Width: 12
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
                   - Node Type: "Hash"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 1111.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 2
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "apples"
                         Alias: "apples"
-                        Startup Cost: 0.00
-                        Total Cost: 1111.00
-                        Plan Rows: 100000
-                        Plan Width: 36
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
           - Node Type: "Hash"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 596.00
-            Total Cost: 596.00
-            Plan Rows: 49600
-            Plan Width: 36
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Plans: 
               - Node Type: "Seq Scan"
                 Parent Relationship: "Outer"
-                Slice: 1
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Relation Name: "box_locations"
                 Alias: "box_locations"
-                Startup Cost: 0.00
-                Total Cost: 596.00
-                Plan Rows: 49600
-                Plan Width: 36
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
   Optimizer: "Postgres-based planner"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 1332.33
-    Plan Rows: 77900
-    Plan Width: 12
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -290,44 +264,41 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: 0.00
-        Total Cost: 293.67
-        Plan Rows: 25967
-        Plan Width: 12
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Postgres-based planner"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    optimizer: "off"
+    random_page_cost: "N"
 (1 row)
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: #
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: ###.##
-    Total Cost: ###.##
-    Plan Rows: #####
-    Plan Width: ##
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -335,311 +306,276 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: #
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: ###.##
-        Total Cost: ###.##
-        Plan Rows: #####
-        Plan Width: ##
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Postgres-based planner"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
+    optimizer: "off"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 3577.00
-    Total Cost: 11272.25
-    Plan Rows: 77900
-    Plan Width: 84
-    Actual Startup Time: 70.104
-    Actual Total Time: 70.104
-    Actual Rows: 0
-    Actual Loops: 1
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
+    Actual Startup Time: N.N
+    Actual Total Time: N.N
+    Actual Rows: N
+    Actual Loops: N
     Plans: 
       - Node Type: "Hash Join"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 3577.00
-        Total Cost: 9714.25
-        Plan Rows: 77900
-        Plan Width: 84
-        Actual Startup Time: 0.000
-        Actual Total Time: 0.000
-        Actual Rows: 0
-        Actual Loops: 0
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
+        Actual Startup Time: N.N
+        Actual Total Time: N.N
+        Actual Rows: N
+        Actual Loops: N
         Inner Unique: true
         Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 2361.00
-            Total Cost: 7427.12
-            Plan Rows: 77900
-            Plan Width: 48
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Hash Key: "boxes.location_id"
             Plans: 
               - Node Type: "Hash Join"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 2361.00
-                Total Cost: 5869.12
-                Plan Rows: 77900
-                Plan Width: 48
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
                 Inner Unique: true
                 Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 2437.00
-                    Plan Rows: 77900
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Hash Key: "boxes.apple_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 879.00
-                        Plan Rows: 77900
-                        Plan Width: 12
-                        Actual Startup Time: 0.000
-                        Actual Total Time: 0.000
-                        Actual Rows: 0
-                        Actual Loops: 0
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
                   - Node Type: "Hash"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 1111.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
-                    Actual Startup Time: 58.354
-                    Actual Total Time: 58.354
-                    Actual Rows: 33462
-                    Actual Loops: 1
-                    Hash Buckets: 131072
-                    Original Hash Buckets: 131072
-                    Hash Batches: 1
-                    Original Hash Batches: 1
-                    Peak Memory Usage: 2332
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
+                    Hash Buckets: N
+                    Original Hash Buckets: N
+                    Hash Batches: N
+                    Original Hash Batches: N
+                    Peak Memory Usage: N
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 2
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "apples"
                         Alias: "apples"
-                        Startup Cost: 0.00
-                        Total Cost: 1111.00
-                        Plan Rows: 100000
-                        Plan Width: 36
-                        Actual Startup Time: 0.088
-                        Actual Total Time: 14.932
-                        Actual Rows: 33462
-                        Actual Loops: 1
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
           - Node Type: "Hash"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 596.00
-            Total Cost: 596.00
-            Plan Rows: 49600
-            Plan Width: 36
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
-            Hash Buckets: 131072
-            Original Hash Buckets: 131072
-            Hash Batches: 1
-            Original Hash Batches: 1
-            Peak Memory Usage: 1024
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
+            Hash Buckets: N
+            Original Hash Buckets: N
+            Hash Batches: N
+            Original Hash Batches: N
+            Peak Memory Usage: N
             Plans: 
               - Node Type: "Seq Scan"
                 Parent Relationship: "Outer"
-                Slice: 1
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Relation Name: "box_locations"
                 Alias: "box_locations"
-                Startup Cost: 0.00
-                Total Cost: 596.00
-                Plan Rows: 49600
-                Plan Width: 36
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
   Optimizer: "Postgres-based planner"
-  Planning Time: 5.148
+  Planning Time: N.N
   Triggers: 
   Slice statistics: 
-    - Slice: 0
-      Executor Memory: 130048
-    - Slice: 1
+    - Slice: N
+      Executor Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 1129528
-        Workers: 3
-        Maximum Memory Used: 1129528
-      Work Maximum Memory: 1048576
-    - Slice: 2
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+      Work Maximum Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 2213776
-        Workers: 3
-        Maximum Memory Used: 2213776
-      Work Maximum Memory: 2119360
-    - Slice: 3
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+      Work Maximum Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 60624
-        Workers: 3
-        Maximum Memory Used: 60624
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
   Statement statistics: 
-    Memory used: 128000
-  Execution Time: 72.942
+    Memory used: N
+  Execution Time: N.N
 (1 row)
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
 --- Check explain analyze sort information in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 width=12) (actual time=0.380..0.380 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12) (actual time=0.000..0.069 rows=0 loops=1)
+  ->  Sort  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
-        Sort Method:  quicksort  Memory: 75kB  Max Memory: 75kB  Avg Memory: 25kB (3 segments)
-        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.010 rows=0 loops=1)
+        Sort Method:  quicksort  Memory: NkB  Max Memory: NkB  Avg Memory: NkB (N segments)
+        Executor Memory: NkB  Segments: N  Max: NkB (segment N)
+        work_mem: NkB  Segments: N  Max: NkB (segment N)  Workfile: (N spilling)
+        ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: Postgres-based planner
-Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
-Planning Time: 0.397 ms
-  (slice0)    Executor memory: 40K bytes.
-  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
-Memory used:  128000kB
-Execution Time: 0.782 ms
+Settings: cpu_index_tuple_cost = 'N.N', optimizer = 'off', random_page_cost = 'N'
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+Memory used:  NkB
+Execution Time: N.N ms
 (18 rows)
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.
 --
 -- This should be enough for those format. The only difference between JSON,
 -- XML, and YAML is in the formatting, after all.
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Function Scan",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Function Name": "generate_series",
-      "Alias": "generate_series"
-    },
-    "Optimizer": "Postgres-based planner"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter_to_json
+[{"Plan": {"Alias": "generate_series", "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Function Scan", "Function Name": "generate_series", "Parallel Aware": false}, "Optimizer": "Postgres-based planner"}]
 (1 row)
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-<explain xmlns="http://www.postgresql.org/2009/explain">
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter
+<explain xmlns="http://www.postgresql.org/N/explain">
   <Query>
     <Plan>
       <Node-Type>Function Scan</Node-Type>
-      <Slice>0</Slice>
-      <Segments>0</Segments>
+      <Slice>N</Slice>
+      <Segments>N</Segments>
       <Gang-Type>unallocated</Gang-Type>
       <Parallel-Aware>false</Parallel-Aware>
       <Function-Name>generate_series</Function-Name>
@@ -654,45 +590,11 @@ QUERY PLAN
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 1,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 1,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 1,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "jsonexplaintest_1_prt_2",
-          "Alias": "jsonexplaintest_1_prt_2",
-          "Filter": "(i = 2)"
-        }
-      ]
-    },
-    "Optimizer": "Postgres-based planner"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "jsonexplaintest_1_prt_2", "Slice": 0, "Filter": "(i = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Relation Name": "jsonexplaintest_1_prt_2", "Parallel Aware": false, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Parallel Aware": false}, "Optimizer": "Postgres-based planner"}]
 (1 row)
--- explain_processing_on
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -702,214 +604,44 @@ SET jit_above_cost = 0;
 SET gp_explain_jit = on;
 -- ORCA GUCs to enable JIT
 set optimizer_jit_above_cost to 0;
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=35.50..35.67 rows=10 width=4)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4)
-        ->  Limit  (cost=35.50..35.61 rows=10 width=4)
-              ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4)
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+        ->  Limit  (cost=N.N..N.N rows=N width=N)
+              ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N)
 Optimizer: Postgres-based planner
 JIT:
-  Functions: 2
+  Functions: N
   Options: Inlining false, Optimization false, Expressions true, Deforming true
 (8 rows)
--- explain_processing_on
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=35.50..35.67 rows=10 width=4) (actual time=13.199..13.310 rows=10 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (actual time=11.848..11.890 rows=10 loops=1)
-        ->  Limit  (cost=35.50..35.61 rows=10 width=4) (actual time=0.861..0.971 rows=10 loops=1)
-              ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4) (actual time=0.029..0.070 rows=10 loops=1)
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
-Planning Time: 0.158 ms
-  (slice0)    Executor memory: 37K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
 JIT:
   Options: Inlining false, Optimization false, Expressions true, Deforming true.
-  (slice0): Functions: 2.00. Timing: 1.381 ms total.
-  (slice1): Functions: 1.00 avg x 3 workers, 1.00 max (seg0). Timing: 0.830 ms avg x 3 workers, 0.854 ms max (seg1).
-Execution Time: 24.023 ms
+  (sliceN): Functions: N.N. Timing: N.N ms total.
+  (sliceN): Functions: N.N avg x N workers, N.N max (segN). Timing: N.N ms avg x N workers, N.N ms max (segN).
+Execution Time: N.N ms
 (14 rows)
--- explain_processing_on
 -- Check explain analyze json format output with jit enable
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"Executor Memory\": \d+/
--- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
--- m/\"Average\": \d+/
--- s/\"Average\": \d+/\"Average\": ###/
--- m/\"Maximum Memory Used\": \d+/
--- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Limit",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Startup Cost": 35.50,
-      "Total Cost": 35.67,
-      "Plan Rows": 10,
-      "Plan Width": 4,
-      "Actual Startup Time": 1.378,
-      "Actual Total Time": 1.576,
-      "Actual Rows": 10,
-      "Actual Loops": 1,
-      "Plans": [
-        {
-          "Node Type": "Gather Motion",
-          "Senders": 3,
-          "Receivers": 1,
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Startup Cost": 35.50,
-          "Total Cost": 36.01,
-          "Plan Rows": 30,
-          "Plan Width": 4,
-          "Actual Startup Time": 0.815,
-          "Actual Total Time": 0.889,
-          "Actual Rows": 10,
-          "Actual Loops": 1,
-          "Plans": [
-            {
-              "Node Type": "Limit",
-              "Parent Relationship": "Outer",
-              "Slice": 1,
-              "Segments": 3,
-              "Gang Type": "primary reader",
-              "Parallel Aware": false,
-              "Startup Cost": 35.50,
-              "Total Cost": 35.61,
-              "Plan Rows": 10,
-              "Plan Width": 4,
-              "Actual Startup Time": 0.711,
-              "Actual Total Time": 0.870,
-              "Actual Rows": 10,
-              "Actual Loops": 1,
-              "Plans": [
-                {
-                  "Node Type": "Seq Scan",
-                  "Parent Relationship": "Outer",
-                  "Slice": 1,
-                  "Segments": 3,
-                  "Gang Type": "primary reader",
-                  "Parallel Aware": false,
-                  "Relation Name": "jit_explain_output",
-                  "Alias": "jit_explain_output",
-                  "Startup Cost": 0.00,
-                  "Total Cost": 355.00,
-                  "Plan Rows": 32100,
-                  "Plan Width": 4,
-                  "Actual Startup Time": 0.025,
-                  "Actual Total Time": 0.099,
-                  "Actual Rows": 10,
-                  "Actual Loops": 1
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "Optimizer": "Postgres-based planner",
-    "Planning Time": 0.244,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 37800
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36760,
-          "Workers": 3,
-          "Maximum Memory Used": 36760
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "JIT": {
-        "Options": {
-          "Inlining": false,
-          "Optimization": false,
-          "Expressions": true,
-          "Deforming": true
-        },
-        "slice": {
-          "slice": 0,
-          "functions": 2.00,
-          "Timing": 0.001
-        },
-        "slice": {
-          "slice": 1,
-          "Functions": {
-            "avg": 1.00,
-            "nworker": 3,
-            "max": 1.00,
-            "segid": 0
-          },
-          "Timing": {
-            "avg": 0.531,
-            "nworker": 3,
-            "max": 0.686,
-            "segid": 0
-          }
-        }
-    },
-    "Execution Time": 2.889
-  }
-]
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter_to_json
+[{"JIT": {"slice": {"slice": 0, "Timing": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}, "Functions": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "Postgres-based planner", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
--- explain_processing_on
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
--- start_matchsubs
--- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
--- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
--- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
--- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
--- end_matchsubs
 -- Greenplum hash table extra message
 CREATE TABLE test_src_tbl AS
 SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
@@ -922,409 +654,160 @@ CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
-Extra Text: (seg0)   hash table(s): 1; chain length 2.3 avg, 5 max; using 3368 of 8192 buckets; total 1 expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        Group Key: a
+        Planned Partitions: N
+        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+        ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              Group Key: a, b
+              Extra Text: (segN)   hash table(s): N; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+              ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: Postgres-based planner
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(18 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (seg1)   hash table(s): 1; 6769 groups total in 16 batches, 21400 spill partitions; disk usage: 1120KB; chain length 2.7 avg, 11 max; using 6769 of 34816 buckets; total 0 expansions.
-Extra Text: (seg0)   hash table(s): 2; 6736 groups total in 8 batches, 120508 spill partitions; disk usage: 1920KB; chain length 2.2 avg, 6 max; using 3368 of 18432 buckets; total 0 expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Finalize HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        Group Key: a, b, (GROUPINGSET_ID())
+        Planned Partitions: N
+        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+        ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              Hash Key: a, b, (GROUPINGSET_ID())
+              ->  Partial HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Hash Key: a
+                    Hash Key: b
+                    Planned Partitions: N
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: Postgres-based planner
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(23 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled
---
--- start_matchsubs
--- m{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}{I/O Timings: read=##.### write=##.###}
--- m{I/O Timings: read=\d*\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+.*}{I/O Timings: read=##.###.*}
--- m{I/O Read Time: \d*\.\d+}
--- s{I/O Read Time: \d*\.\d+}{I/O Read Time: ##.###}
--- m{I/O Write Time: \d*\.\d+}
--- s{I/O Write Time: \d*\.\d+}{I/O Write Time: ##.###}
--- m{Shared Hit Blocks: \d+}
--- s{Shared Hit Blocks: \d+}{Shared Hit Blocks: ###}
--- m{Shared Read Blocks: \d+}
--- s{Shared Read Blocks: \d+}{Shared Read Blocks: ###}
--- m{Shared Dirtied Blocks: \d+}
--- s{Shared Dirtied Blocks: \d+}{Shared Dirtied Blocks: ###}
--- m{Shared Written Blocks: \d+}
--- s{Shared Written Blocks: \d+}{Shared Written Blocks: ###}
--- m{Temp Read Blocks: \d+}
--- s{Temp Read Blocks: \d+}{Temp Read Blocks: ###}
--- m{Temp Written Blocks: \d+}
--- s{Temp Written Blocks: \d+}{Temp Written Blocks: ###}
--- m/Buffers: shared hit=\d+\s+/
--- s/Buffers: shared hit=\d+\s+Buffers: shared hit=###/
--- m/Buffers: shared hit=\d+ read=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+\s+/Buffers: shared hit=### read=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/Buffers: shared hit=### read=### dirtied=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/Buffers: shared hit=### read=### dirtied=### written=###/
--- end_matchsubs
 -- Insert rows into a single segment
 SET track_io_timing = on;
 CREATE TABLE stat_io_timing(a, b) AS SELECT 0, i FROM generate_series(1, 10000) i DISTRIBUTED BY (a);
 ANALYZE stat_io_timing;
 -- explain_processing_off
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.804..0.805 rows=5 loops=1)
-  ->  Seq Scan on stat_io_timing (actual time=0.021..0.722 rows=5 loops=1)
-        Filter: ((b >= 5) AND (b <= 9))
-        Rows Removed by Filter: 9995
-        Buffers: shared hit=12
+WHERE b BETWEEN 5 AND 9;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Filter: ((b >= N) AND (b <= N))
+        Rows Removed by Filter: N
 Optimizer: Postgres-based planner
-Planning Time: 0.209 ms
-  (slice0)    Executor memory: 36K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 0.962 ms
-(11 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(10 rows)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.664..0.664 rows=5 loops=1)
-  ->  Seq Scan on stat_io_timing (actual time=0.015..0.603 rows=5 loops=1)
-        Filter: ((b >= 5) AND (b <= 9))
-        Rows Removed by Filter: 9995
-        Buffers: shared hit=12
+WHERE b BETWEEN 5 AND 9;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Filter: ((b >= N) AND (b <= N))
+        Rows Removed by Filter: N
 Optimizer: Postgres-based planner
-(6 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-Insert on stat_io_timing (actual time=0.000..6.526 rows=0 loops=1)
-  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=0.012..0.994 rows=10000 loops=1)
-        Buffers: shared hit=12
+(5 rows)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter
+Insert on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
-Planning Time: 0.064 ms
-  (slice0)    Executor memory: 35K bytes avg x 3 workers, 35K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 6.695 ms
-(8 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "ModifyTable",
-      "Operation": "Insert",
-      "Slice": 0,
-      "Segments": 3,
-      "Gang Type": "primary writer",
-      "Parallel Aware": false,
-      "Relation Name": "stat_io_timing",
-      "Alias": "stat_io_timing",
-      "Actual Startup Time": 0.000,
-      "Actual Total Time": 12.771,
-      "Actual Rows": 0,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Member",
-          "Slice": 0,
-          "Segments": 3,
-          "Gang Type": "primary writer",
-          "Parallel Aware": false,
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing_1",
-          "Actual Startup Time": 0.017,
-          "Actual Total Time": 2.014,
-          "Actual Rows": 20000,
-          "Actual Loops": 1,
-          "Shared Hit Blocks": 23,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "Postgres-based planner",
-    "Planning Time": 0.089,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": {
-          "Average": 35432,
-          "Workers": 3,
-          "Maximum Memory Used": 35432
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 12.971
-  }
-]
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(7 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter_to_json
+[{"Plan": {"Alias": "stat_io_timing", "Plans": [{"Alias": "stat_io_timing_1", "Slice": 0, "Segments": 0, "Gang Type": "primary writer", "Node Type": "Seq Scan", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Member", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}], "Slice": 0, "Segments": 0, "Gang Type": "primary writer", "Node Type": "ModifyTable", "Operation": "Insert", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "Postgres-based planner", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-Insert on stat_io_timing (actual time=0.000..25.757 rows=0 loops=1)
-  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=0.017..4.024 rows=40000 loops=1)
-        Buffers: shared hit=45
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter
+Insert on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
-(4 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 3,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 3,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Actual Startup Time": 4.286,
-      "Actual Total Time": 4.287,
-      "Actual Rows": 8,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing",
-          "Actual Startup Time": 0.022,
-          "Actual Total Time": 4.201,
-          "Actual Rows": 8,
-          "Actual Loops": 1,
-          "Filter": "(b = 50)",
-          "Rows Removed by Filter": 79992,
-          "Shared Hit Blocks": 89,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "Postgres-based planner",
-    "Planning Time": 0.120,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 36488
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36104,
-          "Workers": 3,
-          "Maximum Memory Used": 36104
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 4.504
-  }
-]
+(3 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "stat_io_timing", "Slice": 0, "Filter": "(b = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0, "Rows Removed by Filter": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "Postgres-based planner", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
 CREATE INDEX stat_io_timing_idx ON stat_io_timing (b);
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.232..0.233 rows=8 loops=1)
-  ->  Index Only Scan using stat_io_timing_idx on stat_io_timing (actual time=0.102..0.106 rows=8 loops=1)
-        Index Cond: (b = 50)
-        Heap Fetches: 8
-        Buffers: shared hit=8 read=3
-        I/O Timings: read=0.079
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Index Only Scan using stat_io_timing_idx on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Index Cond: (b = N)
+        Heap Fetches: N
+        I/O Timings: read=N.N
 Optimizer: Postgres-based planner
-Planning Time: 0.300 ms
-  (slice0)    Executor memory: 39K bytes.
-  (slice1)    Executor memory: 105K bytes avg x 3 workers, 105K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 0.514 ms
-(12 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 3,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 3,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Actual Startup Time": 0.170,
-      "Actual Total Time": 0.171,
-      "Actual Rows": 8,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Index Only Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Scan Direction": "Forward",
-          "Index Name": "stat_io_timing_idx",
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing",
-          "Actual Startup Time": 0.019,
-          "Actual Total Time": 0.031,
-          "Actual Rows": 8,
-          "Actual Loops": 1,
-          "Index Cond": "(b = 50)",
-          "Rows Removed by Index Recheck": 0,
-          "Heap Fetches": 8,
-          "Shared Hit Blocks": 11,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "Postgres-based planner",
-    "Planning Time": 0.153,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 39496
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 107448,
-          "Workers": 3,
-          "Maximum Memory Used": 107448
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 0.377
-  }
-]
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(11 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "stat_io_timing", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Index Only Scan", "Index Cond": "(b = 0)", "Index Name": "stat_io_timing_idx", "Actual Rows": 0, "Actual Loops": 0, "Heap Fetches": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Scan Direction": "Forward", "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0, "Rows Removed by Index Recheck": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "Postgres-based planner", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=5.725..5.726 rows=0 loops=1)
-  ->  Hash Join (actual time=0.000..5.632 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Hash Join (actual time=N.N..N.N rows=N loops=N)
         Hash Cond: (s2.b = s1.b)
         ->  Seq Scan on stat_io_timing s2 (never executed)
-        ->  Hash (actual time=0.000..2.114 rows=0 loops=1)
-              Buckets: 524288  Batches: 1  Memory Usage: 4096kB
-              ->  Broadcast Motion 1:3  (slice2; segments: 1) (actual time=0.000..2.113 rows=0 loops=1)
-                    ->  Seq Scan on stat_io_timing s1 (actual time=0.000..3.914 rows=0 loops=1)
-                          Filter: (a = 50)
+        ->  Hash (actual time=N.N..N.N rows=N loops=N)
+              Buckets: N  Batches: N  Memory Usage: NkB
+              ->  Broadcast Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+                    ->  Seq Scan on stat_io_timing s1 (actual time=N.N..N.N rows=N loops=N)
+                          Filter: (a = N)
 Optimizer: Postgres-based planner
-Planning Time: 0.434 ms
-  (slice0)    Executor memory: 39K bytes.
-  (slice1)    Executor memory: 4112K bytes avg x 3 workers, 4112K bytes max (seg0).  Work_mem: 4096K bytes max.
-  (slice2)    Executor memory: 37K bytes (seg1).
-Memory used:  128000kB
-Execution Time: 9.526 ms
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+  (sliceN)    Executor memory: NK bytes (segN).
+Memory used:  NkB
+Execution Time: N.N ms
 (16 rows)
 -- Test Bitmap Heap Scan block accounting
 SET enable_seqscan = 0;
@@ -1333,25 +816,22 @@ SET optimizer_enable_tablescan = 0;
 SET optimizer_enable_bitmapscan = 1;
 CREATE INDEX stat_io_timing_brin_idx ON stat_io_timing USING brin (b);
 VACUUM ANALYZE stat_io_timing;
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT * FROM stat_io_timing WHERE b = 1;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.375..0.375 rows=8 loops=1)
-  ->  Bitmap Heap Scan on stat_io_timing (actual time=0.127..0.250 rows=8 loops=1)
-        Recheck Cond: (b = 1)
-        Heap Blocks: exact=8
-        Buffers: shared hit=11
-        ->  Bitmap Index Scan on stat_io_timing_idx (actual time=0.118..0.118 rows=8 loops=1)
-              Index Cond: (b = 1)
-              Buffers: shared hit=3
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT * FROM stat_io_timing WHERE b = 1;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Bitmap Heap Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Recheck Cond: (b = N)
+        Heap Blocks: exact=N
+        ->  Bitmap Index Scan on stat_io_timing_idx (actual time=N.N..N.N rows=N loops=N)
+              Index Cond: (b = N)
 Optimizer: Postgres-based planner
-Planning Time: 0.163 ms
-  (slice0)    Executor memory: 54K bytes.
-  (slice1)    Executor memory: 992K bytes avg x 3 workers, 2359K bytes max (seg1).
-Memory used:  128000kB
-Execution Time: 0.570 ms
-(14 rows)
--- explain_processing_on
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(12 rows)
 RESET track_io_timing;
 RESET enable_seqscan;
 RESET enable_bitmapscan;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,38 +1,50 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes \(seg\d+\)\./Executor memory: ####K bytes (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Memory wanted:  \d+\w?kB/
--- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- end_matchsubs
---
+-- Tests EXPLAIN format output
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -41,230 +53,192 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36)
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                explain_filter                                                
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+   ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                Hash Key: boxes.apple_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24)
+               ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                            Hash Key: boxes.location_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12)
-                     ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..6.00 rows=1 width=12)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N)
+                     ->  Index Scan using box_locations_pkey on box_locations  (cost=N.N..N.N rows=N width=N)
                            Index Cond: (id = boxes.location_id)
-         ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12)
+         ->  Index Scan using apples_pkey on apples  (cost=N.N..N.N rows=N width=N)
                Index Cond: (id = boxes.apple_id)
  Optimizer: GPORCA
 (15 rows)
 
--- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                            QUERY PLAN                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36) (actual time=1.912..1.912 rows=0 loops=1)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36) (actual time=0.000..1.443 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                                explain_filter                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+   ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24) (actual time=0.000..1.440 rows=0 loops=1)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                Hash Key: boxes.apple_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24) (actual time=0.000..0.677 rows=0 loops=1)
+               ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.673 rows=0 loops=1)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                            Hash Key: boxes.location_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.021 rows=0 loops=1)
-                     ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..6.00 rows=1 width=12) (never executed)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                     ->  Index Scan using box_locations_pkey on box_locations  (cost=N.N..N.N rows=N width=N) (never executed)
                            Index Cond: (id = boxes.location_id)
-         ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12) (never executed)
+         ->  Index Scan using apples_pkey on apples  (cost=N.N..N.N rows=N width=N) (never executed)
                Index Cond: (id = boxes.apple_id)
  Optimizer: GPORCA
- Planning Time: 40.380 ms
-   (slice0)    Executor memory: 56K bytes.
-   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice3)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).
- Memory used:  256000kB
- Execution Time: 19.964 ms
+ Planning Time: N.N ms
+   (sliceN)    Executor memory: NK bytes.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+ Memory used:  NkB
+ Execution Time: N.N ms
 (22 rows)
 
--- explain_processing_on
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
 -- and its position depends on the longest line. If the width changes, all
 -- lines need to be adjusted for the moved end-of-line-marker.
 \a
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
--- start_matchignore
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 449.00
-    Plan Rows: 3
-    Plan Width: 36
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Plans: 
       - Node Type: "Nested Loop"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 0.00
-        Total Cost: 449.00
-        Plan Rows: 1
-        Plan Width: 36
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Inner Unique: false
         Join Filter: "true"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 0.00
-            Total Cost: 437.00
-            Plan Rows: 1
-            Plan Width: 24
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Hash Key: "boxes.apple_id"
             Plans: 
               - Node Type: "Nested Loop"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 0.00
-                Total Cost: 437.00
-                Plan Rows: 1
-                Plan Width: 24
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
                 Inner Unique: false
                 Join Filter: "true"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 431.00
-                    Plan Rows: 1
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Hash Key: "boxes.location_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 431.00
-                        Plan Rows: 1
-                        Plan Width: 12
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
                   - Node Type: "Index Scan"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
                     Scan Direction: "Forward"
                     Index Name: "box_locations_pkey"
                     Relation Name: "box_locations"
                     Alias: "box_locations"
-                    Startup Cost: 0.00
-                    Total Cost: 6.00
-                    Plan Rows: 1
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Index Cond: "(id = boxes.location_id)"
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
             Scan Direction: "Forward"
             Index Name: "apples_pkey"
             Relation Name: "apples"
             Alias: "apples"
-            Startup Cost: 0.00
-            Total Cost: 12.00
-            Plan Rows: 1
-            Plan Width: 12
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Index Cond: "(id = boxes.apple_id)"
   Optimizer: "GPORCA"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 431.00
-    Plan Rows: 1
-    Plan Width: 12
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -272,44 +246,40 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: 0.00
-        Total Cost: 431.00
-        Plan Rows: 1
-        Plan Width: 12
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "GPORCA"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
 (1 row)
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: #
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: ###.##
-    Total Cost: ###.##
-    Plan Rows: #####
-    Plan Width: ##
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -317,279 +287,243 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: #
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: ###.##
-        Total Cost: ###.##
-        Plan Rows: #####
-        Plan Width: ##
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "GPORCA"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 449.00
-    Plan Rows: 3
-    Plan Width: 36
-    Actual Startup Time: 15.617
-    Actual Total Time: 15.617
-    Actual Rows: 0
-    Actual Loops: 1
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
+    Actual Startup Time: N.N
+    Actual Total Time: N.N
+    Actual Rows: N
+    Actual Loops: N
     Plans: 
       - Node Type: "Nested Loop"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 0.00
-        Total Cost: 449.00
-        Plan Rows: 1
-        Plan Width: 36
-        Actual Startup Time: 0.000
-        Actual Total Time: 0.000
-        Actual Rows: 0
-        Actual Loops: 0
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
+        Actual Startup Time: N.N
+        Actual Total Time: N.N
+        Actual Rows: N
+        Actual Loops: N
         Inner Unique: false
         Join Filter: "true"
-        Rows Removed by Join Filter: 0
+        Rows Removed by Join Filter: N
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 0.00
-            Total Cost: 437.00
-            Plan Rows: 1
-            Plan Width: 24
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Hash Key: "boxes.apple_id"
             Plans: 
               - Node Type: "Nested Loop"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 0.00
-                Total Cost: 437.00
-                Plan Rows: 1
-                Plan Width: 24
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
                 Inner Unique: false
                 Join Filter: "true"
-                Rows Removed by Join Filter: 0
+                Rows Removed by Join Filter: N
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 431.00
-                    Plan Rows: 1
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Hash Key: "boxes.location_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 431.00
-                        Plan Rows: 1
-                        Plan Width: 12
-                        Actual Startup Time: 0.000
-                        Actual Total Time: 0.000
-                        Actual Rows: 0
-                        Actual Loops: 0
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
                   - Node Type: "Index Scan"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
                     Scan Direction: "Forward"
                     Index Name: "box_locations_pkey"
                     Relation Name: "box_locations"
                     Alias: "box_locations"
-                    Startup Cost: 0.00
-                    Total Cost: 6.00
-                    Plan Rows: 1
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Index Cond: "(id = boxes.location_id)"
-                    Rows Removed by Index Recheck: 0
+                    Rows Removed by Index Recheck: N
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
             Scan Direction: "Forward"
             Index Name: "apples_pkey"
             Relation Name: "apples"
             Alias: "apples"
-            Startup Cost: 0.00
-            Total Cost: 12.00
-            Plan Rows: 1
-            Plan Width: 12
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Index Cond: "(id = boxes.apple_id)"
-            Rows Removed by Index Recheck: 0
+            Rows Removed by Index Recheck: N
   Optimizer: "GPORCA"
-  Planning Time: 14.827
+  Planning Time: N.N
   Triggers: 
   Slice statistics: 
-    - Slice: 0
-      Executor Memory: 195920
-    - Slice: 1
+    - Slice: N
+      Executor Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 97488
-        Workers: 3
-        Maximum Memory Used: 97488
-    - Slice: 2
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+    - Slice: N
       Executor Memory: 
-        Average: 97488
-        Workers: 3
-        Maximum Memory Used: 97488
-    - Slice: 3
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+    - Slice: N
       Executor Memory: 
-        Average: 60624
-        Workers: 3
-        Maximum Memory Used: 60624
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
   Statement statistics: 
-    Memory used: 128000
-  Execution Time: 3.332
+    Memory used: N
+  Execution Time: N.N
 (1 row)
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
 --- Check explain analyze sort information in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.388..0.388 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.072 rows=0 loops=1)
+  ->  Sort  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
-        Sort Method:  quicksort  Memory: ###kB  Max Memory: ###kB  Avg Memory: ###kB (3 segments)
-        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.014 rows=0 loops=1)
+        Sort Method:  quicksort  Memory: NkB  Max Memory: NkB  Avg Memory: NkB (N segments)
+        Executor Memory: NkB  Segments: N  Max: NkB (segment N)
+        work_mem: NkB  Segments: N  Max: NkB (segment N)  Workfile: (N spilling)
+        ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: GPORCA
-Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
-Planning Time: 4.622 ms
-  (slice0)    Executor memory: 40K bytes.
-  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
-Memory used:  128000kB
-Execution Time: 0.846 ms
+Settings: cpu_index_tuple_cost = 'N.N', random_page_cost = 'N'
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+Memory used:  NkB
+Execution Time: N.N ms
 (18 rows)
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.
 --
 -- This should be enough for those format. The only difference between JSON,
 -- XML, and YAML is in the formatting, after all.
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Function Scan",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Function Name": "generate_series",
-      "Alias": "generate_series"
-    },
-    "Optimizer": "GPORCA"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter_to_json
+[{"Plan": {"Alias": "generate_series", "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Function Scan", "Function Name": "generate_series", "Parallel Aware": false}, "Optimizer": "GPORCA"}]
 (1 row)
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-<explain xmlns="http://www.postgresql.org/2009/explain">
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter
+<explain xmlns="http://www.postgresql.org/N/explain">
   <Query>
     <Plan>
       <Node-Type>Function Scan</Node-Type>
-      <Slice>0</Slice>
-      <Segments>0</Segments>
+      <Slice>N</Slice>
+      <Segments>N</Segments>
       <Gang-Type>unallocated</Gang-Type>
       <Parallel-Aware>false</Parallel-Aware>
       <Function-Name>generate_series</Function-Name>
@@ -604,46 +538,11 @@ QUERY PLAN
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 1,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 1,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Plans": [
-        {
-          "Node Type": "Dynamic Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 1,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "jsonexplaintest",
-          "Alias": "jsonexplaintest",
-          "Number of partitions to scan": 1,
-          "Filter": "(i = 2)"
-        }
-      ]
-    },
-    "Optimizer": "GPORCA"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "jsonexplaintest", "Slice": 0, "Filter": "(i = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Dynamic Seq Scan", "Relation Name": "jsonexplaintest", "Parallel Aware": false, "Parent Relationship": "Outer", "Number of partitions to scan": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Parallel Aware": false}, "Optimizer": "GPORCA"}]
 (1 row)
--- explain_processing_on
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -653,178 +552,41 @@ SET jit_above_cost = 0;
 SET gp_explain_jit = on;
 -- ORCA GUCs to enable JIT
 set optimizer_jit_above_cost to 0;
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=0.00..431.00 rows=1 width=4)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-        ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4)
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+        ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N)
 Optimizer: GPORCA
 JIT:
-  Functions: 2
+  Functions: N
   Options: Inlining false, Optimization false, Expressions true, Deforming true
 (7 rows)
--- explain_processing_on
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=1.103..1.107 rows=10 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.013..0.014 rows=10 loops=1)
-        ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4) (actual time=0.025..0.030 rows=38 loops=1)
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
-Planning Time: 5.824 ms
-  (slice0)    Executor memory: 37K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
 JIT:
   Options: Inlining false, Optimization false, Expressions true, Deforming true.
-  (slice0): Functions: 2.00. Timing: 1.137 ms total.
-Execution Time: 1.597 ms
+  (sliceN): Functions: N.N. Timing: N.N ms total.
+Execution Time: N.N ms
 (12 rows)
--- explain_processing_on
 -- Check explain analyze json format output with jit enable
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"Executor Memory\": \d+/
--- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
--- m/\"Average\": \d+/
--- s/\"Average\": \d+/\"Average\": ###/
--- m/\"Maximum Memory Used\": \d+/
--- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Limit",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Startup Cost": 0.00,
-      "Total Cost": 431.00,
-      "Plan Rows": 1,
-      "Plan Width": 4,
-      "Actual Startup Time": 0.611,
-      "Actual Total Time": 0.615,
-      "Actual Rows": 10,
-      "Actual Loops": 1,
-      "Plans": [
-        {
-          "Node Type": "Gather Motion",
-          "Senders": 3,
-          "Receivers": 1,
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Startup Cost": 0.00,
-          "Total Cost": 431.00,
-          "Plan Rows": 1,
-          "Plan Width": 4,
-          "Actual Startup Time": 0.014,
-          "Actual Total Time": 0.015,
-          "Actual Rows": 10,
-          "Actual Loops": 1,
-          "Plans": [
-            {
-              "Node Type": "Seq Scan",
-              "Parent Relationship": "Outer",
-              "Slice": 1,
-              "Segments": 3,
-              "Gang Type": "primary reader",
-              "Parallel Aware": false,
-              "Relation Name": "jit_explain_output",
-              "Alias": "jit_explain_output",
-              "Startup Cost": 0.00,
-              "Total Cost": 431.00,
-              "Plan Rows": 1,
-              "Plan Width": 4,
-              "Actual Startup Time": 0.024,
-              "Actual Total Time": 0.028,
-              "Actual Rows": 38,
-              "Actual Loops": 1
-            }
-          ]
-        }
-      ]
-    },
-    "Optimizer": "GPORCA",
-    "Planning Time": 5.884,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 37144
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36104,
-          "Workers": 3,
-          "Maximum Memory Used": 36104
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "JIT": {
-        "Options": {
-          "Inlining": false,
-          "Optimization": false,
-          "Expressions": true,
-          "Deforming": true
-        },
-        "slice": {
-          "slice": 0,
-          "functions": 2.00,
-          "Timing": 0.001
-        }
-    },
-    "Execution Time": 1.221
-  }
-]
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter_to_json
+[{"JIT": {"slice": {"slice": 0, "Timing": 0.0, "functions": 0.0}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "GPORCA", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
--- explain_processing_on
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
--- start_matchsubs
--- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
--- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
--- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
--- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
--- end_matchsubs
 -- Greenplum hash table extra message
 CREATE TABLE test_src_tbl AS
 SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
@@ -836,405 +598,161 @@ SET statement_mem = '1000kB';
 CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 2576 spill partitions; disk usage: 800KB; chain length 2.9 avg, 9 max; using 3368 of 20480 buckets; total 0 expansions.
-Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 4 batches, 1264 spill partitions; disk usage: 800KB; chain length 2.3 avg, 5 max; using 3368 of 40960 buckets; total 1 expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        Group Key: a
+        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+        ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              Group Key: a, b
+              Planned Partitions: N
+              Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+              ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: GPORCA
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(18 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (seg0)   hash table(s): 1; 3368 groups total in 8 batches, 53148 spill partitions; disk usage: 1152KB; chain length 2.2 avg, 5 max; using 3368 of 18432 buckets; total 0 expansions.
-Extra Text: (seg1)   hash table(s): 1; 3385 groups total in 8 batches, 53488 spill partitions; disk usage: 1152KB; chain length 2.1 avg, 4 max; using 3385 of 18432 buckets; total 0 expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Sequence  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Append  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Group Key: share0_ref2.b
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                          Hash Key: share0_ref2.b
+                          ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                                ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Group Key: share0_ref3.a
+                    Planned Partitions: N
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: GPORCA
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(27 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled
---
--- start_matchsubs
--- m{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}{I/O Timings: read=##.### write=##.###}
--- m{I/O Timings: read=\d*\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+.*}{I/O Timings: read=##.###.*}
--- m{I/O Read Time: \d*\.\d+}
--- s{I/O Read Time: \d*\.\d+}{I/O Read Time: ##.###}
--- m{I/O Write Time: \d*\.\d+}
--- s{I/O Write Time: \d*\.\d+}{I/O Write Time: ##.###}
--- m{Shared Hit Blocks: \d+}
--- s{Shared Hit Blocks: \d+}{Shared Hit Blocks: ###}
--- m{Shared Read Blocks: \d+}
--- s{Shared Read Blocks: \d+}{Shared Read Blocks: ###}
--- m{Shared Dirtied Blocks: \d+}
--- s{Shared Dirtied Blocks: \d+}{Shared Dirtied Blocks: ###}
--- m{Shared Written Blocks: \d+}
--- s{Shared Written Blocks: \d+}{Shared Written Blocks: ###}
--- m{Temp Read Blocks: \d+}
--- s{Temp Read Blocks: \d+}{Temp Read Blocks: ###}
--- m{Temp Written Blocks: \d+}
--- s{Temp Written Blocks: \d+}{Temp Written Blocks: ###}
--- m/Buffers: shared hit=\d+\s+/
--- s/Buffers: shared hit=\d+\s+Buffers: shared hit=###/
--- m/Buffers: shared hit=\d+ read=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+\s+/Buffers: shared hit=### read=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/Buffers: shared hit=### read=### dirtied=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/Buffers: shared hit=### read=### dirtied=### written=###/
--- end_matchsubs
 -- Insert rows into a single segment
 SET track_io_timing = on;
 CREATE TABLE stat_io_timing(a, b) AS SELECT 0, i FROM generate_series(1, 10000) i DISTRIBUTED BY (a);
 ANALYZE stat_io_timing;
 -- explain_processing_off
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.785..0.786 rows=5 loops=1)
-  ->  Seq Scan on stat_io_timing (actual time=0.020..0.676 rows=5 loops=1)
-        Filter: ((b >= 5) AND (b <= 9))
-        Rows Removed by Filter: 9995
-        Buffers: shared hit=12
+WHERE b BETWEEN 5 AND 9;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Filter: ((b >= N) AND (b <= N))
+        Rows Removed by Filter: N
 Optimizer: GPORCA
-Planning Time: 3.382 ms
-  (slice0)    Executor memory: 36K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 0.993 ms
-(11 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(10 rows)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.732..0.733 rows=5 loops=1)
-  ->  Seq Scan on stat_io_timing (actual time=0.017..0.663 rows=5 loops=1)
-        Filter: ((b >= 5) AND (b <= 9))
-        Rows Removed by Filter: 9995
-        Buffers: shared hit=12
+WHERE b BETWEEN 5 AND 9;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Filter: ((b >= N) AND (b <= N))
+        Rows Removed by Filter: N
 Optimizer: GPORCA
-(6 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-Insert on stat_io_timing (actual time=0.000..6.500 rows=0 loops=1)
-  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=0.016..0.997 rows=10000 loops=1)
-        Buffers: shared hit=12
+(5 rows)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter
+Insert on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
-Planning Time: 2.432 ms
-  (slice0)    Executor memory: 35K bytes avg x 3 workers, 35K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 6.705 ms
-(8 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "ModifyTable",
-      "Operation": "Insert",
-      "Slice": 0,
-      "Segments": 3,
-      "Gang Type": "primary writer",
-      "Parallel Aware": false,
-      "Relation Name": "stat_io_timing",
-      "Alias": "stat_io_timing",
-      "Actual Startup Time": 0.000,
-      "Actual Total Time": 12.591,
-      "Actual Rows": 0,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Member",
-          "Slice": 0,
-          "Segments": 3,
-          "Gang Type": "primary writer",
-          "Parallel Aware": false,
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing_1",
-          "Actual Startup Time": 0.016,
-          "Actual Total Time": 1.941,
-          "Actual Rows": 20000,
-          "Actual Loops": 1,
-          "Shared Hit Blocks": 23,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "GPORCA",
-    "Planning Time": 2.499,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": {
-          "Average": 35368,
-          "Workers": 3,
-          "Maximum Memory Used": 35368
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 12.799
-  }
-]
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(7 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter_to_json
+[{"Plan": {"Alias": "stat_io_timing", "Plans": [{"Alias": "stat_io_timing_1", "Slice": 0, "Segments": 0, "Gang Type": "primary writer", "Node Type": "Seq Scan", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Member", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}], "Slice": 0, "Segments": 0, "Gang Type": "primary writer", "Node Type": "ModifyTable", "Operation": "Insert", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "GPORCA", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
-QUERY PLAN
-Insert on stat_io_timing (actual time=0.000..31.984 rows=0 loops=1)
-  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=0.019..5.064 rows=40000 loops=1)
-        Buffers: shared hit=45
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
+explain_filter
+Insert on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+  ->  Seq Scan on stat_io_timing stat_io_timing_1 (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
-(4 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 3,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 3,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Actual Startup Time": 4.180,
-      "Actual Total Time": 4.181,
-      "Actual Rows": 8,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing",
-          "Actual Startup Time": 0.021,
-          "Actual Total Time": 4.090,
-          "Actual Rows": 8,
-          "Actual Loops": 1,
-          "Filter": "(b = 50)",
-          "Rows Removed by Filter": 79992,
-          "Shared Hit Blocks": 89,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "GPORCA",
-    "Planning Time": 2.071,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 36488
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36104,
-          "Workers": 3,
-          "Maximum Memory Used": 36104
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 4.362
-  }
-]
+(3 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "stat_io_timing", "Slice": 0, "Filter": "(b = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0, "Rows Removed by Filter": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "GPORCA", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
 CREATE INDEX stat_io_timing_idx ON stat_io_timing (b);
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.235..0.236 rows=8 loops=1)
-  ->  Index Scan using stat_io_timing_idx on stat_io_timing (actual time=0.110..0.116 rows=8 loops=1)
-        Index Cond: (b = 50)
-        Buffers: shared hit=8 read=3
-        I/O Timings: read=0.087
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Index Scan using stat_io_timing_idx on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Index Cond: (b = N)
+        I/O Timings: read=N.N
 Optimizer: GPORCA
-Planning Time: 2.600 ms
-  (slice0)    Executor memory: 40K bytes.
-  (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 0.412 ms
-(11 rows)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 3,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 3,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Actual Startup Time": 0.090,
-      "Actual Total Time": 0.108,
-      "Actual Rows": 8,
-      "Actual Loops": 1,
-      "Shared Hit Blocks": 0,
-      "Shared Read Blocks": 0,
-      "Shared Dirtied Blocks": 0,
-      "Shared Written Blocks": 0,
-      "Local Hit Blocks": 0,
-      "Local Read Blocks": 0,
-      "Local Dirtied Blocks": 0,
-      "Local Written Blocks": 0,
-      "Temp Read Blocks": 0,
-      "Temp Written Blocks": 0,
-      "I/O Read Time": 0.000,
-      "I/O Write Time": 0.000,
-      "Plans": [
-        {
-          "Node Type": "Index Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Scan Direction": "Forward",
-          "Index Name": "stat_io_timing_idx",
-          "Relation Name": "stat_io_timing",
-          "Alias": "stat_io_timing",
-          "Actual Startup Time": 0.004,
-          "Actual Total Time": 0.008,
-          "Actual Rows": 8,
-          "Actual Loops": 1,
-          "Index Cond": "(b = 50)",
-          "Rows Removed by Index Recheck": 0,
-          "Shared Hit Blocks": 11,
-          "Shared Read Blocks": 0,
-          "Shared Dirtied Blocks": 0,
-          "Shared Written Blocks": 0,
-          "Local Hit Blocks": 0,
-          "Local Read Blocks": 0,
-          "Local Dirtied Blocks": 0,
-          "Local Written Blocks": 0,
-          "Temp Read Blocks": 0,
-          "Temp Written Blocks": 0,
-          "I/O Read Time": 0.000,
-          "I/O Write Time": 0.000
-        }
-      ]
-    },
-    "Optimizer": "GPORCA",
-    "Planning Time": 2.104,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 40392
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 42808,
-          "Workers": 3,
-          "Maximum Memory Used": 42808
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "Execution Time": 0.277
-  }
-]
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(10 rows)
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "stat_io_timing", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Index Scan", "Index Cond": "(b = 0)", "Index Name": "stat_io_timing_idx", "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "Relation Name": "stat_io_timing", "I/O Write Time": 0.0, "Parallel Aware": false, "Scan Direction": "Forward", "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer", "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0, "Rows Removed by Index Recheck": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Actual Rows": 0, "Actual Loops": 0, "I/O Read Time": 0.0, "I/O Write Time": 0.0, "Parallel Aware": false, "Local Hit Blocks": 0, "Temp Read Blocks": 0, "Actual Total Time": 0.0, "Local Read Blocks": 0, "Shared Hit Blocks": 0, "Shared Read Blocks": 0, "Actual Startup Time": 0.0, "Temp Written Blocks": 0, "Local Dirtied Blocks": 0, "Local Written Blocks": 0, "Shared Dirtied Blocks": 0, "Shared Written Blocks": 0}, "Triggers": [], "Optimizer": "GPORCA", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=4.311..4.311 rows=0 loops=1)
-  ->  Nested Loop (actual time=0.000..4.184 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Nested Loop (actual time=N.N..N.N rows=N loops=N)
         Join Filter: true
-        ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual time=0.000..4.183 rows=0 loops=1)
-              ->  Seq Scan on stat_io_timing (actual time=0.000..3.904 rows=0 loops=1)
-                    Filter: (a = 50)
+        ->  Broadcast Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+              ->  Seq Scan on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+                    Filter: (a = N)
         ->  Index Scan using stat_io_timing_idx on stat_io_timing stat_io_timing_1 (never executed)
               Index Cond: (b = stat_io_timing.b)
 Optimizer: GPORCA
-Planning Time: 5.088 ms
-  (slice0)    Executor memory: 47K bytes.
-  (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-  (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 8.064 ms
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
 (15 rows)
 -- Test Bitmap Heap Scan block accounting
 SET enable_seqscan = 0;
@@ -1243,21 +761,19 @@ SET optimizer_enable_tablescan = 0;
 SET optimizer_enable_bitmapscan = 1;
 CREATE INDEX stat_io_timing_brin_idx ON stat_io_timing USING brin (b);
 VACUUM ANALYZE stat_io_timing;
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT * FROM stat_io_timing WHERE b = 1;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3) (actual time=0.102..0.122 rows=8 loops=1)
-  ->  Index Scan using stat_io_timing_idx on stat_io_timing (actual time=0.006..0.010 rows=8 loops=1)
-        Index Cond: (b = 1)
-        Buffers: shared hit=11
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT * FROM stat_io_timing WHERE b = 1;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Index Scan using stat_io_timing_idx on stat_io_timing (actual time=N.N..N.N rows=N loops=N)
+        Index Cond: (b = N)
 Optimizer: GPORCA
-Planning Time: 3.022 ms
-  (slice0)    Executor memory: 39K bytes.
-  (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).
-Memory used:  128000kB
-Execution Time: 0.302 ms
-(10 rows)
--- explain_processing_on
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Execution Time: N.N ms
+(9 rows)
 RESET track_io_timing;
 RESET enable_seqscan;
 RESET enable_bitmapscan;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,38 +1,52 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes \(seg\d+\)\./Executor memory: ####K bytes (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Memory wanted:  \d+\w?kB/
--- s/Memory wanted:  \d+\w?kB/Memory wanted: ###kB/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- end_matchsubs
---
+-- Tests EXPLAIN format output
+
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
+
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -40,14 +54,10 @@ CREATE TABLE box_locations(id int PRIMARY KEY, address text);
 CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES box_locations(id));
 
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
--- explain_processing_on
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
--- explain_processing_on
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
@@ -56,75 +66,23 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 \a
 
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
--- start_matchignore
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
+
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
 
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+
 --- Check explain analyze sort information in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 
 --
 -- Test a simple case with JSON and XML output, too.
@@ -133,31 +91,16 @@ RESET cpu_index_tuple_cost;
 -- XML, and YAML is in the formatting, after all.
 
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
 
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
 
 -- Test for an old bug in printing Sequence nodes in JSON/XML format
 -- (https://github.com/greenplum-db/gpdb/issues/9410)
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-
--- explain_processing_on
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
 
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 INSERT INTO jit_explain_output SELECT generate_series(1,100);
 
@@ -168,65 +111,19 @@ SET gp_explain_jit = on;
 -- ORCA GUCs to enable JIT
 set optimizer_jit_above_cost to 0;
 
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
 
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
 
 -- Check explain analyze json format output with jit enable
-
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"Executor Memory\": \d+/
--- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
--- m/\"Average\": \d+/
--- s/\"Average\": \d+/\"Average\": ###/
--- m/\"Maximum Memory Used\": \d+/
--- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
-
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
 
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
 RESET optimizer_jit_above_cost;
 
--- start_matchsubs
--- m/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./
--- s/Extra Text: \(seg\d+\)   hash table\(s\): \d+; \d+ groups total in \d+ batches, \d+ spill partitions; disk usage: \d+KB; chain length \d+.\d+ avg, \d+ max; using \d+ of \d+ buckets; total \d+ expansions./Extra Text: (seg0)   hash table(s): ###; ### groups total in ### batches, ### spill partitions; disk usage: ###KB; chain length ###.## avg, ### max; using ## of ### buckets; total ### expansions./
--- m/Work_mem: \d+K bytes max, \d+K bytes wanted/
--- s/Work_mem: \d+K bytes max, \d+K bytes wanted/Work_mem: ###K bytes max, ###K bytes wanted/
--- end_matchsubs
 -- Greenplum hash table extra message
 CREATE TABLE test_src_tbl AS
 SELECT i % 10000 AS a, i % 10000 + 1 AS b FROM generate_series(1, 50000) i DISTRIBUTED BY (a);
@@ -239,97 +136,53 @@ SET statement_mem = '1000kB';
 -- Hashagg with spilling
 CREATE TABLE test_hashagg_spill AS
 SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+select explain_filter('EXPLAIN ANALYZE SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;');
 
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-  SELECT test_util.get_explain_output(
-    'SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b))',
-    false)
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
 
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 
 -- Check EXPLAIN format output with BUFFERS enabled
---
--- start_matchsubs
--- m{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+ write=\d+\.\d+.*}{I/O Timings: read=##.### write=##.###}
--- m{I/O Timings: read=\d*\.\d+.*}
--- s{I/O Timings: read=\d*\.\d+.*}{I/O Timings: read=##.###.*}
--- m{I/O Read Time: \d*\.\d+}
--- s{I/O Read Time: \d*\.\d+}{I/O Read Time: ##.###}
--- m{I/O Write Time: \d*\.\d+}
--- s{I/O Write Time: \d*\.\d+}{I/O Write Time: ##.###}
--- m{Shared Hit Blocks: \d+}
--- s{Shared Hit Blocks: \d+}{Shared Hit Blocks: ###}
--- m{Shared Read Blocks: \d+}
--- s{Shared Read Blocks: \d+}{Shared Read Blocks: ###}
--- m{Shared Dirtied Blocks: \d+}
--- s{Shared Dirtied Blocks: \d+}{Shared Dirtied Blocks: ###}
--- m{Shared Written Blocks: \d+}
--- s{Shared Written Blocks: \d+}{Shared Written Blocks: ###}
--- m{Temp Read Blocks: \d+}
--- s{Temp Read Blocks: \d+}{Temp Read Blocks: ###}
--- m{Temp Written Blocks: \d+}
--- s{Temp Written Blocks: \d+}{Temp Written Blocks: ###}
--- m/Buffers: shared hit=\d+\s+/
--- s/Buffers: shared hit=\d+\s+Buffers: shared hit=###/
--- m/Buffers: shared hit=\d+ read=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+\s+/Buffers: shared hit=### read=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+\s+/Buffers: shared hit=### read=### dirtied=###/
--- m/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/
--- s/Buffers: shared hit=\d+ read=\d+ dirtied=\d+ written=\d+\s+/Buffers: shared hit=### read=### dirtied=### written=###/
--- end_matchsubs
-
 -- Insert rows into a single segment
 SET track_io_timing = on;
 CREATE TABLE stat_io_timing(a, b) AS SELECT 0, i FROM generate_series(1, 10000) i DISTRIBUTED BY (a);
 ANALYZE stat_io_timing;
 
 -- explain_processing_off
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
+WHERE b BETWEEN 5 AND 9;');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
 SELECT a FROM stat_io_timing
-WHERE b BETWEEN 5 AND 9;
+WHERE b BETWEEN 5 AND 9;');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
-INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, SUMMARY OFF)
+INSERT INTO stat_io_timing (SELECT * FROM stat_io_timing);');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
 
 CREATE INDEX stat_io_timing_idx ON stat_io_timing (b);
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT b FROM stat_io_timing where b=50;
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT b FROM stat_io_timing where b=50;');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
-SELECT b FROM stat_io_timing where b=50;
+select explain_filter_to_json('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, FORMAT JSON)
+SELECT b FROM stat_io_timing where b=50;');
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT s1.b FROM stat_io_timing s1 join stat_io_timing s2 on s1.b=s2.b where s1.a=50;');
 
 -- Test Bitmap Heap Scan block accounting
 SET enable_seqscan = 0;
@@ -340,10 +193,8 @@ SET optimizer_enable_bitmapscan = 1;
 CREATE INDEX stat_io_timing_brin_idx ON stat_io_timing USING brin (b);
 VACUUM ANALYZE stat_io_timing;
 
-EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
-SELECT * FROM stat_io_timing WHERE b = 1;
-
--- explain_processing_on
+select explain_filter('EXPLAIN (ANALYZE, BUFFERS, COSTS OFF)
+SELECT * FROM stat_io_timing WHERE b = 1;');
 
 RESET track_io_timing;
 RESET enable_seqscan;


### PR DESCRIPTION
This commit borrows two test helper functions from PG13 https://github.com/postgres/postgres/commit/10013684970453a0ddc86050bba813c611114321 that replace changeable output details in the EXPLAIN output. 

As a result, remove the complex matchsubs in the explain_format.sql regression test. This results in stable test output across planner/orca and assert/non-assert builds.
