### PR TITLE
Fix error is thrown even if group by clause does not reference a recursive CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2204,14 +2204,16 @@ set_worktable_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 * Remember WTS path cannot be turned to replicated(means broadcast)
 	 * when dealing with join. Most of the cases, it is OK. But for
 	 * replicated table whose locus is CdbLocusType_SegmentGeneral,
-	 * it can not be taken as everywhere, we will gather it to singleQE
-	 * or redistribute it when joining.
+	 * or locus is CdbLocusType_General, it can not be taken as everywhere,
+	 * we will gather it to singleQE or redistribute it when joining.
 	 *
-	 * To avoid such case, if cteplan's locus is CdbLocusType_SegmentGeneral,
-	 * we build WTS path using singlQE, and later in the function
-	 * `set_recursive_union_flow` to add a gather on the top of cteplan.
+	 * To avoid such case, if cteplan's locus is CdbLocusType_SegmentGeneral
+	 * or CdbLocusType_General, we build WTS path using singlQE, and later
+	 * in the function `set_recursive_union_flow` to add a gather on the top
+	 * of cteplan.
 	 */
-	if (cteplan->flow->locustype == CdbLocusType_SegmentGeneral)
+	if (cteplan->flow->locustype == CdbLocusType_SegmentGeneral
+		||cteplan->flow->locustype == CdbLocusType_General)
 		ctelocus = CdbLocusType_SingleQE;
 	else
 		ctelocus = cteplan->flow->locustype;

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -56,6 +56,7 @@
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbsetop.h"
 #include "cdb/cdbvars.h"
+#include "cdb/cdbmutate.h"
 #include "commands/tablecmds.h"
 
 
@@ -495,6 +496,11 @@ generate_recursion_plan(SetOperationStmt *setOp, PlannerInfo *root,
 										 groupList, numGroups);
 
 	*sortClauses = NIL;			/* RecursiveUnion result is always unsorted */
+
+	/*
+	 * Check whether there is a motion above WorkTableScan
+	 */
+	checkMotionAboveWorkTableScan((Node *)rplan, root);
 
 	return plan;
 }

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2962,12 +2962,13 @@ create_worktablescan_path(PlannerInfo *root, RelOptInfo *rel,
 		CdbPathLocus_MakeSingleQE(&result, numsegments);
 	else if (ctelocus == CdbLocusType_General)
 		CdbPathLocus_MakeGeneral(&result, numsegments);
-	else if (ctelocus == CdbLocusType_SegmentGeneral)
+	else if (ctelocus == CdbLocusType_SegmentGeneral
+		|| ctelocus == CdbLocusType_General)
 	{
 		/* See comments in set_worktable_pathlist */
 		elog(ERROR,
 			 "worktable scan path can never have "
-			 "segmentgeneral locus.");
+			 "segmentgeneral or general locus.");
 	}
 	else
 		CdbPathLocus_MakeStrewn(&result, numsegments);

--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -92,9 +92,6 @@ static void checkWellFormedRecursion(CteState *cstate);
 static bool checkWellFormedRecursionWalker(Node *node, CteState *cstate);
 static void checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate);
 
-static void checkSelfRefInRangeSubSelect(SelectStmt *stmt, CteState *cstate);
-static void checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate);
-
 /*
  * transformWithClause -
  *	  Transform the list of WITH clause "common table expressions" into
@@ -858,26 +855,6 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 		else
 			checkWellFormedSelectStmt(stmt, cstate);
 
-		if (cstate->context == RECURSION_OK)
-		{
-			if (stmt->distinctClause)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("DISTINCT in a recursive query is not implemented"),
-						 parser_errposition(cstate->pstate,
-											exprLocation((Node *) stmt->distinctClause))));
-			if (stmt->groupClause)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("GROUP BY in a recursive query is not implemented"),
-						 parser_errposition(cstate->pstate,
-											exprLocation((Node *) stmt->groupClause))));
-
-			checkWindowFuncInRecursiveTerm(stmt, cstate);
-		}
-
-		checkSelfRefInRangeSubSelect(stmt, cstate);
-
 		/* We're done examining the SelectStmt */
 		return false;
 	}
@@ -943,19 +920,6 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 		checkWellFormedRecursionWalker(sl->subselect, cstate);
 		cstate->context = save_context;
 		checkWellFormedRecursionWalker(sl->testexpr, cstate);
