### PR TITLE
Optimize classic DDL syntax for partition creation

### DIFF
--- a/.abi-check/7.0.0/postgres.symbols.ignore
+++ b/.abi-check/7.0.0/postgres.symbols.ignore
@@ -4,3 +4,6 @@ ConfigureNamesEnum_gp
 ConfigureNamesString_gp
 UpdateOrAddAttributeEncodings
 createDir
+generatePartitions
+MergeAttributes
+makePartitionCreateStmt

--- a/.abi-check/7.0.0/postgres.types.ignore
+++ b/.abi-check/7.0.0/postgres.types.ignore
@@ -6,3 +6,4 @@ struct AOCSInsertDescData
 struct AOCSWriteColumnDescData
 struct AppendOnlyFetchDescData
 struct AppendOnlyInsertDescData
+struct CreateForeignTableStmt

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -132,7 +132,7 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 	create->oncommit = into->onCommit;
 	create->tablespacename = into->tableSpaceName;
 	create->if_not_exists = false;
-	create->gp_style_alter_part = false;
+	create->origin = ORIGIN_NO_GEN;
 
 	create->distributedBy = NULL; /* We will pass a pre-made intoPolicy instead */
 	create->partitionBy = NULL; /* CTAS does not not support partition. */

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -116,7 +116,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	createStmt->tablespacename = NULL;
 	createStmt->distributedBy = createExtStmt->distributedBy; /* policy was set in transform */
 	createStmt->ownerid = userid;
-	createStmt->gp_style_alter_part = false;
+	createStmt->origin = ORIGIN_NO_GEN;
 
 	switch (exttypeDesc->exttabletype)
 	{

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -254,7 +254,7 @@ DefineSequence(ParseState *pstate, CreateSeqStmt *seq)
 	stmt->if_not_exists = seq->if_not_exists;
 	stmt->relKind = RELKIND_SEQUENCE;
 	stmt->ownerid = GetUserId();
-	stmt->gp_style_alter_part = false;
+	stmt->origin = ORIGIN_NO_GEN;
 
 	address = DefineRelation(stmt, RELKIND_SEQUENCE, seq->ownerId, NULL, NULL,
 							 false, /* dispatch */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -276,7 +276,8 @@ static void truncate_check_activity(Relation rel);
 static void RangeVarCallbackForTruncate(const RangeVar *relation,
 										Oid relId, Oid oldRelId, void *arg);
 static List *MergeAttributes(List *schema, List *supers, char relpersistence,
-							 bool is_partition, List **supconstr, bool gp_alter_part);
+							 bool is_partition, List **supconstr,
+							 CreateStmtOrigin origin);
 static void MergeAttributesIntoExisting(Relation child_rel, Relation parent_rel);
 static bool MergeCheckConstraint(List *constraints, char *name, Node *expr);
 static void MergeConstraintsIntoExisting(Relation child_rel, Relation parent_rel);
@@ -899,7 +900,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 							stmt->relation->relpersistence,
 							stmt->partbound != NULL,
 							&old_constraints,
-							stmt->gp_style_alter_part);
+							stmt->origin);
 	}
 	else
 	{
@@ -2589,7 +2590,7 @@ storage_name(char c)
  */
 List *
 MergeAttributes(List *schema, List *supers, char relpersistence,
-				bool is_partition, List **supconstr, bool gp_style_alter_part)
+				bool is_partition, List **supconstr, CreateStmtOrigin origin)
 {
 	ListCell   *entry;
 	List	   *inhSchema = NIL;
@@ -2723,7 +2724,7 @@ MergeAttributes(List *schema, List *supers, char relpersistence,
 		 * already held by alter command, and when we generate CREATE 
 		 * STMT and execute them we have 2 reference instead on 1 here.
 		 */
-		if (is_partition && (Gp_role != GP_ROLE_DISPATCH || !gp_style_alter_part))
+		if (is_partition && (Gp_role != GP_ROLE_DISPATCH || origin != ORIGIN_GP_CLASSIC_ALTER_GEN))
 			CheckTableNotInUse(relation, "CREATE TABLE .. PARTITION OF");
 
 		/*
@@ -16900,7 +16901,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
 		cs->ownerid = rel->rd_rel->relowner;
 		cs->tablespacename = get_tablespace_name(rel->rd_rel->reltablespace);
 		cs->buildAoBlkdir = false;
-		cs->gp_style_alter_part = false;
+		cs->origin = ORIGIN_NO_GEN;
 
 		if (isTmpTableAo &&
 			rel->rd_rel->relhasindex)

--- a/src/backend/commands/tablecmds_gp.c
+++ b/src/backend/commands/tablecmds_gp.c
@@ -992,7 +992,7 @@ AtExecGPSplitPartition(Relation rel, AlterTableCmd *cmd)
 		elem->options = p_reloptions;
 
 		/* create first partition stmt */
-		stmts = lappend(stmts, makePartitionCreateStmt(rel, partname1, boundspec1, NULL, elem, &partcomp));
+		stmts = lappend(stmts, makePartitionCreateStmt(rel, partname1, boundspec1, NULL, elem, &partcomp, ORIGIN_GP_CLASSIC_ALTER_GEN));
 
 		/* create second partition stmt */
 		if (defaultpartname)
@@ -1000,7 +1000,7 @@ AtExecGPSplitPartition(Relation rel, AlterTableCmd *cmd)
 			partcomp.tablename = defaultpartname;
 			partname2 = NULL;
 		}
-		stmts = lappend(stmts, makePartitionCreateStmt(rel, partname2, boundspec2, NULL, elem, &partcomp));
+		stmts = lappend(stmts, makePartitionCreateStmt(rel, partname2, boundspec2, NULL, elem, &partcomp, ORIGIN_GP_CLASSIC_ALTER_GEN));
 	}
 
 	foreach (l, stmts)
