### PR TITLE
Fix crashes of lateral join

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2005,3 +2005,48 @@ checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root)
 
 	(void) cte_motion_search_walker(node, (void *) &context);
 }
+
+typedef struct MotionWithParamContext
+{
+	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
+	Bitmapset  *nestLoopParams; /* nestloop params */
+} MotionWithParamContext;
+
+/*
+ * check whether pass params by a motion
+ */
+static bool
+checkMotionWithParamWalker(Node *node, MotionWithParamContext* motionWithParamcontext)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Motion))
+	{
+		Plan * plan = (Plan *) node;
+		Bitmapset  *finalExtParam;
+		if (!bms_is_empty(plan->extParam))
+		{
+			finalExtParam = bms_intersect(plan->extParam, motionWithParamcontext->nestLoopParams);
+			if (!bms_is_empty(finalExtParam))
+			{
+				elog(ERROR, "Passing parameters across motion is not supported.");
+			}
+		}
+	}
+
+	return plan_tree_walker(node, checkMotionWithParamWalker, motionWithParamcontext, true);
+}
+
+/*
+ * We can not deliver a param by a motion node.
+ * If there is a param on motion node, we should throw an error.
+ */
+void
+checkMotionWithParam(Node *node, Bitmapset *bmsNestParams, PlannerInfo *root)
+{
+	MotionWithParamContext motionWithParamcontext;
+	motionWithParamcontext.nestLoopParams = bmsNestParams;
+	planner_init_plan_tree_base(&motionWithParamcontext.base, root);
+	checkMotionWithParamWalker(node, &motionWithParamcontext);
+}

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -56,4 +56,5 @@ extern Plan *cdbpathtoplan_create_sri_plan(RangeTblEntry *rte, PlannerInfo *subr
 
 extern bool contains_outer_params(Node *node, void *context);
 extern void checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root);
+extern void checkMotionWithParam(Node *node, Bitmapset *bmsNestParams, PlannerInfo *root);
 #endif   /* CDBMUTATE_H */

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3116,9 +3116,13 @@ order by 1,2;
 
 --
 -- variant where a PlaceHolderVar is needed at a join, but not above the join
--- Greenplum does not fully support the lateral join, ignore the below case.
 --
--- start_ignore
+-- TODO_LATERAL: failed to generate plan
+-- If the left path needs params of outer path.
+-- We can not add any motion above left path.
+-- however, in right join, we can not add broadcast motion above right path.
+-- So We can not add proper motion to generate path for right join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (costs off)
 select * from
   int4_tbl as i41,
@@ -3142,7 +3146,11 @@ select * from
       where ss1.loc = ss1.lat) as ss2
 where i41.f1 > 0;
 ERROR:  could not devise a query plan for the given query (pathnode.c:275)
--- end_ignore
+select * from int4_tbl a inner join int4_tbl b on false;
+ f1 | f1 
+----+----
+(0 rows)
+
 --
 -- test the corner cases FULL JOIN ON TRUE and FULL JOIN ON FALSE
 --
@@ -4225,7 +4233,6 @@ select * from
 --
 -- test for appropriate join order in the presence of lateral references
 --
--- start_ignore
 explain (verbose, costs off)
 select * from
   text_tbl t1
@@ -4233,25 +4240,38 @@ select * from
   on i8.q2 = 123,
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss
 where t1.f1 = ss.f1;
-                    QUERY PLAN                    
---------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Nested Loop
    Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1
    Join Filter: (t1.f1 = t2.f1)
-   ->  Nested Loop Left Join
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: t1.f1, i8.q1, i8.q2
-         ->  Seq Scan on public.text_tbl t1
-               Output: t1.f1
-         ->  Materialize
-               Output: i8.q1, i8.q2
-               ->  Seq Scan on public.int8_tbl i8
+         ->  Nested Loop Left Join
+               Output: t1.f1, i8.q1, i8.q2
+               ->  Seq Scan on public.text_tbl t1
+                     Output: t1.f1
+               ->  Materialize
                      Output: i8.q1, i8.q2
-                     Filter: (i8.q2 = 123)
-   ->  Limit
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           Output: i8.q1, i8.q2
+                           ->  Seq Scan on public.int8_tbl i8
+                                 Output: i8.q1, i8.q2
+                                 Filter: (i8.q2 = 123)
+   ->  Materialize
          Output: (i8.q1), t2.f1
