### PR TITLE
Consider MPP FDW LIMIT pushdown when both offset and limit clause are specified

### DIFF
--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -937,8 +937,7 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
   3 |  3
 (3 rows)
 
--- Simple query with OFFSET and LIMIT clause together is NOT pushed down.
--- Because it's unsafe to do offset and limit in multiple remote servers.
+-- Simple query with OFFSET and LIMIT clause together is pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
                                           QUERY PLAN                                           
@@ -948,12 +947,10 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
    ->  Gather Motion 2:1  (slice1; segments: 2)
          Output: c1, c2
          Merge Key: c1
-         ->  Limit
+         ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               ->  Foreign Scan on public.mpp_ft2
-                     Output: c1, c2
-                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres query optimizer
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (2::bigint + 3::bigint)
+ Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (12 rows)
 
@@ -964,6 +961,30 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
   4 |  4
   5 |  5
 (3 rows)
+
+-- Simple query with only OFFSET clause is NOT pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
+  c1  | c2 
+------+----
+  999 |  9
+ 1000 |  0
+(2 rows)
 
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -1,9 +1,4 @@
 -- This file is used to test the feature that there are multiple remote postgres servers.
---
--- start_matchsubs
--- m/\(cost=.*\)/
--- s/\(cost=.*\)//
--- end_matchsubs
 -- ===================================================================
 -- create FDW objects
 -- ===================================================================
@@ -122,10 +117,10 @@ ALTER FOREIGN TABLE mpp_ft1 OPTIONS (add use_remote_estimate 'true');
 EXPLAIN VERBOSE SELECT * FROM mpp_ft1 ORDER BY c1;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=102.22..102.74 rows=20 width=8)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=101.11..101.37 rows=10 width=8)
    Output: c1, c2
    Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft1  (cost=102.22..102.44 rows=10 width=8)
+   ->  Foreign Scan on public.mpp_ft1  (cost=101.11..101.22 rows=5 width=8)
          Output: c1, c2
          Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 1" ORDER BY c1 ASC NULLS LAST
  Optimizer: Postgres query optimizer
@@ -913,19 +908,19 @@ ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
 -- Queries with LIMIT/OFFSET clauses
 -- ===================================================================
 -- Simple query with LIMIT clause is pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Limit
+ Limit  (cost=100.00..100.10 rows=3 width=8)
    Output: c1, c2
-   ->  Gather Motion 2:1  (slice1; segments: 2)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=100.00..100.19 rows=6 width=8)
          Output: c1, c2
          Merge Key: c1
-         ->  Foreign Scan on public.mpp_ft2
+         ->  Foreign Scan on public.mpp_ft2  (cost=100.00..100.10 rows=3 width=8)
                Output: c1, c2
                Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 3::bigint
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
 
@@ -938,21 +933,21 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
 (3 rows)
 
 -- Simple query with OFFSET and LIMIT clause together is pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Limit
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=100.06..100.16 rows=3 width=8)
    Output: c1, c2
-   ->  Gather Motion 2:1  (slice1; segments: 2)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=100.00..100.32 rows=10 width=8)
          Output: c1, c2
          Merge Key: c1
-         ->  Foreign Scan on public.mpp_ft2
+         ->  Foreign Scan on public.mpp_ft2  (cost=100.00..100.17 rows=5 width=8)
                Output: c1, c2
                Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (2::bigint + 3::bigint)
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
-(12 rows)
+(10 rows)
 
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
  c1 | c2 
@@ -963,16 +958,16 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
 (3 rows)
 
 -- Simple query with only OFFSET clause is NOT pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Limit
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit  (cost=132.62..2421.00 rows=70002 width=8)
    Output: c1, c2
-   ->  Gather Motion 2:1  (slice1; segments: 2)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=100.00..2421.00 rows=71000 width=8)
          Output: c1, c2
          Merge Key: c1
-         ->  Foreign Scan on public.mpp_ft2
+         ->  Foreign Scan on public.mpp_ft2  (cost=100.00..1356.00 rows=35500 width=8)
                Output: c1, c2
                Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
  Optimizer: Postgres-based planner

--- a/contrib/postgres_fdw/postgres_clean.bash
+++ b/contrib/postgres_fdw/postgres_clean.bash
@@ -2,8 +2,8 @@
 if [ -d "testdata/pgdata" ] && [ -d "testdata/pgsql" ] ; then
 	pgbin="testdata/pgsql"
 	${pgbin}/bin/pg_ctl -D testdata/pgdata  stop || true