@@ -1248,7 +1248,7 @@ ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd)
 										 list_length(ancestors), gpPartDef);
 			List *cstmts = generatePartitions(RelationGetRelid(rel),
 											  gpPartDef, subpart, cmd->queryString,
-											  NIL, NULL, NULL, true);
+											  NIL, NULL, NULL, ORIGIN_GP_CLASSIC_ALTER_GEN);
 			foreach(l, cstmts)
 			{
 				Node *stmt = (Node *) lfirst(l);

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -2269,7 +2269,7 @@ DefineCompositeType(RangeVar *typevar, List *coldeflist)
 	createStmt->oncommit = ONCOMMIT_NOOP;
 	createStmt->tablespacename = NULL;
 	createStmt->if_not_exists = false;
-	createStmt->gp_style_alter_part = false;
+	createStmt->origin = ORIGIN_NO_GEN;
 
 	/*
 	 * Check for collision with an existing type name. If there is one and

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -268,7 +268,7 @@ DefineVirtualRelation(RangeVar *relation, List *tlist, bool replace,
 		createStmt->tablespacename = NULL;
 		createStmt->relKind = RELKIND_VIEW;
 		createStmt->if_not_exists = false;
-		createStmt->gp_style_alter_part = false;
+		createStmt->origin = ORIGIN_NO_GEN;
 
 		/*
 		 * Create the relation (this will error out if there's an existing

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3978,7 +3978,7 @@ CopyCreateStmtFields(const CreateStmt *from, CreateStmt *newnode)
 	COPY_STRING_FIELD(tablespacename);
 	COPY_STRING_FIELD(accessMethod);
 	COPY_SCALAR_FIELD(if_not_exists);
-	COPY_SCALAR_FIELD(gp_style_alter_part);
+	COPY_SCALAR_FIELD(origin);
 
 	COPY_NODE_FIELD(distributedBy);
 	COPY_NODE_FIELD(partitionBy);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1346,7 +1346,7 @@ _equalCreateStmt(const CreateStmt *a, const CreateStmt *b)
 	COMPARE_STRING_FIELD(tablespacename);
 	COMPARE_STRING_FIELD(accessMethod);
 	COMPARE_SCALAR_FIELD(if_not_exists);
-	COMPARE_SCALAR_FIELD(gp_style_alter_part);
+	COMPARE_SCALAR_FIELD(origin);
 
 	COMPARE_NODE_FIELD(distributedBy);
 	COMPARE_SCALAR_FIELD(relKind);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3169,7 +3169,7 @@ _outCreateStmtInfo(StringInfo str, const CreateStmt *node)
 	WRITE_STRING_FIELD(tablespacename);
 	WRITE_STRING_FIELD(accessMethod);
 	WRITE_BOOL_FIELD(if_not_exists);
-	WRITE_BOOL_FIELD(gp_style_alter_part);
+	WRITE_ENUM_FIELD(origin, CreateStmtOrigin);
 
 	WRITE_NODE_FIELD(distributedBy);
 	WRITE_NODE_FIELD(partitionBy);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -741,7 +741,7 @@ _readCreateStmt_common(CreateStmt *local_node)
 	READ_STRING_FIELD(tablespacename);
 	READ_STRING_FIELD(accessMethod);
 	READ_BOOL_FIELD(if_not_exists);
-	READ_BOOL_FIELD(gp_style_alter_part);
+	READ_ENUM_FIELD(origin, CreateStmtOrigin);
 
 	READ_NODE_FIELD(distributedBy);
 	READ_NODE_FIELD(partitionBy);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4583,7 +4583,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $12;
 					n->tablespacename = $13;
 					n->if_not_exists = false;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = (DistributedBy *) $14;
 					n->relKind = RELKIND_RELATION;
 
@@ -4614,7 +4614,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $15;
 					n->tablespacename = $16;
 					n->if_not_exists = true;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = (DistributedBy *) $17;
 					n->relKind = RELKIND_RELATION;
 
@@ -4646,7 +4646,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $11;
 					n->tablespacename = $12;
 					n->if_not_exists = false;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = (DistributedBy *) $13;
 					n->relKind = RELKIND_RELATION;
 
@@ -4678,7 +4678,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $14;
 					n->tablespacename = $15;
 					n->if_not_exists = true;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = (DistributedBy *) $16;
 					n->relKind = RELKIND_RELATION;
 
@@ -4710,7 +4710,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $13;
 					n->tablespacename = $14;
 					n->if_not_exists = false;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = NULL;
 					n->relKind = RELKIND_RELATION;
 
@@ -4742,7 +4742,7 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->oncommit = $16;
 					n->tablespacename = $17;
 					n->if_not_exists = true;
-					n->gp_style_alter_part = false;
+					n->origin = ORIGIN_NO_GEN;
 					n->distributedBy = NULL;
 					n->relKind = RELKIND_RELATION;
 

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -65,17 +65,20 @@ static List *generateRangePartitions(ParseState *pstate,
 									 GpPartDefElem *elem,
 									 PartitionSpec *subPart,
 									 partname_comp *partnamecomp,
-									 bool *hasImplicitRangeBounds);
+									 bool *hasImplicitRangeBounds,
+									 CreateStmtOrigin origin);
 static List *generateListPartition(ParseState *pstate,
 								   Relation parentrel,
 								   GpPartDefElem *elem,
 								   PartitionSpec *subPart,
-								   partname_comp *partnamecomp);
+								   partname_comp *partnamecomp,
+								   CreateStmtOrigin origin);
 static List *generateDefaultPartition(ParseState *pstate,
 									  Relation parentrel,
 									  GpPartDefElem *elem,
 									  PartitionSpec *subPart,
-									  partname_comp *partnamecomp);
+									  partname_comp *partnamecomp,
+									  CreateStmtOrigin origin);
 
 static char *extract_tablename_from_options(List **options);
 
@@ -353,7 +356,7 @@ list_qsort_arg(List *list, qsort_arg_comparator cmp, void *arg)
  * END, deduce the value and update the corresponding list of CreateStmts.
  */
 static void
-deduceImplicitRangeBounds(ParseState *pstate, Relation parentrel, List *stmts, bool addpartition)
+deduceImplicitRangeBounds(ParseState *pstate, Relation parentrel, List *stmts, CreateStmtOrigin origin)
 {
 	PartitionKey key = RelationRetrievePartitionKey(parentrel);
 	PartitionDesc desc = RelationRetrievePartitionDesc(parentrel);
@@ -366,7 +369,7 @@ deduceImplicitRangeBounds(ParseState *pstate, Relation parentrel, List *stmts, b
 	 * a whole new set of child partitions of a parent table, or an ALTER TABLE
 	 * ADD PARTTION to add to an existing set of sibling partitions.
 	 */
-	if (!addpartition)
+	if (origin != ORIGIN_GP_CLASSIC_ALTER_GEN)
 	{
 		/*
 		 * CREATE TABLE or ALTER TABLE SET SUBPARTITION TEMPLATE. We deduce the
@@ -734,10 +737,14 @@ ChoosePartitionName(const char *parentname, int level, Oid naemspaceId,
 							  false);
 }
 
+/*
+ * Construct a CreateStmt representing a single partition to be created as part
+ * of a legacy style CREATE/ALTER statement.
+ */
 CreateStmt *
 makePartitionCreateStmt(Relation parentrel, char *partname, PartitionBoundSpec *boundspec,
 						PartitionSpec *subPart, GpPartDefElem *elem,
-						partname_comp *partnamecomp)
+						partname_comp *partnamecomp, CreateStmtOrigin origin)
 {
 	CreateStmt *childstmt;
 	RangeVar   *parentrv;
@@ -774,7 +781,7 @@ makePartitionCreateStmt(Relation parentrel, char *partname, PartitionBoundSpec *
 	childstmt->tablespacename = elem->tablespacename ? pstrdup(elem->tablespacename) : NULL;
 	childstmt->accessMethod = elem->accessMethod ? pstrdup(elem->accessMethod) : NULL;
 	childstmt->if_not_exists = false;
-	childstmt->gp_style_alter_part = true;
+	childstmt->origin = origin;
 	childstmt->distributedBy = make_distributedby_for_rel(parentrel);
 	childstmt->partitionBy = NULL;
 	childstmt->relKind = 0;
@@ -791,7 +798,8 @@ generateRangePartitions(ParseState *pstate,
 						GpPartDefElem *elem,
 						PartitionSpec *subPart,
 						partname_comp *partnamecomp,
-						bool *hasImplicitRangeBounds)
+						bool *hasImplicitRangeBounds,
+						CreateStmtOrigin origin)
 {
 	GpPartitionRangeSpec *boundspec;
 	List				 *result = NIL;
@@ -891,7 +899,7 @@ generateRangePartitions(ParseState *pstate,
 			partname = elem->partName;
 
 		childstmt = makePartitionCreateStmt(parentrel, partname, boundspec,
-											copyObject(subPart), elem, partnamecomp);
+											copyObject(subPart), elem, partnamecomp, origin);
 		result = lappend(result, childstmt);
 	}
 
@@ -905,7 +913,8 @@ generateListPartition(ParseState *pstate,
 					  Relation parentrel,
 					  GpPartDefElem *elem,
 					  PartitionSpec *subPart,
-					  partname_comp *partnamecomp)
+					  partname_comp *partnamecomp,
+					  CreateStmtOrigin origin)
 {
 	GpPartitionListSpec *gpvaluesspec;
 	PartitionBoundSpec  *boundspec;
@@ -950,7 +959,7 @@ generateListPartition(ParseState *pstate,
 	boundspec->location = -1;
 
 	childstmt = makePartitionCreateStmt(parentrel, elem->partName, boundspec, subPart,
-										elem, partnamecomp);
+										elem, partnamecomp, origin);
 
 	return list_make1(childstmt);
 }
@@ -960,7 +969,8 @@ generateDefaultPartition(ParseState *pstate,
 						 Relation parentrel,
 						 GpPartDefElem *elem,
 						 PartitionSpec *subPart,
-						 partname_comp *partnamecomp)
+						 partname_comp *partnamecomp,
+						 CreateStmtOrigin origin)
 {
 	PartitionBoundSpec *boundspec;
 	CreateStmt *childstmt;
@@ -972,7 +982,7 @@ generateDefaultPartition(ParseState *pstate,
 	/* default partition always needs name to be specified */
 	Assert(elem->partName != NULL);
 	childstmt = makePartitionCreateStmt(parentrel, elem->partName, boundspec, subPart,
-										elem, partnamecomp);
+										elem, partnamecomp, origin);
 	return list_make1(childstmt);
 }
 
@@ -1710,7 +1720,7 @@ List *
 generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 				   PartitionSpec *subPartSpec, const char *queryString,
 				   List *parentoptions, const char *parentaccessmethod,
-				   List *parentattenc, bool addpartition)
+				   List *parentattenc, CreateStmtOrigin origin)
 {
 	Relation	parentrel;
 	List	   *result = NIL;
@@ -1829,7 +1839,9 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 			elem->colencs = merge_partition_encoding(pstate, elem->colencs, penc_cls);
 
 		if (elem->isDefault)
-			new_parts = generateDefaultPartition(pstate, parentrel, elem, tmpSubPartSpec, &partcomp);
+			new_parts = generateDefaultPartition(pstate, parentrel, elem,
+												 tmpSubPartSpec, &partcomp,
+												 origin);
 		else
 		{
 			PartitionKey key = RelationRetrievePartitionKey(parentrel);
@@ -1839,12 +1851,18 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 				case PARTITION_STRATEGY_RANGE:
 				{
 					new_parts = generateRangePartitions(pstate, parentrel,
-														elem, tmpSubPartSpec, &partcomp, &hasImplicitRangeBounds);
+														elem, tmpSubPartSpec,
+														&partcomp,
+														&hasImplicitRangeBounds,
+														origin);
 					break;
 				}
 
 				case PARTITION_STRATEGY_LIST:
-					new_parts = generateListPartition(pstate, parentrel, elem, tmpSubPartSpec, &partcomp);
+					new_parts = generateListPartition(pstate, parentrel, elem,
+													  tmpSubPartSpec,
+													  &partcomp,
+													  origin);
 					break;
 				default:
 					elog(ERROR, "Not supported partition strategy");
@@ -1862,7 +1880,7 @@ generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSpec,
 	 * bounds for implicit START/END.
 	 */
 	if (hasImplicitRangeBounds)
-		deduceImplicitRangeBounds(pstate, parentrel, result, addpartition);
+		deduceImplicitRangeBounds(pstate, parentrel, result, origin);
 
 	free_parsestate(pstate);
 	table_close(parentrel, NoLock);

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -899,7 +899,8 @@ generateRangePartitions(ParseState *pstate,
 			partname = elem->partName;
 
 		childstmt = makePartitionCreateStmt(parentrel, partname, boundspec,
-											copyObject(subPart), elem, partnamecomp, origin);
+											copyObject(subPart), elem, partnamecomp,
+											origin);
 		result = lappend(result, childstmt);
 	}
 
