### PR TITLE
[6X][backport] updated max range value in help file for gpexpand -n option

### DIFF
--- a/gpMgmt/doc/gpexpand_help
+++ b/gpMgmt/doc/gpexpand_help
@@ -139,7 +139,7 @@ OPTIONS
 
 -n <parallel_processes>
  The number of tables to redistribute simultaneously. Valid values 
- are 1 - 16. Each table redistribution process requires two database 
+ are 1 - 96. Each table redistribution process requires two database
  connections: one to alter the table, and another to update the table's 
  status in the expansion schema. Before increasing -n, check the current 
  value of the server configuration parameter max_connections and make 


### PR DESCRIPTION
Issue: gpexpand --help was showing wrong for -n option

-n <parallel_processes>
 The number of tables to redistribute simultaneously. Valid values
 are 1 - 16. Each table redistribution process requires two database
 connections: one to alter the table, and another to update the table's
 status in the expansion schema. Before increasing -n, check the current
 value of the server configuration parameter max_connections and make
 sure the maximum connection limit is not exceeded.
instead of 1 - 16 it should be 1 - 96 as per the code MAX_PARALLEL_EXPANDS = 96

Fix: updated max range value in help file.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
