### PR TITLE
Fix FTSReplicationStatusLock LWlock already held PANIC

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -138,7 +138,8 @@ FTSReplicationStatusCreateIfNotExist(const char *app_name)
 		return;
 	}
 
-	/* No need to release LWLock before fatal since abort will release it */
+	LWLockRelease(FTSReplicationStatusLock);
+
 	ereport(FATAL,
 			(errcode(ERRCODE_TOO_MANY_CONNECTIONS),
 				errmsg("number of requested standby connections "


### PR DESCRIPTION
When we got `FATAL` in `FTSReplicationStatusCreateIfNotExist`, the afterwards elog process phase will call `WalSndKill` in shem_exit, which will finally evoke`FTSReplicationStatusMarkDisconnectForReplication`, and will grab the `FTSReplicationStatusLock` LWLock again.

A typical call chain is:
```
        FTSReplicationStatusCreateIfNotExist
          errfinish
            proc_exit
            ...
              WalSndKill
                FTSReplicationStatusMarkDisconnectForReplication
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