-         ->  Seq Scan on public.text_tbl t2
-               Output: i8.q1, t2.f1
-(16 rows)
+         ->  Limit
+               Output: (i8.q1), t2.f1
+               ->  Result
+                     Output: i8.q1, t2.f1
+                     ->  Materialize
+                           Output: t2.f1
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Output: t2.f1
+                                 ->  Seq Scan on public.text_tbl t2
+                                       Output: t2.f1
+ Optimizer: Postgres-based planner
+(29 rows)
 
 select * from
   text_tbl t1
@@ -4272,31 +4292,49 @@ select * from
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss1,
   lateral (select ss1.* from text_tbl t3 limit 1) as ss2
 where t1.f1 = ss2.f1;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Nested Loop
    Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1, ((i8.q1)), (t2.f1)
    Join Filter: (t1.f1 = (t2.f1))
    ->  Nested Loop
          Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1
-         ->  Nested Loop Left Join
+         ->  Gather Motion 3:1  (slice1; segments: 3)
                Output: t1.f1, i8.q1, i8.q2
-               ->  Seq Scan on public.text_tbl t1
-                     Output: t1.f1
-               ->  Materialize
-                     Output: i8.q1, i8.q2
-                     ->  Seq Scan on public.int8_tbl i8
+               ->  Nested Loop Left Join
+                     Output: t1.f1, i8.q1, i8.q2
+                     ->  Seq Scan on public.text_tbl t1
+                           Output: t1.f1
+                     ->  Materialize
                            Output: i8.q1, i8.q2
-                           Filter: (i8.q2 = 123)
-         ->  Limit
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 Output: i8.q1, i8.q2
+                                 ->  Seq Scan on public.int8_tbl i8
+                                       Output: i8.q1, i8.q2
+                                       Filter: (i8.q2 = 123)
+         ->  Materialize
                Output: (i8.q1), t2.f1
-               ->  Seq Scan on public.text_tbl t2
-                     Output: i8.q1, t2.f1
-   ->  Limit
+               ->  Limit
+                     Output: (i8.q1), t2.f1
+                     ->  Result
+                           Output: i8.q1, t2.f1
+                           ->  Materialize
+                                 Output: t2.f1
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       Output: t2.f1
+                                       ->  Seq Scan on public.text_tbl t2
+                                             Output: t2.f1
+   ->  Materialize
          Output: ((i8.q1)), (t2.f1)
-         ->  Seq Scan on public.text_tbl t3
-               Output: (i8.q1), t2.f1
-(22 rows)
+         ->  Limit
+               Output: ((i8.q1)), (t2.f1)
+               ->  Result
+                     Output: (i8.q1), t2.f1
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice4; segments: 3)
+                                 ->  Seq Scan on public.text_tbl t3
+ Optimizer: Postgres-based planner
+(40 rows)
 
 select * from
   text_tbl t1
@@ -4318,38 +4356,56 @@ select 1 from
   left join text_tbl as tt4 on (tt3.f1 = tt4.f1),
   lateral (select tt4.f1 as c0 from text_tbl as tt5 limit 1) as ss1
 where tt1.f1 = ss1.c0;
-                        QUERY PLAN                        
-----------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Nested Loop
    Output: 1
-   ->  Nested Loop Left Join
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: tt1.f1, tt4.f1
-         ->  Nested Loop
-               Output: tt1.f1
-               ->  Seq Scan on public.text_tbl tt1
-                     Output: tt1.f1
-                     Filter: (tt1.f1 = 'foo'::text)
-               ->  Seq Scan on public.text_tbl tt2
-                     Output: tt2.f1
-         ->  Materialize
-               Output: tt4.f1
+         ->  Hash Left Join
+               Output: tt1.f1, tt4.f1
+               Hash Cond: (tt3.f1 = tt4.f1)
                ->  Nested Loop Left Join
-                     Output: tt4.f1
-                     Join Filter: (tt3.f1 = tt4.f1)
-                     ->  Seq Scan on public.text_tbl tt3
+                     Output: tt1.f1, tt3.f1
+                     ->  Nested Loop
+                           Output: tt1.f1
+                           ->  Seq Scan on public.text_tbl tt1
+                                 Output: tt1.f1
+                                 Filter: (tt1.f1 = 'foo'::text)
+                           ->  Materialize
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: 'foo'::text
+                                       ->  Seq Scan on public.text_tbl tt2
+                     ->  Materialize
                            Output: tt3.f1
