### PR TITLE
[ORCA] Fix CDynamicPtrArray sort/compare that contains large objects

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
@@ -130,6 +130,24 @@ public:
 
 	IOstream &OsPrint(IOstream &os) const;
 
+	BOOL
+	operator==(const CColumnDescriptor &other) const
+	{
+		if (this == &other)
+		{
+			// same object reference
+			return true;
+		}
+
+		return Name().Equals(other.Name()) &&
+			   RetrieveType()->MDId()->Equals(other.RetrieveType()->MDId()) &&
+			   TypeModifier() == other.TypeModifier() &&
+			   AttrNum() == other.AttrNum() &&
+			   IsNullable() == other.IsNullable() &&
+			   IsSystemColumn() == other.IsSystemColumn() &&
+			   Width() == other.Width() && IsDistCol() == other.IsDistCol();
+	}
+
 };	// class CColumnDescriptor
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -614,6 +614,24 @@ public:
 	void DbgPrintWithProperties();
 #endif
 
+	// Compare function used by CDynamicPtrArray::Sort
+	static INT
+	Compare(const void *left, const void *right)
+	{
+		if ((*((CGroup **) left))->Id() < (*((CGroup **) right))->Id())
+		{
+			return -1;
+		}
+		else if ((*((CGroup **) left))->Id() > ((*(CGroup **) right))->Id())
+		{
+			return 1;
+		}
+
+		GPOS_ASSERT((*((CGroup **) left))->Id() ==
+					((*(CGroup **) right))->Id());
+		return 0;
+	}
+
 };	// class CGroup
 
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -71,9 +71,9 @@ CGroupExpression::CGroupExpression(CMemoryPool *mp, COperator *pop,
 	{
 		m_pdrgpgroupSorted = GPOS_NEW(mp) CGroupArray(mp, pdrgpgroup->Size());
 		m_pdrgpgroupSorted->AppendArray(pdrgpgroup);
-		m_pdrgpgroupSorted->Sort();
+		m_pdrgpgroupSorted->Sort(CGroup::Compare);
 
-		GPOS_ASSERT(m_pdrgpgroupSorted->IsSorted());
+		GPOS_ASSERT(m_pdrgpgroupSorted->IsSorted(CGroup::Compare));
 	}
 
 	m_ppartialplancostmap = GPOS_NEW(mp) PartialPlanToCostMap(mp);

--- a/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
@@ -254,10 +254,22 @@ public:
 
 		for (ULONG i = 0; i < m_size && is_equal; i++)
 		{
-			is_equal = (m_elems[i] == arr->m_elems[i]);
+			is_equal = (*m_elems[i] == *arr->m_elems[i]);
 		}
 
 		return is_equal;
+	}
+
+	BOOL
+	operator==(const CDynamicPtrArray<T, CleanupFn> &other)
+	{
+		if (this == &other)
+		{
+			// same object reference
+			return true;
+		}
+
+		return Equals(&other);
 	}
 
 	// lookup object

--- a/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDynamicPtrArray.h
@@ -57,6 +57,14 @@ CleanupRelease(T *elem)
 	(dynamic_cast<CRefCount *>(elem))->Release();
 }
 
+// Compare function used by CDynamicPtrArray::Sort
+inline INT
+CompareUlongPtr(const void *right, const void *left)
+{
+	return *((ULONG *) right) - *((ULONG *) left);
+}
+
+
 // commonly used array types
 
 // arrays of unsigned integers
@@ -102,26 +110,6 @@ private:
 
 	// actual array
 	T **m_elems;
-
-	// comparison function for pointers
-	static INT
-	PtrCmp(const void *p1, const void *p2)
-	{
-		ULONG_PTR ulp1 = *(ULONG_PTR *) p1;
-		ULONG_PTR ulp2 = *(ULONG_PTR *) p2;
-
-		if (ulp1 < ulp2)
-		{
-			return -1;
-		}
-
-		if (ulp1 > ulp2)
-		{
-			return 1;
-		}
-
-		return 0;
-	}
 
 	// resize function
 	void
@@ -241,7 +229,7 @@ public:
 
 	// sort array
 	void
-	Sort(CompareFn compare_func = PtrCmp)
+	Sort(CompareFn compare_func)
 	{
 		clib::Qsort(m_elems, m_size, sizeof(T *), compare_func);
 	}
@@ -309,7 +297,7 @@ public:
 #ifdef GPOS_DEBUG
 	// check if array is sorted
 	BOOL
