### PR TITLE
Added support to include datadir in gpsegconf_dump file

### DIFF
--- a/src/backend/cdb/dispatcher/test/gpsegconfig_dump
+++ b/src/backend/cdb/dispatcher/test/gpsegconfig_dump
@@ -1,4 +1,4 @@
-1 -1 p p n u 6000 localhost localhost
-2 0 p p n u 6002 localhost localhost
-3 1 p p n u 6003 localhost localhost
-4 2 p p n u 6004 localhost localhost
+1 -1 p p n u 6000 localhost localhost /data/temp1
+2 0 p p n u 6002 localhost localhost /data/temp2
+3 1 p p n u 6003 localhost localhost /data/temp3
+4 2 p p n u 6004 localhost localhost /data/temp4


### PR DESCRIPTION
fts process dumps gpsegconfig_dump file in coordinator datadir. in the current dump it does not include datadir from gp_segment_configuration. 

In this commit added support to include datadir in segment configuration dump.

following functions updated
 writeGpSegConfigToFTSFiles()
 readGpSegConfigFromFTSFiles()
 
 Location:  $COORDINATOR_DATA_DIRECTORY/gpsegconfig_dump

 sample output of gpsegconfig_dump file (before change) 
```
 1 -1 p p n u 7000 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
2 0 p p s u 7002 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
5 0 m m s u 7005 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
3 1 p p s u 7003 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
6 1 m m s u 7006 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
4 2 p p s u 7004 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com 
7 2 m m s u 7007 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com
```
The output of gpsegconfig_dump file (after change) 

```
1 -1 p p n u 7000 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
2 0 p p s u 7002 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
5 0 m m s u 7005 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
3 1 p p s u 7003 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
6 1 m m s u 7006 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
4 2 p p s u 7004 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
7 2 m m s u 7007 shrakeshSMD6M.vmware.com shrakeshSMD6M.vmware.com /Users/shrakesh/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2 
```

Test: 
Updated gpsegconfig_dump test file and added dummy datadir.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