-                           Filter: (tt3.f1 = 'foo'::text)
-                     ->  Seq Scan on public.text_tbl tt4
-                           Output: tt4.f1
-                           Filter: (tt4.f1 = 'foo'::text)
-   ->  Subquery Scan on ss1
-         Output: ss1.c0
-         Filter: (ss1.c0 = 'foo'::text)
-         ->  Limit
-               Output: (tt4.f1)
-               ->  Seq Scan on public.text_tbl tt5
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                                 Output: tt3.f1
+                                 Hash Key: 'foo'::text
+                                 ->  Seq Scan on public.text_tbl tt3
+                                       Output: tt3.f1
+                                       Filter: (tt3.f1 = 'foo'::text)
+               ->  Hash
                      Output: tt4.f1
-(29 rows)
+                     ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                           Output: tt4.f1
+                           Hash Key: 'foo'::text
+                           ->  Seq Scan on public.text_tbl tt4
+                                 Output: tt4.f1
+                                 Filter: (tt4.f1 = 'foo'::text)
+   ->  Materialize
+         Output: ss1.c0
+         ->  Subquery Scan on ss1
+               Output: ss1.c0
+               Filter: (ss1.c0 = 'foo'::text)
+               ->  Limit
+                     Output: (tt4.f1)
+                     ->  Result
+                           Output: tt4.f1
+                           ->  Materialize
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)
+                                       ->  Seq Scan on public.text_tbl tt5
+ Optimizer: Postgres-based planner
+(47 rows)
 
 select 1 from
   text_tbl as tt1
@@ -4362,14 +4418,9 @@ where tt1.f1 = ss1.c0;
 ----------
 (0 rows)
 
---end_ignore
 --
 -- check a case in which a PlaceHolderVar forces join order
 --
---start_ignore
---GPDB_94_STABLE_MERGE_FIXME: This query is lateral related and its plan is
---different from PostgreSQL's.  Do not know why yet. Ignore its plan
---temporarily.
 explain (verbose, costs off)
 select ss2.* from
   int4_tbl i41
@@ -4380,36 +4431,47 @@ select ss2.* from
   on i41.f1 = ss1.c1,
   lateral (select i41.*, i8.*, ss1.* from text_tbl limit 1) ss2
 where ss1.c2 = 0;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Nested Loop
    Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
