### PR TITLE
[ORCA] Add GUC to disable right outer join (ROJ)

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -517,6 +517,15 @@ CConfigParamMapping::PackConfigParamInBitset(
 	// enable using opfamilies in distribution specs for GPDB 6
 	traceflag_bitset->ExchangeSet(EopttraceConsiderOpfamiliesForDistribution);
 
+	if (!optimizer_enable_right_outer_join)
+	{
+		// disable right outer join if the corresponding GUC is turned off
+		traceflag_bitset->ExchangeSet(
+			GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftJoin2RightJoin));
+		traceflag_bitset->ExchangeSet(
+			GPOPT_DISABLE_XFORM_TF(CXform::ExfRightOuterJoin2HashJoin));
+	}
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformRightOuterJoin2HashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformRightOuterJoin2HashJoin.h
@@ -6,7 +6,7 @@
 //		CXformRightOuterJoin2HashJoin.h
 //
 //	@doc:
-//		Transform left outer join to left outer hash join
+//		Transform right outer join to right outer hash join
 //---------------------------------------------------------------------------
 #ifndef GPOPT_CXformRightOuterJoin2HashJoin_H
 #define GPOPT_CXformRightOuterJoin2HashJoin_H
@@ -24,7 +24,7 @@ using namespace gpos;
 //		CXformRightOuterJoin2HashJoin
 //
 //	@doc:
-//		Transform left outer join to left outer hash join
+//		Transform right outer join to right outer hash join
 //
 //---------------------------------------------------------------------------
 class CXformRightOuterJoin2HashJoin : public CXformImplementation

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -339,6 +339,7 @@ bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
 bool		optimizer_force_comprehensive_join_implementation;
 bool		optimizer_enable_replicated_table;
 bool		optimizer_enable_foreign_table;
+bool		optimizer_enable_right_outer_join;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -2998,6 +2999,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_foreign_table,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_enable_right_outer_join", PGC_USERSET, QUERY_TUNING_METHOD,
+		 gettext_noop("Enable Orca to generate plans containing right outer joins."),
+		 NULL,
+		 GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_right_outer_join,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -511,6 +511,7 @@ extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
 extern bool optimizer_force_comprehensive_join_implementation;
 extern bool optimizer_enable_replicated_table;
 extern bool optimizer_enable_foreign_table;
+extern bool optimizer_enable_right_outer_join;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -390,6 +390,7 @@
 		"optimizer_enable_streaming_material",
 		"optimizer_enable_tablescan",
 		"optimizer_enable_foreign_table",
+		"optimizer_enable_right_outer_join",
 		"optimizer_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13119,6 +13119,25 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: t2.c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t2.c
+               ->  Hash Right Join
+                     Hash Cond: (t2.c = t1.a)
+                     ->  Seq Scan on roj2 t2
+                     ->  Hash
+                           ->  Seq Scan on roj1 t1
+ Optimizer: Postgres-based planner
+(11 rows)
+
+reset optimizer_enable_right_outer_join;
 reset optimizer_enable_motion_redistribute;
 reset enable_sort;
 -- simple check for btree indexes on AO tables

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13249,6 +13249,26 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ GroupAggregate
+   Group Key: roj2.c
+   ->  Sort
+         Sort Key: roj2.c
+         ->  Hash Left Join
+               Hash Cond: (roj1.a = roj2.c)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on roj1
+               ->  Hash
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Seq Scan on roj2
+ Optimizer: GPORCA
+(12 rows)
+
+reset optimizer_enable_right_outer_join;
 reset optimizer_enable_motion_redistribute;
 reset enable_sort;
 -- simple check for btree indexes on AO tables

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2900,6 +2900,12 @@ analyze roj2;
 set optimizer_enable_motion_redistribute=off;
 select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
 explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+reset optimizer_enable_right_outer_join;
+
 reset optimizer_enable_motion_redistribute;
 
 reset enable_sort;


### PR DESCRIPTION
In production systems, we encountered scenarios where poor cardinality
estimations led to plans with ROJ that yielded memory related workfile
limit errors. In those cases, the only way to turn off ROJ was to either
rewrite the query or turn off the xform. A query rewrite takes time to
come up with and turning off the xform doesn't work at the per-user
level. This commit introduces a GUC optimizer_enable_right_outer_join as
a convenient way to work around this problem.