### PR TITLE
Fix incorrect message while selecting system columns from appendoptimized table

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -617,8 +617,8 @@ scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte, char *colname,
 			Gp_role != GP_ROLE_UTILITY)
 			return result;
 
-		/*
-		 *
+		/* In GPDB tables that have append-optimized storage system columns are not
+		 * stored in tuples, so we check it here
 		 */
 		if (IsAppendOptimizedByOid(rte->relid))
 			return result;

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -39,7 +39,6 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "cdb/cdbvars.h"
-#include "cdb/cdbpartition.h"
 
 
 static RangeTblEntry *scanNameSpaceForRefname(ParseState *pstate,
@@ -533,12 +532,12 @@ GetCTEForRTE(ParseState *pstate, RangeTblEntry *rte, int rtelevelsup)
 }
 
 static bool
-IsAppendOptimizedByOid(Oid oid)
+IsAppendOptimizedByOid(Oid relid)
 {
 	Relation	rel;
 	bool		result;
 
-	rel = heap_open(oid, NoLock);
+	rel = heap_open(relid, NoLock);
 
 	result = RelationIsAppendOptimized(rel);
 	heap_close(rel, NoLock);
@@ -618,6 +617,9 @@ scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte, char *colname,
 			Gp_role != GP_ROLE_UTILITY)
 			return result;
 
+		/*
+		 *
+		 */
 		if (IsAppendOptimizedByOid(rte->relid))
 			return result;
 

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -804,3 +804,8 @@ insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5)
 select count(*) from fix_ao_truncate_last_sequence;
 abort;
 
+-- Check if system columns in ao table can be selected
+DROP TABLE IF EXISTS ttt_ao;
+CREATE TABLE ttt (id int) WITH (appendonly=true) DISTRIBUTED BY (id);
+INSERT INTO ttt VALUES(1);
+SELECT xmin FROM ttt;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1706,3 +1706,12 @@ select count(*) from fix_ao_truncate_last_sequence;
 (1 row)
 
 abort;
+
+-- Check if system columns in ao table can be selected
+DROP TABLE IF EXISTS ttt_ao;
+CREATE TABLE ttt (id int) WITH (appendonly=true) DISTRIBUTED BY (id);
+INSERT INTO ttt VALUES(1);
+SELECT xmin FROM ttt;
+ERROR:  column "xmin" does not exist
+LINE 1: select xmin from ttt;
+               ^


### PR DESCRIPTION
Now if we run in GP version 6:
```
create table ttt (id int) with (appendonly=true) distributed by (id);
insert into ttt values(1);
select xmin from ttt;

```

We will have something like:
`ERROR:  Invalid attnum: -3 (execTuples.c:1600)  (seg1 slice1 127.0.1.1:6003 pid=11576) (execTuples.c:1600)
`

I tried to turn it to getting more useful message:
```
LINE 1: select xmin from ttt;
               ^

```

## Here are some reminders before you submit the pull request
- [+] Add tests for the change
- [+] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
