### PR TITLE
[6X] pg_dump should addDistributedBy if it is a child table

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13847,7 +13847,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		/*
 		 * Dump distributed by clause.
 		 */
-		if (dumpPolicy && tbinfo->relkind != RELKIND_FOREIGN_TABLE && !tbinfo->parents)
+		if (dumpPolicy && tbinfo->relkind != RELKIND_FOREIGN_TABLE)
 			addDistributedBy(fout, q, tbinfo, actual_atts);
 
 		/*


### PR DESCRIPTION
### Wrong behavior:
`pg_dump -t` an inherits child table will miss `distributed by`.
```SQL
$ pg_dump -h 127.0.0.1 -p 15432 -U gpadmin -s -t '"public"."capitalsxxxxx"' 'gpadmin' 
-- ,,,,,,,,,skip sth,,,,,,,,
CREATE TABLE public.capitalsxxxxx (
    state character(2) NOT NULL
)
INHERITS (public.cities) -- pay attention, `distributed by` disappeared
;

-- ,,,,,,,,,skip sth,,,,,,,,

```
Only 6X has this bug.
Related issue https://github.com/greenplum-db/gpdb/issues/16933

### RCA

The behavior changes at this commit https://github.com/greenplum-db/gpdb/commit/cef5b96ea89f532929ee92b994d283d7ef3817d1#diff-36e3806266f5e832b422f878e1d7fef4ebeea2143b1733ea3fa2f90a99bad5c5L14472-L14479
miss these code `&& !tbinfo->parents` when pg_dump judges whether it should `Dump distributed by clause` or not.

### Solutions

Keep the same behavior to 5X and 7X, add the judgement condition `&& !tbinfo->parents`
Related code in 5X: https://github.com/greenplum-db/gpdb/blob/5X_STABLE/src/bin/pg_dump/pg_dump.c#L10073-L10074 
Related code in 7X: https://github.com/greenplum-db/gpdb/blob/main/src/bin/pg_dump/pg_dump.c#L17116-L17117

**_CI pipeline_**:  https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-hyt-rocky8-dist-bt (green)