-		return false;
-	}
-	if (IsA(node, RangeSubselect))
-	{
-		RangeSubselect *rs = (RangeSubselect *) node;
-
-		/*
-		 * we intentionally override outer context, since subquery is
-		 * independent
-		 */
-		cstate->context = RECURSION_SUBLINK;
-		checkWellFormedRecursionWalker(rs->subquery, cstate);
-		cstate->context = save_context;
 		return false;
 	}
 	return raw_expression_tree_walker(node,
@@ -1030,84 +994,5 @@ checkWellFormedSelectStmt(SelectStmt *stmt, CteState *cstate)
 				elog(ERROR, "unrecognized set op: %d",
 					 (int) stmt->op);
 		}
-	}
-}
-
-/*
- * Check if a recursive cte is referred to in a RangeSubSelect's SelectStmt.
- * This is currently not supported and is checked for in the parsing stage
- */
-static void
-checkSelfRefInRangeSubSelect(SelectStmt *stmt, CteState *cstate)
-{
-	ListCell *lc;
-	RecursionContext cxt = cstate->context;
-
-	foreach(lc, stmt->fromClause)
-	{
-		if (IsA((Node *) lfirst(lc), RangeSubselect))
-		{
-			cstate->context = RECURSION_SUBLINK;
-			RangeSubselect *rs = (RangeSubselect *) lfirst(lc);
-			SelectStmt *subquery = (SelectStmt *) rs->subquery;
-			checkWellFormedSelectStmt(subquery, cstate);
-		}
-	}
-	cstate->context = cxt;
-}
-
-/*
- * GPDB:
- * Check if the recursive term of a recursive cte contains a window function
- * or ordered set aggregate function (special aggs). This is currently not
- * supported and is checked for in the parsing stage. Refer to dicussion:
- * https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/GIYw6t-uX7s
- */
-typedef struct CTEWindowAggSearchContext
-{
-	bool       found; /* flag to show if we have found */
-	FuncCall  *func;  /* if found is true, this field is the Agg */
-} CTEWindowAggSearchContext;
-
-static bool
-cte_window_agg_walker(Node *node, CTEWindowAggSearchContext *context)
-{
-	if (node == NULL)
-		return false;
-
-	if (IsA(node, FuncCall))
-	{
-		FuncCall *fc = (FuncCall *) node;
-		if (fc->over != NULL)
-		{
-			context->found = true;
-			context->func  = fc;
-
-			return true;
-		}
-	}
-
-	return raw_expression_tree_walker(node, cte_window_agg_walker, context);
-}
-
-static void
-checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate)
-{
-	CTEWindowAggSearchContext context;
-
-	context.found = false;
-	context.func  = NULL;
-
-	(void) raw_expression_tree_walker((Node *) stmt->targetList,
-									  cte_window_agg_walker,
-									  (void *) &context);
-
-	if (context.found)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_GP_FEATURE_NOT_YET),
-				 errmsg("window functions in the target list of a recursive query is not supported in Greenplum"),
-				 parser_errposition(cstate->pstate,
-									exprLocation((Node *) context.func))));
 	}
 }

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -78,4 +78,5 @@ extern SplitUpdate *make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *s
 									 RangeTblEntry *rte);
 extern bool contains_outer_params(Node *node, void *context);
 extern void checkMotionWithParam(Node *node, Bitmapset *bmsNestParams, PlannerInfo *root);
+extern void checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root);
 #endif   /* CDBMUTATE_H */

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -660,3 +660,95 @@ select count(*) from rcte;
 RESET enable_nestloop;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
