### PR TITLE
[ORCA] Add GUC to disable right outer join (ROJ)

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -509,6 +509,15 @@ CConfigParamMapping::PackConfigParamInBitset(
 	traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(
 		CXform::ExfExpandDynamicGetWithExternalPartitions));
 
+	if (!optimizer_enable_right_outer_join)
+	{
+		// disable right outer join if the corresponding GUC is turned off
+		traceflag_bitset->ExchangeSet(
+			GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftJoin2RightJoin));
+		traceflag_bitset->ExchangeSet(
+			GPOPT_DISABLE_XFORM_TF(CXform::ExfRightOuterJoin2HashJoin));
+	}
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -368,6 +368,7 @@ bool		optimizer_prune_unused_columns;
 bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
 bool		optimizer_force_comprehensive_join_implementation;
 bool		optimizer_enable_replicated_table;
+bool		optimizer_enable_right_outer_join;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -3285,6 +3286,29 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 &gp_log_resqueue_priority_sleep_time,
 		 false,
 		 NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_right_outer_join", PGC_USERSET, QUERY_TUNING_METHOD,
+		 gettext_noop("Enable Orca to generate plans containing right outer joins."),
+		 gettext_noop("Right outer join can be re-written from left outer join. "
+					  "However, there are scenarios due to cardinality and cost "
+					  "misestimation, right outer join plan may be sub-optimal and "
+					  "can either be slower than the left outer join plan alternative "
+					  "or hit out-of-memory (OOM). The root cause can be identified "
+					  "by viewing the explain analyze plan and observing that the "
+					  "right outer join plan node is consuming all resources "
+					  "(CPU/memory) or the explain analyze itself hits OOM. By "
+					  "setting this GUC value to \"false\" users can force GPORCA to "
+					  "generate an equivalent left outer join plan. We recommend that "
+					  "the GUC be set at the query level as there can be several use "
+					  "cases where right outer join is the best plan alternative to "
+					  "choose."),
+		 GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_right_outer_join,
+		true,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -498,6 +498,7 @@ extern bool optimizer_prune_unused_columns;
 extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
 extern bool optimizer_force_comprehensive_join_implementation;
 extern bool optimizer_enable_replicated_table;
+extern bool optimizer_enable_right_outer_join;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -400,6 +400,7 @@
 		"optimizer_enable_redistribute_nestloop_loj_inner_child",
 		"optimizer_force_comprehensive_join_implementation",
 		"optimizer_enable_replicated_table",
+		"optimizer_enable_right_outer_join",
 		"optimizer_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13263,6 +13263,27 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  HashAggregate
+         Group Key: t2.c
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t2.c
+               ->  HashAggregate
+                     Group Key: t2.c
+                     ->  Hash Right Join
+                           Hash Cond: (t2.c = t1.a)
+                           ->  Seq Scan on roj2 t2
+                           ->  Hash
+                                 ->  Seq Scan on roj1 t1
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+reset optimizer_enable_right_outer_join;
 reset optimizer_enable_motion_redistribute;
 reset optimizer_trace_fallback;
 reset enable_sort;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13468,6 +13468,26 @@ explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ GroupAggregate
+   Group Key: roj2.c
+   ->  Sort
+         Sort Key: roj2.c
+         ->  Hash Left Join
+               Hash Cond: (roj1.a = roj2.c)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on roj1
+               ->  Hash
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Seq Scan on roj2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+reset optimizer_enable_right_outer_join;
 reset optimizer_enable_motion_redistribute;
 reset optimizer_trace_fallback;
 reset enable_sort;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2822,6 +2822,12 @@ analyze roj2;
 set optimizer_enable_motion_redistribute=off;
 select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
 explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+
+-- check that ROJ can be disabled via GUC
+set optimizer_enable_right_outer_join=off;
+explain (costs off) select count(*), t2.c from roj1 t1 left join roj2 t2 on t1.a = t2.c group by t2.c;
+reset optimizer_enable_right_outer_join;
+
 reset optimizer_enable_motion_redistribute;
 
 reset optimizer_trace_fallback;


### PR DESCRIPTION
In production systems, we encountered scenarios where poor cardinality estimations led to plans with ROJ that yielded memory related workfile limit errors. In those cases, the only way to turn off ROJ was to either rewrite the query or turn off the xform. A query rewrite takes time to come up with and turning off the xform doesn't work at the per-user level. This commit introduces a GUC optimizer_enable_right_outer_join as a convenient way to work around this problem.

(cherry picked from commit 0978e256e887ab86aca8381354c08cea74fd6097)