### PR TITLE
[6X] Add GUC gp_max_system_slices with superuser(PGC_SUSET) only

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -433,6 +433,7 @@ bool		optimizer_replicated_table_insert;
 
 /* GUCs for slice table*/
 int			gp_max_slices;
+int			gp_max_system_slices;
 
 /* System Information */
 static int	gp_server_version_num;
@@ -4669,6 +4670,16 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_slices,
+		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"gp_max_system_slices", PGC_SUSET, PRESET_OPTIONS,
+			gettext_noop("Maximum slices for a single query (superuser guc)"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_max_system_slices,
 		0, 0, INT_MAX, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -563,6 +563,7 @@ extern bool optimizer_replicated_table_insert;
 
 /* GUCs for slice table*/
 extern int	gp_max_slices;
+extern int	gp_max_system_slices;
 
 /**
  * Enable logging of DPE match in optimizer.

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -59,6 +59,7 @@
 		"gp_max_packet_size",
 		"gp_max_partition_level",
 		"gp_max_slices",
+		"gp_max_system_slices",
 		"gp_mk_sort_check",
 		"gp_motion_slice_noop",
 		"gp_partitioning_dynamic_selection_log",

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -58,8 +58,6 @@
 		"gp_log_suboverflow_statement",
 		"gp_max_packet_size",
 		"gp_max_partition_level",
-		"gp_max_slices",
-		"gp_max_system_slices",
 		"gp_mk_sort_check",
 		"gp_motion_slice_noop",
 		"gp_partitioning_dynamic_selection_log",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -221,6 +221,8 @@
 		"gp_max_local_distributed_cache",
 		"gp_max_parallel_cursors",
 		"gp_max_plan_size",
+		"gp_max_slices",
+		"gp_max_system_slices",
 		"gp_motion_cost_per_row",
 		"gp_perfmon_segment_interval",
 		"gp_print_create_gang_time",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14647,3 +14647,50 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (14 rows)
 
 DROP TABLE t_outer_srf, t_inner_srf;
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: (foo.b = bar.b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: foo.b
+               ->  Seq Scan on foo
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: bar.b
+                     ->  Seq Scan on bar
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 4
+HINT:  rewrite your query
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 4
+HINT:  rewrite your query
+reset gp_max_system_slices;
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user ruser;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+set session authorization ruser;
+set gp_max_system_slices=10;
+ERROR:  permission denied to set parameter "gp_max_system_slices"
+reset session authorization;
+drop user ruser;
+drop table foo, bar;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14884,3 +14884,47 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (13 rows)
 
 DROP TABLE t_outer_srf, t_inner_srf;
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (foo.b = bar.b)
+         ->  Seq Scan on foo
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on bar
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 3
+HINT:  rewrite your query
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+ERROR:  at most 1 slices are allowed in a query, current number: 3
+HINT:  rewrite your query
+reset gp_max_system_slices;
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user ruser;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+set session authorization ruser;
+set gp_max_system_slices=10;
+ERROR:  permission denied to set parameter "gp_max_system_slices"
+reset session authorization;
+drop user ruser;
+drop table foo, bar;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3353,6 +3353,40 @@ EXPLAIN (VERBOSE, COSTS OFF)
   SELECT * FROM t_outer_srf WHERE t_outer_srf.b IN (SELECT generate_series(1, t_outer_srf.b)  FROM t_inner_srf);
 DROP TABLE t_outer_srf, t_inner_srf;
 
+-- Testcases to validate the behavior of the GUC gp_max_system_slices
+
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+
+create table foo (a int, b int) distributed by(a);
+create table bar (a int, b int) distributed by(a);
+
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 0 (unlimited)
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+
+-- gp_max_slices : 1 and gp_max_system_slices : 0 (unlimited)
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_slices
+set gp_max_slices=1;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+
+-- gp_max_slices : 0 (unlimited) and gp_max_system_slices : 1
+-- Query should generate an error because the number of slices in the query exceeds the gp_max_system_slices
+set gp_max_system_slices=1;
+reset gp_max_slices;
+explain (costs off) select foo.a, foo.b from foo, bar where foo.b=bar.b;
+reset gp_max_system_slices;
+
+-- Ensure that a regular user cannot set the GUC gp_max_system_slices
+create user ruser;
+set session authorization ruser;
+set gp_max_system_slices=10;
+reset session authorization;
+
+drop user ruser;
+drop table foo, bar;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
This pull request introduces a new GUC, gp_max_system_slices, mirroring gp_max_slices, with the distinction that it is restricted to superusers (PGC_SUSET). Because there are many instances of users already using gp_max_slices, we will retain that guc and its behavior to ease the upgrade path

```
# create user user1;
CREATE ROLE
# set session authorization user1;
SET
=> select current_user;
 current_user
--------------
 user1
(1 row)

=> set gp_max_slices=100;
SET
=> set gp_max_system_slices=100;
ERROR:  permission denied to set parameter "gp_max_system_slices"
```
(cherry picked from commit https://github.com/greenplum-db/gpdb/commit/2a5338d223e0ca2f3a3d35614dd26c6bbe3a1d58)

pipeline: https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6X/jobs/compile_and_test_gpdb/builds/602