### PR TITLE
gpinitsystem should return code 1 when invalid option is used

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -222,6 +222,9 @@ LOG_MSG () {
 		*FATAL*)
 			EXIT_STATUS=1
 			;;
+	        *ERROR*)
+			EXIT_STATUS=1
+			;;
 		esac
 
 		if [ x"" == x"$DEBUG_LEVEL" ];then

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -352,7 +352,7 @@ Feature: gpinitsystem tests
 
     Scenario: gpinitsystem should pass the default value of trusted_shell properly to gpcreateseg
         Given create demo cluster config
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -h ../gpAux/gpdemo/hostfile --ignore-warnings"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -h ../gpAux/gpdemo/hostfile"
         Then gpinitsystem should return a return code of 0
         When the user runs command "grep -q '.*gpcreateseg\.sh.*Completed .*lalshell.*' ~/gpAdminLogs/gpinitsystem*log"
         Then grep should return a return code of 0
@@ -385,3 +385,11 @@ Feature: gpinitsystem tests
         Then gpconfig should return a return code of 0
         When the user runs "gpstop -ar"
         Then gpstop should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 1 when the user provides invalid option
+        Given create demo cluster config
+         When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings" eok
+         Then gpinitsystem should return a return code of 1
+          And gpinitsystem should print "Unknown option --ignore-warnings" to stdout
+        Given the user runs "gpstate"
+         Then gpstate should return a return code of 2


### PR DESCRIPTION
**Fixes:** https://github.com/greenplum-db/gpdb/issues/16848

**Issue:** gpinitsystem fails with an error when an invalid option is provided. But the exit code is 0 not 1. It should fail with exit code 1.

**Fix:** LOG_MSG fn is being used to print the error which sets EXIT_STATUS to 1 only when message is a FATAL message. Updated LOG_MSG to set the EXIT_STATUS to 1 in case of ERROR messages also.

Current behaviour:
```
[~/workspace/gpdb/gpMgmt: {gpinitsystem_invalid_options} ?]$ gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile -h ../gpAux/gpdemo/hostfile --sdbds
20231215:11:01:58:098912 gpinitsystem:ashahaniKMD6M:ashahani-[ERROR]:-Unknown option --sdbds

      gpinitsystem -c gp_config_file [OPTIONS]

      Creates a new Greenplum Database instance on a Coordinator host and a number of
      segment instance hosts.

      General options:
      -v, display version information & exit

      Logging options:
      -a, don't ask to confirm instance creation [default:- ask]
      -D, set log output to debug level, shows all function calls
      -l, logfile_directory [optional]
          Alternative logfile directory
      -q, quiet mode, do not log progress to screen [default:- verbose output to screen]

      Configuration options:
      -b, <size> shared_buffers per instance [default 128000kB]
          Specify either the number of database I/O buffers (without suffix) or the
          amount of memory to use for buffers (with suffix 'kB', 'MB' or 'GB').
          Applies to coordinator and all segments.
      -B, <number> run this batch of create segment processes in parallel [default 60]
      -c, gp_config_file [mandatory]
          Supplies all Greenplum configuration information required by this utility.
          Full description of all parameters contained within the example file
          supplied with this distribution.
          Also see file gpinitsystem_help for greater detail on
          the operation and configuration of this script
      -e, <password>, password to set for Greenplum superuser in database [default gparray]
      -S, standby_datadir [optional]
      -h, gp_hostlist_file [optional]
          Contains a list of all segment instance hostnames required to participate in
          the new Greenplum instance. Normally set in gp_config_file.
      -I, <input_configuration_file>
          The full path and filename of an input configuration file, which defines the
          Greenplum Database members and segments using the QD_PRIMARY_ARRAY and
          PRIMARY_ARRAY parameters. The input configuration file is typically created by
          using gpinitsystem with the -O <output_configuration_file> option. You must
          provide either the -c <cluster_configuration_file> option or the -I
          <input_configuration_file> option to gpinitsystem.
      -m, maximum number of connections for coordinator instance [default 250]
      -n, <locale>, setting for locale to be set when database initialized [defaults to system locale]
      -O, <output_configuration_file>
          When used with the -O option, gpinitsystem does not create a new Greenplum
          Database cluster but instead writes the supplied cluster configuration
          information to the specified output_configuration_file. This file defines
          Greenplum Database members and segments using the QD_PRIMARY_ARRAY and
          PRIMARY_ARRAY parameters, and can be later used with -I
          <input_configuration_file> to initialize a new cluster.
      -p, postgresql_conf_gp_additions [optional]
          List of additional PostgreSQL parameters to be applied to each Coordinator/Segment
          postgresql.conf file during Greenplum database initialization.
      -P, standby_port [optional]
      -s, standby_hostname [optional]

      Return codes:
      0 - No problems encountered with requested operation
      1 - Fatal error, instance not created/started, or in an inconsistent state,
          see log file for failure reason.

[~/workspace/gpdb/gpMgmt: {gpinitsystem_invalid_options} ?]$ echo $?
0
```