@@ -1609,7 +1610,6 @@ transformGpPartitionDefinition(Oid parentrelid, const char *queryString,
 	ParseState				*pstate;
 	List					*partDefElems = NIL;
 	List					*encClauses = NIL;
-	bool					defaultPartDefElemFound = false;
 	PartitionKey 			partkey;
 
 	result = makeNode(GpPartitionDefinition);
@@ -1670,15 +1670,7 @@ transformGpPartitionDefinition(Oid parentrelid, const char *queryString,
 							parser_errposition(pstate, elem->location)));
 
 			if (elem->isDefault)
-			{
-				if (defaultPartDefElemFound)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-							 errmsg("multiple default partitions are not allowed"),
-							 parser_errposition(pstate, elem->location)));
-				defaultPartDefElemFound = true;
 				partDefElems = lcons(elem, partDefElems);
-			}
 			else
 			{
 				switch (partkey->strategy)

--- a/src/backend/partitioning/partdesc.c
+++ b/src/backend/partitioning/partdesc.c
@@ -46,6 +46,9 @@ typedef struct PartitionDirectoryEntry
 	Relation	rel;
 	PartitionDesc pd;
 } PartitionDirectoryEntry;
+
+static void RelationBuildPartitionDesc_guts(Relation rel, bool validate);
+
 /*
  * RelationRetrievePartitionDesc -- get partition descriptor, if relation is partitioned
  *
@@ -74,6 +77,24 @@ RelationRetrievePartitionDesc(Relation rel)
 
 	return rel->rd_partdesc;
 }
+
+/*
+ * GPDB: Build and validate the partition descriptor. Used for deferred
+ * partition constraint validation. Deferred constraint validation comes into
+ * play when we defer bounds validation to the end of command, for range
+ * partitions created with the classic syntax. This is done to avoid
+ * constructing the partition descriptor over and over again, for each and every
+ * partition added to the hierarchy. Constructing the parent's partition desc
+ * can have very significant overhead.
+ */
+void
+RelationValidatePartitionDesc(Relation rel)
+{
+	Assert (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE);
+
+	RelationBuildPartitionDesc_guts(rel, /* validate */ true);
+}
+
 /*
  * RelationBuildPartitionDesc
  *		Form rel's partition descriptor, and store in relcache entry
@@ -94,9 +115,22 @@ RelationRetrievePartitionDesc(Relation rel)
  * context the current context except in very brief code sections, out of fear
  * that some of our callees allocate memory on their own which would be leaked
  * permanently.
+ *
+ * GPDB: This function assumes that bounds validation was already performed
+ * beforehand for all partitions added to the hierarchy, if 'validate' is false.
+ *
+ * When 'validate' is true, perform bounds validation.
+ *
+ * See RelationValidatePartitionDesc() for details on when 'validate' is true.
  */
 void
 RelationBuildPartitionDesc(Relation rel)
