### PR TITLE
6X Backport: Enable MPP support for pg_buffercache and build by default

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -23,6 +23,7 @@ all:
 	$(MAKE) -C contrib/pg_trgm all
 	$(MAKE) -C contrib/btree_gin all
 	$(MAKE) -C contrib/isn all
+	$(MAKE) -C contrib/pg_buffercache all
 ifeq ($(OS),Darwin)
 	@echo "dblink and postgres_fdw can't be built on Mac"
 else
@@ -76,6 +77,7 @@ install:
 	$(MAKE) -C contrib/pg_trgm $@
 	$(MAKE) -C contrib/btree_gin $@
 	$(MAKE) -C contrib/isn $@
+	$(MAKE) -C contrib/pg_buffercache $@
 ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/postgres_fdw $@
@@ -177,6 +179,7 @@ ICW_TARGETS += contrib/amcheck contrib/auto_explain contrib/citext
 ICW_TARGETS += contrib/formatter_fixedwidth
 ICW_TARGETS += contrib/extprotocol
 ICW_TARGETS += contrib/pg_trgm contrib/btree_gin contrib/isn
+ICW_TARGETS += contrib/pg_buffercache
 ifneq ($(OS),Darwin)
 	ICW_TARGETS += contrib/dblink contrib/postgres_fdw
 endif

--- a/contrib/pg_buffercache/.gitignore
+++ b/contrib/pg_buffercache/.gitignore
@@ -1,1 +1,4 @@
-/pg_buffercache.sql
+# Generated subdirectories
+/log/
+/results/
+/tmp_check/

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -4,7 +4,8 @@ MODULE_big = pg_buffercache
 OBJS = pg_buffercache_pages.o
 
 EXTENSION = pg_buffercache
-DATA = pg_buffercache--1.0.sql pg_buffercache--unpackaged--1.0.sql
+DATA = pg_buffercache--1.1.sql pg_buffercache--1.0--1.1.sql pg_buffercache--unpackaged--1.0.sql
+PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -7,6 +7,8 @@ EXTENSION = pg_buffercache
 DATA = pg_buffercache--1.1.sql pg_buffercache--1.0--1.1.sql pg_buffercache--unpackaged--1.0.sql
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
+REGRESS = pg_buffercache
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -1,0 +1,10 @@
+CREATE EXTENSION pg_buffercache;
+select count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers')
+from pg_buffercache;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -8,3 +8,25 @@ from pg_buffercache;
  t
 (1 row)
 
+SELECT count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers') *
+                   (select count(*) from gp_segment_configuration where role='p')
+                   as buffers
+FROM gp_buffercache;
+ buffers 
+---------
+ t
+(1 row)
+
+-- Check that the functions / views can't be accessed by default.
+CREATE ROLE buffercache_test;
+SET ROLE buffercache_test;
+SELECT * FROM pg_buffercache;
+ERROR:  permission denied for view pg_buffercache
+SELECT * FROM pg_buffercache_pages() AS p (wrong int);
+ERROR:  permission denied for function pg_buffercache_pages
+SELECT * FROM gp_buffercache;
+ERROR:  permission denied for view gp_buffercache
+RESET ROLE;
+DROP ROLE buffercache_test;

