### PR TITLE
Enable fts for mirrorless and log doublefault in gp_configuration_history

### DIFF
--- a/src/backend/fts/test/ftsprobe_test.c
+++ b/src/backend/fts/test/ftsprobe_test.c
@@ -708,6 +708,14 @@ test_PrimayUpMirrorUpNotInSync_to_PrimaryDown(void **state)
 	expect_value(PQfinish, conn, context.perSegInfos[1].conn);
 	will_be_called(PQfinish);
 
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, false);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
+
 	/* No update must happen */
 	bool is_updated = processResponse(&context);
 
@@ -1218,6 +1226,14 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimayUpMirrorUpSync(void **state)
 	expect_value(PQfinish, conn, context.perSegInfos[0].conn);
 	will_be_called(PQfinish);
 
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, true);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
+
 	bool is_updated = processResponse(&context);
 
 	assert_true(is_updated);
@@ -1297,6 +1313,14 @@ test_PrimaryUpMirrorDownNotInSync_to_PrimaryDown(void **state)
 	will_be_called(PQfinish);
 	expect_value(PQfinish, conn, context.perSegInfos[1].conn);
 	will_be_called(PQfinish);
+
+	will_be_called(StartTransactionCommand);
+	will_be_called(GetTransactionSnapshot);
+	expect_value(probeUpdateConfHistory, primary, context.perSegInfos[0].primary_cdbinfo);
+	expect_value(probeUpdateConfHistory, isSegmentAlive, false);
+	expect_value(probeUpdateConfHistory, hasMirrors, true);
+	will_be_called(probeUpdateConfHistory);
+	will_be_called(CommitTransactionCommand);
 
 	bool is_updated = processResponse(&context);
 

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -75,7 +75,6 @@ extern bool FtsIsActive(void);
 extern void HandleFtsMessage(const char* query_string);
 extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 									bool IsSegmentAlive, bool IsInSync);
-
 extern bool FtsProbeStartRule(Datum main_arg);
 extern void FtsProbeMain (Datum main_arg);
 extern pid_t FtsProbePID(void);

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -75,6 +75,9 @@ extern bool FtsIsActive(void);
 extern void HandleFtsMessage(const char* query_string);
 extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 									bool IsSegmentAlive, bool IsInSync);
+extern void probeUpdateConfHistory(const CdbComponentDatabaseInfo *primary,
+									bool isSegmentAlive,
+									bool hasMirrors);
 extern bool FtsProbeStartRule(Datum main_arg);
 extern void FtsProbeMain (Datum main_arg);
 extern pid_t FtsProbePID(void);

--- a/src/include/postmaster/ftsprobe.h
+++ b/src/include/postmaster/ftsprobe.h
@@ -110,6 +110,7 @@ typedef struct
 
 typedef struct
 {
+	bool has_mirrors; /* mirrored or mirrorless cluster */
 	int num_pairs; /* number of primary-mirror pairs FTS wants to probe */
 	fts_segment_info *perSegInfos;
 } fts_context;

