### PR TITLE
[ORCA] Fix Missing pdshashedEquiv in IndexOnlyScan, Especially under InnerIndexNLJoin.

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-InnerJoin.mdp
@@ -1298,7 +1298,7 @@
     <dxl:Plan Id="0" SpaceSize="54">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="12.000557" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.000507" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1312,7 +1312,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.000527" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.000477" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1374,9 +1374,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicIndexOnlyScan>
-          <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000211" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000161" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -1404,7 +1404,7 @@
                 <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:IndexScan>
+          </dxl:IndexOnlyScan>
           <dxl:NLJIndexParamList>
             <dxl:NLJIndexParam ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:NLJIndexParamList>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexOnlyScan-LeftJoin.mdp
@@ -1296,10 +1296,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="45">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="12.000557" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.000507" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1313,7 +1313,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.000527" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.000477" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1375,9 +1375,9 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicIndexOnlyScan>
-          <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000211" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000161" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -1405,7 +1405,7 @@
                 <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
-          </dxl:IndexScan>
+          </dxl:IndexOnlyScan>
           <dxl:NLJIndexParamList>
             <dxl:NLJIndexParam ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:NLJIndexParamList>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
@@ -156,8 +156,10 @@ CPhysicalScan::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 {
 	BOOL fIndexOrBitmapScan =
 		COperator::EopPhysicalIndexScan == Eopid() ||
+		COperator::EopPhysicalIndexOnlyScan == Eopid() ||
 		COperator::EopPhysicalBitmapTableScan == Eopid() ||
 		COperator::EopPhysicalDynamicIndexScan == Eopid() ||
+		COperator::EopPhysicalDynamicIndexOnlyScan == Eopid() ||
 		COperator::EopPhysicalDynamicBitmapTableScan == Eopid();
 	if (fIndexOrBitmapScan && CDistributionSpec::EdtHashed == m_pds->Edt() &&
 		exprhdl.HasOuterRefs())

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -1451,3 +1451,50 @@ explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
  Optimizer: Postgres query optimizer
 (9 rows)
 
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;
+RESET enable_indexonlyscan;
+RESET seq_page_cost;
+-- Test IndexNLJoin on IndexOnlyScan in ORCA (both heap and AOCS table)
+create table index_only_join_test (a int, b int) distributed by (a);
+create table index_only_join_test_aocs (a int, b int) with (appendonly='true') distributed by (a);
+create index index_only_join_test_a_idx on index_only_join_test(a);
+create index index_only_join_test_b_idx on index_only_join_test(b) include (a);
+create index index_only_join_test_aocs_a_idx on index_only_join_test_aocs(a);
+create index index_only_join_test_aocs_b_idx on index_only_join_test_aocs(b) include (a);
+insert into index_only_join_test select i,i from generate_series(1, 100)i;
+insert into index_only_join_test_aocs select i,i from generate_series(1, 100)i;
+analyze index_only_join_test;
+analyze index_only_join_test_aocs;
+set enable_nestloop to on;
+set enable_seqscan to off;
+set optimizer_enable_indexscan to off;
+explain select t1.a from index_only_join_test t1, index_only_join_test t2 where t1.a = t2.a and t1.b < 10;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.31..21.14 rows=13 width=4)
+   ->  Nested Loop  (cost=0.31..20.96 rows=4 width=4)
+         ->  Index Only Scan using index_only_join_test_b_idx on index_only_join_test t1  (cost=0.15..8.41 rows=3 width=4)
+               Index Cond: (b < 10)
+         ->  Index Only Scan using index_only_join_test_a_idx on index_only_join_test t2  (cost=0.15..4.17 rows=1 width=4)
+               Index Cond: (a = t1.a)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+reset optimizer_enable_indexscan;
+explain select t1.a from index_only_join_test_aocs t1, index_only_join_test_aocs t2 where t1.a = t2.a and t1.b < 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.31..12.48 rows=13 width=4)
+   ->  Nested Loop  (cost=0.31..12.31 rows=4 width=4)
+         ->  Index Only Scan using index_only_join_test_aocs_b_idx on index_only_join_test_aocs t1  (cost=0.15..4.49 rows=3 width=4)
+               Index Cond: (b < 10)
+         ->  Index Only Scan using index_only_join_test_aocs_a_idx on index_only_join_test_aocs t2  (cost=0.15..2.59 rows=1 width=4)
+               Index Cond: (a = t1.a)
+ Optimizer: Postgres-based planner
+(7 rows)
+
+reset enable_nestloop;
+reset enable_seqscan;
+drop table index_only_join_test;
+drop table index_only_join_test_aocs;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -1407,3 +1407,52 @@ explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;
+RESET enable_indexonlyscan;
+RESET seq_page_cost;
+-- Test IndexNLJoin on IndexOnlyScan in ORCA (both heap and AOCS table)
+create table index_only_join_test (a int, b int) distributed by (a);
+create table index_only_join_test_aocs (a int, b int) with (appendonly='true') distributed by (a);
+create index index_only_join_test_a_idx on index_only_join_test(a);
+create index index_only_join_test_b_idx on index_only_join_test(b) include (a);
+create index index_only_join_test_aocs_a_idx on index_only_join_test_aocs(a);
+create index index_only_join_test_aocs_b_idx on index_only_join_test_aocs(b) include (a);
+insert into index_only_join_test select i,i from generate_series(1, 100)i;
+insert into index_only_join_test_aocs select i,i from generate_series(1, 100)i;
+analyze index_only_join_test;
+analyze index_only_join_test_aocs;
+set enable_nestloop to on;
+set enable_seqscan to off;
+set optimizer_enable_indexscan to off;
+explain select t1.a from index_only_join_test t1, index_only_join_test t2 where t1.a = t2.a and t1.b < 10;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..60.55 rows=10 width=4)
+   ->  Nested Loop  (cost=0.00..60.55 rows=4 width=4)
+         Join Filter: true
+         ->  Index Only Scan using index_only_join_test_b_idx on index_only_join_test  (cost=0.00..6.00 rows=4 width=4)
+               Index Cond: (b < 10)
+         ->  Index Only Scan using index_only_join_test_a_idx on index_only_join_test index_only_join_test_1  (cost=0.00..54.55 rows=1 width=1)
+               Index Cond: (a = index_only_join_test.a)
+ Optimizer: GPORCA
+(8 rows)
+
+reset optimizer_enable_indexscan;
+explain select t1.a from index_only_join_test_aocs t1, index_only_join_test_aocs t2 where t1.a = t2.a and t1.b < 10;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..60.65 rows=10 width=4)
+   ->  Nested Loop  (cost=0.00..60.65 rows=4 width=4)
+         Join Filter: true
+         ->  Index Only Scan using index_only_join_test_aocs_b_idx on index_only_join_test_aocs  (cost=0.00..6.05 rows=4 width=4)
+               Index Cond: (b < 10)
+         ->  Index Only Scan using index_only_join_test_aocs_a_idx on index_only_join_test_aocs index_only_join_test_aocs_1  (cost=0.00..54.60 rows=1 width=1)
+               Index Cond: (a = index_only_join_test_aocs.a)
+ Optimizer: GPORCA
+(8 rows)
+
+reset enable_nestloop;
+reset enable_seqscan;
+drop table index_only_join_test;
+drop table index_only_join_test_aocs;

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -490,10 +490,11 @@ SELECT pt.a, pt.b FROM test_cover_index_on_pt AS pt JOIN test_basic_cover_index 
                Heap Fetches: 0
                Number of partitions to scan: 1 (out of 4)
                Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
