### PR TITLE
Revise the description of the max_resource_portals_per_transaction variable

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3366,7 +3366,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"max_resource_portals_per_transaction", PGC_POSTMASTER, RESOURCES_MGM,
-			gettext_noop("Maximum number of resource queues."),
+			gettext_noop("Sets the maximum number of simultaneously open cursors allowed per transaction."),
 			NULL
 		},
 		&MaxResourcePortalsPerXact,


### PR DESCRIPTION
The description of description in 6X_STABLE in same as max_resource_queues, which is very confusing.
```
{
                {"max_resource_queues", PGC_POSTMASTER, RESOURCES_MGM,
                        gettext_noop("Maximum number of resource queues."),
                        NULL
                },
                &MaxResourceQueues,
                9, 0, INT_MAX,
                NULL, NULL, NULL
        },

        {
                {"max_resource_portals_per_transaction", PGC_POSTMASTER, RESOURCES_MGM,
                        gettext_noop("Maximum number of resource queues."),
                        NULL
                },
                &MaxResourcePortalsPerXact,
                64, 0, INT_MAX,
                NULL, NULL, NULL
        },
```
I open a MR to Revise the description of the max_resource_portals_per_transaction guc. Please hava a look at this.