### PR TITLE
gpssh with -v will not load gpssh.conf no matther if the file is exist or not

### DIFF
--- a/gpMgmt/bin/gpssh
+++ b/gpMgmt/bin/gpssh
@@ -109,7 +109,7 @@ def parseConfigFile():
 
     try:
         config = configparser.RawConfigParser()
-        config.read(gp.get_coordinator_datadir() + '/gpssh.conf')
+        config.read(get_coordinatordatadir() + '/gpssh.conf')
         if GV.DELAY_BEFORE_SEND is None:
             GV.DELAY_BEFORE_SEND = config.getfloat('gpssh', 'delaybeforesend')
         if GV.PROMPT_VALIDATION_TIMEOUT is None:


### PR DESCRIPTION
## Problem summary

In current release of GPDBv7, if we run `gpssh -v` it will always report warning like below:

``` bash
$ gpssh -v -f ~/all_segment_hosts.txt  -e "uptime"
[WARN] Reference default values as $COORDINATOR_DATA_DIRECTORY/gpssh.conf could not be found
Using delaybeforesend 0.05 and prompt_validation_timeout 1.0
```

it does not matter if the file is exists or not

```
$ cat $COORDINATOR_DATA_DIRECTORY/gpssh.conf  | grep -v "^#" | grep -v "^$"
[gpssh]
delaybeforesend = 0.05
prompt_validation_timeout = 1.0
sync_retries = 3
```

## The root cause

the issue in under below line (line#112) of `$GPHOME/bin/gpssh`

```python
110     try:
111         config = configparser.RawConfigParser()
112         config.read(gp.get_coordinator_datadir() + '/gpssh.conf')
```

Noted that in GPv6 we do not have such issue, seems GPv6 using a different way to get the file:

```python
109     try:
110         config = ConfigParser.RawConfigParser()
111         config.read(os.environ.get('MASTER_DATA_DIRECTORY') + '/gpssh.conf')
```

issue#1: since we import the lib via below code, so when calling the function we do not need add `gp.` in front of the function name

```python
 34 from gppylib.commands.gp import get_coordinatordatadir
```

- since the code is under try, so the error will not shows up. 
- with the code with `gp.`, acturally this line will fail with error `NameError: name 'gp' is not defined`

Issue#2: the function name should be `get_coordinatordatadir` not `get_coordinator_datadir`

- if we try to run the code with `get_coordinator_datadir()`, it will fail with `NameError: name 'get_coordinator_datadir' is not defined`
- from the gp.py lib file we can confirm the same, as below

```python
# cat $GPHOME/lib/python/gppylib/commands/gp.py | grep get_coordinator_datadir | wc -l
0

# cat $GPHOME/lib/python/gppylib/commands/gp.py | grep get_coordinatordatadir
...
def get_coordinatordatadir():
...
```

## The fix

To fix this, seems we just need change this line

- from: `config.read(gp.get_coordinator_datadir() + '/gpssh.conf')`
- to: `config.read(get_coordinatordatadir() + '/gpssh.conf')`

## the text after chaneg the code

```bash
$ gpssh -v -f ~/all_segment_hosts.txt  -e "uptime"
Using delaybeforesend 0.05 and prompt_validation_timeout 1.0

[Reset ...]
[INFO] login sdw1
[sdw1] uptime
[sdw1] 14:42:45 up  4:18,  4 users,  load average: 0.00, 0.00, 0.00
[INFO] completed successfully

[Cleanup...]

$ diff ./gpMgmt/bin/gpssh /data/gpssh
112c112
<         config.read(get_coordinatordatadir() + '/gpssh.conf')
---
>         config.read(gp.get_coordinator_datadir() + '/gpssh.conf')
```