-         ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=1 loops=1)
+         ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=1 loops=1)
                Index Cond: ((a = test_cover_index_on_pt.a) AND (a < 10))
+               Heap Fetches: 0
  Optimizer: GPORCA
-(12 rows)
+(13 rows)
 
 SELECT pt.a, pt.b FROM test_cover_index_on_pt AS pt JOIN test_basic_cover_index AS t ON pt.a=t.a WHERE pt.a<10 and pt.b=2;
  a | b 
@@ -515,10 +516,11 @@ SELECT pt.a, pt.b FROM test_cover_index_on_pt AS pt LEFT JOIN test_basic_cover_i
                Heap Fetches: 0
                Number of partitions to scan: 1 (out of 4)
                Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
-         ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=1 loops=1)
+         ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=1 loops=1)
                Index Cond: ((a = test_cover_index_on_pt.a) AND (a < 10))
+               Heap Fetches: 0
  Optimizer: GPORCA
-(12 rows)
+(13 rows)
 
 SELECT pt.a, pt.b FROM test_cover_index_on_pt AS pt LEFT JOIN test_basic_cover_index AS t ON pt.a=t.a WHERE pt.a<10 and pt.b=2;
  a | b 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13310,9 +13310,8 @@ explain (costs off) select * from tpart_dim d join t_ao_btree f on d.a=f.a where
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               ->  Seq Scan on tpart_dim
-                     Filter: (b = 1)
+         ->  Seq Scan on tpart_dim
+               Filter: (b = 1)
          ->  Index Only Scan using t_ao_btree_ix on t_ao_btree
                Index Cond: (a = tpart_dim.a)
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -361,7 +361,8 @@ explain (costs off)
          ->  Partial Aggregate
                ->  Nested Loop
                      Join Filter: true