--- a/contrib/pg_buffercache/pg_buffercache--1.0--1.1.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.0--1.1.sql
@@ -1,0 +1,11 @@
+/* contrib/pg_buffercache/pg_buffercache--1.0--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_buffercache UPDATE TO '1.1'" to load this file. \quit
+
+-- Upgrade view to 1.1. format
+CREATE OR REPLACE VIEW pg_buffercache AS
+	SELECT P.* FROM pg_buffercache_pages() AS P
+	(bufferid integer, relfilenode oid, reltablespace oid, reldatabase oid,
+	 relforknumber int2, relblocknumber int8, isdirty bool, usagecount int2,
+	 pinning_backends int4);

--- a/contrib/pg_buffercache/pg_buffercache--1.0--1.1.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.0--1.1.sql
@@ -9,3 +9,13 @@ CREATE OR REPLACE VIEW pg_buffercache AS
 	(bufferid integer, relfilenode oid, reltablespace oid, reldatabase oid,
 	 relforknumber int2, relblocknumber int8, isdirty bool, usagecount int2,
 	 pinning_backends int4);
+
+CREATE VIEW gp_buffercache AS
+	SELECT gp_execution_segment() AS gp_segment_id, *
+	FROM gp_dist_random('pg_buffercache')
+	UNION ALL
+	SELECT -1 AS gp_segment_id, *
+  FROM pg_buffercache
+  ORDER BY 1,2;
+
+REVOKE ALL ON gp_buffercache FROM PUBLIC;

--- a/contrib/pg_buffercache/pg_buffercache--1.1.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.1.sql
@@ -1,4 +1,4 @@
-/* contrib/pg_buffercache/pg_buffercache--1.0.sql */
+/* contrib/pg_buffercache/pg_buffercache--1.1.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_buffercache" to load this file. \quit
@@ -13,7 +13,8 @@ LANGUAGE C;
 CREATE VIEW pg_buffercache AS
 	SELECT P.* FROM pg_buffercache_pages() AS P
 	(bufferid integer, relfilenode oid, reltablespace oid, reldatabase oid,
-	 relforknumber int2, relblocknumber int8, isdirty bool, usagecount int2);
+	 relforknumber int2, relblocknumber int8, isdirty bool, usagecount int2,
+	 pinning_backends int4);
 
 -- Don't want these to be available to public.
 REVOKE ALL ON FUNCTION pg_buffercache_pages() FROM PUBLIC;

--- a/contrib/pg_buffercache/pg_buffercache--1.1.sql
+++ b/contrib/pg_buffercache/pg_buffercache--1.1.sql
@@ -16,6 +16,15 @@ CREATE VIEW pg_buffercache AS
 	 relforknumber int2, relblocknumber int8, isdirty bool, usagecount int2,
 	 pinning_backends int4);
 
+CREATE VIEW gp_buffercache AS
+	SELECT gp_execution_segment() AS gp_segment_id, *
+	FROM gp_dist_random('pg_buffercache')
+	UNION ALL
+	SELECT -1 AS gp_segment_id, *
+  FROM pg_buffercache
+  ORDER BY 1,2;
+
 -- Don't want these to be available to public.
 REVOKE ALL ON FUNCTION pg_buffercache_pages() FROM PUBLIC;
 REVOKE ALL ON pg_buffercache FROM PUBLIC;
+REVOKE ALL ON gp_buffercache FROM PUBLIC;

--- a/contrib/pg_buffercache/pg_buffercache.control
+++ b/contrib/pg_buffercache/pg_buffercache.control
@@ -1,5 +1,5 @@
 # pg_buffercache extension
 comment = 'examine the shared buffer cache'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/pg_buffercache'
 relocatable = true

--- a/contrib/pg_buffercache/pg_buffercache_pages.c
+++ b/contrib/pg_buffercache/pg_buffercache_pages.c
@@ -137,17 +137,12 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 		MemoryContextSwitchTo(oldcontext);
 
 		/*
-		 * To get a consistent picture of the buffer state, we must lock all
-		 * partitions of the buffer map.  Needless to say, this is horrible
-		 * for concurrency.  Must grab locks in increasing order to avoid
-		 * possible deadlocks.
-		 */
-		for (i = 0; i < NUM_BUFFER_PARTITIONS; i++)
-			LWLockAcquire(BufMappingPartitionLockByIndex(i), LW_SHARED);
-
-		/*
-		 * Scan though all the buffers, saving the relevant fields in the
+		 * Scan through all the buffers, saving the relevant fields in the
 		 * fctx->record structure.
+		 *
+		 * We don't hold the partition locks, so we don't get a consistent
+		 * snapshot across all buffers, but we do grab the buffer header
+		 * locks, so the information of each buffer is self-consistent.
 		 */
 		for (i = 0, bufHdr = BufferDescriptors; i < NBuffers; i++, bufHdr++)
 		{
@@ -176,16 +171,6 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 
 			UnlockBufHdr(bufHdr);
 		}
