### PR TITLE
[6X] pg_dump: Ignore indexes of tables not to be dumped

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5442,6 +5442,10 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 		if (!tbinfo->hasindex)
 			continue;
 
+		/* Ignore indexes of tables not to be dumped */
+		if (!tbinfo->dobj.dump)
+			continue;
+
 		/*
 		 * We can ignore indexes of uninteresting tables.
 		 */


### PR DESCRIPTION
### Wrong behavior:
`pg_dump -t` an inherits child table will dump its parent table's index.
``` SQL
$ pg_dump --gp-syntax -h cdw -p 5432 -U gpadmin -s -t '"public"."capitals"' 'testdb_gpcopy_ginkgo1'

-- .....skip sth.......
CREATE TABLE public.capitals (
    state character(2)
)
INHERITS (public.cities)
;
-- .....skip sth.......
CREATE INDEX cities_id_idx ON public.cities USING btree (id); -- pay attention, should not to be dumped
-- .....skip sth.......
```
Only 6X has this bug.
Related issue https://github.com/greenplum-db/gpdb/issues/16926

### RCA

The behavior of func `getIndexes()` changes at this https://github.com/greenplum-db/gpdb/commit/4428ef34782ec9dc4bc96e07d3d7dd102adb42f7 
When we refactored it, miss these code
```
/* Ignore indexes of tables not to be dumped */
if (!tbinfo->dobj.dump)
    continue;
```

### Solutions
Keep the same behavior with PG9.4, ignore the indexes of tables not to be dumped.
Related code in PG9.4: https://github.com/postgres/postgres/blob/REL9_4_STABLE/src/bin/pg_dump/pg_dump.c#L5190-L5192



_**CI pipeline**_: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-hyt-rocky8-inherit (green)