Behaviour after the fix:
```
[~/workspace/gpdb/gpMgmt: {gpinitsystem_invalid_options} ?]$ gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile -h ../gpAux/gpdemo/hostfile --sdbds
20231215:11:01:58:098912 gpinitsystem:ashahaniKMD6M:ashahani-[ERROR]:-Unknown option --sdbds

      gpinitsystem -c gp_config_file [OPTIONS]

      Creates a new Greenplum Database instance on a Coordinator host and a number of
      segment instance hosts.

      General options:
      -v, display version information & exit

      Logging options:
      -a, don't ask to confirm instance creation [default:- ask]
      -D, set log output to debug level, shows all function calls
      -l, logfile_directory [optional]
          Alternative logfile directory
      -q, quiet mode, do not log progress to screen [default:- verbose output to screen]

      Configuration options:
      -b, <size> shared_buffers per instance [default 128000kB]
          Specify either the number of database I/O buffers (without suffix) or the
          amount of memory to use for buffers (with suffix 'kB', 'MB' or 'GB').
          Applies to coordinator and all segments.
      -B, <number> run this batch of create segment processes in parallel [default 60]
      -c, gp_config_file [mandatory]
          Supplies all Greenplum configuration information required by this utility.
          Full description of all parameters contained within the example file
          supplied with this distribution.
          Also see file gpinitsystem_help for greater detail on
          the operation and configuration of this script
      -e, <password>, password to set for Greenplum superuser in database [default gparray]
      -S, standby_datadir [optional]
      -h, gp_hostlist_file [optional]
          Contains a list of all segment instance hostnames required to participate in
          the new Greenplum instance. Normally set in gp_config_file.
      -I, <input_configuration_file>
          The full path and filename of an input configuration file, which defines the
          Greenplum Database members and segments using the QD_PRIMARY_ARRAY and
          PRIMARY_ARRAY parameters. The input configuration file is typically created by
          using gpinitsystem with the -O <output_configuration_file> option. You must
          provide either the -c <cluster_configuration_file> option or the -I
          <input_configuration_file> option to gpinitsystem.
      -m, maximum number of connections for coordinator instance [default 250]
      -n, <locale>, setting for locale to be set when database initialized [defaults to system locale]
      -O, <output_configuration_file>
          When used with the -O option, gpinitsystem does not create a new Greenplum
          Database cluster but instead writes the supplied cluster configuration
          information to the specified output_configuration_file. This file defines
          Greenplum Database members and segments using the QD_PRIMARY_ARRAY and
          PRIMARY_ARRAY parameters, and can be later used with -I
          <input_configuration_file> to initialize a new cluster.
      -p, postgresql_conf_gp_additions [optional]
          List of additional PostgreSQL parameters to be applied to each Coordinator/Segment
          postgresql.conf file during Greenplum database initialization.
      -P, standby_port [optional]
      -s, standby_hostname [optional]

      Return codes:
      0 - No problems encountered with requested operation
      1 - Fatal error, instance not created/started, or in an inconsistent state,
          see log file for failure reason.

[~/workspace/gpdb/gpMgmt: {gpinitsystem_invalid_options} ?]$ echo $?
1
```


Added behave scenario to validate the changes

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