-	IsSorted(CompareFn compare_func = PtrCmp) const
+	IsSorted(CompareFn compare_func) const
 	{
 		for (ULONG i = 1; i < m_size; i++)
 		{

--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringBase.h
@@ -98,6 +98,14 @@ public:
 
 	// count how many times the character appears in string
 	ULONG CountOccurrencesOf(const WCHAR wc) const;
+
+	static INT
+	Compare(const void *left, const void *right)
+	{
+		CWStringBase *leftstr = *(CWStringBase **) left;
+		CWStringBase *rightstr = *(CWStringBase **) right;
+		return wcscmp(leftstr->GetBuffer(), rightstr->GetBuffer());
+	}
 };
 
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CDynamicPtrArrayTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CDynamicPtrArrayTest.h
@@ -34,6 +34,7 @@ public:
 	static GPOS_RESULT EresUnittest_ArrayAppendExactFit();
 	static GPOS_RESULT EresUnittest_PdrgpulSubsequenceIndexes();
 	static GPOS_RESULT EresUnittest_Equals();
+	static GPOS_RESULT EresUnittest_Sort();
 
 	// destructor function for char's
 	static void DestroyChar(char *);

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CDynamicPtrArrayTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CDynamicPtrArrayTest.h
@@ -33,6 +33,7 @@ public:
 	static GPOS_RESULT EresUnittest_ArrayAppend();
 	static GPOS_RESULT EresUnittest_ArrayAppendExactFit();
 	static GPOS_RESULT EresUnittest_PdrgpulSubsequenceIndexes();
+	static GPOS_RESULT EresUnittest_Equals();
 
 	// destructor function for char's
 	static void DestroyChar(char *);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
@@ -11,9 +11,12 @@
 
 #include "unittest/gpos/common/CDynamicPtrArrayTest.h"
 
+#include <string.h>
+
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/memory/CAutoMemoryPool.h"
+#include "gpos/string/CWStringConst.h"
 #include "gpos/test/CUnittest.h"
 
 using namespace gpos;
@@ -37,6 +40,7 @@ CDynamicPtrArrayTest::EresUnittest()
 			CDynamicPtrArrayTest::EresUnittest_ArrayAppendExactFit),
 		GPOS_UNITTEST_FUNC(
 			CDynamicPtrArrayTest::EresUnittest_PdrgpulSubsequenceIndexes),
+		GPOS_UNITTEST_FUNC(CDynamicPtrArrayTest::EresUnittest_Equals),
 	};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
@@ -349,4 +353,44 @@ CDynamicPtrArrayTest::EresUnittest_PdrgpulSubsequenceIndexes()
 	return GPOS_OK;
 }
 
+//---------------------------------------------------------------------------
+//     @function:
+//             CDynamicPtrArrayTest::EresUnittest_Equals
+//
+//     @doc:
+//             Testing whether two arrays are equal
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CDynamicPtrArrayTest::EresUnittest_Equals()
+{
+	CAutoMemoryPool amp;
+	CMemoryPool *mp = amp.Pmp();
+
+	StringPtrArray *myStringArray = GPOS_NEW(mp) StringPtrArray(mp);
+	myStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "a_string"));
+	myStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "b_string"));
+
+	StringPtrArray *yourStringArray = GPOS_NEW(mp) StringPtrArray(mp);
+	yourStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "a_string"));
+	yourStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "b_string"));
+
+	// string array with same elements, in the same order should be equal
+	GPOS_ASSERT(myStringArray->Equals(yourStringArray));
+	GPOS_ASSERT(yourStringArray->Equals(myStringArray));
+
+	// string array with same elements, in the different order should not be equal
+	StringPtrArray *ourStringArray = GPOS_NEW(mp) StringPtrArray(mp);
+	ourStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "b_string"));
+	ourStringArray->Append(GPOS_NEW(mp) CWStringConst(mp, "a_string"));
+
+	GPOS_ASSERT(!myStringArray->Equals(ourStringArray));
+	GPOS_ASSERT(!ourStringArray->Equals(myStringArray));
+
+	myStringArray->Release();
+	yourStringArray->Release();
+	ourStringArray->Release();
+
+	return GPOS_OK;
+}
 // EOF

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapIterTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapIterTest.cpp
@@ -97,8 +97,8 @@ CHashMapIterTest::EresUnittest_Basic()
 			pdrgpulIterValues->Append(mi.Value());
 		}
 
