### PR TITLE
Fix resource ‘filedump_src’ is not used for genpipeline cli

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -420,11 +420,13 @@ resources:
     - gpdb-doc/*
     - README*
 
+{% if "icw" in test_sections %}
 - name: filedump_src
   type: git
   source:
     branch: main
     uri: https://github.com/greenplum-db/filedump.git
+{% endif %}
 
 {% if os_type == compile_platform or (os_type != compile_platform and "icw" in test_sections) %}
 - name: gpdb7-[[ os_type ]]-build


### PR DESCRIPTION
Authored-by: Anusha Shakarad <shakarada@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