-                     ->  Broadcast Motion 1:3  (slice2)
+                     ->  Redistribute Motion 1:3  (slice2)
+                           Hash Key: (max(tenk2.unique1))
                            ->  Aggregate
                                  ->  Limit
                                        ->  Gather Motion 3:1  (slice3; segments: 3)

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -981,7 +981,7 @@ where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
                                        Hash Key: tenk1.unique2
                                        ->  Index Scan using tenk1_thous_tenthous on tenk1
                                              Index Cond: (thousand = 1)
-                                 ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
+                                 ->  Index Only Scan using tenk1_unique1 on tenk1 tenk1_1
                                        Index Cond: (unique1 = tenk1.unique2)
  Optimizer: GPORCA
 (17 rows)

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -621,3 +621,33 @@ set optimizer_enable_indexscan=off;
 -- identical plans
 explain select * from two_idx_tbl where x = 'cc' or y = 'dd';
 explain select * from two_idx_tbl where 'cc' = x or 'dd' = y;
+
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;
+RESET enable_indexonlyscan;
+RESET seq_page_cost;
+
+-- Test IndexNLJoin on IndexOnlyScan in ORCA (both heap and AOCS table)
+create table index_only_join_test (a int, b int) distributed by (a);
+create table index_only_join_test_aocs (a int, b int) with (appendonly='true') distributed by (a);
+
+create index index_only_join_test_a_idx on index_only_join_test(a);
+create index index_only_join_test_b_idx on index_only_join_test(b) include (a);
+create index index_only_join_test_aocs_a_idx on index_only_join_test_aocs(a);
+create index index_only_join_test_aocs_b_idx on index_only_join_test_aocs(b) include (a);
+insert into index_only_join_test select i,i from generate_series(1, 100)i;
+insert into index_only_join_test_aocs select i,i from generate_series(1, 100)i;
+analyze index_only_join_test;
+analyze index_only_join_test_aocs;
+
+set enable_nestloop to on;
+set enable_seqscan to off;
+set optimizer_enable_indexscan to off;
+explain select t1.a from index_only_join_test t1, index_only_join_test t2 where t1.a = t2.a and t1.b < 10;
+reset optimizer_enable_indexscan;
+explain select t1.a from index_only_join_test_aocs t1, index_only_join_test_aocs t2 where t1.a = t2.a and t1.b < 10;
+reset enable_nestloop;
+reset enable_seqscan;
+
+drop table index_only_join_test;
+drop table index_only_join_test_aocs;


### PR DESCRIPTION
It's also a problem of IndexOnlyScan on AO/AOCS tables that can not generate IndexScan but can generate IndexOnlyScan. For example:

create table test (a int, b int)
with (appendonly='true') distributed by (a);
create index test_a_idx on test(a);
create index test_b_idx on test(b) include (a);
insert into test select i,i from generate_series(1, 10000)i;
analyze test;
explain (costs off) select t1.a from test t1, test t2 where t1.a = t2.a and t1.b < 10;
                         QUERY PLAN
-------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Nested Loop
         Join Filter: true
         ->  Broadcast Motion 3:3  (slice2; segments: 3)
               ->  Index Only Scan using test_b_idx on test
                     Index Cond: (b < 10)
         ->  Index Only Scan using test_a_idx on test test_1
               Index Cond: (a = test.a)
 Optimizer: GPORCA
(9 rows)

This Broadcast Motion is obviously not necessary, but it appeared because IndexOnlyScan did not generate pdshashedEquiv just like other index or bitmap index scan.
It may be a glaring omission, when 'Add Orca support for index only scan'.

TODO: It has also been noticed that the cost of index only scan is similar to the cost of index scan, which might be improved upon.