-	${pgbin}/bin/pg_ctl -D testdara/pgdata2 -o "-p 5555"  stop || true
+	${pgbin}/bin/pg_ctl -D testdata/pgdata2 -o "-p 5555"  stop || true
 	rm -rf testdata/pgdata
-	rm -rf testdara/pgdata2
+	rm -rf testdata/pgdata2
 fi
 rm -rf testdata/pglog

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -6765,12 +6765,6 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
 		return;
 
 	/*
-	 * It's unsafe to pushdown OFFSET/LIMIT when mpp_execute = 'all segments' and the OFFSET is specified.
-	 */
-	if (final_rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS && parse->limitOffset)
-		return;
-
-	/*
 	 * Also, the LIMIT/OFFSET cannot be pushed down, if their expressions are
 	 * not safe to remote.
 	 */

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -6784,6 +6784,29 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	fpextra->count_est = extra->count_est;
 	fpextra->offset_est = extra->offset_est;
 
+	/* If mpp_execute = 'all segments', we need to adjust origin count_est and offset_est. */
+	if (final_rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS && fpextra->offset_est > 0)
+	{
+		if (fpextra->count_est > 0)
+		{
+			/*
+			 * When both OFFSET and LIMIT clause are specified,
+			 * we need to fetch tuples from 0 to limitOffset + limitCount from remote servers.
+			 */
+			fpextra->count_est += fpextra->offset_est;
+		}
+		else
+		{
+			/*
+			 * When only OFFSET clasue is specified,
+			 * we need to fetch all tuples from remote servers.
+			 */
+			fpextra->count_est = 0;
+		}
+
+		fpextra->offset_est = 0;
+	}
+
 	/*
 	 * Estimate the costs of performing the final sort and the LIMIT
 	 * restriction remotely.  If has_final_sort is false, we wouldn't need to

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -231,11 +231,14 @@ ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
--- Simple query with OFFSET and LIMIT clause together is NOT pushed down.
--- Because it's unsafe to do offset and limit in multiple remote servers.
+-- Simple query with OFFSET and LIMIT clause together is pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
+-- Simple query with only OFFSET clause is NOT pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -1,10 +1,4 @@
 -- This file is used to test the feature that there are multiple remote postgres servers.
---
--- start_matchsubs
--- m/\(cost=.*\)/
--- s/\(cost=.*\)//
--- end_matchsubs
-
 -- ===================================================================
 -- create FDW objects
 -- ===================================================================
@@ -228,15 +222,15 @@ ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
 -- Queries with LIMIT/OFFSET clauses
 -- ===================================================================
 -- Simple query with LIMIT clause is pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3;
 -- Simple query with OFFSET and LIMIT clause together is pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
 -- Simple query with only OFFSET clause is NOT pushed down.
-EXPLAIN (VERBOSE, COSTS OFF)
+EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 -- Query with aggregates and limit clause together is NOT pushed down.


### PR DESCRIPTION
### What this PR does
Before this PR, GPDB won't push OFFSET/LIMIT in the remote servers for MPP FDW when both offset and limit clause are specified.
Because it's **unsafe** if we don't adjust `Remote SQL`.

In this PR, we consider MPP FDW OFFSET/LIMIT pushdown when both OFFSET and LIMIT clause are specified.
We will adjust `Remote SQL` when `mpp_execute = 'all segments'` for query including OFFSET/LIMIT clause.

### Implementation Details
There are 3 cases for query including OFFSET/LIMIT clause.

**Case 1: only LIMIT is specified**
Two-phase LIMIT plan is enough and there is NO need to adjust `Remote SQL`.
This case had been supported. (Look at PR https://github.com/greenplum-db/gpdb/pull/16177 for more information.)
   
**Case 2: both LIMIT and OFFSET are specified**
We also need to adjust `Remote SQL` to let GPDB fetch tuples from 0 to limitOffset + limitCount from remote servers.
```
-- Simple query with OFFSET and LIMIT clause together is pushed down.
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
                                          QUERY PLAN                                           
-----------------------------------------------------------------------------------------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (2::bigint + 3::bigint)
 Optimizer: Postgres-based planner
 ```
   

**Case 3: only OFFSET is specified**
   In this case, we also need to adjust `Remote SQL` to let GPDB fetch all tuples of foreign table from remote servers.
```
-- Simple query with only OFFSET clause is NOT pushed down.
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
                                       QUERY PLAN                                        
-----------------------------------------------------------------------------------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
 Optimizer: Postgres-based planner
 ```

**Pipeline**: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-improve_mpp_offset_limit_pushdown-rocky8?group=all
