### PR TITLE
[7X] gprecoverseg -o behaviour change

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -84,12 +84,24 @@ class GpRecoverSegmentProgram:
     def outputToFile(self, mirrorBuilder, gpArray, fileName):
         lines = []
 
+        # Entry for a failed segment will be commented if failed segment host is unreachable to inform the user about
+        # those unreachable hosts. As we know gprecoverseg skips the recovery of a segment if host is unreachable so if
+        # the user wants to recover it to another host, they can do so by uncommenting the line and adding the
+        # failover details.
+        lines.append("# If any entry is commented, please know that it belongs to failed segment which is unreachable."
+                     "\n# If you need to recover them, please modify the segment entry and add failover details "
+                     "\n# (failed_addresss|failed_port|failed_dataDirectory<space>failover_addresss|failover_port|failover_dataDirectory) "
+                     "to recover it to another host.\n")
+
         # one entry for each failure
         for mirror in mirrorBuilder.getMirrorsToBuild():
             output_str = ""
             seg = mirror.getFailedSegment()
             addr = canonicalize_address(seg.getSegmentAddress())
             output_str += ('%s|%d|%s' % (addr, seg.getSegmentPort(), seg.getSegmentDataDirectory()))
+            if seg.unreachable:
+                # Entry is commented if failed segment host is unreachable
+                output_str = "#{}".format(output_str)
 
             seg = mirror.getFailoverSegment()
             if seg is not None:

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -689,7 +689,7 @@ Feature: gprecoverseg tests
       Then gprecoverseg should return a return code of 0
       And gprecoverseg should print "One or more hosts are not reachable via SSH." to stdout
       And gprecoverseg should print "Host invalid_host is unreachable" to stdout
-      And the created config file /tmp/output_config contains the row for unreachable failed segment
+      And the created config file /tmp/output_config contains the commented row for unreachable failed segment
       And the cluster is returned to a good state
 
     @demo_cluster


### PR DESCRIPTION
**Context:**
PR https://github.com/greenplum-db/gpdb/pull/16529 changed the behviour of gprecoverseg -o to also add entry for a failed segment that is not reachable. If the generated file is used as input for recovery, gprecoverseg will skip the recovery of unreachable failed segments. If the user wants to recover that segment to somewhere else (any other reachable host) they should modify the entry of such segments (unreachable) and add failover details in output config file. But there is no way for the user to identify those entries from config file which require attention.

**Solution:**
 To inform the user about failed segment entry with unreachable hosts, the entry will be commented in the output config file. gprecoverseg skips the recovery of a segment if the host is unreachable so if the user wants to recover it to another host, they can do so by uncommenting the line and adding the failover details.

**Output file format before the change:**
```
invalid_host|7003|/Users/ashahani/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1 -> failed segment on unrechable host 
ashahaniKMD6M.vmware.com|7004|/Users/ashahani/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
```

**Output file format after the change:**
```
# If any of the entries are commented, please know that it belongs to failed segment which is unreachable.
# Add failover details if you want to recover it to another host.

#invalid_host|7003|/Users/ashahani/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1 -> entry is commented as invalid_host is unreachable
ashahaniKMD6M.vmware.com|7004|/Users/ashahani/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
