### PR TITLE
Remove redundant hash keys of motion

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-1-RegularAgg.mdp
@@ -265,7 +265,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="575.682217" Rows="4.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-2-RegularAgg.mdp
@@ -310,7 +310,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="576.580308" Rows="4.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate1.mdp
@@ -231,7 +231,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000376" Rows="3.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
@@ -329,7 +329,7 @@ drop table if exists foo;
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.119547" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarOnDistCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarOnDistCol.mdp
@@ -248,7 +248,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000184" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
@@ -341,7 +341,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.619812" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
@@ -328,7 +328,7 @@ explain select count(distinct b ) from foo;
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.272788" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -22,7 +22,7 @@
                                      ->  Sort  (cost=0.00..431.00 rows=14 width=8)
                                            Sort Key: gp_segment_id, b
                                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
-                                                 Hash Key: gp_segment_id, b, b
+                                                 Hash Key: gp_segment_id, b
                                                  ->  Seq Scan on t  (cost=0.00..431.00 rows=14 width=8)
                  Optimizer: Pivotal Optimizer (GPORCA)
                 (13 rows)
@@ -305,7 +305,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="34">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.007097" Rows="40.000000" Width="12"/>
@@ -417,9 +417,6 @@
                   <dxl:HashExprList>
                     <dxl:HashExpr Opfamily="0.1977.1.0">
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr Opfamily="0.1977.1.0">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                     <dxl:HashExpr Opfamily="0.1977.1.0">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5705,7 +5705,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="26759194">
+    <dxl:Plan Id="0" SpaceSize="24690162">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2587.328257" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
@@ -342,7 +342,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="131">
+    <dxl:Plan Id="0" SpaceSize="121">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="583.692435" Rows="5.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -454,7 +454,7 @@ SQL:
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12376">
+    <dxl:Plan Id="0" SpaceSize="9296">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.104458" Rows="10.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
@@ -445,7 +445,7 @@ SQL:
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10528">
+    <dxl:Plan Id="0" SpaceSize="8288">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.076760" Rows="111.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -498,7 +498,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1067404800">
+    <dxl:Plan Id="0" SpaceSize="398361600">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.144639" Rows="134.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
@@ -451,7 +451,7 @@ SQL:
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1874">
+    <dxl:Plan Id="0" SpaceSize="1010">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.007238" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
@@ -18,7 +18,7 @@
                        ->  Streaming HashAggregate  (cost=0.00..441.31 rows=33334 width=8)
                              Group Key: c, b
                              ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..433.10 rows=33334 width=8)
-                                   Hash Key: c, b, b
+                                   Hash Key: c, b
                                    ->  Seq Scan on foo  (cost=0.00..431.77 rows=33334 width=8)
          Optimizer: Pivotal Optimizer (GPORCA)
         (11 rows)
@@ -1421,7 +1421,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="449.305467" Rows="100000.000000" Width="8"/>
@@ -1520,9 +1520,6 @@
                   <dxl:HashExprList>
                     <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                     <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
@@ -260,7 +260,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="51">
+    <dxl:Plan Id="0" SpaceSize="47">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="578.788946" Rows="4.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
@@ -250,7 +250,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="506.587261" Rows="4.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
@@ -250,7 +250,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="506.587137" Rows="2.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
@@ -250,7 +250,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="458.507885" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctDistrCol.mdp
@@ -240,7 +240,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="446.513125" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
@@ -248,7 +248,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19">
+    <dxl:Plan Id="0" SpaceSize="15">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="452.780838" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg.mdp
@@ -250,7 +250,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="571.059435" Rows="4.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -394,7 +394,7 @@
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="117306">
+    <dxl:Plan Id="0" SpaceSize="92610">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.002353" Rows="13.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
@@ -445,7 +445,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
         </dxl:LogicalWindow>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14532">
+    <dxl:Plan Id="0" SpaceSize="11404">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3141.988407" Rows="333333.333333" Width="24"/>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -240,7 +240,8 @@ CPhysicalAgg::PdsRequiredAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 			GPOS_ASSERT(0 < m_pdrgpcr->Size());
 
 			ULONG length = m_pdrgpcrArgDQA->Size();