-
-		/*
-		 * And release locks.  We do this in reverse order for two reasons:
-		 * (1) Anyone else who needs more than one of the locks will be trying
-		 * to lock them in increasing order; we don't want to release the
-		 * other process until it can get all the locks it needs. (2) This
-		 * avoids O(N^2) behavior inside LWLockRelease.
-		 */
-		for (i = NUM_BUFFER_PARTITIONS; --i >= 0;)
-			LWLockRelease(BufMappingPartitionLockByIndex(i));
 	}
 
 	funcctx = SRF_PERCALL_SETUP();

--- a/contrib/pg_buffercache/pg_buffercache_pages.c
+++ b/contrib/pg_buffercache/pg_buffercache_pages.c
@@ -15,7 +15,8 @@
 #include "storage/bufmgr.h"
 
 
-#define NUM_BUFFERCACHE_PAGES_ELEM	8
+#define NUM_BUFFERCACHE_PAGES_MIN_ELEM	8
+#define NUM_BUFFERCACHE_PAGES_ELEM	9
 
 PG_MODULE_MAGIC;
 
@@ -34,6 +35,12 @@ typedef struct
 	bool		isvalid;
 	bool		isdirty;
 	uint16		usagecount;
+	/*
+	 * An int32 is sufficiently large, as MAX_BACKENDS prevents a buffer from
+	 * being pinned by too many backends and each backend will only pin once
+	 * because of bufmgr.c's PrivateRefCount array.
+	 */
+	int32		pinning_backends;
 } BufferCachePagesRec;
 
 
@@ -61,6 +68,7 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 	MemoryContext oldcontext;
 	BufferCachePagesContext *fctx;		/* User function context. */
 	TupleDesc	tupledesc;
+	TupleDesc	expected_tupledesc;
 	HeapTuple	tuple;
 
 	if (SRF_IS_FIRSTCALL())
@@ -76,8 +84,23 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 		/* Create a user function context for cross-call persistence */
 		fctx = (BufferCachePagesContext *) palloc(sizeof(BufferCachePagesContext));
 
+		/*
+		 * To smoothly support upgrades from version 1.0 of this extension
+		 * transparently handle the (non-)existance of the pinning_backends
+		 * column. We unfortunately have to get the result type for that... -
+		 * we can't use the result type determined by the function definition
+		 * without potentially crashing when somebody uses the old (or even
+		 * wrong) function definition though.
+		 */
+		if (get_call_result_type(fcinfo, NULL, &expected_tupledesc) != TYPEFUNC_COMPOSITE)
+			elog(ERROR, "return type must be a row type");
+
+		if (expected_tupledesc->natts < NUM_BUFFERCACHE_PAGES_MIN_ELEM ||
+			expected_tupledesc->natts > NUM_BUFFERCACHE_PAGES_ELEM)
+			elog(ERROR, "incorrect number of output arguments");
+
 		/* Construct a tuple descriptor for the result rows. */
-		tupledesc = CreateTemplateTupleDesc(NUM_BUFFERCACHE_PAGES_ELEM, false);
+		tupledesc = CreateTemplateTupleDesc(expected_tupledesc->natts, false);
 		TupleDescInitEntry(tupledesc, (AttrNumber) 1, "bufferid",
 						   INT4OID, -1, 0);
 		TupleDescInitEntry(tupledesc, (AttrNumber) 2, "relfilenode",
@@ -94,6 +117,10 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 						   BOOLOID, -1, 0);
 		TupleDescInitEntry(tupledesc, (AttrNumber) 8, "usage_count",
 						   INT2OID, -1, 0);
