### PR TITLE
Add hidden flag --gp-mirror-fast-wait to pg_ctl

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -180,6 +180,10 @@ class CmdArgs(list):
             self.append("-D '%s'" % (cfg_array))
         return self
 
+    def set_mirror_fast_wait(self, mirrorFastWait):
+        if mirrorFastWait:
+            self.append("--gp-mirror-fast-wait")
+        return self
 
 
 class PgCtlBackendOptions(CmdArgs):
@@ -267,7 +271,7 @@ class PgCtlStartArgs(CmdArgs):
      '-o', '"', '-p', '5432', '--silent-mode=true', '"', 'start']
     """
 
-    def __init__(self, datadir, backend, era, wrapper, args, wait, timeout=None):
+    def __init__(self, datadir, backend, era, wrapper, args, wait, timeout=None, mirrorFastWait=False):
         """
         @param datadir: database data directory
         @param backend: backend options string from PgCtlBackendOptions
@@ -288,6 +292,7 @@ class PgCtlStartArgs(CmdArgs):
         ])
         self.set_wrapper(wrapper, args)
         self.set_wait_timeout(wait, timeout)
+        self.set_mirror_fast_wait(mirrorFastWait)
         self.extend([
             "-o", "\"", str(backend), "\"",
             "start"
@@ -381,7 +386,8 @@ class SegmentStart(Command):
     def __init__(self, name, gpdb, numContentsInCluster, era, mirrormode,
                  utilityMode=False, ctxt=LOCAL, remoteHost=None,
                  pg_ctl_wait=True, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None):
+                 specialMode=None, wrapper=None, wrapper_args=None,
+                 mirrorFastWait=False):
 
         # This is referenced from calling code
         self.segment = gpdb
@@ -399,7 +405,7 @@ class SegmentStart(Command):
         b.set_special(specialMode)
 
         # build pg_ctl command
-        c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, pg_ctl_wait, timeout)
+        c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, pg_ctl_wait, timeout, mirrorFastWait)
         logger.info("SegmentStart pg_ctl cmd is %s", c)
         self.cmdStr = str(c) + ' 2>&1'
 

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -256,6 +256,7 @@ class GpSegStart:
                     self.overall_status.mark_failed(datadir, msg, reasoncode)
                     continue
 
+            mirrorFastWait = seg.isSegmentMirror(current_role=True)
             cmd = gp.SegmentStart("Starting seg at dir %s" % datadir,
                                   seg,
                                   self.num_cids,
@@ -264,7 +265,8 @@ class GpSegStart:
                                   timeout=self.timeout,
                                   specialMode=self.specialMode,
                                   wrapper=self.wrapper,
-                                  wrapper_args=self.wrapper_args)
+                                  wrapper_args=self.wrapper_args,
+                                  mirrorFastWait=mirrorFastWait)
             self.pool.addCommand(cmd)
 
         self.pool.join()

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -57,10 +57,11 @@ Feature: gpstart behave tests
 
     @concourse_cluster
     @demo_cluster
-    Scenario: gpstart starts even if a segment host is unreachable
+    Scenario: gpstart starts even if a segment host is unreachable and mirror is promoted
         Given the database is running
-          And the host for the primary on content 0 is made unreachable
-          And the host for the mirror on content 1 is made unreachable
+          And fts probing is disabled
+          And the host for the primary on content 0 is made unreachable and do not wait for failover
+          And the host for the mirror on content 1 is made unreachable and do not wait for failover
 
           And the user runs command "pkill -9 postgres" on all hosts without validation
          When "gpstart" is run with prompts accepted
@@ -69,6 +70,7 @@ Feature: gpstart behave tests
           And gpstart should print unreachable host messages for the down segments
           And the status of the primary on content 0 should be "d"
           And the status of the mirror on content 1 should be "d"
+          And the role of the mirror on content 0 should be "p"
           And the cluster is returned to a good state
 
     @concourse_cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -377,6 +377,16 @@ def impl(context, content_ids):
                       remoteHost=seg.getSegmentHostName(), ctxt=REMOTE)
         cmd.run(validateAfter=True)
 
+@given('fts probing is disabled')
+@when('fts probing is disabled')
+@then('fts probing is disabled')
+def impl(context):
+    create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
+    execute_sql('postgres', create_fault_query)
+
+    inject_fault_query = "SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;"
+    execute_sql('postgres', inject_fault_query)
+    return
 
 @given('the user {action} the walsender on the {segment} on content {content_ids}')
 @when('the user {action} the walsender on the {segment} on content {content_ids}')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -242,8 +242,8 @@ def run_gprecoverseg():
     run_cmd('gprecoverseg -a -v')
 
 