-			CColRefArray *grpAndDistinctCols = CUtils::PdrgpcrExactCopy(mp, m_pdrgpcr);
+			CColRefArray *grpAndDistinctCols =
+				CUtils::PdrgpcrExactCopy(mp, m_pdrgpcr);
 
 			// add the distinct column to the group by at the first stage of
 			// the multi-level aggregation, and also deduplicate them.

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -238,9 +238,24 @@ CPhysicalAgg::PdsRequiredAgg(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		{
 			GPOS_ASSERT(1 == ulOptReq);
 			GPOS_ASSERT(0 < m_pdrgpcr->Size());
-			CColRefArray *grpAndDistinctCols = GPOS_NEW(mp) CColRefArray(mp);
-			grpAndDistinctCols->AppendArray(m_pdrgpcr);
-			grpAndDistinctCols->AppendArray(m_pdrgpcrArgDQA);
+
+			ULONG length = m_pdrgpcrArgDQA->Size();
+			CColRefArray *grpAndDistinctCols = CUtils::PdrgpcrExactCopy(mp, m_pdrgpcr);
+
+			// add the distinct column to the group by at the first stage of
+			// the multi-level aggregation, and also deduplicate them.
+			CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp, m_pdrgpcr);
+			for (ULONG ul = 0; ul < length; ul++)
+			{
+				CColRef *colref = (*m_pdrgpcrArgDQA)[ul];
+				if (!pcrs->FMember(colref))
+				{
+					grpAndDistinctCols->Append(colref);
+					pcrs->Include(colref);
+				}
+			}
+			pcrs->Release();
+
 			CDistributionSpec *pdsSpec =
 				PdsMaximalHashed(mp, grpAndDistinctCols);
 			grpAndDistinctCols->Release();

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2531,6 +2531,37 @@ select id, count(distinct a), avg(b), sum(c) from num_table group by grouping se
   3 |     1 |     3.0000000000000000 |   3
 (3 rows)
 
+explain (verbose on, costs off) select count(distinct b) from num_table group by c;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (count(b)), c
+   ->  HashAggregate
+         Output: count(b), c
+         Group Key: num_table.c
+         ->  HashAggregate
+               Output: c, b
+               Group Key: num_table.c, num_table.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: c, b
+                     Hash Key: c
+                     ->  Streaming HashAggregate
+                           Output: c, b
+                           Group Key: num_table.c, num_table.b
+                           ->  Seq Scan on public.num_table
+                                 Output: id, a, b, c
+ Optimizer: Postgres-based planner
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer = 'off', optimizer_force_multistage_agg = 'on'
+(18 rows)
+
+select count(distinct b) from num_table group by c;
+ count 
+-------
+     1
+     1
+     1
+(3 rows)
+
 reset optimizer_force_multistage_agg;
 -- DQA with Agg(Intermediate Agg)
 set enable_hashagg=on;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2724,6 +2724,43 @@ select id, count(distinct a), avg(b), sum(c) from num_table group by grouping se
   3 |     1 |     3.0000000000000000 |   3
 (3 rows)
 
+explain (verbose on, costs off) select count(distinct b) from num_table group by c;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (count(b))
+   ->  GroupAggregate
+         Output: count(b)
+         Group Key: num_table.c
+         ->  Sort
+               Output: b, c
+               Sort Key: num_table.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c
+                     Hash Key: c
+                     ->  GroupAggregate
+                           Output: b, c
+                           Group Key: num_table.c, num_table.b
+                           ->  Sort
+                                 Output: b, c
+                                 Sort Key: num_table.c, num_table.b
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Output: b, c
+                                       Hash Key: c, b
+                                       ->  Seq Scan on public.num_table
+                                             Output: b, c
+ Optimizer: GPORCA
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
+(24 rows)
+
+select count(distinct b) from num_table group by c;
+ count 
+-------
+     1
+     1
+     1
+(3 rows)
+
 reset optimizer_force_multistage_agg;
 -- DQA with Agg(Intermediate Agg)
 set enable_hashagg=on;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -484,6 +484,9 @@ select count(distinct a), sum(c) from num_table;
 explain select id, count(distinct a), avg(b), sum(c) from num_table group by grouping sets ((id,c));
 select id, count(distinct a), avg(b), sum(c) from num_table group by grouping sets ((id,c));
 
+explain (verbose on, costs off) select count(distinct b) from num_table group by c;
+select count(distinct b) from num_table group by c;
+
 reset optimizer_force_multistage_agg;
 
 -- DQA with Agg(Intermediate Agg)


### PR DESCRIPTION
As we set optimizer_force_multistage_agg=on to force orca choose multi-agg plan, there are redundant hash keys of motion as below `(Hash Key: c, b, b)`, obviously column `b` is redundant anyway.
```

postgres=# explain (costs off) select count(distinct b) from num_table group by c;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  GroupAggregate
         Group Key: c
         ->  Sort
               Sort Key: c
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Hash Key: c
                     ->  GroupAggregate
                           Group Key: c, b
                           ->  Sort
                                 Sort Key: c, b
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                       Hash Key: c, b, b
                                       ->  Seq Scan on num_table
 Optimizer: GPORCA
(15 rows)
```
The reason is that as the first stage agg compute required DistributionSpec for child, now we just
simply append group by columns and distinct columns, but actually we should deduplicate them
because they might have same columns.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