+-- issues: https://github.com/greenplum-db/gpdb/issues/16422
+-- Without a reference to CTE in subselect and with a group clause
+CREATE TABLE test_cte (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select a as c1 , max(b) as c2 from test_cte group by c1
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: (test_cte_1.a = test_cte.a)
+         ->  Recursive Union
+               ->  Seq Scan on test_cte test_cte_1
+               ->  Hash Join
+                     Hash Cond: (r.c1 = tmp_table.c1)
+                     ->  WorkTable Scan on r
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Subquery Scan on tmp_table
+                                       ->  HashAggregate
+                                             Group Key: test_cte_2.a
+                                             ->  Seq Scan on test_cte test_cte_2
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on test_cte
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+-- Without a reference to CTE in subselect and with a distinct clause
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select max (distinct a )as c1 ,max (distinct b) as c2 from test_cte
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Hash Join
+         Hash Cond: (test_cte_1.a = test_cte.a)
+         ->  Redistribute Motion 3:3  (slice5; segments: 3)
+               Hash Key: test_cte_1.a
+               ->  Recursive Union
+                     ->  Seq Scan on test_cte test_cte_1
+                     ->  Hash Join
+                           Hash Cond: (r.c1 = tmp_table.c1)
+                           ->  WorkTable Scan on r
+                           ->  Hash
+                                 ->  Broadcast Motion 1:3  (slice4; segments: 1)
+                                       ->  Subquery Scan on tmp_table
+                                             ->  Nested Loop
+                                                   ->  Aggregate
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                               ->  HashAggregate
+                                                                     Group Key: share0_ref1.a
+                                                                     ->  Shared Scan (share slice:id 1:0)
+                                                                           ->  Materialize
+                                                                                 ->  Seq Scan on test_cte test_cte_2
+                                                   ->  Aggregate
+                                                         ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                               ->  HashAggregate
+                                                                     Group Key: share0_ref2.b
+                                                                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                                           Hash Key: share0_ref2.b
+                                                                           ->  HashAggregate
+                                                                                 Group Key: share0_ref2.b
+                                                                                 ->  Shared Scan (share slice:id 2:0)
+         ->  Hash
+               ->  Seq Scan on test_cte
+ Optimizer: Postgres query optimizer
+(33 rows)
+
+Drop TABLE test_cte;

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -945,6 +945,25 @@ SELECT * FROM y;
  a  
 ----
   1
+  5
+  7
+  8
+  9
+  2
+  3
+  4
+  6
+ 10
+(10 rows)
+
+DROP TABLE y;
+-- although there is a distinct or group by in recursive part of cte,
+-- but there is no motion above worktablescan, that is ok.
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x limit 10;
+ n  
+----
+  1
   2
   3
   4
@@ -956,7 +975,29 @@ SELECT * FROM y;
  10
 (10 rows)
 
-DROP TABLE y;
+CREATE TEMPORARY TABLE bar(c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 |  2
+(1 row)
+
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,22::bigint
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+ level | id 
+-------+----
+     1 | 22
+(1 row)
+
 --
 -- error cases
 --
@@ -982,18 +1023,14 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION [ALL] recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
--- GPDB Specific Error Cases
--- Set operations within the recursive term with a self-reference.
--- Currently set operations in the recursive term involving the cte itself must
--- be prevented. The reason for this is that such a query may lead to a plan
--- where there is a motion between the RecursiveUnion node and the
--- WorkTableScan node.
+--- GPDB Specific Error Cases
+--- Set operations within the recursive term with a self-reference.
+--- Such a query may lead to a plan where there is a motion between
+--- the RecursiveUnion node and the WorkTableScan node.
 CREATE TEMPORARY TABLE z(x int primary key);
 WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
-ERROR:  recursive reference to query "x" must not appear within a subquery
-LINE 1: ...SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SE...
-                                                             ^
+	SELECT * FROM x limit 10;
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3763)
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
 CREATE TEMPORARY TABLE u(x int primary key);
@@ -1022,33 +1059,7 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-ERROR:  recursive reference to query "cte" must not appear within a subquery
-LINE 4:  SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, ba...
-                                               ^
--- recursive term with a distinct operation is not allowed
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
-  SELECT * FROM x;
-ERROR:  DISTINCT in a recursive query is not implemented
--- recursive term with a group by operation is not allowed
-CREATE TEMPORARY TABLE bar(c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, c FROM x, bar GROUP BY 1,2)
-  SELECT * FROM x LIMIT 10;
-ERROR:  GROUP BY in a recursive query is not implemented
-LINE 4:  SELECT level+1, c FROM x, bar GROUP BY 1,2)
-                                                ^
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, row_number() over() FROM x, bar)
-  SELECT * FROM x LIMIT 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
-                         ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3763)
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN
@@ -1144,9 +1155,9 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear within a subquery
-LINE 5:        (SELECT i+1 FROM foo WHERE i < 10
-                                ^
+ERROR:  recursive reference to query "foo" must not appear more than once
+LINE 7:        SELECT i+1 FROM foo WHERE i < 5) AS t
+                               ^
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2197,9 +2197,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select (first_value(c) over (partition by b))::int, a+x
-                  ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3764)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2211,6 +2209,4 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select first_value(c) over (partition by b), a+x
-                 ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3764)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2198,9 +2198,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select (first_value(c) over (partition by b))::int, a+x
-                  ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3764)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2212,6 +2210,4 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
-LINE 5:   select first_value(c) over (partition by b), a+x
-                 ^
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:3764)

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -454,3 +454,37 @@ select count(*) from rcte;
 RESET enable_nestloop;
 RESET enable_hashjoin;
 RESET enable_mergejoin;
