### PR TITLE
Fix regex mistake on regress test case

### DIFF
--- a/src/test/regress/expected/quicklz_fallback.out
+++ b/src/test/regress/expected/quicklz_fallback.out
@@ -10,7 +10,7 @@
 -- s/zstd/VALID/g
 -- m/zlib/
 -- s/zlib/VALID/g
--- m/none
+-- m/none/
 -- s/none/VALID/g
 -- end_matchsubs
 -- Ensure statements correctly ERROR when gp_quicklz_fallback=false.

--- a/src/test/regress/sql/quicklz_fallback.sql
+++ b/src/test/regress/sql/quicklz_fallback.sql
@@ -12,7 +12,7 @@
 -- s/zstd/VALID/g
 -- m/zlib/
 -- s/zlib/VALID/g
--- m/none
+-- m/none/
 -- s/none/VALID/g
 -- end_matchsubs
 


### PR DESCRIPTION
a spelling mistake which cause error message like
```
test quicklz_fallback             ... Having no space between pattern and following word is deprecated at (eval 74) line 3, <$infh> line 15.
Bareword found where operator expected at (eval 74) line 3, near "m/none) { 
$ini =~  s/none"
  (Might be a runaway multi-line // string starting on line 2)
Having no space between pattern and following word is deprecated at (eval 77) line 3, <$infh> line 15.
Bareword found where operator expected at (eval 77) line 3, near "m/none) { 
$ini =~  s/none"
  (Might be a runaway multi-line // string starting on line 2)
ok          549 ms (diff   72 ms)
``