### PR TITLE
Add GUC gp_max_system_slices with superuser(PGC_SUSET)  only

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1174,7 +1174,7 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("at most %d slices are allowed in a query, current number: %d",
 						gp_max_slices, numSlices),
-				 errhint("rewrite your query or adjust GUC gp_max_slices")));
+				 errhint("rewrite your query")));
 
 	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1175,8 +1175,8 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 	 * and `gp_max_system_slices`, otherwise use `gp_max_slices`
 	 */
 	max_slices = (gp_max_system_slices > 0) ?
-		((gp_max_slices < gp_max_system_slices) ? gp_max_slices : gp_max_system_slices)
-		: gp_max_slices;
+		((gp_max_slices > 0 && gp_max_slices < gp_max_system_slices) ?
+		 gp_max_slices : gp_max_system_slices) : gp_max_slices;
 
 	if (max_slices > 0 && numSlices > max_slices)
 		ereport(ERROR,

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1175,7 +1175,7 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 	 * and `gp_max_system_slices`, otherwise use `gp_max_slices`
 	 */
 	max_slices = gp_max_slices;
-	if (gp_max_system_slices > 0  && (gp_max_slices <= 0 ||
+	if (gp_max_system_slices > 0  && (gp_max_slices == 0 ||
 				gp_max_system_slices < gp_max_slices)) {
 		max_slices = gp_max_system_slices;
 	}

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1164,16 +1164,25 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 	SliceTable *table;
 	int			i;
 	int			numSlices;
+	int			max_slices;
 	MemoryContext oldcontext;
 
 	numSlices = plannedstmt->numSlices;
 	Assert(numSlices > 0);
+	/*
+	 * Select the maximum slices based on configuration settings, If
+	 * `gp_max_system_slices` is set, choose the minimum of `gp_max_slices`
+	 * and `gp_max_system_slices`, otherwise use `gp_max_slices`
+	 */
+	max_slices = (gp_max_system_slices > 0) ?
+		((gp_max_slices < gp_max_system_slices) ? gp_max_slices : gp_max_system_slices)
+		: gp_max_slices;
 
-	if (gp_max_slices > 0 && numSlices > gp_max_slices)
+	if (max_slices > 0 && numSlices > max_slices)
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("at most %d slices are allowed in a query, current number: %d",
-						gp_max_slices, numSlices),
+						max_slices, numSlices),
 				 errhint("rewrite your query")));
 
 	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1174,9 +1174,11 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 	 * `gp_max_system_slices` is set, choose the minimum of `gp_max_slices`
 	 * and `gp_max_system_slices`, otherwise use `gp_max_slices`
 	 */
