### PR TITLE
fix compile warning

### DIFF
--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -61,8 +61,8 @@ cdbpath_motion_for_join(PlannerInfo    *root,
 extern bool cdbpath_contains_wts(Path *path);
 extern Path * turn_volatile_seggen_to_singleqe(PlannerInfo *root, Path *path, Node *node);
 
-extern void set_allow_append_initplan_for_function_scan();
-extern void unset_allow_append_initplan_for_function_scan();
-extern bool get_allow_append_initplan_for_function_scan();
+extern void set_allow_append_initplan_for_function_scan(void);
+extern void unset_allow_append_initplan_for_function_scan(void);
+extern bool get_allow_append_initplan_for_function_scan(void);
 
 #endif   /* CDBPATH_H */


### PR DESCRIPTION
As the title said, just fix the compile warning:

```
cdbpath.c:2686:1: warning: no previous prototype for 'unset_allow_append_initplan_for_function_scan' [-Wmissing-prototypes]
 2686 | unset_allow_append_initplan_for_function_scan()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cdbpath.c:2692:1: warning: no previous prototype for 'set_allow_append_initplan_for_function_scan' [-Wmissing-prototypes]
 2692 | set_allow_append_initplan_for_function_scan()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cdbpath.c:2698:1: warning: no previous prototype for 'get_allow_append_initplan_for_function_scan' [-Wmissing-prototypes]
 2698 | get_allow_append_initplan_for_function_scan()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Greenplum Database installation complete.
```

Sorry for not noticing it, will check it more carefully next time.
