### PR TITLE
Update the output file of pg_buffercache

### DIFF
--- a/contrib/pg_buffercache/expected/pg_buffercache.out
+++ b/contrib/pg_buffercache/expected/pg_buffercache.out
@@ -21,6 +21,7 @@ FROM gp_buffercache;
 
 -- Check that the functions / views can't be accessed by default.
 CREATE ROLE buffercache_test;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE buffercache_test;
 SELECT * FROM pg_buffercache;
 ERROR:  permission denied for relation pg_buffercache


### PR DESCRIPTION
Missed a resource queue notice.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-pg_buf_out_6x-rocky8
