### PR TITLE
pg_dump: fix --function-oid when --relation-oid is also used

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -77,6 +77,7 @@ def before_feature(context, feature):
         dbconn.execSQL(context.conn, 'analyze t2')
         dbconn.execSQL(context.conn, 'analyze t3')
         dbconn.execSQL(context.conn, 'analyze spiegelungssätze')
+        dbconn.execSQL(context.conn, 'create or replace function select_one() returns integer as $$ select 1 $$ language sql')
         context.conn.commit()
 
 def after_feature(context, feature):

--- a/gpMgmt/test/behave/mgmt_utils/minirepro.feature
+++ b/gpMgmt/test/behave/mgmt_utils/minirepro.feature
@@ -277,3 +277,15 @@ Feature: Dump minimum database objects that is related to the query
       And the output file "/tmp/out.sql" should contain "Table: spiegelungssätze, Attribute: 列2"
       And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
       And the file "/tmp/in.sql" should be executed in database "minidb_tmp" without error
+
+    @minirepro_core
+    Scenario: Dump database objects of only functions
+      Given the file "/tmp/in.sql" exists and contains "SELECT select_one()"
+      And the file "/tmp/out.sql" does not exist
+      When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
+      Then the output file "/tmp/out.sql" should exist
+      And the output file "/tmp/out.sql" should contain "CREATE FUNCTION public.select_one() RETURNS integer"
+      And the output file "/tmp/out.sql" should contain "LANGUAGE sql"
+      And the output file "/tmp/out.sql" should contain "AS $$ select 1 $$;"
+      And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
+      And the file "/tmp/in.sql" should be executed in database "minidb_tmp" without error

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6329,7 +6329,6 @@ getFuncs(Archive *fout, int *numFuncs)
 
 		/* Decide whether we want to dump it */
 		selectDumpableFunction(&finfo[i]);
-		selectDumpableObject(&(finfo[i].dobj), fout);
 
 		/* Mark whether function has an ACL */
 		if (!PQgetisnull(res, i, i_proacl))


### PR DESCRIPTION
pg_dump does not correctly dump functions when both greenplum specific internal flags `--function-oid` and `--relation-oid` are used at the same time. This is because functions are being marked dumpable or not twice. The first time is by selectDumpableFunction and then again by selectDumpableObject. When `--relation-oid` is used, all namespaces are marked not dumpable which is why selectDumpableObject will mark the function to not be dumped.

This must be a regression. The original commit that introduces greenplum specific selectDumpableFunction removes the usage of the more generic selectDumpableObject.

selectDumpableFunction reference commit:
https://github.com/greenplum-db/gpdb/commit/318b86afc3eb5745f07ddfb390970b1769c63a1b