+{
+	RelationBuildPartitionDesc_guts(rel, /* validate */ false);
+}
+
+static void
+RelationBuildPartitionDesc_guts(Relation rel, bool validate)
 {
 	PartitionDesc partdesc;
 	PartitionBoundInfo boundinfo = NULL;
@@ -247,7 +281,15 @@ RelationBuildPartitionDesc(Relation rel)
 	 * This could fail, but we haven't done any damage if so.
 	 */
 	if (nparts > 0)
-		boundinfo = partition_bounds_create(boundspecs, nparts, key, &mapping);
+	{
+		if (validate)
+			boundinfo = partition_bounds_create_and_validate(boundspecs, nparts,
+															 key, &mapping,
+															 oids);
+		else
+			boundinfo = partition_bounds_create(boundspecs, nparts, key, &mapping);
+	}
+
 
 	/*
 	 * Now build the actual relcache partition descriptor.  Note that the

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1274,7 +1274,8 @@ ProcessUtilitySlow(ParseState *pstate,
 														   cstmt->partspec->subPartSpec,
 														   queryString, cstmt->options,
 														   cstmt->accessMethod,
-														   cstmt->attr_encodings, false);
+														   cstmt->attr_encodings,
+														   ORIGIN_GP_CLASSIC_CREATE_GEN);
 								more_stmts = list_concat(more_stmts, parts);
 							}
 

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -184,6 +184,8 @@ extern void StorePartitionKey(Relation rel,
 extern void RemovePartitionKeyByRelId(Oid relid);
 extern void StorePartitionBound(Relation rel, Relation parent,
 								PartitionBoundSpec *bound);
+extern void StorePartitionBoundSkipInvalidation(Relation rel, Relation parent,
+												PartitionBoundSpec *bound);
 
 /* MPP-6929: metadata tracking */
 extern void MetaTrackAddObject(Oid		classid, 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2318,6 +2318,21 @@ typedef struct VariableShowStmt
 	char	   *name;
 } VariableShowStmt;
 
+/*
+ * GPDB: Where did the CreateStmt originate? Was it generated and if so, what
+ * type of operation generated it?
+ *
+ * Note: 'classic' syntax refers to the legacy GPDB partitioning syntax that
+ * predates the upstream partitioning syntax that was acquired during the
+ * Postgres 12 merge.
+ */
+typedef enum CreateStmtOrigin
+{
+	ORIGIN_NO_GEN,
+	ORIGIN_GP_CLASSIC_CREATE_GEN,
+	ORIGIN_GP_CLASSIC_ALTER_GEN
+} CreateStmtOrigin;
+
 /* ----------------------
  *		Create Table Statement
  *
@@ -2346,7 +2361,7 @@ typedef struct CreateStmt
 	char	   *tablespacename; /* table space to use, or NULL */
 	char	   *accessMethod;	/* table access method */
 	bool		if_not_exists;	/* just do nothing if it already exists? */
-	bool 		gp_style_alter_part; /* is this due to a GP-style ALTER on partition tables? */
+	bool 		gp_style_alter_part; /* unused */
 
 	DistributedBy *distributedBy;   /* what columns we distribute the data by */
 	Node       *partitionBy;     /* what columns we partition the data by */
@@ -2361,6 +2376,8 @@ typedef struct CreateStmt
 	/* names chosen for partition indexes */
 	List	   *part_idx_oids;
 	List	   *part_idx_names;
+
+	CreateStmtOrigin origin;	/* GPDB: provenance of this CreateStmt */
 } CreateStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -880,7 +880,7 @@ typedef struct PartitionSpec
 								 * 'range') */
 	List	   *partParams;		/* List of PartitionElems */
 