+
+		if (expected_tupledesc->natts == NUM_BUFFERCACHE_PAGES_ELEM)
+			TupleDescInitEntry(tupledesc, (AttrNumber) 9, "pinning_backends",
+							   INT4OID, -1, 0);
 
 		fctx->tupdesc = BlessTupleDesc(tupledesc);
 
@@ -134,6 +161,7 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 			fctx->record[i].forknum = bufHdr->tag.forkNum;
 			fctx->record[i].blocknum = bufHdr->tag.blockNum;
 			fctx->record[i].usagecount = bufHdr->usage_count;
+			fctx->record[i].pinning_backends = bufHdr->refcount;
 
 			if (bufHdr->flags & BM_DIRTY)
 				fctx->record[i].isdirty = true;
@@ -188,6 +216,8 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 			nulls[5] = true;
 			nulls[6] = true;
 			nulls[7] = true;
+			/* unused for v1.0 callers, but the array is always long enough */
+			nulls[8] = true;
 		}
 		else
 		{
@@ -205,6 +235,9 @@ pg_buffercache_pages(PG_FUNCTION_ARGS)
 			nulls[6] = false;
 			values[7] = Int16GetDatum(fctx->record[i].usagecount);
 			nulls[7] = false;
+			/* unused for v1.0 callers, but the array is always long enough */
+			values[8] = Int32GetDatum(fctx->record[i].pinning_backends);
+			nulls[8] = false;
 		}
 
 		/* Build and return the tuple. */

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -4,3 +4,19 @@ select count(*) = (select setting::bigint
                    from pg_settings
                    where name = 'shared_buffers')
 from pg_buffercache;
+
+SELECT count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers') *
+                   (select count(*) from gp_segment_configuration where role='p')
+                   as buffers
+FROM gp_buffercache;
+
+-- Check that the functions / views can't be accessed by default.
+CREATE ROLE buffercache_test;
+SET ROLE buffercache_test;
+SELECT * FROM pg_buffercache;
+SELECT * FROM pg_buffercache_pages() AS p (wrong int);
+SELECT * FROM gp_buffercache;
+RESET ROLE;
+DROP ROLE buffercache_test;

--- a/contrib/pg_buffercache/sql/pg_buffercache.sql
+++ b/contrib/pg_buffercache/sql/pg_buffercache.sql
@@ -1,0 +1,6 @@
+CREATE EXTENSION pg_buffercache;
+
+select count(*) = (select setting::bigint
+                   from pg_settings
+                   where name = 'shared_buffers')
+from pg_buffercache;

--- a/doc/src/sgml/pgbuffercache.sgml
+++ b/doc/src/sgml/pgbuffercache.sgml
@@ -106,6 +106,13 @@
       <entry>Clock-sweep access count</entry>
      </row>
 
+     <row>
+      <entry><structfield>pinning_backends</structfield></entry>
+      <entry><type>integer</type></entry>
+      <entry></entry>
+      <entry>Number of backends pinning this buffer</entry>
+     </row>
+
     </tbody>
    </tgroup>
   </table>


### PR DESCRIPTION
This is a partial backport of https://github.com/greenplum-db/gpdb/pull/16819.

Changes from 7X:
- 1.2 updated the extension to be `PARALLEL` safe. 6X does not support the `PARALLEL` keyword, so 1.2 cannot be backported.
- Default monitoring roles were added to the catalog as a larger effort that bumped the version to 1.3. This cannot be backported to a stable branch.
- The `_summary` and `_usage_count` functions added in 1.4 rely on backend behavior introduced in 9.5/9.6 that cannot be backported to a stable branch.
Ref:
https://github.com/postgres/postgres/commit/ed127002d8c592610bc8e716759a1a70657483b6
https://github.com/postgres/postgres/commit/48354581a49c30f5757c203415aa8412d85b0f70
- The view `gp_buffercache` was added directly to `1.1` since this is the first version we're shipping and there will be no further updates to the extension on 6X.