--- a/src/test/isolation2/expected/fts_doublefault.out
+++ b/src/test/isolation2/expected/fts_doublefault.out
@@ -1,0 +1,358 @@
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- Get an entry into gp_conf_history for a segment
+-- start_ignore
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop');
+ pg_ctl
+--------
+ OK
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl
+--------
+ OK
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan
+---------------------------
+ t
+(1 row)
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan
+---------------------------
+ t
+(1 row)
+-- end_ignore
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+(2 rows)
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+(3 rows)
+
+-- stop mirror for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+(5 rows)
+
+-1U: select wait_until_segments_are_down(2);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+
+-- stop primary in order to trigger double fault for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 1 (FTS_PROMOTE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+(6 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+(7 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 3    | FTS: update role, status, and mode for dbid 3 with contentid 1 to p, u, and n 
+ 6    | FTS: update role, status, and mode for dbid 6 with contentid 1 to m, d, and n 
+ 3    | FTS: double fault detected for content id 1                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+ 3    | FTS: content id 1 is out of double fault, dbid 3 is up                        
+(8 rows)
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Test for when ftsprobe process is killed
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+(2 rows)
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+(3 rows)
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: double fault detected for content id 0                                   
+(4 rows)
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                                                                   
+------+-------------------------------------------------------------------------------
+ 2    | FTS: update role, status, and mode for dbid 2 with contentid 0 to m, d, and n 
+ 5    | FTS: update role, status, and mode for dbid 5 with contentid 0 to p, u, and n 
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: double fault detected for content id 0                                   
+ 5    | FTS: content id 0 is out of double fault, dbid 5 is up                        
+(5 rows)
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -32,10 +32,6 @@
 -- end_ignore
 (exited with code 0)
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE FUNCTION
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
  count 

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -32,10 +32,6 @@
 -- end_ignore
 (exited with code 0)
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE FUNCTION
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
  count 

--- a/src/test/isolation2/expected/fts_mirrorless.out
+++ b/src/test/isolation2/expected/fts_mirrorless.out
@@ -1,0 +1,196 @@
+-- Get an entry into gp_conf_history for any segment
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Start of test. Bring two segments down, check entries in gp_configuration_history
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop segment for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+(1 row)
+
+-- stop segment for content 1
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+ 3    | FTS: content id 1 dbid 3 is down 
+(2 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 3    | FTS: content id 1 dbid 3 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+(3 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 3    | FTS: content id 1 dbid 3 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+ 3    | FTS: content id 1 dbid 3 is now up 
+(4 rows)
+
+-1U: drop table last_timestamp;
+DROP TABLE
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+SELECT 1
+
+-- stop primary for content 0
+select pg_ctl((select datadir from gp_segment_configuration c where c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+(1 row)
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                      
+------+----------------------------------
+ 2    | FTS: content id 0 dbid 2 is down 
+ 2    | FTS: content id 0 dbid 2 is down 
+(2 rows)
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+ dbid | description                        
+------+------------------------------------
+ 2    | FTS: content id 0 dbid 2 is down   
+ 2    | FTS: content id 0 dbid 2 is down   
+ 2    | FTS: content id 0 dbid 2 is now up 
+(3 rows)
+
+-1U: drop table last_timestamp;
+DROP TABLE

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -195,3 +195,6 @@ CREATE FUNCTION
 
 CREATE OR REPLACE FUNCTION assert_bogus_file_does_not_exist(datadir text, log_dir text) RETURNS TEXT AS $$ import subprocess import os bogus_file = os.path.join(datadir, log_dir, 'bogusfile') if os.path.exists(bogus_file): raise Exception("bogus file: %s should not exist" % bogus_file) return 'OK' $$ LANGUAGE plpython3u;
 CREATE FUNCTION
+
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE FUNCTION

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -289,6 +289,7 @@ test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset
+test: fts_doublefault
 
 # Reindex tests
 test: reindex/abort_reindex

--- a/src/test/isolation2/mirrorless_schedule
+++ b/src/test/isolation2/mirrorless_schedule
@@ -11,3 +11,6 @@ test: gpdispatch
 test: check_gxid
 test: sync_guc
 test: upgrade_numsegments
+
+# fts tests
+test: fts_mirrorless

--- a/src/test/isolation2/sql/fts_doublefault.sql
+++ b/src/test/isolation2/sql/fts_doublefault.sql
@@ -1,0 +1,124 @@
+-- to make test deterministic and fast
+!\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
+!\retcode gpstop -u;
+
+-- Get an entry into gp_conf_history for a segment
+-- start_ignore
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='m' and c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-- end_ignore
+
+!\retcode gprecoverseg -aF --no-progress;
+!\retcode gprecoverseg -ar;
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop mirror for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='m' and c.content=1), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: select wait_until_segments_are_down(2);
+
+-- stop primary in order to trigger double fault for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=1), 'stop');
+
+-- trigger double fault on content 1 (FTS_PROMOTE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 1;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+
+!\retcode gprecoverseg -ar;
+
+-- Test for when ftsprobe process is killed
+
+-1U: drop table last_timestamp;
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary in order to promote mirror for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-- primary is down, and mirror has now been promoted to primary. Verify
+-1U: select wait_until_segments_are_down(1);
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop acting primary in order to trigger double fault for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.role='p' and c.content=0), 'stop');
+
+-- trigger double fault on content 0 (FTS_PROBE_FAILED)
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port, false) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- fully recover the failed primary as new mirror
+!\retcode gprecoverseg -aF --no-progress;
+
+!\retcode gprecoverseg -ar;
+
+-1U: drop table last_timestamp;
+
+!\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
+!\retcode gpstop -u;

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -20,27 +20,6 @@
 !\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
--- Helper function
-CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
-RETURNS bool AS
-$$
-declare
-retries int; /* in func */
-begin /* in func */
-  retries := 1200; /* in func */
-  loop /* in func */
-    if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
-      return true; /* in func */
-    end if; /* in func */
-    if retries <= 0 then /* in func */
-      return false; /* in func */
-    end if; /* in func */
-    perform pg_sleep(0.1); /* in func */
-    retries := retries - 1; /* in func */
-  end loop; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
 

--- a/src/test/isolation2/sql/fts_mirrorless.sql
+++ b/src/test/isolation2/sql/fts_mirrorless.sql
@@ -1,0 +1,67 @@
+-- Get an entry into gp_conf_history for any segment
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+select gp_request_fts_probe_scan();
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+
+-- Start of test. Bring two segments down, check entries in gp_configuration_history
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop segment for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- stop segment for content 1
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=1), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 1;
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: drop table last_timestamp;
+
+select gp_request_fts_probe_scan();
+
+-- note the last_timestamp in gp_configuration_history, we only need to check entries after this one
+-1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
+
+-- stop primary for content 0
+select pg_ctl((select datadir from gp_segment_configuration c
+               where c.content=0), 'stop');
+
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-- kill the ftsprobe process.
+!\retcode pkill -f ftsprobe;
+
+-- restarts ftsprobe, we should see another entry for content 0 doublefault into gp_configuration_history
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'p' and content = 0;
+select gp_request_fts_probe_scan();
+-1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+
+-1U: drop table last_timestamp;

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -566,3 +566,23 @@ RETURNS TEXT AS $$
         raise Exception("bogus file: %s should not exist" % bogus_file)
     return 'OK'
 $$ LANGUAGE plpython3u;
+
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 1200; /* in func */
+  loop /* in func */
+if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
+      return true; /* in func */
+end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;


### PR DESCRIPTION
Update ftsprobe process to log each double fault occurence into
gp_configuration_history with the message

Also keep track of contents that are currently under doublefault.
Whenever any content comes out of double fault, update that status into
gp_configuration_history

gp_configuration_history log message:
```
 2023-12-13 09:57:54.000504-05 |    5 | FTS: double fault detected for content id 0
 2023-12-13 09:59:10.074589-05 |    5 | FTS: segment started for content id 0
```

Enable fts for mirrorless cluster, and also log segments going down/up into gp_configuration_history
```
 2023-12-13 09:57:54.000504-05 | 2    | FTS: content id 0 dbid 2 is down.  
 2023-12-13 09:59:10.074589-05 | 2    | FTS: content id 0 dbid 2 is now up 
 ```
