### PR TITLE
Fix CDatumSortedSet handling of empty arrays causing errors in ORCA

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CDatumSortedSet.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDatumSortedSet.cpp
@@ -36,6 +36,12 @@ CDatumSortedSet::CDatumSortedSet(CMemoryPool *mp, CExpression *pexprArray,
 			aprngdatum->Append(datum);
 		}
 	}
+
+	// ALL NULLs, just return empty set
+	if (aprngdatum->Size() == 0)
+	{
+		return;
+	}
 	aprngdatum->Sort(&CUtils::IDatumCmp);
 
 	// de-duplicate

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14816,3 +14816,16 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 (5 rows)
 
 ---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------
+-- Test ALL NULL scalar array compare 
+create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
+explain select * from DatumSortedSet_core where b in (NULL, NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..240.69 rows=1 width=36)
+   ->  Seq Scan on datumsortedset_core  (cost=0.00..240.67 rows=1 width=36)
+         Filter: ((b)::text = ANY ('{NULL,NULL}'::text[]))
+ Optimizer: Postgres-based planner
+(4 rows)
+
+---------------------------------------------------------------------------------

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14911,3 +14911,15 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 (5 rows)
 
 ---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------
+-- Test ALL NULL scalar array compare 
+create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
+explain select * from DatumSortedSet_core where b in (NULL, NULL);
+                QUERY PLAN                 
+-------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=12)
+   One-Time Filter: false
+ Optimizer: GPORCA
+(3 rows)
+
+---------------------------------------------------------------------------------

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3625,6 +3625,12 @@ CREATE TABLE schema_test_table(a numeric, b numeric(5,2), c char(10) NOT NULL) d
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM schema_test_table WHERE 1=0;
 ---------------------------------------------------------------------------------
 
+---------------------------------------------------------------------------------
+-- Test ALL NULL scalar array compare 
+create table DatumSortedSet_core (a int, b character varying NOT NULL) distributed by (a);
+explain select * from DatumSortedSet_core where b in (NULL, NULL);
+---------------------------------------------------------------------------------
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Previously, when constructing CDatumSortedSet from an array expression with all NULL elements, the aprngdatum was becoming an empty array. This caused unexpected errors that could lead to ORCA fallback to the planner, or even coredump.

The bug has been fixed by ensuring that no unnecessary operations are performed on the empty aprngdatum array.
