### PR TITLE
change the default char to signed char to fix 15206 and 15207

### DIFF
--- a/configure
+++ b/configure
@@ -22164,6 +22164,8 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+# force set char to signed char
+CFLAGS="-fsigned-char $CFLAGS"
 
 # Begin output steps
 

--- a/configure.in
+++ b/configure.in
@@ -2873,6 +2873,8 @@ tr '.' '	' |
 $AWK '{printf "%d%02d%02d", $1, $2, (NF >= 3) ? $3 : 0}'`"]
 AC_DEFINE_UNQUOTED(GP_VERSION_NUM, $GP_VERSION_NUM, [Greenplum version as a number])
 
+# force set char to signed char
+CFLAGS="-fsigned-char $CFLAGS"
 
 # Begin output steps
 

--- a/gpcontrib/gp_sparse_vector/Makefile
+++ b/gpcontrib/gp_sparse_vector/Makefile
@@ -3,8 +3,6 @@ ifeq "$(CC)" "icc"
 	USE_ICC = 1
 endif
 
-override CFLAGS+=-std=gnu99
-
 MODULE_big = gp_svec
 EXTENSION = gp_sparse_vector
 DATA = gp_sparse_vector--1.0.1.sql gp_sparse_vector--1.0.0--1.0.1.sql
@@ -21,6 +19,8 @@ else
 	include $(top_builddir)/src/Makefile.global
 	include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+override CFLAGS+=-std=gnu99
 
 ifdef USE_ICC
 	override CFLAGS=-O3 -Werror -std=c99 -vec-report2 -vec-threshold0

--- a/gpcontrib/gp_sparse_vector/SparseData.h
+++ b/gpcontrib/gp_sparse_vector/SparseData.h
@@ -252,7 +252,7 @@ static inline int64 compword_to_int8(const char *entry)
 	char *numptr2 = (char *)(&num_2);
 	int32_t num_4;
 	char *numptr4 = (char *)(&num_4);
-	int64 num;
+	int64 num = 0;
 	char *numptr8 = (char *)(&num);
 
 	switch(size) {
@@ -284,6 +284,13 @@ static inline int64 compword_to_int8(const char *entry)
 			numptr8[6] = entry[7];
 			numptr8[7] = entry[8];
 			break;
+
+		default:
+		{
+			ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("compword_to_int8 get a error size %d", size)));
+		}
 	}
 
 	return num;
@@ -759,7 +766,8 @@ static inline SparseData op_sdata_by_sdata(int operation,SparseData left,
 		}
 		tot_run_length += (nextpos-lastpos);
 //		printf("New_value,runlength = %f,%d\n",new_value,nextpos-lastpos);
-		if ((left_nxt==right_nxt)&&(left_nxt==(left->total_value_count))) {
+		if ((left_nxt>=(left->total_value_count)) &&
+			(right_nxt>=(right->total_value_count))) {
 //			printf("STOPPING: i,j,left_nxt,right_nxt,nextpos=%d,%d,%d,%d,%d\n",i,j,nextpos,left_nxt,right_nxt);
 			break;
 		} else if (left_nxt==right_nxt) {


### PR DESCRIPTION
    gp_sparse_vector relies on char being a signed number, while char is
    unsigned by default on ARM platform, which makes *((char *)(ptr)) in
    int8compstoragesize impossible to be negative.  This results in an
    error where int8compstoragesize is used, resulting in compword_to_int8
    size is not 0, 1, 3, 5, 9 as specified in the case, thus returning a
    num, but num is not initialized, so it may be random. The subsequent
    execution logic is faulty.

    There are three main parts to this fix:
    1.  Specify the type of char as the desired signed type via the gcc argument -fsign-char argument
    2.  Preventative error reporting when the wrong size is obtained
    3.  Modify the exit conditions in op_sdata_by_sdata that may cause an endless loop