### PR TITLE
gpexpand fails on calculation table sizes

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1170,7 +1170,7 @@ class gpexpand:
         if len(contentIds_with_running_basebackup) > 0:
             raise Exception(
                 "Found pg_basebackup running for segments with contentIds %s" % contentIds_with_running_basebackup)
-        
+
         for seg in inputFileEntryList:
             self.gparray.addExpansionSeg(content=int(seg.contentId)
                                          , preferred_role=seg.role
@@ -1384,7 +1384,7 @@ class gpexpand:
         dbconn.execSQL(self.conn, "CHECKPOINT")
         self.conn.close()
 
-        # increase expand version 
+        # increase expand version
         self.conn = dbconn.connect(self.dburl, utility=True, encoding='UTF8')
         dbconn.execSQL(self.conn, "select gp_expand_bump_version()")
         self.conn.close()
@@ -1781,7 +1781,7 @@ class gpexpand:
             FROM
                 pg_class c
                 JOIN pg_inherits a on (a.inhrelid = c.oid)
-                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.schemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
+                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.partitionschemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
                 JOIN pg_class d on (a.inhparent = d.oid)
                 JOIN pg_namespace n on (c.relnamespace = n.oid)
                 LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)


### PR DESCRIPTION
`gpexpand` fails with error like
```
[ERROR]:-gpexpand failed: error 'ERROR:  relation "archive.sat_lnk_loan_exposure_management_1_prt_outlying_dates" does not exist  (entry db 172.16.0.77:5432 pid=1480168)
' in 'COPY (with table_size_cte(table_oid, size) as
        (
           select table_oid, sum(size)
           from (
             select oid as table_oid,
                    pg_relation_size(oid) as size
             from gp_dist_random('pg_class')
             where oid >= 16384 and relstorage <> 'x'
           ) x(table_oid, size)
           group by table_oid
        )
        
        select
          s1.dbname,
          s1.fq_name,
          s1.table_oid,
          s1.root_partition_oid,
          s1.rank,
          s1.external_writable,
          s1.undone_status,
          s1.expansion_started,
          s1.expansion_finished,
          coalesce(table_size_cte.size, 0) as source_bytes,
          s1.rel_storage as rel_storage
        from (
             SELECT
                current_database() as dbname,
                quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
                c.oid as table_oid,
                d.oid as root_partition_oid,
                2 as rank,
                pe.writable is not null as external_writable,
                'NOT STARTED' as undone_status,
                NULL as expansion_started,
                NULL as expansion_finished,
                0 as source_bytes,
                c.relstorage as rel_storage
            FROM
                pg_class c
                JOIN pg_inherits a on (a.inhrelid = c.oid)
                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.schemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
                JOIN pg_class d on (a.inhparent = d.oid)
                JOIN pg_namespace n on (c.relnamespace = n.oid)
                LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)
            where
                c.relhassubclass = false
        )s1 left join table_size_cte
        on s1.table_oid = table_size_cte.table_oid
        ) TO '/var/lib/greenplum/status_detail.dat'' 
```

if table has partitions in different schemas like this
```
dwh=# \d+ archive.sat_lnk_loan_exposure_management
                                                    Append-Only Columnar Table "archive.sat_lnk_loan_exposure_management"
                Column                 |            Type             | Modifiers | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description
---------------------------------------+-----------------------------+-----------+----------+--------------+------------------+-------------------+------------+-------------
 lnk_loan_exposure_management_hash_key | character(32)               | not null  | extended |              | zlib             | 6                 | 32768      |
 load_date                             | timestamp without time zone | not null  | plain    |              | zlib             | 6                 | 32768      |
 record_source                         | character varying(255)      | not null  | extended |              | zlib             | 6                 | 32768      |
 loan_exposure_management_key          | integer                     |           | plain    |              | zlib             | 6                 | 32768      |
 loan_key                              | integer                     |           | plain    |              | zlib             | 6                 | 32768      |
 transaction_date                      | timestamp without time zone |           | plain    |              | zlib             | 6                 | 32768      |
 principal_current                     | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 principal_overdue                     | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 interest_current                      | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 interest_overdue                      | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 penalties_fixed_total                 | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 penalties_var_total                   | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 interest_after_end_date               | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 total_due_after_transaction           | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 next_billing_due                      | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 dpd_counter                           | integer                     |           | plain    |              | zlib             | 6                 | 32768      |
 dpd_counter_no_penalties              | integer                     |           | plain    |              | zlib             | 6                 | 32768      |
 sum_allocated                         | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 money_allocated                       | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 respite_allocated                     | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 return_allocated                      | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 created                               | timestamp without time zone |           | plain    |              | zlib             | 6                 | 32768      |
 modified                              | timestamp without time zone |           | plain    |              | zlib             | 6                 | 32768      |
 close_dt                              | timestamp without time zone |           | plain    |              | zlib             | 6                 | 32768      |
 all_payment_amt                       | numeric(8,2)                |           | main     |              | zlib             | 6                 | 32768      |
 created_by                            | character varying(256)      |           | extended |              | zlib             | 6                 | 32768      |
 modified_by                           | character varying(256)      |           | extended |              | zlib             | 6                 | 32768      |
Checksum: t
Child tables: abs_1c_dv.sat_lnk_loan_exposure_management_1_prt_outlying_dates,   # <==  PROBLEM
              archive.sat_lnk_loan_exposure_management_1_prt_10,
              archive.sat_lnk_loan_exposure_management_1_prt_100,
              archive.sat_lnk_loan_exposure_management_1_prt_101,
              archive.sat_lnk_loan_exposure_management_1_prt_102,
              archive.sat_lnk_loan_exposure_management_1_prt_103,
              archive.sat_lnk_loan_exposure_management_1_prt_104,
              archive.sat_lnk_loan_exposure_management_1_prt_105,
              archive.sat_lnk_loan_exposure_management_1_prt_106,
              archive.sat_lnk_loan_exposure_management_1_prt_107,
              archive.sat_lnk_loan_exposure_management_1_prt_108,
              archive.sat_lnk_loan_exposure_management_1_prt_109,
              archive.sat_lnk_loan_exposure_management_1_prt_11,
              archive.sat_lnk_loan_exposure_management_1_prt_110,
              archive.sat_lnk_loan_exposure_management_1_prt_111,
              archive.sat_lnk_loan_exposure_management_1_prt_112,
```