### PR TITLE
Fix for gpcheckcat when issue `gpcheckcat -C pg_class`

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1258,7 +1258,7 @@ def checkTableACL(cat):
     try:
         conn = connect2(GV.cfg[GV.coordinator_dbid], utilityMode=False)
         with conn.cursor() as curs:
-            curs = db.execute(qry)
+            curs.execute(qry)
             nrows = curs.rowcount
 
             if nrows == 0:

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -9,6 +9,9 @@ Feature: gpcheckcat tests
         Given database "all_good" is dropped and recreated
         Then the user runs "gpcheckcat -A"
         Then gpcheckcat should return a return code of 0
+        When the user runs "gpcheckcat -C pg_class"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "Execution error:" to stdout
         And the user runs "dropdb all_good"
 
     Scenario: gpcheckcat should drop leaked schemas


### PR DESCRIPTION
This commit is a cherry-pick of community PR [#16809 ](https://github.com/greenplum-db/gpdb/pull/16809)
Changes are approved as part of that PR.

Error occurs when we issue command `gpcheckcat -C pg_class`. Reported error is "[ERROR] executing: Cross consistency check for pg_class\n  Execution error: name 'db' is not defined". This is because of use of an undefined variable 'db'. This commit fixes the issue by removing its usage.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
