### PR TITLE
[6X] Add GUC gp_max_system_slices with superuser(PGC_SUSET) only 

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1764,7 +1764,7 @@ InitSliceTable(EState *estate, int nMotions, int nSubplans)
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("at most %d slices are allowed in a query, current number: %d", gp_max_slices, n),
-				 errhint("rewrite your query or adjust GUC gp_max_slices")));
+				 errhint("rewrite your query")));
 
 	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4649,6 +4649,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_max_system_slices", PGC_SUSET, PRESET_OPTIONS,
+			gettext_noop("Maximum slices for a single query"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_max_slices,
+		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
 		{"gp_dispatch_keepalives_idle", PGC_POSTMASTER, GP_ARRAY_TUNING,
 			gettext_noop("Time between issuing TCP keepalives from GPDB QD to its QEs."),
 			gettext_noop("A value of 0 uses the system default."),

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -59,6 +59,7 @@
 		"gp_max_packet_size",
 		"gp_max_partition_level",
 		"gp_max_slices",
+		"gp_max_system_slices",
 		"gp_mk_sort_check",
 		"gp_motion_slice_noop",
 		"gp_partitioning_dynamic_selection_log",


### PR DESCRIPTION
This pull request,
  -  Introduces a new GUC, gp_max_system_slices, mirroring gp_max_slices, with the distinction that it is restricted to superusers (PGC_SUSET). Because there are many instances of users already using gp_max_slices, we will retain that guc and its behavior to ease the upgrade path.
 -  The error message is being updated by removing the GUC name (gp_max_slices)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
