### PR TITLE
Docs gp stat progress dtx recovery

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -840,7 +840,9 @@ The `gp_stat_progress_create_index_summary` view aggregates across the Greenplum
 
 ### <a id="gp_stat_progress_dtx_recovery"></a>gp_stat_progress_dtx_recovery
 
-The `gp_stat_progress_dtx_recovery` view is a cluster-wide view that displays the progress of the routine to recover distributed transactions.
+The `gp_stat_progress_dtx_recovery` view is a cluster-wide view that displays the progress of the Distributed Transaction (DTX) Recovery process, which runs in the backgroup during Postgres startup. 
+
+This view may be useful if a coordinator restart remains in a recovery state for a long time. Greenplum will not accept connections until all "in-doubt" transactions are resolved. In-doubt transactions are transactions that have been prepared but not committed yet. If there were many transactions running before the coordinator restarted, the recovery of the database may take longer than expected, and you may use this view to monitor the current phase of the recovery. Note that in this scenario, as Greenplum is still starting up, you will need to access the database in utility mode to check this view.
 
 |Column|Type|Description|
 |------|----|-----------|

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -36,6 +36,7 @@ Greenplum Database provides the following system views:
 -   [gp_stat_progress_cluster](#gp_stat_progress_cluster)
 -   [gp_stat_progress_copy](#gp_stat_progress_copy)
 -   [gp_stat_progress_create_index](#gp_stat_progress_create_index)
+-   [gp_stat_progress_dtx_recovery](#gp_stat_progress_dtx_recovery)
 -   [gp_stat_progress_vacuum](#gp_stat_progress_vacuum)
 -   [gp_stat_replication](#gp_stat_replication)
 -   [gp_stat_resqueues](#gp_stat_resqueues)
@@ -100,6 +101,7 @@ For more information on summary views, see [Summary Views](#summary_views), belo
 - gp_stat_progress_cluster_summary
 - gp_stat_progress_copy_summary
 - gp_stat_progress_create_index_summary
+- gp_stat_progress_dtx_recovery
 - gp_stat_progress_vacuum_summary
 - gp_stat_slru_summary
 - gp_stat_sys_indexes_summary
@@ -835,6 +837,18 @@ The `gp_stat_progress_create_index_summary` view aggregates across the Greenplum
 | `tuples_done` | bigint | Number of tuples already processed in the current phase. |
 | `partitions_total` | bigint | When creating an index on a partitioned table, this column is set to the total number of partitions on which the index is to be created. This field is 0 during a `REINDEX`. |
 | `partitions_done` | bigint | When creating an index on a partitioned table, this column is set to the number of partitions on which the index has been completed. This field is 0 during a `REINDEX`. |
+
+### <a id="gp_stat_progress_dtx_recovery"></a>gp_stat_progress_dtx_recovery
+
+The `gp_stat_progress_dtx_recovery` view is a cluster-wide view that displays the progress of the routine to recover distributed transactions.
+
+|Column|Type|Description|
+|------|----|-----------|
+|`phase`|text | Status of the recovery. The possible values are: 'initializing', 'recovering commited distributed transactions', 'gathering in-doubt transactions', 'aborting in-doubt transactions', 'gathering in-doubt orphaned transactions', and 'managing in-doubt orphaned transactions'.|
+|`recover_commited_dtx_total`|integer| Total number of commited transactions found to recover.|
+|`recover_commited_dtx_completed`|integer| Total number of in-doubt transaction found, used in startup and non-startup phases.|
+|`in_doubt_tx_in_progress`|integer| Number of in-progress, in-doubt transactions. Its value is always 0 for startup.|
+|`in_doubt_tx_aborted`|integer| Number of aborted in-doubt transactions.|
 
 ### <a id="gp_stat_progress_vacuum"></a>gp_stat_progress_vacuum
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -850,7 +850,7 @@ This view may be useful if a coordinator restart remains in a recovery state for
 |`recover_commited_dtx_total`|integer| Total number of committed transactions found to recover.|
 |`recover_commited_dtx_completed`|integer| Number of committed transactions that have been recovered.| 
 | in_doubt_tx_total`|integer| Total number of in-doubt transaction found, used in startup and non-startup phases.|
-|`in_doubt_tx_in_progress`|integer| Number of in-progress, in-doubt transactions. Its value is always 0 for startup.|
+|`in_doubt_tx_in_progress`|integer| Number of in-progress, in-doubt transactions.|
 |`in_doubt_tx_aborted`|integer| Number of aborted in-doubt transactions.|
 
 ### <a id="gp_stat_progress_vacuum"></a>gp_stat_progress_vacuum

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -847,8 +847,9 @@ This view may be useful if a coordinator restart remains in a recovery state for
 |Column|Type|Description|
 |------|----|-----------|
 |`phase`|text | Status of the recovery. The possible values are: 'initializing', 'recovering commited distributed transactions', 'gathering in-doubt transactions', 'aborting in-doubt transactions', 'gathering in-doubt orphaned transactions', and 'managing in-doubt orphaned transactions'.|
-|`recover_commited_dtx_total`|integer| Total number of commited transactions found to recover.|
-|`recover_commited_dtx_completed`|integer| Total number of in-doubt transaction found, used in startup and non-startup phases.|
+|`recover_commited_dtx_total`|integer| Total number of committed transactions found to recover.|
+|`recover_commited_dtx_completed`|integer| Number of committed transactions that have been recovered.| 
+| in_doubt_tx_total`|integer| Total number of in-doubt transaction found, used in startup and non-startup phases.|
 |`in_doubt_tx_in_progress`|integer| Number of in-progress, in-doubt transactions. Its value is always 0 for startup.|
 |`in_doubt_tx_aborted`|integer| Number of aborted in-doubt transactions.|
 


### PR DESCRIPTION
This PR adds the view `gp_stat_progress_dtx_recovery` to the documentation reference pages for system views. 
Based on https://github.com/greenplum-db/gpdb/pull/15945
Let me know if the column types and descriptions are correct. 