### PR TITLE
Docs: new reference page for system catalog functions

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
@@ -1,0 +1,17 @@
+# System Catalog Functions
+
+Greenplum Database provides the following system catalog functions:
+
+> **Note** This list is provisional and may be incomplete.
+
+-   [pg_stat_get_backend_subxact](#pg_stat_get_backend_subxact)
+
+## <a id="statistics"></a>Statistics Functions
+
+The following functions support collection and reporting of information about server activity.
+
+### <a id="pg_stat_get_backend_subxact"></a>pg_stat_get_backend_subxacts
+
+`pg_stat_get_backend_subxact(integer)` return type is `record`.
+
+Returns a record of information about the subtransactions of the backend with the specified ID. The fields returned are `subxact_count`, which is the number of subtransactions in the backend's subtransaction cache, and `subxact_overflow`, which indicates whether the backend's subtransaction cache is overflowed or not.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
@@ -10,6 +10,12 @@ Greenplum Database provides the following system catalog functions:
 
 The following functions support collection and reporting of information about server activity.
 
+### <a id="gp_get_suboverflowed_backends"></a>gp_get_suboverflowed_backends
+
+`gp_get_suboverflowed_backends()` return type is `integer[]`.
+
+Returns an array of integers which indicate the process IDs  of all the sessions in which a backend has subtransaction overflows on the running segment. For a cluster-wide view of the suboverflowed backends on every segment, use the view [gp_suboverflowed_backend](catalog_ref-views.html#gp_suboverflowed_backend).
+
 ### <a id="pg_stat_get_backend_subxact"></a>pg_stat_get_backend_subxacts
 
 `pg_stat_get_backend_subxact(integer)` return type is `record`.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref.html.md
@@ -1,6 +1,6 @@
 # System Catalogs 
 
-This reference describes the Greenplum Database system catalog tables, views, catalog definitions and catalog functions. System tables prefixed with `gp_` relate to the parallel features of Greenplum Database. Tables prefixed with `pg_` are either standard PostgreSQL system catalog tables supported in Greenplum Database, or are related to features Greenplum that provides to enhance PostgreSQL for data warehousing workloads. Note that the global system catalog for Greenplum Database resides on the coordinator instance.
+This reference describes the Greenplum Database system catalog tables, views, and functions. System tables prefixed with `gp_` relate to the parallel features of Greenplum Database. Tables prefixed with `pg_` are either standard PostgreSQL system catalog tables supported in Greenplum Database, or are related to features Greenplum that provides to enhance PostgreSQL for data warehousing workloads. Note that the global system catalog for Greenplum Database resides on the coordinator instance.
 
 > **Caution** Changes to Greenplum Database system catalog tables or views are not supported. If a catalog table or view is changedby the customer, the VMware Greenplum cluster is not supported. The cluster must be reinitialized and restored by the customer.
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref.html.md
@@ -1,12 +1,13 @@
 # System Catalogs 
 
-This reference describes the Greenplum Database system catalog tables and views. System tables prefixed with `gp_` relate to the parallel features of Greenplum Database. Tables prefixed with `pg_` are either standard PostgreSQL system catalog tables supported in Greenplum Database, or are related to features Greenplum that provides to enhance PostgreSQL for data warehousing workloads. Note that the global system catalog for Greenplum Database resides on the coordinator instance.
+This reference describes the Greenplum Database system catalog tables, views, catalog definitions and catalog functions. System tables prefixed with `gp_` relate to the parallel features of Greenplum Database. Tables prefixed with `pg_` are either standard PostgreSQL system catalog tables supported in Greenplum Database, or are related to features Greenplum that provides to enhance PostgreSQL for data warehousing workloads. Note that the global system catalog for Greenplum Database resides on the coordinator instance.
 
 > **Caution** Changes to Greenplum Database system catalog tables or views are not supported. If a catalog table or view is changedby the customer, the VMware Greenplum cluster is not supported. The cluster must be reinitialized and restored by the customer.
 
 -   [System Tables](catalog_ref-tables.html)
 -   [System Views](catalog_ref-views.html)
 -   [System Catalogs Definitions](catalog_ref-html.html)
+-   [System Catalog Functions](catalog_ref-functions.html)
 
 **Parent topic:** [Greenplum Database Reference Guide](../ref_guide.html)
 


### PR DESCRIPTION
This PR:

- Creates a new documentation reference page for System Catalog Functions.
- Creates a sub-menu for Statistics Functions.
- Adds the function `pg_stat_get_backend_subxact` to the list under Statistics Functions.

Question:
- Should we also add `gp_get_suboverflowed_backends` to the list? Is this a wrapper of `pg_stat_get_backend_subxact`? I can see that the system view `gp_suboverflowed_backend` exists. What is the relationship among them all?

Review site:
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-catfunct/greenplum-database/ref_guide-system_catalogs-catalog_ref-functions.html