### PR TITLE
Docs: add PL/Container support with Resource Groups back

### DIFF
--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -16,7 +16,7 @@ The following table compares the main concepts of resource management and how ea
 |Queueing|Queue when no slot is available or not enough available memory|Queue when no slot is available|
 |Query Failure|Query may fail after reaching transaction fixed memory limit when no shared resource group memory exists and the transaction requests more memory|Query may fail if the allocated memory for the query surpasses the available system memory and spill limits|
 |Limit Bypass|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
-|External Components|Manage PL/Container CPU and memory resources|None|
+|External Components|Manage PL/Container CPU and memory resources|Manage PL/Container CPU and memory resources|
 
 > **Note** Disk I/O limits are only available when you use Linux Control Groups v2. See [Configuring and Using Resource Groups](workload_mgmt_resgroups.html#topic71717999) for more information.
 

--- a/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
+++ b/gpdb-doc/markdown/admin_guide/about-resgroups-changes.html.md
@@ -16,7 +16,7 @@ The following table compares the main concepts of resource management and how ea
 |Queueing|Queue when no slot is available or not enough available memory|Queue when no slot is available|
 |Query Failure|Query may fail after reaching transaction fixed memory limit when no shared resource group memory exists and the transaction requests more memory|Query may fail if the allocated memory for the query surpasses the available system memory and spill limits|
 |Limit Bypass|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
-|External Components|Manage PL/Container CPU and memory resources|Manage PL/Container CPU and memory resources|
+|External Components|Manage PL/Container CPU and memory resources|Manage PL/Container CPU resources|
 
 > **Note** Disk I/O limits are only available when you use Linux Control Groups v2. See [Configuring and Using Resource Groups](workload_mgmt_resgroups.html#topic71717999) for more information.
 

--- a/gpdb-doc/markdown/admin_guide/wlmgmt.html.md
+++ b/gpdb-doc/markdown/admin_guide/wlmgmt.html.md
@@ -20,7 +20,7 @@ The following table summarizes some of the differences between resource queues a
 |Queueing|Queue when no slot available or not enough available memory|Queue only when no slot is available|
 |Query Failure|Query may fail immediately if the allocated memory for the query surpasses the available system memory and spill limits|Query may fail if the allocated memory for the query surpasses the available system memory and spill limits|
 |Limit Bypass|Limits are not enforced for `SUPERUSER` roles and certain operators and functions|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
-|External Components|None|None|
+|External Components|None|Manage PL/Container CPU and memory resources|
 
 **Parent topic:** [Managing Performance](partV.html)
 

--- a/gpdb-doc/markdown/admin_guide/wlmgmt.html.md
+++ b/gpdb-doc/markdown/admin_guide/wlmgmt.html.md
@@ -20,7 +20,7 @@ The following table summarizes some of the differences between resource queues a
 |Queueing|Queue when no slot available or not enough available memory|Queue only when no slot is available|
 |Query Failure|Query may fail immediately if the allocated memory for the query surpasses the available system memory and spill limits|Query may fail if the allocated memory for the query surpasses the available system memory and spill limits|
 |Limit Bypass|Limits are not enforced for `SUPERUSER` roles and certain operators and functions|Limits are not enforced on `SET`, `RESET`, and `SHOW` commands. Additionally, certain queries may be configured to bypass the concurrency limit|
-|External Components|None|Manage PL/Container CPU and memory resources|
+|External Components|None|Manage PL/Container CPU resources|
 
 **Parent topic:** [Managing Performance](partV.html)
 

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -312,12 +312,12 @@ You may encounter the error `Invalid argument` after running the above commands.
     ```
 Since resource groups manually manage cgroup files, the above settings will become ineffective after a system reboot. Add the following bash script for systemd so it runs automatically during system startup. Perform the following steps as user root:
 
-1. Create `gpdb-service`.
+1. Create `gpdb.service`.
    ```
    vim /etc/systemd/system/gpdb.service 
    ```
 
-2. Write the following content into `gpdb-service`, if the user is not `gpadmin`, replace it with the appropriate user.
+2. Write the following content into `gpdb.service`, if the user is not `gpadmin`, replace it with the appropriate user.
 
    ```
    [Unit]

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -2,7 +2,7 @@
 title: Using Resource Groups 
 ---
 
-You use resource groups to manage and protect the resource allocation of CPU, memory, concurrent transaction limits, and disk I/O in Greenplum Database. Once you define a resource group, you assign the group to one or more Greenplum Database roles, or to an external componen such as PL/Container, in order to control the resources used by them. 
+You use resource groups to manage and protect the resource allocation of CPU, memory, concurrent transaction limits, and disk I/O in Greenplum Database. Once you define a resource group, you assign the group to one or more Greenplum Database roles, or to an external component such as PL/Container, in order to control the resources used by them. 
 
 When you assign a resource group to a role, the resource limits that you define for the group apply to all of the roles to which you assign the group. For example, the memory limit for a resource group identifies the maximum memory usage for all running transactions submitted by Greenplum Database users in all roles to which you assign the group.
 
@@ -22,7 +22,7 @@ When a user runs a query, Greenplum Database evaluates the query against a set o
 
 Within a resource group for roles, transactions are evaluated on a first in, first out basis. Greenplum Database periodically assesses the active workload of the system, reallocating resources and starting/queuing jobs as necessary.
 
-You can also use resource groups to manage the CPU and memory resources of external components such as PL/Container. Resource groups for external components use Linux cgroups to manage both the total CPU and total memory resources for the component.
+You can also use resource groups to manage the CPU and memory resources of external components such as PL/Container. Resource groups for external components use Linux cgroups to manage the total CPU resources for the component.
 
 ## <a id="topic8339introattrlim"></a>Resource Group Attributes and Limits 
 

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -2,9 +2,11 @@
 title: Using Resource Groups 
 ---
 
-You use resource groups to manage and protect the resource allocation of CPU, memory, concurrent transaction limits, and disk I/O in Greenplum Database. Once you define a resource group, you assign the group to one or more Greenplum Database roles in order to control the resources used by them. 
+You use resource groups to manage and protect the resource allocation of CPU, memory, concurrent transaction limits, and disk I/O in Greenplum Database. Once you define a resource group, you assign the group to one or more Greenplum Database roles, or to an external componen such as PL/Container, in order to control the resources used by them. 
 
 When you assign a resource group to a role, the resource limits that you define for the group apply to all of the roles to which you assign the group. For example, the memory limit for a resource group identifies the maximum memory usage for all running transactions submitted by Greenplum Database users in all roles to which you assign the group.
+
+Similarly, when you assign a resource group to an external component, the group limits apply to all running instances of the component. For example, if you create a resource group for a PL/Container external component, the memory limit that you define for the group specifies the maximum memory usage for all running instances of each PL/Container runtime to which you assign the group.
 
 Greenplum Database uses Linux-based control groups for CPU resource management, and Runaway Detector for statistics, tracking and management of memory. 
 
@@ -14,11 +16,15 @@ When using resource groups to control resources like CPU cores, review the Hyper
 
 ## <a id="topic8339intro"></a>Understanding Role and Component Resource Groups 
 
+Greenplum Database supports two types of resource groups: groups that manage resources for roles, and groups that manage resources for external components such as PL/Container.
+
 The most common application for resource groups is to manage the number of active queries that different roles may run concurrently in your Greenplum Database cluster. You can also manage the amount of CPU, memory resources, and disk I/O that Greenplum allocates to each query.
 
 When a user runs a query, Greenplum Database evaluates the query against a set of limits defined for the resource group. Greenplum Database runs the query immediately if the group's resource limits have not yet been reached and the query does not cause the group to exceed the concurrent transaction limit. If these conditions are not met, Greenplum Database queues the query. For example, if the maximum number of concurrent transactions for the resource group has already been reached, a subsequent query is queued and must wait until other queries complete before it runs. Greenplum Database may also run a pending query when the resource group's concurrency and memory limits are altered to large enough values.
 
 Within a resource group for roles, transactions are evaluated on a first in, first out basis. Greenplum Database periodically assesses the active workload of the system, reallocating resources and starting/queuing jobs as necessary.
+
+You can also use resource groups to manage the CPU and memory resources of external components such as PL/Container. Resource groups for external components use Linux cgroups to manage both the total CPU and total memory resources for the component.
 
 ## <a id="topic8339introattrlim"></a>Resource Group Attributes and Limits 
 
@@ -308,36 +314,37 @@ You may encounter the error `Invalid argument` after running the above commands.
     ```
 Since resource groups manually manage cgroup files, the above settings will become ineffective after a system reboot. Add the following bash script for systemd so it runs automatically during system startup. Perform the following steps as user root:
 
-1. Create `greenplum-cgroup-v2-config.service`.
+1. Create `gpdb-service`.
    ```
-   vim /etc/systemd/system/greenplum-cgroup-v2-config.service
+   vim /etc/systemd/system/gpdb.service 
    ```
 
-2. Write the following content into `greenplum-cgroup-v2-config.service`, if the user is not `gpadmin`, replace it with the appropriate user.
+2. Write the following content into `gpdb-service`, if the user is not `gpadmin`, replace it with the appropriate user.
 
    ```
    [Unit]
    Description=Greenplum Cgroup v2 Configuration Service
-   
    [Service]
-   Type=oneshot
-   RemainAfterExit=yes
-   WorkingDirectory=/sys/fs/cgroup
+   Type=simple
+   WorkingDirectory=/sys/fs/cgroup/gpdb.service
    Delegate=yes
-   # set hierarchies only if cgroup v2 mounted
+   Slice=-.slice
+
+   set hierarchies only if cgroup v2 mounted
    ExecCondition=bash -c '[ xcgroup2fs = x$(stat -fc "%%T" /sys/fs/cgroup) ] || exit 1'
-   ExecStart=bash -ec " \
-                       [ -d gpdb ] || mkdir gpdb; \
-                       chown -R gpadmin:gpadmin gpdb; \
-                       chmod a+w cgroup.procs;"
-   
+   ExecStartPre=bash -ec " \
+   chown -R gpadmin:gpadmin .; \
+   chmod a+w ../cgroup.procs; \
+   mkdir -p helper.scope"
+   ExecStart=sleep infinity
+   ExecStartPost=bash -ec "echo $MAINPID > ./helper.scope/cgroup.procs;"
    [Install]
    WantedBy=basic.target
    ```
 1. Reload systemd daemon and enable the service:
    ```
    systemctl daemon-reload
-   systemctl enable greenplum-cgroup-v2-config.service
+   systemctl enable gpdb.service
    ```
 
 ## <a id="topic8"></a>Enabling Resource Groups 
@@ -488,6 +495,8 @@ To view a resource group's running queries, pending queries, and how long the pe
 SELECT query, rsgname,wait_event_type, wait_event 
 FROM pg_stat_activity;
 ```
+
+`pg_stat_activity` displays information about the user/role that initiated a query. A query that uses an external component such as PL/Container is composed of two parts: the query operator that runs in Greenplum Database and the UDF that runs in a PL/Container instance. Greenplum Database processes the query operators under the resource group assigned to the role that initiated the query. A UDF running in a PL/Container instance runs under the resource group assigned to the PL/Container runtime. The latter is not represented in the `pg_stat_activity` view; Greenplum Database does not have any insight into how external components such as PL/Container manage memory in running instances.
 
 ### <a id="topic27"></a>Cancelling a Running or Queued Transaction in a Resource Group 
 

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -6,8 +6,6 @@ You use resource groups to manage and protect the resource allocation of CPU, me
 
 When you assign a resource group to a role, the resource limits that you define for the group apply to all of the roles to which you assign the group. For example, the memory limit for a resource group identifies the maximum memory usage for all running transactions submitted by Greenplum Database users in all roles to which you assign the group.
 
-Similarly, when you assign a resource group to an external component, the group limits apply to all running instances of the component. For example, if you create a resource group for a PL/Container external component, the memory limit that you define for the group specifies the maximum memory usage for all running instances of each PL/Container runtime to which you assign the group.
-
 Greenplum Database uses Linux-based control groups for CPU resource management, and Runaway Detector for statistics, tracking and management of memory. 
 
 When using resource groups to control resources like CPU cores, review the Hyperthreading note in [Hardware and Network](../install_guide/platform-requirements-overview.html#hardware-requirements).
@@ -330,7 +328,7 @@ Since resource groups manually manage cgroup files, the above settings will beco
    Delegate=yes
    Slice=-.slice
 
-   set hierarchies only if cgroup v2 mounted
+   # set hierarchies only if cgroup v2 mounted
    ExecCondition=bash -c '[ xcgroup2fs = x$(stat -fc "%%T" /sys/fs/cgroup) ] || exit 1'
    ExecStartPre=bash -ec " \
    chown -R gpadmin:gpadmin .; \

--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -18,10 +18,10 @@ PL/Container manages resource usage at two levels - the container level and the 
 
 You cannot, by default, restrict the number of running PL/Container container instances, nor can you restrict the total amount of memory or CPU resources that they consume.
 
-Resource groups for external components such as PL/Container use Linux control groups \(cgroups\) to manage component-level use of memory and CPU resources. 
+Resource groups for external components such as PL/Container use Linux control groups \(cgroups\) to manage component-level use of CPU resources. 
 
 ```
-CREATE RESOURCE GROUP plpy_run1_rg WITH (CONCURRENCY=10, CPU_MAX_PERCENT=10, MEMORY_LIMIT=10);
+CREATE RESOURCE GROUP plpy_run1_rg WITH (CONCURRENCY=10, CPU_MAX_PERCENT=10);
 ```
 
 You can create one or more resource groups to manage your running PL/Container instances. After you create a resource group for PL/Container, you assign the resource group to one or more PL/Container runtimes. You make this assignment using the `groupid` of the resource group. You can determine the `groupid` for a given resource group name from the `gp_resgroup_config` `gp_toolkit` view. For example, the following query displays the `groupid` of a resource group named `plpy_run1_rg`:
@@ -44,7 +44,7 @@ plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:
 
 You can also assign a resource group to a PL/Container runtime using the `plcontainer runtime-edit` command. For information about the `plcontainer` command, see [plcontainer](../utility_guide/ref/plcontainer.html) reference page.
 
-After you assign a resource group to a PL/Container runtime, all container instances that share the same runtime configuration are subject to the CPU limit that you configured for the group. If you decrease the memory limit of a PL/Container resource group, queries running in containers in the group may fail with an out of memory error. If you drop a PL/Container resource group while there are running container instances, Greenplum Database terminates the running containers.
+After you assign a resource group to a PL/Container runtime, all container instances that share the same runtime configuration are subject to the CPU limit that you configured for the group. If you drop a PL/Container resource group while there are running container instances, Greenplum Database terminates the running containers.
 
 ### <a id="topic_resgroupcfg"></a>Configuring Resource Groups for PL/Container 
 

--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -12,11 +12,95 @@ This topic covers further details on:
 
 ## <a id="topic_resmgmt"></a>PL/Container Resource Management 
 
-The Docker containers and the Greenplum Database servers share CPU and memory resources on the same hosts. You can control container-level CPU and memory resources with the `memory_mb` and `cpu_share` settings that you configure for the PL/Container runtime. `memory_mb` governs the memory resources available to each container instance. The `cpu_share` setting identifies the relative weighting of a container's CPU usage compared to other containers. See [plcontainer Configuration File](../utility_guide/ref/plcontainer-configuration.html) for further details.
+The Docker containers and the Greenplum Database servers share CPU and memory resources on the same hosts. In the default case, Greenplum Database is unaware of the resources consumed by running PL/Container instances. You can use Greenplum Database resource groups to control overall CPU and memory resource usage for running PL/Container instances.
 
-You cannot, by default, restrict the number of running PL/Container container instances, nor can you restrict the total amount of memory or CPU resources that they consume. Greenplum Database is unaware of the resources consumed by running PL/Container instances. 
+PL/Container manages resource usage at two levels - the container level and the runtime level. You can control container-level CPU and memory resources with the `memory_mb` and `cpu_share` settings that you configure for the PL/Container runtime. `memory_mb` governs the memory resources available to each container instance. The `cpu_share` setting identifies the relative weighting of a container's CPU usage compared to other containers. See [plcontainer Configuration File](../utility_guide/ref/plcontainer-configuration.html) for further details.
 
->**Caution** In this release of Greenplum 7, you cannot use resource groups to manage and limit the total CPU and memory resources for a PL/Container runtime. Container instances are limited only by system resources, and the containers may consume resources at the expense of the Greenplum Database server. Future releases of Greenplum 7 may restore functionality to manage PL/Container resources using resource groups.
+You cannot, by default, restrict the number of running PL/Container container instances, nor can you restrict the total amount of memory or CPU resources that they consume.
+
+Resource groups for external components such as PL/Container use Linux control groups \(cgroups\) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all container instances that share the same PL/Container runtime configuration.
+
+When you create a resource group to manage the resources of a PL/Container runtime, you must specify `MEMORY_AUDITOR=cgroup` and `CONCURRENCY=0` in addition to the required CPU and memory limits. For example, the following command creates a resource group named `plpy_run1_rg` for a PL/Container runtime:
+
+```
+CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+                                                  CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);
+```
+
+PL/Container does not use the `MEMORY_SHARED_QUOTA` and `MEMORY_SPILL_RATIO` resource group memory limits. Refer to the [CREATE RESOURCE GROUP](../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html) reference page for detailed information about this SQL command.
+
+You can create one or more resource groups to manage your running PL/Container instances. After you create a resource group for PL/Container, you assign the resource group to one or more PL/Container runtimes. You make this assignment using the `groupid` of the resource group. You can determine the `groupid` for a given resource group name from the `gp_resgroup_config` `gp_toolkit` view. For example, the following query displays the `groupid` of a resource group named `plpy_run1_rg`:
+
+```
+SELECT groupname, groupid FROM gp_toolkit.gp_resgroup_config
+ WHERE groupname='plpy_run1_rg';
+                            
+ groupname   |  groupid
+ --------------+----------
+ plpy_run1_rg |   16391
+ (1 row)
+```
+
+You assign a resource group to a PL/Container runtime configuration by specifying the `-s resource_group_id=rg\_groupid` option to the `plcontainer runtime-add` \(new runtime\) or `plcontainer runtime-replace` \(existing runtime\) commands. For example, to assign the `plpy_run1_rg` resource group to a new PL/Container runtime named `python_run1`:
+
+```
+plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391
+```
+
+You can also assign a resource group to a PL/Container runtime using the `plcontainer runtime-edit` command. For information about the `plcontainer` command, see [plcontainer](../utility_guide/ref/plcontainer.html) reference page.
+
+After you assign a resource group to a PL/Container runtime, all container instances that share the same runtime configuration are subject to the memory limit and the CPU limit that you configured for the group. If you decrease the memory limit of a PL/Container resource group, queries running in containers in the group may fail with an out of memory error. If you drop a PL/Container resource group while there are running container instances, Greenplum Database terminates the running containers.
+
+### <a id="topic_resgroupcfg"></a>Configuring Resource Groups for PL/Container 
+
+To use Greenplum Database resource groups to manage PL/Container resources, you must explicitly configure both resource groups and PL/Container.
+
+Perform the following procedure to configure PL/Container to use Greenplum Database resource groups for CPU and memory resource management:
+
+1.  If you have not already configured and enabled resource groups in your Greenplum Database deployment, configure cgroups and enable Greenplum Database resource groups as described in [Using Resource Groups](../admin_guide/workload_mgmt_resgroups.html#topic71717999) in the *Greenplum Database Administrator Guide*.
+
+    > **Note** If you have previously configured and enabled resource groups in your deployment, ensure that the Greenplum Database resource group `gpdb.conf` cgroups configuration file includes a `memory { }` block as described in the previous link.
+2.  Analyze the resource usage of your Greenplum Database deployment. Determine the percentage of resource group CPU and memory resources that you want to allocate to PL/Container Docker containers.
+3.  Determine how you want to distribute the total PL/Container CPU and memory resources that you identified in the step above among the PL/Container runtimes. Identify:
+    -   The number of PL/Container resource group\(s\) that you require.
+    -   The percentage of memory and CPU resources to allocate to each resource group.
+    -   The resource-group-to-PL/Container-runtime assignment\(s\).
+4.  Create the PL/Container resource groups that you identified in the step above. For example, suppose that you choose to allocate 25% of both memory and CPU Greenplum Database resources to PL/Container. If you further split these resources among 2 resource groups 60/40, the following SQL commands create the resource groups:
+
+    ```
+    CREATE RESOURCE GROUP plr_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+                                               CPU_RATE_LIMIT=15, MEMORY_LIMIT=15);
+     CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
+                                              CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);
+    ```
+
+5.  Find and note the `groupid` associated with each resource group that you created. For example:
+
+    ```
+    SELECT groupname, groupid FROM gp_toolkit.gp_resgroup_config
+    WHERE groupname IN ('plpy_run1_rg', 'plr_run1_rg');
+                                        
+    groupname   |  groupid
+    --------------+----------
+    plpy_run1_rg |   16391
+    plr_run1_rg  |   16393
+    (1 row)
+    ```
+
+6.  Assign each resource group that you created to the desired PL/Container runtime configuration. If you have not yet created the runtime configuration, use the `plcontainer runtime-add` command. If the runtime already exists, use the `plcontainer runtime-replace` or `plcontainer runtime-edit` command to add the resource group assignment to the runtime configuration. For example:
+
+    ```
+    plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391
+    plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel -l r -s resource_group_id=16393
+    ```
+
+    For information about the `plcontainer` command, see [plcontainer](../utility_guide/ref/plcontainer.html) reference page.
+
+### <a id="topic_resgroup"></a>Using Resource Groups to Manage PL/Container Resources 
+
+With PL/Container 1.2.0 and later, you can use Greenplum Database resource groups to manage and limit the total CPU and memory resources of containers in PL/Container runtimes. For more information about enabling, configuring, and using Greenplum Database resource groups, refer to [Using Resource Groups](../admin_guide/workload_mgmt_resgroups.html) in the *Greenplum Database Administrator Guide*.
+
+> **Note** If you do not explicitly configure resource groups for a PL/Container runtime, its container instances are limited only by system resources. The containers may consume resources at the expense of the Greenplum Database server.
 
 ## <a id="plc_notes"></a>PL/Container Logging
 

--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -12,22 +12,17 @@ This topic covers further details on:
 
 ## <a id="topic_resmgmt"></a>PL/Container Resource Management 
 
-The Docker containers and the Greenplum Database servers share CPU and memory resources on the same hosts. In the default case, Greenplum Database is unaware of the resources consumed by running PL/Container instances. You can use Greenplum Database resource groups to control overall CPU and memory resource usage for running PL/Container instances.
+The Docker containers and the Greenplum Database servers share CPU and memory resources on the same hosts. In the default case, Greenplum Database is unaware of the resources consumed by running PL/Container instances. You can use Greenplum Database resource groups to control overall CPU resource usage for running PL/Container instances.
 
 PL/Container manages resource usage at two levels - the container level and the runtime level. You can control container-level CPU and memory resources with the `memory_mb` and `cpu_share` settings that you configure for the PL/Container runtime. `memory_mb` governs the memory resources available to each container instance. The `cpu_share` setting identifies the relative weighting of a container's CPU usage compared to other containers. See [plcontainer Configuration File](../utility_guide/ref/plcontainer-configuration.html) for further details.
 
 You cannot, by default, restrict the number of running PL/Container container instances, nor can you restrict the total amount of memory or CPU resources that they consume.
 
-Resource groups for external components such as PL/Container use Linux control groups \(cgroups\) to manage component-level use of memory and CPU resources. When you manage PL/Container resources with resource groups, you configure both a memory limit and a CPU limit that Greenplum Database applies to all container instances that share the same PL/Container runtime configuration.
-
-When you create a resource group to manage the resources of a PL/Container runtime, you must specify `MEMORY_AUDITOR=cgroup` and `CONCURRENCY=0` in addition to the required CPU and memory limits. For example, the following command creates a resource group named `plpy_run1_rg` for a PL/Container runtime:
+Resource groups for external components such as PL/Container use Linux control groups \(cgroups\) to manage component-level use of memory and CPU resources. 
 
 ```
-CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
-                                                  CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);
+CREATE RESOURCE GROUP plpy_run1_rg WITH (CONCURRENCY=10, CPU_MAX_PERCENT=10, MEMORY_LIMIT=10);
 ```
-
-PL/Container does not use the `MEMORY_SHARED_QUOTA` and `MEMORY_SPILL_RATIO` resource group memory limits. Refer to the [CREATE RESOURCE GROUP](../ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html) reference page for detailed information about this SQL command.
 
 You can create one or more resource groups to manage your running PL/Container instances. After you create a resource group for PL/Container, you assign the resource group to one or more PL/Container runtimes. You make this assignment using the `groupid` of the resource group. You can determine the `groupid` for a given resource group name from the `gp_resgroup_config` `gp_toolkit` view. For example, the following query displays the `groupid` of a resource group named `plpy_run1_rg`:
 
@@ -49,32 +44,27 @@ plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:
 
 You can also assign a resource group to a PL/Container runtime using the `plcontainer runtime-edit` command. For information about the `plcontainer` command, see [plcontainer](../utility_guide/ref/plcontainer.html) reference page.
 
-After you assign a resource group to a PL/Container runtime, all container instances that share the same runtime configuration are subject to the memory limit and the CPU limit that you configured for the group. If you decrease the memory limit of a PL/Container resource group, queries running in containers in the group may fail with an out of memory error. If you drop a PL/Container resource group while there are running container instances, Greenplum Database terminates the running containers.
+After you assign a resource group to a PL/Container runtime, all container instances that share the same runtime configuration are subject to the CPU limit that you configured for the group. If you decrease the memory limit of a PL/Container resource group, queries running in containers in the group may fail with an out of memory error. If you drop a PL/Container resource group while there are running container instances, Greenplum Database terminates the running containers.
 
 ### <a id="topic_resgroupcfg"></a>Configuring Resource Groups for PL/Container 
 
 To use Greenplum Database resource groups to manage PL/Container resources, you must explicitly configure both resource groups and PL/Container.
 
-Perform the following procedure to configure PL/Container to use Greenplum Database resource groups for CPU and memory resource management:
+Perform the following procedure to configure PL/Container to use Greenplum Database resource groups for CPU resource management:
 
-1.  If you have not already configured and enabled resource groups in your Greenplum Database deployment, configure cgroups and enable Greenplum Database resource groups as described in [Using Resource Groups](../admin_guide/workload_mgmt_resgroups.html#topic71717999) in the *Greenplum Database Administrator Guide*.
-
-    > **Note** If you have previously configured and enabled resource groups in your deployment, ensure that the Greenplum Database resource group `gpdb.conf` cgroups configuration file includes a `memory { }` block as described in the previous link.
-2.  Analyze the resource usage of your Greenplum Database deployment. Determine the percentage of resource group CPU and memory resources that you want to allocate to PL/Container Docker containers.
-3.  Determine how you want to distribute the total PL/Container CPU and memory resources that you identified in the step above among the PL/Container runtimes. Identify:
+1.  Analyze the resource usage of your Greenplum Database deployment. Determine the percentage of resource group CPU resources that you want to allocate to PL/Container Docker containers.
+1.  Determine how you want to distribute the total PL/Container CPU resources that you identified in the step above among the PL/Container runtimes. Identify:
     -   The number of PL/Container resource group\(s\) that you require.
-    -   The percentage of memory and CPU resources to allocate to each resource group.
+    -   The percentage of CPU resources to allocate to each resource group.
     -   The resource-group-to-PL/Container-runtime assignment\(s\).
-4.  Create the PL/Container resource groups that you identified in the step above. For example, suppose that you choose to allocate 25% of both memory and CPU Greenplum Database resources to PL/Container. If you further split these resources among 2 resource groups 60/40, the following SQL commands create the resource groups:
+1.  Create the PL/Container resource groups that you identified in the step above. For example, suppose that you choose to allocate 25% of CPU Greenplum Database resources to PL/Container. If you further split these resources among two resource groups 60/40, the following SQL commands create the resource groups:
 
     ```
-    CREATE RESOURCE GROUP plr_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
-                                               CPU_RATE_LIMIT=15, MEMORY_LIMIT=15);
-     CREATE RESOURCE GROUP plpy_run1_rg WITH (MEMORY_AUDITOR=cgroup, CONCURRENCY=0,
-                                              CPU_RATE_LIMIT=10, MEMORY_LIMIT=10);
+    CREATE RESOURCE GROUP plr_run1_rg WITH (CONCURRENCY=0, CPU_MAX_PERCENT=15);
+    CREATE RESOURCE GROUP plpy_run1_rg WITH (CONCURRENCY=0, CPU_MAX_PERCENT=10);
     ```
 
-5.  Find and note the `groupid` associated with each resource group that you created. For example:
+1.  Find and note the `groupid` associated with each resource group that you created. For example:
 
     ```
     SELECT groupname, groupid FROM gp_toolkit.gp_resgroup_config
@@ -87,7 +77,7 @@ Perform the following procedure to configure PL/Container to use Greenplum Datab
     (1 row)
     ```
 
-6.  Assign each resource group that you created to the desired PL/Container runtime configuration. If you have not yet created the runtime configuration, use the `plcontainer runtime-add` command. If the runtime already exists, use the `plcontainer runtime-replace` or `plcontainer runtime-edit` command to add the resource group assignment to the runtime configuration. For example:
+1.  Assign each resource group that you created to the desired PL/Container runtime configuration. If you have not yet created the runtime configuration, use the `plcontainer runtime-add` command. If the runtime already exists, use the `plcontainer runtime-replace` or `plcontainer runtime-edit` command to add the resource group assignment to the runtime configuration. For example:
 
     ```
     plcontainer runtime-add -r python_run1 -i pivotaldata/plcontainer_python_shared:devel -l python -s resource_group_id=16391
@@ -98,7 +88,7 @@ Perform the following procedure to configure PL/Container to use Greenplum Datab
 
 ### <a id="topic_resgroup"></a>Using Resource Groups to Manage PL/Container Resources 
 
-With PL/Container 1.2.0 and later, you can use Greenplum Database resource groups to manage and limit the total CPU and memory resources of containers in PL/Container runtimes. For more information about enabling, configuring, and using Greenplum Database resource groups, refer to [Using Resource Groups](../admin_guide/workload_mgmt_resgroups.html) in the *Greenplum Database Administrator Guide*.
+With PL/Container 2.4.0 and later, you can use Greenplum Database resource groups to manage and limit the total CPU resources of containers in PL/Container runtimes. For more information about enabling, configuring, and using Greenplum Database resource groups, refer to [Using Resource Groups](../admin_guide/workload_mgmt_resgroups.html) in the *Greenplum Database Administrator Guide*.
 
 > **Note** If you do not explicitly configure resource groups for a PL/Container runtime, its container instances are limited only by system resources. The containers may consume resources at the expense of the Greenplum Database server.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1455,6 +1455,16 @@ When set to `true` (the default) Greenplum Database's resource group scheduler b
 |-----------|-------|-------------------|
 |Boolean|true|local, session, reload|
 
+## <a id="gp_resource_group_cgroup_parent"></a>gp_resource_group_cgroup_parent
+
+> **Note** The `gp_resource_group_cgroup_parent` server configuration parameter is enforced only when resource group-based resource management is active and cgroup v2 is used.
+
+Identifies the root path of the `gpdb` cgroup hierarchy.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|char|"gpdb.service"|local, system, restart, superuser|
+
 ## <a id="gp_resource_group_cpu_limit"></a>gp\_resource\_group\_cpu\_limit 
 
 > **Note** The `gp_resource_group_cpu_limit` server configuration parameter is enforced only when resource group-based resource management is active.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -419,6 +419,7 @@ The following parameters configure the Greenplum Database resource group workloa
 - [gp_resource_group_bypass](guc-list.html#gp_resource_group_bypass)
 - [gp_resource_group_bypass_catalog_query](guc-list.html#gp_resource_group_bypass_catalog_query)
 - [gp_resource_group_bypass_direct_dispatch](guc-list.html#gp_resource_group_bypass_direct_dispatch)
+- [gp_resource_group_cgroup_parent](guc-list.html#gp_resource_group_cgroup_parent)
 - [gp_resource_group_cpu_limit](guc-list.html#gp_resource_group_cpu_limit)
 - [gp_resource_group_cpu_priority](guc-list.html#gp_resource_group_cpu_priority)
 - [gp_resource_group_move_timeout](guc-list.html#gp_resource_group_move_timeout)

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
@@ -50,6 +50,8 @@ When you alter the CPU resource management mode or limit of a resource group, th
 
 When you alter a memory limit of a resource group that you create for roles, the new resource limit is immediately applied if current resource usage is less than or equal to the new value and there are no running transactions in the resource group. If the current resource usage exceeds the new memory limit value, or if there are running transactions in other resource groups that hold some of the resource, then Greenplum Database defers assigning the new limit until resource usage falls within the range of the new value.
 
+When you increase the memory limit of a resource group that you create for external components, the new resource limit is phased in as system memory resources become available. If you decrease the memory limit of a resource group that you create for external components, the behavior is component-specific. For example, if you decrease the memory limit of a resource group that you create for a PL/Container runtime, queries in a running container may fail with an out of memory error.
+
 You can alter one limit type in a single `ALTER RESOURCE GROUP` call.
 
 ## <a id="parameters"></a>Parameters 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_RESOURCE_GROUP.html.md
@@ -50,7 +50,7 @@ When you alter the CPU resource management mode or limit of a resource group, th
 
 When you alter a memory limit of a resource group that you create for roles, the new resource limit is immediately applied if current resource usage is less than or equal to the new value and there are no running transactions in the resource group. If the current resource usage exceeds the new memory limit value, or if there are running transactions in other resource groups that hold some of the resource, then Greenplum Database defers assigning the new limit until resource usage falls within the range of the new value.
 
-When you increase the memory limit of a resource group that you create for external components, the new resource limit is phased in as system memory resources become available. If you decrease the memory limit of a resource group that you create for external components, the behavior is component-specific. For example, if you decrease the memory limit of a resource group that you create for a PL/Container runtime, queries in a running container may fail with an out of memory error.
+When you increase the memory limit of a resource group that you create for external components, the new resource limit is phased in as system memory resources become available. If you decrease the memory limit of a resource group that you create for external components, the behavior is component-specific. 
 
 You can alter one limit type in a single `ALTER RESOURCE GROUP` call.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
@@ -41,17 +41,21 @@ Where `<io_limit_option_vlaue>` is:
 
 ## <a id="section3"></a>Description 
 
-Creates a new resource group for Greenplum Database resource management. 
+Creates a new resource group for Greenplum Database resource management. You can create resource groups to manage resources for roles or to manage the resources of a Greenplum Database external component such as PL/Container.
 
 A resource group that you create to manage a user role identifies concurrent transaction, memory, CPU, and disk I/O limits for the role when resource groups are enabled. You may assign such resource groups to one or more roles.
+
+A resource group that you create to manage the resources of a Greenplum Database external component such as PL/Container identifies the memory and CPU limits for the component when resource groups are enabled. These resource groups use cgroups for both CPU and memory management. Assignment of resource groups to external components is component-specific. For example, you assign a PL/Container resource group when you configure a PL/Container runtime. You cannot assign a resource group that you create for external components to a role, nor can you assign a resource group that you create for roles to an external component.
 
 You must have `SUPERUSER` privileges to create a resource group. The maximum number of resource groups allowed in your Greenplum Database cluster is 100.
 
 Greenplum Database pre-defines three default resource groups: `admin_group`, `default_group`, and `system_group`. These group names, as well as the group name `none`, are reserved.
 
-To set appropriate limits for resource groups, the Greenplum Database administrator must be familiar with the queries typically run on the system, as well as the users/roles running those queries.
+To set appropriate limits for resource groups, the Greenplum Database administrator must be familiar with the queries typically run on the system, as well as the users/roles running those queries and the external components they may be using, such as PL/Containers
 
 After creating a resource group for a role, assign the group to one or more roles using the [ALTER ROLE](ALTER_ROLE.html) or [CREATE ROLE](CREATE_ROLE.html) commands.
+
+After you create a resource group to manage the CPU and memory resources of an external component, configure the external component to use the resource group. For example, configure the PL/Container runtime `resource_group_id`.
 
 ## <a id="section4"></a>Parameters 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_RESOURCE_GROUP.html.md
@@ -45,7 +45,7 @@ Creates a new resource group for Greenplum Database resource management. You can
 
 A resource group that you create to manage a user role identifies concurrent transaction, memory, CPU, and disk I/O limits for the role when resource groups are enabled. You may assign such resource groups to one or more roles.
 
-A resource group that you create to manage the resources of a Greenplum Database external component such as PL/Container identifies the memory and CPU limits for the component when resource groups are enabled. These resource groups use cgroups for both CPU and memory management. Assignment of resource groups to external components is component-specific. For example, you assign a PL/Container resource group when you configure a PL/Container runtime. You cannot assign a resource group that you create for external components to a role, nor can you assign a resource group that you create for roles to an external component.
+A resource group that you create to manage the resources of a Greenplum Database external component such as PL/Container identifies the CPU limits for the component when resource groups are enabled. These resource groups use cgroups for both CPU management. Assignment of resource groups to external components is component-specific. For example, you assign a PL/Container resource group when you configure a PL/Container runtime. You cannot assign a resource group that you create for external components to a role, nor can you assign a resource group that you create for roles to an external component.
 
 You must have `SUPERUSER` privileges to create a resource group. The maximum number of resource groups allowed in your Greenplum Database cluster is 100.
 
@@ -55,7 +55,7 @@ To set appropriate limits for resource groups, the Greenplum Database administra
 
 After creating a resource group for a role, assign the group to one or more roles using the [ALTER ROLE](ALTER_ROLE.html) or [CREATE ROLE](CREATE_ROLE.html) commands.
 
-After you create a resource group to manage the CPU and memory resources of an external component, configure the external component to use the resource group. For example, configure the PL/Container runtime `resource_group_id`.
+After you create a resource group to manage the CPU resources of an external component, configure the external component to use the resource group. For example, configure the PL/Container runtime `resource_group_id`.
 
 ## <a id="section4"></a>Parameters 
 


### PR DESCRIPTION
This PR reintroduces PL/Container support with Resource Groups. 
It aligns most of the GPDB 7 documentation to what GPDB 6 supported, plus a few additions:

- New guc gp_resource_group_cgroup_parent
- Modification of the bash script for resource groups using cgroup v2 to automatically start during system startup.

Questions:
- Can you provide an example of creating a resource group for the `CREATE RESOURCE GROUP` reference page that uses PL/Container? The previous examples used memory auditor.
- Can you review  the page gpdb-doc/markdown/analytics/pl_container_using.html.md to help adapt concepts to the GPDB 7 resource group concepts? I only ported back the changes that were removed on https://github.com/greenplum-db/gpdb/pull/16490 so it needs some editing. Especially around memory management.
- Regarding GUC `gp_resource_group_cgroup_parent`, can you confirm that the default value, parameter categories, explanation, etc are correct?

Any other changes I might have missed please let me know
Staging site:
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-plcontainer/greenplum-database/admin_guide-workload_mgmt_resgroups.html
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-plcontainer/greenplum-database/analytics-pl_container.html
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-plcontainer/greenplum-database/ref_guide-config_params-guc-list.html#gp_resource_group_cgroup_parent