+
+-- issues: https://github.com/greenplum-db/gpdb/issues/16422
+-- Without a reference to CTE in subselect and with a group clause
+CREATE TABLE test_cte (a int, b int);
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select a as c1 , max(b) as c2 from test_cte group by c1
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+
+-- Without a reference to CTE in subselect and with a distinct clause
+EXPLAIN (costs off)
+WITH RECURSIVE r(c1, c2) as
+(
+  select a as c1, b as c2 from test_cte
+  union all
+  select r.c1, r.c2 from r
+  join
+  (
+    select max (distinct a )as c1 ,max (distinct b) as c2 from test_cte
+  ) as tmp_table
+  on r.c1 = tmp_table.c1
+)
+select * from r join test_cte on r.c1 = a;
+
+Drop TABLE test_cte;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -414,6 +414,24 @@ SELECT * FROM y;
 
 DROP TABLE y;
 
+-- although there is a distinct or group by in recursive part of cte,
+-- but there is no motion above worktablescan, that is ok.
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
+  SELECT * FROM x limit 10;
+
+CREATE TEMPORARY TABLE bar(c int);
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,2
+	UNION ALL
+	SELECT level+1, c FROM x, bar GROUP BY 1,2)
+  SELECT * FROM x LIMIT 10;
+
+WITH RECURSIVE x(level, id) AS (
+	SELECT 1,22::bigint
+	UNION ALL
+	SELECT level+1, row_number() over() FROM x, bar)
+  SELECT * FROM x LIMIT 10;
+
 --
 -- error cases
 --
@@ -432,15 +450,13 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT SELECT n+1 FROM x)
 WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 	SELECT * FROM x;
 
--- GPDB Specific Error Cases
--- Set operations within the recursive term with a self-reference.
--- Currently set operations in the recursive term involving the cte itself must
--- be prevented. The reason for this is that such a query may lead to a plan
--- where there is a motion between the RecursiveUnion node and the
--- WorkTableScan node.
+--- GPDB Specific Error Cases
+--- Set operations within the recursive term with a self-reference.
+--- Such a query may lead to a plan where there is a motion between
+--- the RecursiveUnion node and the WorkTableScan node.
 CREATE TEMPORARY TABLE z(x int primary key);
 WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT * FROM x UNION SELECT * FROM z)foo)
-	SELECT * FROM x;
+	SELECT * FROM x limit 10;
 
 -- Set operation in recursive term that does not have a self-reference
 -- This is supported
@@ -462,24 +478,6 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-
--- recursive term with a distinct operation is not allowed
-WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT distinct(n+1) FROM x)
-  SELECT * FROM x;
-
--- recursive term with a group by operation is not allowed
-CREATE TEMPORARY TABLE bar(c int);
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, c FROM x, bar GROUP BY 1,2)
-  SELECT * FROM x LIMIT 10;
-
-WITH RECURSIVE x(n) AS (
-	SELECT 1,2
-	UNION ALL
-	SELECT level+1, row_number() over() FROM x, bar)
-  SELECT * FROM x LIMIT 10;
 
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);


### PR DESCRIPTION
We can not pass params by a motion,
We may add a motion above worktablescan if the recursive term of a recursive cte
contains group by, distinct or window functions.
So we add commit: https://github.com/greenplum-db/gpdb/commit/3f5cf5c730f in GPDB to process above problems, 
Currently Recursive CTE's do not support the following operations in the recursive term:
    - Group By
    - Window Functions
    - Subqueries with a self-reference
    - Distinct

Sometimes this is over-restricted. Although there is group by or distinct clause in recursive term, 
The slices of workTableScan and RecursiveUnion are still the same. 
In this situation, the SQL should be executed.

Solution:
Revert the commit: https://github.com/greenplum-db/gpdb/commit/3f5cf5c730f to Align with upstream.
Add a walker to check whether there is a motion above workTableScan.

Backport from #16695