-   ->  Hash Join
-         Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, 42
-         Hash Cond: (i41.f1 = i42.f1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, (42)
          ->  Nested Loop
-               Output: i8.q1, i8.q2, i43.f1, i41.f1
+               Output: i41.f1, i42.f1, i8.q1, i8.q2, i43.f1, 42
                ->  Nested Loop
-                     Output: i8.q1, i8.q2, i43.f1
+                     Output: i41.f1, i42.f1, i8.q1, i8.q2
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: i41.f1, i42.f1
+                           Hash Key: 0
+                           ->  Hash Join
+                                 Output: i41.f1, i42.f1
+                                 Hash Cond: (i41.f1 = i42.f1)
+                                 ->  Seq Scan on public.int4_tbl i41
+                                       Output: i41.f1
+                                 ->  Hash
+                                       Output: i42.f1
+                                       ->  Seq Scan on public.int4_tbl i42
+                                             Output: i42.f1
                      ->  Seq Scan on public.int8_tbl i8
                            Output: i8.q1, i8.q2
                            Filter: (i8.q1 = 0)
-                     ->  Seq Scan on public.int4_tbl i43
-                           Output: i43.f1
-                           Filter: (i43.f1 = 0)
-               ->  Seq Scan on public.int4_tbl i41
-                     Output: i41.f1
-         ->  Hash
-               Output: i42.f1
-               ->  Seq Scan on public.int4_tbl i42
-                     Output: i42.f1
-   ->  Limit
+               ->  Seq Scan on public.int4_tbl i43
+                     Output: i43.f1
+                     Filter: (i43.f1 = 0)
+   ->  Materialize
          Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
-         ->  Seq Scan on public.text_tbl
-               Output: i41.f1, i8.q1, i8.q2, i42.f1, i43.f1, (42)
-(25 rows)
+         ->  Limit
+               Output: (i41.f1), (i8.q1), (i8.q2), (i42.f1), (i43.f1), ((42))
+               ->  Result
+                     Output: i41.f1, i8.q1, i8.q2, i42.f1, i43.f1, (42)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Seq Scan on public.text_tbl
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(37 rows)
 
---end_ignore
 select ss2.* from
   int4_tbl i41
   left join int8_tbl i8
@@ -4446,7 +4508,7 @@ select * from
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
                                  Hash Key: (1)
                                  ->  Result
- Optimizer: Postgres query optimizer
+ Optimizer: Postgres-based planner
 (13 rows)
 
 select * from
@@ -4910,8 +4972,6 @@ where ss.stringu2 !~* ss.case1;
 
 rollback;
 -- test case to expose miscomputation of required relid set for a PHV
--- Greenplum does not fully support the lateral join, ignore the below case.
--- start_ignore
 explain (verbose, costs off)
 select i8.*, ss.v, t.unique2
   from int8_tbl i8
@@ -4948,9 +5008,8 @@ where q2 = 456;
                                        ->  Seq Scan on public.int4_tbl i4
                                              Output: i4.f1
                                              Filter: (i4.f1 = 1)
- Optimizer: Postgres query optimizer
- Settings: optimizer = 'off'
-(29 rows)
+ Optimizer: Postgres-based planner
+(28 rows)
 
 select i8.*, ss.v, t.unique2
   from int8_tbl i8
@@ -4963,7 +5022,6 @@ where q2 = 456;
  123 | 456 |   |        
 (1 row)
 
--- end_ignore
 -- and check a related issue where we miscompute required relids for
 -- a PHV that's been translated to a child rel
 create temp table parttbl (a integer primary key) partition by range (a);
@@ -5201,11 +5259,6 @@ explain (costs off)
 (7 rows)
 
 -- lateral with UNION ALL subselect
--- start_ignore
--- GPDB_96_MERGE_FIXME: we used to get a better plan here, with
--- the Nested Loop join being done on segments, and just a single
--- Gather Motion at the top. Can we improve?
--- end_ignore
 explain (costs off)
   select * from generate_series(100,200) g,
     lateral (select * from int8_tbl a where g = q1 union all
@@ -5296,96 +5349,23 @@ select count(*) from tenk1 a,
 (1 row)
 
 -- lateral injecting a strange outer join condition
--- start_ignore
--- GPDB_93_MERGE_FIXME: These queries are failing at the moment. Need to investigate.
--- There were a lot of LATERAL fixes in upstream minor versions, so I'm hoping that
--- these will get fixed once we catch up to those. Or if not, at least it will be
--- nicer to work on the code, knowing that there aren't going to be a dozen commits
--- coming up, touching the same area.
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (costs off)
   select * from int8_tbl a,
     int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
       on x.q2 = ss.z
   order by a.q1, a.q2, x.q1, x.q2, ss.z;
-                   QUERY PLAN                   
-------------------------------------------------
- Sort
-   Sort Key: a.q1, a.q2, x.q1, x.q2, (a.q1)
-   ->  Nested Loop
-         ->  Seq Scan on int8_tbl a
-         ->  Hash Right Join
-               Hash Cond: ((a.q1) = x.q2)
-               ->  Seq Scan on int4_tbl y
-               ->  Hash
-                     ->  Seq Scan on int8_tbl x
-(9 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:275)
 select * from int8_tbl a,
   int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
     on x.q2 = ss.z
   order by a.q1, a.q2, x.q1, x.q2, ss.z;
-        q1        |        q2         |        q1        |        q2         |        z         
-------------------+-------------------+------------------+-------------------+------------------
-              123 |               456 |              123 |               456 |                 
-              123 |               456 |              123 |  4567890123456789 |                 
-              123 |               456 | 4567890123456789 | -4567890123456789 |                 
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |  4567890123456789 |                 
-              123 |  4567890123456789 |              123 |               456 |                 
-              123 |  4567890123456789 |              123 |  4567890123456789 |                 
-              123 |  4567890123456789 | 4567890123456789 | -4567890123456789 |                 
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |  4567890123456789 |                 
- 4567890123456789 | -4567890123456789 |              123 |               456 |                 
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 | -4567890123456789 | 4567890123456789 |               123 |                 
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |               456 |                 
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 |               123 | 4567890123456789 |               123 |                 
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |               456 |                 
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 |                 
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
-(57 rows)
-
---end_ignore
+ERROR:  could not devise a query plan for the given query (pathnode.c:275)
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
   lateral (select x) ss2(y);
@@ -5819,9 +5799,12 @@ select * from int4_tbl a,
 (25 rows)
 
 -- lateral reference in a PlaceHolderVar evaluated at join level
--- GPDB_94_STABLE_MERGE_FIXME: The query fails. The change is related to
--- upstream commit acfcd4. Need to come back to fix it when understanding more
--- about that commit.
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (verbose, costs off)
 select * from
   int8_tbl a left join lateral
@@ -6195,53 +6178,23 @@ create table join_pt1p1p1 partition of join_pt1p1 for values from (0) to (100);
 insert into join_pt1 values (1, 1, 'x'), (101, 101, 'y');
 create table join_ut1 (a int, b int, c varchar);
 insert into join_ut1 values (101, 101, 'y'), (2, 2, 'z');
--- GPDB_12_MERGE_FIXME: The query fails. This test query is new with v12,
--- but a corresponding query fails on GPDB main, too. I think this is
--- similar to the case marked with GPDB_94_STABLE_MERGE_FIXME above.
--- upstream commit acfcd4. Need to come back to fix it when understanding more
--- about that commit.
--- start_ignore
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (verbose, costs off)
 select t1.b, ss.phv from join_ut1 t1 left join lateral
               (select t2.a as t2a, t3.a t3a, least(t1.a, t2.a, t3.a) phv
 					  from join_pt1 t2 join join_ut1 t3 on t2.a = t3.b) ss
               on t1.a = ss.t2a order by t1.a;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Sort
-   Output: t1.b, (LEAST(t1.a, t2.a, t3.a)), t1.a
-   Sort Key: t1.a
-   ->  Nested Loop Left Join
-         Output: t1.b, (LEAST(t1.a, t2.a, t3.a)), t1.a
-         ->  Seq Scan on public.join_ut1 t1
-               Output: t1.a, t1.b, t1.c
-         ->  Hash Join
-               Output: t2.a, LEAST(t1.a, t2.a, t3.a)
-               Hash Cond: (t3.b = t2.a)
-               ->  Seq Scan on public.join_ut1 t3
-                     Output: t3.a, t3.b, t3.c
-               ->  Hash
-                     Output: t2.a
-                     ->  Append
-                           ->  Seq Scan on public.join_pt1p1p1 t2
-                                 Output: t2.a
-                                 Filter: (t1.a = t2.a)
-                           ->  Seq Scan on public.join_pt1p2 t2_1
-                                 Output: t2_1.a
-                                 Filter: (t1.a = t2_1.a)
-(21 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:275)
 select t1.b, ss.phv from join_ut1 t1 left join lateral
               (select t2.a as t2a, t3.a t3a, least(t1.a, t2.a, t3.a) phv
 					  from join_pt1 t2 join join_ut1 t3 on t2.a = t3.b) ss
               on t1.a = ss.t2a order by t1.a;
-  b  | phv 
------+-----
-   2 |    
- 101 | 101
-(2 rows)
-
--- end_ignore
+ERROR:  could not devise a query plan for the given query (pathnode.c:275)
 drop table join_pt1;
 drop table join_ut1;
 --

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3183,9 +3183,13 @@ order by 1,2;
 
 --
 -- variant where a PlaceHolderVar is needed at a join, but not above the join
--- Greenplum does not fully support the lateral join, ignore the below case.
 --
--- start_ignore
+-- TODO_LATERAL: failed to generate plan
+-- If the left path needs params of outer path.
+-- We can not add any motion above left path.
+-- however, in right join, we can not add broadcast motion above right path.
+-- So We can not add proper motion to generate path for right join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (costs off)
 select * from
   int4_tbl as i41,
@@ -3209,7 +3213,11 @@ select * from
       where ss1.loc = ss1.lat) as ss2
 where i41.f1 > 0;
 ERROR:  could not devise a query plan for the given query (pathnode.c:275)
--- end_ignore
+select * from int4_tbl a inner join int4_tbl b on false;
+ f1 | f1 
+----+----
+(0 rows)
+
 --
 -- test the corner cases FULL JOIN ON TRUE and FULL JOIN ON FALSE
 --
@@ -4367,11 +4375,6 @@ select * from
 --
 -- test for appropriate join order in the presence of lateral references
 --
--- start_ignore
--- GPDB_94_STABLE_MERGE_FIXME: Currently LATERAL is not fully supported in GPDB
--- and the queries below are failing at the moment (The first one fails with
--- error and the other two fail with panic). Comment them off temporarily.
-/*
 explain (verbose, costs off)
 select * from
   text_tbl t1
@@ -4379,6 +4382,38 @@ select * from
   on i8.q2 = 123,
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss
 where t1.f1 = ss.f1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1
+   Join Filter: (t1.f1 = t2.f1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: t1.f1, i8.q1, i8.q2
+         ->  Nested Loop Left Join
+               Output: t1.f1, i8.q1, i8.q2
+               ->  Seq Scan on public.text_tbl t1
+                     Output: t1.f1
+               ->  Materialize
+                     Output: i8.q1, i8.q2
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           Output: i8.q1, i8.q2
+                           ->  Seq Scan on public.int8_tbl i8
+                                 Output: i8.q1, i8.q2
+                                 Filter: (i8.q2 = 123)
+   ->  Materialize
+         Output: (i8.q1), t2.f1
+         ->  Limit
+               Output: (i8.q1), t2.f1
+               ->  Result
+                     Output: i8.q1, t2.f1
+                     ->  Materialize
+                           Output: t2.f1
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Output: t2.f1
+                                 ->  Seq Scan on public.text_tbl t2
+                                       Output: t2.f1
+ Optimizer: Postgres-based planner
+(29 rows)
 
 select * from
   text_tbl t1
@@ -4386,6 +4421,10 @@ select * from
   on i8.q2 = 123,
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss
 where t1.f1 = ss.f1;
+  f1  |        q1        | q2  |        q1        |  f1  
+------+------------------+-----+------------------+------
+ doh! | 4567890123456789 | 123 | 4567890123456789 | doh!
+(1 row)
 
 explain (verbose, costs off)
 select * from
@@ -4395,6 +4434,49 @@ select * from
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss1,
   lateral (select ss1.* from text_tbl t3 limit 1) as ss2
 where t1.f1 = ss2.f1;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Nested Loop
+   Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1, ((i8.q1)), (t2.f1)
+   Join Filter: (t1.f1 = (t2.f1))
+   ->  Nested Loop
+         Output: t1.f1, i8.q1, i8.q2, (i8.q1), t2.f1
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: t1.f1, i8.q1, i8.q2
+               ->  Nested Loop Left Join
+                     Output: t1.f1, i8.q1, i8.q2
+                     ->  Seq Scan on public.text_tbl t1
+                           Output: t1.f1
+                     ->  Materialize
+                           Output: i8.q1, i8.q2
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 Output: i8.q1, i8.q2
+                                 ->  Seq Scan on public.int8_tbl i8
+                                       Output: i8.q1, i8.q2
+                                       Filter: (i8.q2 = 123)
+         ->  Materialize
+               Output: (i8.q1), t2.f1
+               ->  Limit
+                     Output: (i8.q1), t2.f1
+                     ->  Result
+                           Output: i8.q1, t2.f1
+                           ->  Materialize
+                                 Output: t2.f1
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       Output: t2.f1
+                                       ->  Seq Scan on public.text_tbl t2
+                                             Output: t2.f1
+   ->  Materialize
+         Output: ((i8.q1)), (t2.f1)
+         ->  Limit
+               Output: ((i8.q1)), (t2.f1)
+               ->  Result
+                     Output: (i8.q1), t2.f1
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice4; segments: 3)
+                                 ->  Seq Scan on public.text_tbl t3
+ Optimizer: Postgres-based planner
+(40 rows)
 
 select * from
   text_tbl t1
@@ -4403,6 +4485,10 @@ select * from
   lateral (select i8.q1, t2.f1 from text_tbl t2 limit 1) as ss1,
   lateral (select ss1.* from text_tbl t3 limit 1) as ss2
 where t1.f1 = ss2.f1;
+  f1  |        q1        | q2  |        q1        |  f1  |        q1        |  f1  
+------+------------------+-----+------------------+------+------------------+------
+ doh! | 4567890123456789 | 123 | 4567890123456789 | doh! | 4567890123456789 | doh!
+(1 row)
 
 explain (verbose, costs off)
 select 1 from
@@ -4412,6 +4498,56 @@ select 1 from
   left join text_tbl as tt4 on (tt3.f1 = tt4.f1),
   lateral (select tt4.f1 as c0 from text_tbl as tt5 limit 1) as ss1
 where tt1.f1 = ss1.c0;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Nested Loop
+   Output: 1
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: tt1.f1, tt4.f1
+         ->  Hash Left Join
+               Output: tt1.f1, tt4.f1
+               Hash Cond: (tt3.f1 = tt4.f1)
+               ->  Nested Loop Left Join
+                     Output: tt1.f1, tt3.f1
+                     ->  Nested Loop
+                           Output: tt1.f1
+                           ->  Seq Scan on public.text_tbl tt1
+                                 Output: tt1.f1
+                                 Filter: (tt1.f1 = 'foo'::text)
+                           ->  Materialize
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: 'foo'::text
+                                       ->  Seq Scan on public.text_tbl tt2
+                     ->  Materialize
+                           Output: tt3.f1
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                                 Output: tt3.f1
+                                 Hash Key: 'foo'::text
+                                 ->  Seq Scan on public.text_tbl tt3
+                                       Output: tt3.f1
+                                       Filter: (tt3.f1 = 'foo'::text)
+               ->  Hash
+                     Output: tt4.f1
+                     ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                           Output: tt4.f1
+                           Hash Key: 'foo'::text
+                           ->  Seq Scan on public.text_tbl tt4
+                                 Output: tt4.f1
+                                 Filter: (tt4.f1 = 'foo'::text)
+   ->  Materialize
+         Output: ss1.c0
+         ->  Subquery Scan on ss1
+               Output: ss1.c0
+               Filter: (ss1.c0 = 'foo'::text)
+               ->  Limit
+                     Output: (tt4.f1)
+                     ->  Result
+                           Output: tt4.f1
+                           ->  Materialize
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)
+                                       ->  Seq Scan on public.text_tbl tt5
+ Optimizer: Postgres-based planner
+(47 rows)
 
 select 1 from
   text_tbl as tt1
@@ -4420,15 +4556,13 @@ select 1 from
   left join text_tbl as tt4 on (tt3.f1 = tt4.f1),
   lateral (select tt4.f1 as c0 from text_tbl as tt5 limit 1) as ss1
 where tt1.f1 = ss1.c0;
-*/
---end_ignore
+ ?column? 
+----------
+(0 rows)
+
 --
 -- check a case in which a PlaceHolderVar forces join order
 --
---start_ignore
---GPDB_94_STABLE_MERGE_FIXME: This query is lateral related and its plan is
---different from PostgreSQL's.  Do not know why yet. Ignore its plan
---temporarily.
 explain (verbose, costs off)
 select ss2.* from
   int4_tbl i41
@@ -4479,7 +4613,6 @@ where ss1.c2 = 0;
  Optimizer: Postgres query optimizer
 (36 rows)
 
---end_ignore
 select ss2.* from
   int4_tbl i41
   left join int8_tbl i8
@@ -4979,8 +5112,6 @@ where ss.stringu2 !~* ss.case1;
 
 rollback;
 -- test case to expose miscomputation of required relid set for a PHV
--- Greenplum does not fully support the lateral join, ignore the below case.
--- start_ignore
 explain (verbose, costs off)
 select i8.*, ss.v, t.unique2
   from int8_tbl i8
@@ -5031,7 +5162,6 @@ where q2 = 456;
  123 | 456 |   |        
 (1 row)
 
--- end_ignore
 -- and check a related issue where we miscompute required relids for
 -- a PHV that's been translated to a child rel
 create temp table parttbl (a integer primary key) partition by range (a);
@@ -5365,13 +5495,12 @@ select count(*) from tenk1 a,
 (1 row)
 
 -- lateral injecting a strange outer join condition
--- start_ignore
--- GPDB_93_MERGE_FIXME: These queries are failing at the moment. Need to investigate.
--- There were a lot of LATERAL fixes in upstream minor versions, so I'm hoping that
--- these will get fixed once we catch up to those. Or if not, at least it will be
--- nicer to work on the code, knowing that there aren't going to be a dozen commits
--- coming up, touching the same area.
--- FAIL with ERROR:  could not devise a query plan for the given query (pathnode.c:416)
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (costs off)
   select * from int8_tbl a,
     int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
@@ -5383,7 +5512,6 @@ select * from int8_tbl a,
     on x.q2 = ss.z
   order by a.q1, a.q2, x.q1, x.q2, ss.z;
 ERROR:  could not devise a query plan for the given query (pathnode.c:275)
---end_ignore
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
   lateral (select x) ss2(y);
@@ -5813,9 +5941,12 @@ select * from int4_tbl a,
 (25 rows)
 
 -- lateral reference in a PlaceHolderVar evaluated at join level
--- GPDB_94_STABLE_MERGE_FIXME: The query fails. The change is related to
--- upstream commit acfcd4. Need to come back to fix it when understanding more
--- about that commit.
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (verbose, costs off)
 select * from
   int8_tbl a left join lateral
@@ -6191,12 +6322,12 @@ create table join_ut1 (a int, b int, c varchar);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into join_ut1 values (101, 101, 'y'), (2, 2, 'z');
--- GPDB_12_MERGE_FIXME: The query fails. This test query is new with v12,
--- but a corresponding query fails on GPDB main, too. I think this is
--- similar to the case marked with GPDB_94_STABLE_MERGE_FIXME above.
--- upstream commit acfcd4. Need to come back to fix it when understanding more
--- about that commit.
--- start_ignore
+-- TODO_LATERAL: failed to generate plan
+-- If the right path needs params of outer path.
+-- We can not add any motion above right path.
+-- however, in left join, we can not add broadcast motion above left path.
+-- So We can not add proper motion to generate path for left join,
+-- And hit the error: could not devise a query plan for the given query.
 explain (verbose, costs off)
 select t1.b, ss.phv from join_ut1 t1 left join lateral
               (select t2.a as t2a, t3.a t3a, least(t1.a, t2.a, t3.a) phv
@@ -6208,7 +6339,6 @@ select t1.b, ss.phv from join_ut1 t1 left join lateral
 					  from join_pt1 t2 join join_ut1 t3 on t2.a = t3.b) ss
               on t1.a = ss.t2a order by t1.a;
 ERROR:  could not devise a query plan for the given query (pathnode.c:275)
--- end_ignore
 drop table join_pt1;
 drop table join_ut1;
 --

--- a/src/test/regress/expected/tablesample.out
+++ b/src/test/regress/expected/tablesample.out
@@ -347,40 +347,35 @@ RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_nestloop;
 -- check behavior during rescans, as well as correct handling of min/max pct
--- Greenplum: does not support laterals completely, rescan specific tests above
--- start_ignore
 select * from
   (values (0),(100)) v(pct),
   lateral (select count(*) from tenk1 tablesample bernoulli (pct)) ss;
- pct | count 
------+-------
-   0 |     0
- 100 | 10000
-(2 rows)
-
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:2033)
 select * from
   (values (0),(100)) v(pct),
   lateral (select count(*) from tenk1 tablesample system (pct)) ss;