-		pdrgpulIterKeys->Sort();
-		pdrgpulIterValues->Sort();
+		pdrgpulIterKeys->Sort(CompareUlongPtr);
+		pdrgpulIterValues->Sort(CompareUlongPtr);
 
 		GPOS_ASSERT(pdrgpulKeys->Equals(pdrgpulIterKeys.Value()));
 		GPOS_ASSERT(pdrgpulValues->Equals(pdrgpulIterValues.Value()));

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetIterTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetIterTest.cpp
@@ -71,7 +71,7 @@ CHashSetIterTest::EresUnittest_Basic()
 			pdrgpulIterValues->Append(si.Get());
 		}
 
-		pdrgpulIterValues->Sort();
+		pdrgpulIterValues->Sort(CompareUlongPtr);
 
 		GPOS_ASSERT(pdrgpulValues->Equals(pdrgpulIterValues.Value()));
 	}

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
@@ -142,6 +142,18 @@ public:
 	virtual BOOL StatsAreComparable(const IDatum *datum) const;
 
 	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
+
+	BOOL
+	operator==(const IDatum &other) const
+	{
+		if (this == &other)
+		{
+			// same object reference
+			return true;
+		}
+
+		return Matches(&other);
+	}
 };	// class IDatum
 
 // array of idatums

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -152,6 +152,25 @@ public:
 		return left_mdid->Equals(right_mdid);
 	}
 
+	// Compare function used by CDynamicPtrArray::Sort
+	static INT
+	CompareHashVal(const void *left, const void *right)
+	{
+		if ((*((IMDId **) left))->HashValue() <
+			(*((IMDId **) right))->HashValue())
+		{
+			return -1;
+		}
+		else if ((*((IMDId **) left))->HashValue() >
+				 ((*(IMDId **) right))->HashValue())
+		{
+			return 1;
+		}
+
+		GPOS_ASSERT((*((IMDId **) left))->HashValue() ==
+					((*(IMDId **) right))->HashValue());
+		return 0;
+	}
 
 	// is the mdid valid
 	virtual BOOL IsValid() const = 0;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -200,6 +200,27 @@ public:
 		return (IStatistics::EsjtLeftAntiSemiJoin == join_type) ||
 			   (IStatistics::EsjtLeftSemiJoin == join_type);
 	}
+
+	BOOL
+	operator==(const IStatistics &other) const
+	{
+		if (this == &other)
+		{
+			// same object reference
+			return true;
+		}
+
+		// XXX: How are we supposed to compar statistics objects?  I suppose we
+		//      could print it out and compare, but that seems expensive.
+		//      Instead, we opt for some basic comparison, knowing that it's
+		//      nowhere near exhaustive.
+		return Rows() == other.Rows() && RelPages() == other.RelPages() &&
+			   RelAllVisible() == other.RelAllVisible() &&
+			   IsEmpty() == other.IsEmpty() &&
+			   NumRebinds() == other.NumRebinds() && Width() == other.Width() &&
+			   StatsEstimationRisk() == other.StatsEstimationRisk() &&
+			   GetNumberOfPredicates() == other.GetNumberOfPredicates();
+	}
 };	// class IStatistics
 
 // shorthand for printing

--- a/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -407,7 +407,7 @@ CJoinStatsProcessor::SetResultingJoinStats(
 			mdid_inner->AddRef();
 			mdid_pair->Append(mdid_outer);
 			mdid_pair->Append(mdid_inner);
-			mdid_pair->Sort();
+			mdid_pair->Sort(IMDId::CompareHashVal);
 
 			if (colref_outer->IsDistCol() && colref_inner->IsDistCol())
 			{


### PR DESCRIPTION
CDynamicPtrArray has methods to sort itself and compare equality against
another array. However, the implementation of these methods makes strong
assumptions about the size of the stored data type. If the data type has
significant bits beyond 8 bytes (sizeof ULONG_PTR), then the effects of
these functions may yield unexpected behavior.

This commit targets StringPtrArray, but there are other bad types, too.
That can be seen by a static_assert sizeof(T) <= sizeof(ULONG_PTR). It
is surprising that we hadn't noticed this earlier. It may be the case
that equal elements generally share the same allocated memory. And so,
the first 8 bytes of the object behind the pointer could correctly match
on equality.

As a blanket fix for other types larger than 8 bytes, a memcmp is done
for sizeof(T). If that is found to be insufficient, then more template
specializations for compare_func may be needed.