-	max_slices = (gp_max_system_slices > 0) ?
-		((gp_max_slices > 0 && gp_max_slices < gp_max_system_slices) ?
-		 gp_max_slices : gp_max_system_slices) : gp_max_slices;
+	max_slices = gp_max_slices;
+	if (gp_max_system_slices > 0  && (gp_max_slices <= 0 ||
+				gp_max_system_slices < gp_max_slices)) {
+		max_slices = gp_max_system_slices;
+	}
 
 	if (max_slices > 0 && numSlices > max_slices)
 		ereport(ERROR,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4289,7 +4289,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_max_system_slices", PGC_SUSET, PRESET_OPTIONS,
-			gettext_noop("Maximum slices for a single query by a superuser"),
+			gettext_noop("Maximum slices for a single query (superuser guc)"),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4278,7 +4278,17 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_max_slices", PGC_SUSET, PRESET_OPTIONS,
+		{"gp_max_slices", PGC_USERSET, PRESET_OPTIONS,
+			gettext_noop("Maximum slices for a single query"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_max_slices,
+		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"gp_max_system_slices", PGC_SUSET, PRESET_OPTIONS,
 			gettext_noop("Maximum slices for a single query"),
 			NULL,
 			GUC_NOT_IN_SAMPLE

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4278,7 +4278,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"gp_max_slices", PGC_USERSET, PRESET_OPTIONS,
+		{"gp_max_slices", PGC_SUSET, PRESET_OPTIONS,
 			gettext_noop("Maximum slices for a single query"),
 			NULL,
 			GUC_NOT_IN_SAMPLE

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -404,7 +404,7 @@ bool		optimizer_replicated_table_insert;
 
 /* GUCs for slice table*/
 int			gp_max_slices;
-
+int			gp_max_system_slices;
 /* System Information */
 static int	gp_server_version_num;
 static char *gp_server_version_string;
@@ -4289,11 +4289,11 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_max_system_slices", PGC_SUSET, PRESET_OPTIONS,
-			gettext_noop("Maximum slices for a single query"),
+			gettext_noop("Maximum slices for a single query by a superuser"),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},
-		&gp_max_slices,
+		&gp_max_system_slices,
 		0, 0, INT_MAX, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -581,6 +581,7 @@ extern bool optimizer_replicated_table_insert;
 
 /* GUCs for slice table*/
 extern int	gp_max_slices;
+extern int	gp_max_system_slices;
 
 /**
  * Enable logging of DPE match in optimizer.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -202,6 +202,7 @@
 		"gp_max_parallel_cursors",
 		"gp_max_plan_size",
 		"gp_max_slices",
+		"gp_max_system_slices",
 		"gp_motion_cost_per_row",
 		"gp_pause_on_restore_point_replay",
 		"gp_postmaster_inet_address_family",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14877,11 +14877,12 @@ reset gp_max_slices;
 explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
 ERROR:  at most 1 slices are allowed in a query, current number: 4
 HINT:  rewrite your query
+reset gp_max_system_slices;
 -- Ensure that a regular user cannot set the GUC gp_max_system_slices
-create user test;
-set session authorization test;
+create user ruser;
+set session authorization ruser;
 set gp_max_system_slices=10;
 ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
-drop user test;
+drop user ruser;
 drop table foo, bar;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14828,7 +14828,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
--- Test ALL NULL scalar array compare
+-- Test ALL NULL scalar array compare 
 create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
                                   QUERY PLAN

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13133,7 +13133,7 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
 -- check that ROJ can be disabled via GUC
 set optimizer_enable_right_outer_join=off;
 explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
-                         QUERY PLAN                         
+                         QUERY PLAN
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
@@ -14817,7 +14817,7 @@ CREATE TABLE schema_test_table(a numeric, b numeric(5,2), c char(10) NOT NULL) d
 -- Below query is used by external libraries to fetch schema of table.
 -- Test that the typmod of column type is correct in explain plan.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
-                                                                      QUERY PLAN                                                                      
+                                                                      QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------------------------------------
  Result
    Output: a, b, c
@@ -14828,10 +14828,10 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
--- Test ALL NULL scalar array compare 
+-- Test ALL NULL scalar array compare
 create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
-                                  QUERY PLAN                                   
+                                  QUERY PLAN
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..240.69 rows=1 width=36)
    ->  Seq Scan on datumsortedset_core  (cost=0.00..240.67 rows=1 width=36)
@@ -14840,3 +14840,48 @@ explain select * from DatumSortedSet_core where b in (NULL, NULL);
 (4 rows)
 
 ---------------------------------------------------------------------------------
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (foo.b = bar.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: foo.b
+               ->  Seq Scan on foo
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: bar.b
+                     ->  Seq Scan on bar
+ Optimizer: Postgres-based planner
+(11 rows)
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 4
+HINT:  rewrite your query
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 4
+HINT:  rewrite your query
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user test;
+set session authorization test;
+set gp_max_system_slices=10;
+ERROR:  permission denied to set parameter "gp_max_system_slices"
+reset session authorization;
+drop user test;
+drop table foo, bar;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14918,7 +14918,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
--- Test ALL NULL scalar array compare
+-- Test ALL NULL scalar array compare 
 create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
                 QUERY PLAN

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13259,7 +13259,7 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
 -- check that ROJ can be disabled via GUC
 set optimizer_enable_right_outer_join=off;
 explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
-                            QUERY PLAN                            
+                            QUERY PLAN
 ------------------------------------------------------------------
  GroupAggregate
    Group Key: roj2.c
@@ -14907,7 +14907,7 @@ CREATE TABLE schema_test_table(a numeric, b numeric(5,2), c char(10) NOT NULL) d
 -- Below query is used by external libraries to fetch schema of table.
 -- Test that the typmod of column type is correct in explain plan.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
-                                                            QUERY PLAN                                                             
+                                                            QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------
  Result
    Output: NULL::numeric, NULL::numeric(5,2), NULL::character(10)
@@ -14918,10 +14918,10 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
--- Test ALL NULL scalar array compare 
+-- Test ALL NULL scalar array compare
 create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
-                QUERY PLAN                 
+                QUERY PLAN
 -------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=12)
    One-Time Filter: false
@@ -14929,3 +14929,45 @@ explain select * from DatumSortedSet_core where b in (NULL, NULL);
 (3 rows)
 
 ---------------------------------------------------------------------------------
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+                          QUERY PLAN
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (foo.b = bar.b)
+         ->  Seq Scan on foo
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on bar
+ Optimizer: GPORCA
+(8 rows)
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 3
+HINT:  rewrite your query
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 3
+HINT:  rewrite your query
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user test;
+set session authorization test;
+set gp_max_system_slices=10;
+ERROR:  permission denied to set parameter "gp_max_system_slices"
+reset session authorization;
+drop user test;
+drop table foo, bar;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14963,11 +14963,12 @@ reset gp_max_slices;
 explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
 ERROR:  at most 1 slices are allowed in a query, current number: 3
 HINT:  rewrite your query
+reset gp_max_system_slices;
 -- Ensure that a regular user cannot set the GUC gp_max_system_slices
-create user test;
-set session authorization test;
+create user ruser;
+set session authorization ruser;
 set gp_max_system_slices=10;
 ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
-drop user test;
+drop user ruser;
 drop table foo, bar;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3638,6 +3638,39 @@ create table DatumSortedSet_core (a int, b character varying NOT NULL) distribut
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
 ---------------------------------------------------------------------------------
 
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user test;
+set session authorization test;
+set gp_max_system_slices=10;
+reset session authorization;
+
+drop user test;
+drop table foo, bar;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3661,14 +3661,15 @@ explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
 set gp_max_system_slices=1;
 reset gp_max_slices;
 explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+reset gp_max_system_slices;
 
 -- Ensure that a regular user cannot set the GUC gp_max_system_slices
-create user test;
-set session authorization test;
+create user ruser;
+set session authorization ruser;
 set gp_max_system_slices=10;
 reset session authorization;
 
-drop user test;
+drop user ruser;
 drop table foo, bar;
 
 -- start_ignore


### PR DESCRIPTION
This pull request introduces a new GUC, gp_max_system_slices, mirroring gp_max_slices, with the distinction that it is restricted to superusers (PGC_SUSET). Because there are many instances of users already using gp_max_slices, we will retain that guc and its behavior to ease the upgrade path.

After Fix on 7X:
```
# create user user1;
CREATE ROLE
# set session authorization user1;
SET
=> select current_user;
 current_user
--------------
 user1
(1 row)

=> set gp_max_slices=100;
SET
=> set gp_max_system_slices=100;
ERROR:  permission denied to set parameter "gp_max_system_slices"
```