- pct | count 
------+-------
-   0 |     0
- 100 | 10000
-(2 rows)
-
+ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:2033)
 explain (costs off)
 select pct, count(unique1) from
   (values (0),(100)) v(pct),
   lateral (select * from tenk1 tablesample bernoulli (pct)) ss
   group by pct;
-                       QUERY PLAN                       
---------------------------------------------------------
- HashAggregate
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Finalize GroupAggregate
    Group Key: "*VALUES*".column1
-   ->  Nested Loop
-         ->  Values Scan on "*VALUES*"
-         ->  Sample Scan on tenk1
-               Sampling: bernoulli ("*VALUES*".column1)
-(6 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: "*VALUES*".column1
+         ->  Partial GroupAggregate
+               Group Key: "*VALUES*".column1
+               ->  Sort
+                     Sort Key: "*VALUES*".column1
+                     ->  Nested Loop
+                           ->  Values Scan on "*VALUES*"
+                           ->  Sample Scan on tenk1
+                                 Sampling: bernoulli ("*VALUES*".column1)
+ Optimizer: Postgres-based planner
+(13 rows)
 
 select pct, count(unique1) from
   (values (0),(100)) v(pct),
@@ -400,7 +395,6 @@ select pct, count(unique1) from
  100 | 10000
 (1 row)
 
--- end_ignore
 -- Greenplum: we do have to test min/max pct tests though
 select 0 as pct, count(*) from tenk1 tablesample bernoulli (0)
 union all

--- a/src/test/regress/sql/tablesample.sql
+++ b/src/test/regress/sql/tablesample.sql
@@ -92,8 +92,6 @@ RESET enable_mergejoin;
 RESET enable_nestloop;
 
 -- check behavior during rescans, as well as correct handling of min/max pct
--- Greenplum: does not support laterals completely, rescan specific tests above
--- start_ignore
 select * from
   (values (0),(100)) v(pct),
   lateral (select count(*) from tenk1 tablesample bernoulli (pct)) ss;
@@ -113,7 +111,6 @@ select pct, count(unique1) from
   (values (0),(100)) v(pct),
   lateral (select * from tenk1 tablesample system (pct)) ss
   group by pct;
--- end_ignore
 
 -- Greenplum: we do have to test min/max pct tests though
 select 0 as pct, count(*) from tenk1 tablesample bernoulli (0)


### PR DESCRIPTION
1、In gpdb7 there are a few testcases will still cause panic.
     Backport "check whether motion contains nestloop params" from 6X_STABLE to gpdb7.
     If we pass params by a motion, throw an error instead of panic.
```
SELECT * FROM
        (VALUES (0.0),(10.3),(100.5)) v(nrows),
         LATERAL (SELECT count(*) FROM test_tablesample
         TABLESAMPLE system_rows (nrows::float8)) ss;
```  

2、Remove start_ignore and end_ignore of lateral testcases.
     Some can execute correctly and some will throw an error.
     Those which throw an error will try to be supported later.
     