-	struct GpPartitionDefinition *gpPartDef;
+	struct GpPartitionDefinition *gpPartDef; /* contains legacy partition definition */
 	struct PartitionSpec         *subPartSpec;     /* subpartition specification */
 	int                          location;		/* token location, or -1 if unknown */
 } PartitionSpec;
@@ -2330,7 +2330,7 @@ typedef enum CreateStmtOrigin
 {
 	ORIGIN_NO_GEN,
 	ORIGIN_GP_CLASSIC_CREATE_GEN,
-	ORIGIN_GP_CLASSIC_ALTER_GEN
+	ORIGIN_GP_CLASSIC_ALTER_GEN,
 } CreateStmtOrigin;
 
 /* ----------------------

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -48,7 +48,7 @@ extern List *generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSp
 								PartitionSpec *subPartSpec,
 								const char *queryString, List *parentoptions,
 								const char *parentaccessmethod,
-								List *parentattenc, bool addpartition);
+								List *parentattenc, CreateStmtOrigin origin);
 GpPartitionDefinition *
 transformGpPartitionDefinition(Oid parentrelid, const char *queryString,
 							   GpPartitionDefinition *gpPartDef_orig);
@@ -66,7 +66,8 @@ extern CreateStmt *makePartitionCreateStmt(Relation parentrel, char *partname,
 										   PartitionBoundSpec *boundspec,
 										   PartitionSpec *subPart,
 										   GpPartDefElem *elem,
-										   partname_comp *partnamecomp);
+										   partname_comp *partnamecomp,
+										   CreateStmtOrigin origin);
 extern char *ChoosePartitionName(const char *parentname, int level,
 								 Oid naemspaceId, const char *partname,
 								 int partnum);

--- a/src/include/partitioning/partbounds.h
+++ b/src/include/partitioning/partbounds.h
@@ -89,6 +89,11 @@ extern List *get_qual_from_partbound(Relation rel, Relation parent,
 									 PartitionBoundSpec *spec);
 extern PartitionBoundInfo partition_bounds_create(PartitionBoundSpec **boundspecs,
 												  int nparts, PartitionKey key, int **mapping);
+extern PartitionBoundInfo partition_bounds_create_and_validate(PartitionBoundSpec **boundspecs,
+															   int nparts,
+															   PartitionKey key,
+															   int **mapping,
+															   Oid *oids);
 extern bool partition_bounds_equal(int partnatts, int16 *parttyplen,
 								   bool *parttypbyval, PartitionBoundInfo b1,
 								   PartitionBoundInfo b2);

--- a/src/include/partitioning/partdesc.h
+++ b/src/include/partitioning/partdesc.h
@@ -56,6 +56,7 @@ typedef struct PartitionDescData
 
 extern PartitionDesc RelationRetrievePartitionDesc(Relation rel);
 extern void RelationBuildPartitionDesc(Relation rel);
+extern void RelationValidatePartitionDesc(Relation rel);
 
 extern PartitionDirectory CreatePartitionDirectory(MemoryContext mcxt);
 extern PartitionDesc PartitionDirectoryLookup(PartitionDirectory, Relation);

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -606,7 +606,7 @@ partition by range (f1)
 NOTICE:  identifier "mpp3542_000000000011111111112222222222333333333344444444445555555555556666666666777777777788888888889999999999" will be truncated to "mpp3542_0000000000111111111122222222223333333333444444444455555"
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  partition "mpp3542_00000000001111111111222222222233333333_1_prt_New York_4" would overlap partition "mpp3542_00000000001111111111222222222233333_1_prt_Los Angeles_1"
+ERROR:  partition "mpp3542_00000000001111111111222222222233333_1_prt_Los Angeles_1" would overlap partition "mpp3542_00000000001111111111222222222233333333_1_prt_New York_4"
 -- Truncates the table name to mpp3542_0000000000111111111122222222223333333333444444444455555, but partition name is too long, so ERROR
 alter table mpp3542_000000000011111111112222222222333333333344444444445555555555556666666666777777777788888888889999999999 rename partition "Los Angeles_1" to "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 NOTICE:  identifier "mpp3542_000000000011111111112222222222333333333344444444445555555555556666666666777777777788888888889999999999" will be truncated to "mpp3542_0000000000111111111122222222223333333333444444444455555"
@@ -1774,7 +1774,7 @@ partition by range (f1)
 );
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  partition "mpp3114_1_prt_est_4" would overlap partition "mpp3114_1_prt_pst_1"
+ERROR:  partition "mpp3114_1_prt_pst_1" would overlap partition "mpp3114_1_prt_est_4"
 DROP TABLE mpp3114;
 ERROR:  table "mpp3114" does not exist
 CREATE TABLE sg_cal_detail_r1 (

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -358,7 +358,7 @@ partition by range (b)
 partition bb start (date '2008-01-01') end (date '2009-01-01'),
 partition aa start (date '2007-01-01') end (date '2008-01-01') inclusive
 );
-ERROR:  partition "ggg_1_prt_aa" would overlap partition "ggg_1_prt_bb"
+ERROR:  partition "ggg_1_prt_bb" would overlap partition "ggg_1_prt_aa"
 drop table ggg cascade;
 ERROR:  table "ggg" does not exist
 -- legal because start of bb not inclusive
@@ -1198,9 +1198,7 @@ default partition j3,
 default partition j4);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'aa' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  multiple default partitions are not allowed
-LINE 6: default partition j4);
-        ^
+ERROR:  partition "jjj_1_prt_j3" conflicts with existing default partition "jjj_1_prt_j4"
 -- check default
 create table foz (i int, d date) distributed by (i)
 partition by range (d)

--- a/src/test/regress/input/partition_ddl.source
+++ b/src/test/regress/input/partition_ddl.source
@@ -862,6 +862,16 @@ alter table mpp3260 drop partition for (800);
 alter table mpp3260 drop partition for (900);
 insert into mpp3260 (unique1) values (1);
 
+create table multi_level_overlap (a int, b int, c int)
+partition by range(b) subpartition by range(c)
+(partition p1 start (1) end (5)
+  (subpartition sp1 start(1) end(9),
+   subpartition sp2 start(11) end(20)),
+ partition p2 start (5) end (10)
+   (subpartition sp1 start(1) end(9),
+   subpartition sp2 start(2) end(5)) -- overlaps
+);
+
 CREATE TABLE mpp3260a (
         unique1         int4,
         unique2         int4,

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -2676,7 +2676,7 @@ partition by range (f1)
   partition "Los Angeles" start (time with time zone '00:00 PST') end (time with time zone '23:00 PST') EVERY (INTERVAL '1 hour'),
   partition "New York" start (time with time zone '00:00 EST') end (time with time zone '23:00 EST') EVERY (INTERVAL '1 hour')
 );
-ERROR:  partition "mpp3523_1_prt_New York_4" would overlap partition "mpp3523_1_prt_Los Angeles_1"
+ERROR:  partition "mpp3523_1_prt_Los Angeles_1" would overlap partition "mpp3523_1_prt_New York_4"
 -- Tries to truncate first, but the partition name is still too long, so ERROR
 alter table mpp3523 rename partition "Los Angeles_1" to "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 ERROR:  relation "mpp3523" does not exist
@@ -2687,7 +2687,7 @@ partition by range (f1)
   partition "Los Angeles" start (time with time zone '00:00 PST') end (time with time zone '23:00 PST') EVERY (INTERVAL '1 hour'),
   partition "New York" start (time with time zone '00:00 EST') end (time with time zone '23:00 EST') EVERY (INTERVAL '1 hour')
 );
-ERROR:  partition "mpp3523_00000000001111111111222222222233333333_1_prt_New York_4" would overlap partition "mpp3523_00000000001111111111222222222233333_1_prt_Los Angeles_1"
+ERROR:  partition "mpp3523_00000000001111111111222222222233333_1_prt_Los Angeles_1" would overlap partition "mpp3523_00000000001111111111222222222233333333_1_prt_New York_4"
 -- Truncates the table name to mpp3523_0000000000111111111122222222223333333333444444444455555, but partition name is too long, so ERROR
 alter table mpp3523_000000000011111111112222222222333333333344444444445555555555556666666666777777777788888888889999999999 rename partition "Los Angeles_1" to "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 ERROR:  relation "mpp3523_0000000000111111111122222222223333333333444444444455555" does not exist
@@ -2732,6 +2732,16 @@ alter table mpp3260 drop partition for (700);
 alter table mpp3260 drop partition for (800);
 alter table mpp3260 drop partition for (900);
 insert into mpp3260 (unique1) values (1);
+create table multi_level_overlap (a int, b int, c int)
+partition by range(b) subpartition by range(c)
+(partition p1 start (1) end (5)
+  (subpartition sp1 start(1) end(9),
+   subpartition sp2 start(11) end(20)),
+ partition p2 start (5) end (10)
+   (subpartition sp1 start(1) end(9),
+   subpartition sp2 start(2) end(5)) -- overlaps
+);
+ERROR:  partition "multi_level_overlap_1_prt_p2_2_prt_sp2" would overlap partition "multi_level_overlap_1_prt_p2_2_prt_sp1"
 CREATE TABLE mpp3260a (
         unique1         int4,
         unique2         int4,


### PR DESCRIPTION
Currently, in the classic CREATE workflow, we rebuild the partition
descriptor of parent relations once for each child. This
has significant overhead.

To eliminate that overhead, we have to avoid calls to
RelationRetrievePartitionDesc(). In this commit, we avoid the following:

* We avoid locking the default partition, for each child.

* We avoid calling check_new_partition_bound() for each child. Instead,
we defer all bounds checks to the end of the command.

* We avoid performing repeated relcache invalidations for default partitions.

This gives us close to a 3x improvement in performance.

Note: Currently, we perform this optimization only for range partitions
created with classic syntax. However, this can also be extended to ALTER
ADD and other types of partitions.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/optimize_create

Some performance numbers (with O3 retail build):
```
CREATE TABLE p3(a int, b int, c int) with (appendonly=true)
partition by range (a)
( partition aa start (1) end (3000) inclusive every (1) );

6x: 9s,main: 23s, branch: 6s
```

Perf diff between 6X and main branch showing the overhead from the repeated partition descriptor builds:

```
Perf diff (classic):
6X (Baseline)    vs   7X

# Baseline  Delta Abs  Shared Object      Symbol                                            
# ........  .........  .................  ..................................................
#
              +19.31%  postgres           [.] pg_strtok
               +6.17%  libc.so.6          [.] __GI_____strtoll_l_internal
     0.50%     +3.36%  postgres           [.] nocachegetattr
     0.10%     +3.25%  postgres           [.] AllocSetAlloc
     4.31%     -2.87%  postgres           [.] _bt_compare
               +2.77%  postgres           [.] SearchCatCache1
     0.26%     +1.95%  postgres           [.] LWLockAcquire
               +1.89%  postgres           [.] make_one_partition_rbound
     1.17%     +1.81%  libc.so.6          [.] __memmove_avx_unaligned_erms
     1.84%     -1.79%  postgres           [.] pg_strcasecmp

Drilling into the extra 20% on pg_strtok:-  

19.31%  postgres  postgres           [.] pg_strtok
   - pg_strtok                                        
      + 8.24% _readConst (inlined)
      + 3.65% _readPartitionBoundSpec
      + 2.46% parseNodeString
      + 2.28% readDatum
      + 2.02% _readPartitionRangeDatum
        0.52% nodeRead
```