-def getRows(dbname, exec_sql):
-    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
+def getRows(dbname, exec_sql, utility=False):
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), utility=utility, unsetSearchPath=False)) as conn:
         curs = dbconn.query(conn, exec_sql)
         results = curs.fetchall()
     return results
@@ -298,7 +298,7 @@ def create_database(context, dbname=None, host=None, port=0, user=None):
 
 def get_segment_hostnames(context, dbname):
     sql = "SELECT DISTINCT(hostname) FROM gp_segment_configuration WHERE content != -1;"
-    return getRows(dbname, sql)
+    return getRows(dbname, sql, utility=True)
 
 
 def check_table_exists(context, dbname, table_name, table_type=None, host=None, port=0, user=None):
@@ -595,7 +595,7 @@ def check_row_count(context, tablename, dbname, nrows):
 
 def get_coordinator_hostname(dbname='template1'):
     coordinator_hostname_sql = "SELECT DISTINCT hostname FROM gp_segment_configuration WHERE content=-1 AND role='p'"
-    return getRows(dbname, coordinator_hostname_sql)
+    return getRows(dbname, coordinator_hostname_sql, utility=True)
 
 
 def get_hosts(dbname='template1'):

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -123,6 +123,7 @@ static char *register_password = NULL;
 static char *argv0 = NULL;
 static bool allow_core_files = false;
 static time_t start_time;
+static bool gp_mirror_fast_wait = false;
 
 static char postopts_file[MAXPGPATH];
 static char version_file[MAXPGPATH];
@@ -737,7 +738,8 @@ wait_for_postmaster_start(pgpid_t pm_pid, bool do_checkpoint)
 				}
 				else /* I'm one of coordinator, standby-coor, primary, mirror */
 				{
-					if (strcmp(pmstatus, pmReadyStatuses[pmStartMode]) == 0)
+					if (strcmp(pmstatus, pmReadyStatuses[pmStartMode]) == 0 ||
+						(gp_mirror_fast_wait && pmStartMode == IS_MIRROR && strcmp(pmstatus, PM_STATUS_STANDBY) == 0))
 					{
 						/* postmaster is done starting up */
 						free_readfile(optlines);
@@ -2589,6 +2591,7 @@ main(int argc, char **argv)
 		{"wrapper-args", optional_argument, NULL, 'Q'},
 		{"wait", no_argument, NULL, 'w'},
 		{"no-wait", no_argument, NULL, 'W'},
+		{"gp-mirror-fast-wait", no_argument, NULL, 128},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -2751,6 +2754,15 @@ main(int argc, char **argv)
 					break;
 				case 'Q':
 					wrapper_args = pg_strdup(optarg);
+					break;
+				case 128:
+					/*
+					 * GPDB: Wait for mirror's postmaster.pid to show
+					 * 'standby' instead of 'wrecvstreaming'. This is useful
+					 * for utilities (e.g. gpstart) that do not care if a
+					 * mirror's wal receiver has starting streaming or not.
+					 */
+					gp_mirror_fast_wait = true;
 					break;
 				default:
 					/* getopt_long already issued a suitable error message */


### PR DESCRIPTION
There was a recent commit that made pg_ctl wait for mirrors to display 'wrecvstreaming' in its postmaster.pid instead of 'standby'. However, this caused a regression in gpstart where it would wait for the mirror to finish starting up before eventually failing due to timeout because its primary segment was not able to start up. In this scenario, the mirror would be in lock status 'standby' and is able to be promoted by FTS but FTS is unavailable during gpstart because the coordinator segment is not up when primary and mirror segments are brought up. To fix the issue, we add a new hidden flag to pg_ctl which will allow pg_ctl to complete its wait loop if the mirror is in lock status 'standby'. This should be okay for gpstart since it doesn't care too much if a mirror's wal receiver has started streaming or not... whereas tools like gprecoverseg, gpaddmirrors, and gpmovemirrors would require it.

To add coverage for this scenario, a gpstart Behave test has been refactored accordingly. The previous testing logic was not ideal since it had an immediate segment failover which made the gpstart host checking logic kinda useless. The new testing logic prevents the segment failover and allows gpstart to demonstrate that it can start up the cluster when a primary or mirror cannot be brought up.

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/1d2b2288d9b4b98c785b4e594ccefc0f8eb90a7f

Note: The `--gp-mirror-fast-wait` flag name can be changed if someone else has a better name for it.  I went with this one since `pg_ctl` uses the terms "fast" and "wait" as well.  This also made it so I only had to change code related to `gpstart`.  I made the flag hidden since I didn't see the need for it to be exposed to users... but I can make it exposed if someone feels it should be.