### PR TITLE
Fix for finding child output columns when parent is union while join pruning

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+pgarch_start

--- a/.abi-check/7.1.0/postgres.types.ignore
+++ b/.abi-check/7.1.0/postgres.types.ignore
@@ -1,0 +1,2 @@
+enum PMSignalReason
+enum AuxProcType

--- a/src/backend/gporca/libgpopt/src/operators/CLeftJoinPruningPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLeftJoinPruningPreprocessor.cpp
@@ -454,7 +454,9 @@ CLeftJoinPruningPreprocessor::ComputeOutputColumns(
 	if (CUtils::FLogicalSetOp(pexpr->Pop()))
 	{
 		CLogicalSetOp *pop = CLogicalSetOp::PopConvert(pexpr->Pop());
-		for (ULONG i = 0; i < pop->PdrgpdrgpcrInput()->Size(); i++)
+		// Starting from index 1, since the 0th input column array is the same
+		// as the output column array
+		for (ULONG i = 1; i < pop->PdrgpdrgpcrInput()->Size(); i++)
 		{
 			CColRefArray *pdrgpcrInput = (*pop->PdrgpdrgpcrInput())[i];
 			for (ULONG j = 0; j < pdrgpcrInput->Size(); j++)

--- a/src/backend/gporca/libgpopt/src/operators/CLeftJoinPruningPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLeftJoinPruningPreprocessor.cpp
@@ -455,59 +455,16 @@ CLeftJoinPruningPreprocessor::ComputeOutputColumns(
 	// child if possible. Similar is the case for Intersect/IntersectAll and
 	// Difference/DifferenceAll.
 
-	CLogicalSetOp *pop = nullptr;
-	BOOL isLogicalSetOp = false;
-	switch (pexpr->Pop()->Eopid())
+	if (CUtils::FLogicalSetOp(pexpr->Pop()))
 	{
-		case COperator::EopLogicalUnion:
+		CLogicalSetOp *pop = CLogicalSetOp::PopConvert(pexpr->Pop());
+		for (ULONG i = 0; i < pop->PdrgpdrgpcrInput()->Size(); i++)
 		{
-			pop = CLogicalUnion::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		case COperator::EopLogicalUnionAll:
-		{
-			pop = CLogicalUnionAll::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		case COperator::EopLogicalIntersect:
-		{
-			pop = CLogicalIntersect::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		case COperator::EopLogicalIntersectAll:
-		{
-			pop = CLogicalIntersectAll::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		case COperator::EopLogicalDifference:
-		{
-			pop = CLogicalDifference::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		case COperator::EopLogicalDifferenceAll:
-		{
-			pop = CLogicalDifferenceAll::PopConvert(pexpr->Pop());
-			isLogicalSetOp = true;
-			break;
-		}
-		default:
-			break;
-	}
-
-	if (isLogicalSetOp)
-	{
-		for (ULONG uli = 0; uli < pop->PdrgpdrgpcrInput()->Size(); uli++)
-		{
-			for (ULONG ulj = 0; ulj < (*pop->PdrgpdrgpcrInput())[uli]->Size();
-				 ulj++)
+			ULONG size = (*pop->PdrgpdrgpcrInput())[i]->Size();
+			for (ULONG j = 0; j < size; j++)
 			{
 				childs_output_columns->Include(
-					(*(*pop->PdrgpdrgpcrInput())[uli])[ulj]);
+					(*(*pop->PdrgpdrgpcrInput())[i])[j]);
 			}
 		}
 	}

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -2028,9 +2028,10 @@ explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  Optimizer: Postgres-based planner
 (17 rows)
 
+-- join will be pruned
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
 select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                             QUERY PLAN
+                                             QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=2938.00..5808.00 rows=172200 width=8)
    ->  HashAggregate  (cost=2938.00..3512.00 rows=57400 width=8)
@@ -2043,9 +2044,95 @@ select bar.a,bar.b from bar left join foo on foo.a=bar.a;
  Optimizer: Postgres-based planner
 (9 rows)
 
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3799.00 rows=172200 width=8)
+   ->  Append  (cost=0.00..1503.00 rows=57400 width=8)
+         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
+   ->  HashSetOp Intersect  (cost=0.00..2938.00 rows=28700 width=12)
+         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
+   ->  HashSetOp Intersect All  (cost=0.00..2938.00 rows=28700 width=12)
+         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
+   ->  HashSetOp Except  (cost=0.00..2938.00 rows=28700 width=12)
+         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
+   ->  HashSetOp Except All  (cost=0.00..2938.00 rows=28700 width=12)
+         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+-- join will not be pruned
+-- the outer query of union/intersect/except will be pruned but the inner
+-- query will not be pruned.
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
 select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                             QUERY PLAN
+                                             QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=3980.09..6850.09 rows=172200 width=8)
    ->  HashAggregate  (cost=3980.09..4554.09 rows=57400 width=8)
@@ -2061,6 +2148,109 @@ select bar.a,foo.b from bar left join foo on foo.a=bar.a;
                                  ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
  Optimizer: Postgres-based planner
 (13 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4841.09 rows=172200 width=8)
+   ->  Append  (cost=0.00..2545.09 rows=57400 width=8)
+         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+               Hash Cond: (bar.a = foo_1.a)
+               ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+               ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                     ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
+   ->  HashSetOp Intersect  (cost=0.00..3980.09 rows=28700 width=12)
+         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
+                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+                                 Hash Cond: (bar.a = foo_1.a)
+                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(16 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
+   ->  HashSetOp Intersect All  (cost=0.00..3980.09 rows=28700 width=12)
+         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
+                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+                                 Hash Cond: (bar.a = foo_1.a)
+                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(16 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
+   ->  HashSetOp Except  (cost=0.00..3980.09 rows=28700 width=12)
+         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
+                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+                                 Hash Cond: (bar.a = foo_1.a)
+                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(16 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
+   ->  HashSetOp Except All  (cost=0.00..3980.09 rows=28700 width=12)
+         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
+                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
+                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
+                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
+                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+                                 Hash Cond: (bar.a = foo_1.a)
+                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(16 rows)
 
 drop table foo;
 drop table bar;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -2030,7 +2030,14 @@ union select foo.a, bar.b from foo join bar on foo.a = bar.a;
  Optimizer: Postgres-based planner
 (17 rows)
 
--- join will be pruned
+-------------------------------------
+-- CASES WHERE JOIN WILL BE PRUNED --
+-------------------------------------
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                          QUERY PLAN                         
@@ -2058,6 +2065,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (6 rows)
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                 QUERY PLAN                
@@ -2087,6 +2099,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  3 |   
 (12 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2114,6 +2131,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 20
 (3 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2142,6 +2164,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 20
 (4 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2168,6 +2195,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 30
 (2 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2195,9 +2227,16 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 30
 (3 rows)
 
--- join will not be pruned
--- the outer query of union/intersect/except will be pruned but the inner
--- query will not be pruned.
+------------------------------------------
+-- CASES WHERE JOIN WILL NOT BE PRUNED --
+------------------------------------------
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                          QUERY PLAN                         
@@ -2232,6 +2271,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
    | 20
 (9 rows)
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                  QUERY PLAN                 
@@ -2265,6 +2311,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (12 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2294,6 +2347,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (1 row)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2323,6 +2383,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (1 row)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            
@@ -2355,6 +2422,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  2 | 20
 (4 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                             QUERY PLAN                            

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -2028,6 +2028,40 @@ explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  Optimizer: Postgres-based planner
 (17 rows)
 
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                             QUERY PLAN
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2938.00..5808.00 rows=172200 width=8)
+   ->  HashAggregate  (cost=2938.00..3512.00 rows=57400 width=8)
+         Group Key: foo.a, foo.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2651.00 rows=57400 width=8)
+               Hash Key: foo.a, foo.b
+               ->  Append  (cost=0.00..1503.00 rows=57400 width=8)
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+                     ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                             QUERY PLAN
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3980.09..6850.09 rows=172200 width=8)
+   ->  HashAggregate  (cost=3980.09..4554.09 rows=57400 width=8)
+         Group Key: foo.a, foo.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3693.09 rows=57400 width=8)
+               Hash Key: foo.a, foo.b
+               ->  Append  (cost=0.00..2545.09 rows=57400 width=8)
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+                     ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+                           Hash Cond: (bar.a = foo_1.a)
+                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
+                           ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                                 ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(13 rows)
+
 drop table foo;
 drop table bar;
 -----------------------------------------------------------------

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -2002,255 +2002,392 @@ drop table barJoinPruning;
 --
 -- Cases where join under union
 --
-create table foo(a int primary key, b int);
-create table bar(a int primary key, b int);
-explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
- union
-   select foo.a, bar.b from foo join bar on foo.a = bar.a;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=5022.18..7892.18 rows=172200 width=8)
-   ->  HashAggregate  (cost=5022.18..5596.18 rows=57400 width=8)
+create table foo(a int primary key, b int,c int);
+create table bar(a int primary key, b int,c int);
+insert into foo values (1,1,10),(2,1,10),(3,2,20),(4,2,30),(5,2,30),(6,NULL,NULL),(7,NULL,3);
+insert into bar values (1,1,10),(2,2,20),(3,NULL,NULL),(4,3,NULL),(5,1,10);
+analyze foo,bar;
+explain (costs off) select foo.a, bar.b from foo left join bar on foo.a = bar.a
+union select foo.a, bar.b from foo join bar on foo.a = bar.a;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
          Group Key: foo.a, bar.b
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=679.75..4735.18 rows=57400 width=8)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: foo.a, bar.b
-               ->  Append  (cost=679.75..3587.18 rows=57400 width=8)
-                     ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
+               ->  Append
+                     ->  Hash Left Join
                            Hash Cond: (foo.a = bar.a)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=4)
-                           ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
-                     ->  Hash Join  (cost=679.75..1363.09 rows=28700 width=8)
+                           ->  Seq Scan on foo
+                           ->  Hash
+                                 ->  Seq Scan on bar
+                     ->  Hash Join
                            Hash Cond: (foo_1.a = bar_1.a)
-                           ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=4)
-                           ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                 ->  Seq Scan on bar bar_1  (cost=0.00..321.00 rows=28700 width=8)
+                           ->  Seq Scan on foo foo_1
+                           ->  Hash
+                                 ->  Seq Scan on bar bar_1
  Optimizer: Postgres-based planner
 (17 rows)
 
 -- join will be pruned
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2938.00..5808.00 rows=172200 width=8)
-   ->  HashAggregate  (cost=2938.00..3512.00 rows=57400 width=8)
-         Group Key: foo.a, foo.b
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2651.00 rows=57400 width=8)
-               Hash Key: foo.a, foo.b
-               ->  Append  (cost=0.00..1503.00 rows=57400 width=8)
-                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-                     ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: foo.b, foo.c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: foo.b, foo.c
+               ->  Append
+                     ->  Seq Scan on foo
+                     ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (9 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3799.00 rows=172200 width=8)
-   ->  Append  (cost=0.00..1503.00 rows=57400 width=8)
-         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |   
+ 2 | 30
+   |  3
+ 2 | 20
+ 3 |   
+ 1 | 10
+(6 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on foo
+         ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (5 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
-   ->  HashSetOp Intersect  (cost=0.00..2938.00 rows=28700 width=12)
-         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+   |   
+ 1 | 10
+ 1 | 10
+ 1 | 10
+ 1 | 10
+ 2 | 20
+ 2 | 30
+   |  3
+ 2 | 20
+   |   
+ 3 |   
+(12 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Intersect
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Seq Scan on bar
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
  Optimizer: Postgres-based planner
 (12 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
-   ->  HashSetOp Intersect All  (cost=0.00..2938.00 rows=28700 width=12)
-         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |   
+ 1 | 10
+ 2 | 20
+(3 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Intersect All
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Seq Scan on bar
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
  Optimizer: Postgres-based planner
 (12 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
-   ->  HashSetOp Except  (cost=0.00..2938.00 rows=28700 width=12)
-         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |   
+ 1 | 10
+ 1 | 10
+ 2 | 20
+(4 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Except
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (12 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4086.00 rows=86100 width=12)
-   ->  HashSetOp Except All  (cost=0.00..2938.00 rows=28700 width=12)
-         ->  Append  (cost=0.00..2651.00 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |  3
+ 2 | 30
+(2 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Except All
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (12 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |  3
+ 2 | 30
+ 2 | 30
+(3 rows)
 
 -- join will not be pruned
 -- the outer query of union/intersect/except will be pruned but the inner
 -- query will not be pruned.
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3980.09..6850.09 rows=172200 width=8)
-   ->  HashAggregate  (cost=3980.09..4554.09 rows=57400 width=8)
-         Group Key: foo.a, foo.b
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..3693.09 rows=57400 width=8)
-               Hash Key: foo.a, foo.b
-               ->  Append  (cost=0.00..2545.09 rows=57400 width=8)
-                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-                     ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-                           Hash Cond: (bar.a = foo_1.a)
-                           ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-                           ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                 ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: foo.b, foo.c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: foo.b, foo.c
+               ->  Append
+                     ->  Seq Scan on foo
+                     ->  Hash Right Join
+                           Hash Cond: (foo_1.a = bar.a)
+                           ->  Seq Scan on foo foo_1
+                           ->  Hash
+                                 ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (13 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4841.09 rows=172200 width=8)
-   ->  Append  (cost=0.00..2545.09 rows=57400 width=8)
-         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-               Hash Cond: (bar.a = foo_1.a)
-               ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-               ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                     ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 10
+   |   
+ 2 | 30
+   |  3
+ 3 | 30
+ 1 | 10
+ 1 | 30
+ 2 | 20
+   | 20
+(9 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                 QUERY PLAN                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on foo
+         ->  Hash Right Join
+               Hash Cond: (foo_1.a = bar.a)
+               ->  Seq Scan on foo foo_1
+               ->  Hash
+                     ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (9 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
-   ->  HashSetOp Intersect  (cost=0.00..3980.09 rows=28700 width=12)
-         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
-                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-                                 Hash Cond: (bar.a = foo_1.a)
-                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 30
+   |  3
+ 2 | 10
+   | 20
+ 3 | 30
+ 2 | 30
+   |   
+ 1 | 30
+ 1 | 10
+ 1 | 10
+(12 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Intersect
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Hash Right Join
+                                 Hash Cond: (foo.a = bar.a)
+                                 ->  Seq Scan on foo
+                                 ->  Hash
+                                       ->  Seq Scan on bar
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo foo_1
  Optimizer: Postgres-based planner
 (16 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
-   ->  HashSetOp Intersect All  (cost=0.00..3980.09 rows=28700 width=12)
-         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
-                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-                                 Hash Cond: (bar.a = foo_1.a)
-                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+(1 row)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Intersect All
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Hash Right Join
+                                 Hash Cond: (foo.a = bar.a)
+                                 ->  Seq Scan on foo
+                                 ->  Hash
+                                       ->  Seq Scan on bar
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo foo_1
  Optimizer: Postgres-based planner
 (16 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
-   ->  HashSetOp Except  (cost=0.00..3980.09 rows=28700 width=12)
-         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
-                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-                                 Hash Cond: (bar.a = foo_1.a)
-                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+(1 row)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Except
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Hash Right Join
+                                 Hash Cond: (foo_1.a = bar.a)
+                                 ->  Seq Scan on foo foo_1
+                                 ->  Hash
+                                       ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (16 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5128.09 rows=86100 width=12)
-   ->  HashSetOp Except All  (cost=0.00..3980.09 rows=28700 width=12)
-         ->  Append  (cost=0.00..3693.09 rows=57400 width=12)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1182.00 rows=28700 width=12)
-                     Hash Key: "*SELECT* 1".a, "*SELECT* 1".b
-                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..608.00 rows=28700 width=12)
-                           ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=679.75..2224.09 rows=28700 width=12)
-                     Hash Key: "*SELECT* 2".a, "*SELECT* 2".b
-                     ->  Subquery Scan on "*SELECT* 2"  (cost=679.75..1650.09 rows=28700 width=12)
-                           ->  Hash Left Join  (cost=679.75..1363.09 rows=28700 width=8)
-                                 Hash Cond: (bar.a = foo_1.a)
-                                 ->  Seq Scan on bar  (cost=0.00..321.00 rows=28700 width=4)
-                                 ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-                                       ->  Seq Scan on foo foo_1  (cost=0.00..321.00 rows=28700 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |  3
+   |   
+ 2 | 30
+ 2 | 20
+(4 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashSetOp Except All
+         ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*SELECT* 1".b, "*SELECT* 1".c
+                     ->  Subquery Scan on "*SELECT* 1"
+                           ->  Seq Scan on foo
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: "*SELECT* 2".b, "*SELECT* 2".c
+                     ->  Subquery Scan on "*SELECT* 2"
+                           ->  Hash Right Join
+                                 Hash Cond: (foo_1.a = bar.a)
+                                 ->  Seq Scan on foo foo_1
+                                 ->  Hash
+                                       ->  Seq Scan on bar
  Optimizer: Postgres-based planner
 (16 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |  3
+   |   
+ 2 | 30
+ 2 | 30
+ 2 | 20
+ 1 | 10
+(6 rows)
 
 drop table foo;
 drop table bar;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1993,259 +1993,452 @@ drop table barJoinPruning;
 --
 -- Cases where join under union
 --
-create table foo(a int primary key, b int);
-create table bar(a int primary key, b int);
-explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
- union
-   select foo.a, bar.b from foo join bar on foo.a = bar.a;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..874.00 rows=1 width=8)
-   ->  GroupAggregate  (cost=0.00..874.00 rows=1 width=8)
+create table foo(a int primary key, b int,c int);
+create table bar(a int primary key, b int,c int);
+insert into foo values (1,1,10),(2,1,10),(3,2,20),(4,2,30),(5,2,30),(6,NULL,NULL),(7,NULL,3);
+insert into bar values (1,1,10),(2,2,20),(3,NULL,NULL),(4,3,NULL),(5,1,10);
+analyze foo,bar;
+explain (costs off) select foo.a, bar.b from foo left join bar on foo.a = bar.a
+union select foo.a, bar.b from foo join bar on foo.a = bar.a;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
          Group Key: foo.a, bar.b
-         ->  Sort  (cost=0.00..874.00 rows=1 width=8)
+         ->  Sort
                Sort Key: foo.a, bar.b
-               ->  Append  (cost=0.00..874.00 rows=1 width=8)
-                     ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
-                           Join Filter: true
-                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Index Scan using bar_pkey on bar  (cost=0.00..6.00 rows=1 width=4)
-                                 Index Cond: (a = foo.a)
-                     ->  Nested Loop  (cost=0.00..437.00 rows=1 width=8)
-                           Join Filter: true
-                           ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Index Scan using bar_pkey on bar bar_1  (cost=0.00..6.00 rows=1 width=4)
-                                 Index Cond: (a = foo_1.a)
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.a, bar.b
+                           ->  Nested Loop Left Join
+                                 Join Filter: true
+                                 ->  Seq Scan on foo
+                                 ->  Index Scan using bar_pkey on bar
+                                       Index Cond: (a = foo.a)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: foo_1.a, bar_1.b
+                           ->  Nested Loop
+                                 Join Filter: true
+                                 ->  Seq Scan on bar bar_1
+                                 ->  Index Scan using foo_pkey on foo foo_1
+                                       Index Cond: (a = bar_1.a)
  Optimizer: GPORCA
-(17 rows)
+(21 rows)
 
 -- join will be pruned
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-         Group Key: foo.a, foo.b
-         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-               Sort Key: foo.a, foo.b
-               ->  Append  (cost=0.00..862.00 rows=1 width=8)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: foo.b, foo.c
+         ->  Sort
+               Sort Key: foo.b, foo.c
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: bar.b, bar.c
+                           ->  Seq Scan on bar
  Optimizer: GPORCA
-(9 rows)
+(13 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Append  (cost=0.00..862.00 rows=1 width=8)
-         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+   |  3
+   |   
+ 1 | 10
+ 2 | 20
+ 3 |   
+(6 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on foo
+         ->  Seq Scan on bar
  Optimizer: GPORCA
 (5 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+ 1 | 10
+ 1 | 10
+ 2 | 20
+ 2 | 30
+   |  3
+ 2 | 20
+   |   
+ 3 |   
+ 2 | 30
+   |   
+ 1 | 10
+(12 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)))
-         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM bar.c)))
+         ->  GroupAggregate
+               Group Key: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: bar.b, bar.c
+                     ->  Sort
+                           Sort Key: bar.b, bar.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, bar.c
+                                 ->  Seq Scan on bar
  Optimizer: GPORCA
-(7 rows)
+(19 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |   
+ 1 | 10
+ 2 | 20
+(3 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
-         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-               Partition By: foo.a, foo.b
-               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                     Sort Key: foo.a, foo.b
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-                     Partition By: bar.a, bar.b
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                           Sort Key: bar.a, bar.b
-                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM bar.c)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg
+               Partition By: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  WindowAgg
+                     Partition By: bar.b, bar.c
+                     ->  Sort
+                           Sort Key: bar.b, bar.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, bar.c
+                                 ->  Seq Scan on bar
+ Optimizer: GPORCA
+(19 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+   |   
+ 1 | 10
+ 1 | 10
+ 2 | 20
+(4 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: foo.b, foo.c
+         ->  Sort
+               Sort Key: foo.b, foo.c
+               ->  Hash Anti Join
+                     Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM bar.c)))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, bar.c
+                                 ->  Seq Scan on bar
  Optimizer: GPORCA
 (15 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)))
-         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: GPORCA
-(7 rows)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+   |  3
+(2 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
-         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-               Partition By: foo.a, foo.b
-               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                     Sort Key: foo.a, foo.b
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-                     Partition By: bar.a, bar.b
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                           Sort Key: bar.a, bar.b
-                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM bar.c)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg
+               Partition By: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  WindowAgg
+                     Partition By: bar.b, bar.c
+                     ->  Sort
+                           Sort Key: bar.b, bar.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, bar.c
+                                 ->  Seq Scan on bar
  Optimizer: GPORCA
-(15 rows)
+(19 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+ 2 | 30
+   |  3
+(3 rows)
 
 -- join will not be pruned
 -- the outer query of union/intersect/except will be pruned but the inner
 -- query will not be pruned.
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  GroupAggregate  (cost=0.00..868.00 rows=1 width=8)
-         Group Key: foo.a, foo.b
-         ->  Sort  (cost=0.00..868.00 rows=1 width=8)
-               Sort Key: foo.a, foo.b
-               ->  Append  (cost=0.00..868.00 rows=1 width=8)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
-                           Join Filter: true
-                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
-                                 Index Cond: (a = bar.a)
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: foo.b, foo.c
+         ->  Sort
+               Sort Key: foo.b, foo.c
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: bar.b, foo_1.c
+                           ->  Nested Loop Left Join
+                                 Join Filter: true
+                                 ->  Seq Scan on bar
+                                 ->  Index Scan using foo_pkey on foo foo_1
+                                       Index Cond: (a = bar.a)
  Optimizer: GPORCA
-(13 rows)
+(17 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  Append  (cost=0.00..868.00 rows=1 width=8)
-         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+ 1 | 30
+ 2 | 20
+   | 20
+ 2 | 10
+ 2 | 30
+ 3 | 30
+   |  3
+   |   
+(9 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on foo
+         ->  Nested Loop Left Join
                Join Filter: true
-               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-               ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+               ->  Seq Scan on bar
+               ->  Index Scan using foo_pkey on foo foo_1
                      Index Cond: (a = bar.a)
  Optimizer: GPORCA
 (9 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  Hash Join  (cost=0.00..868.00 rows=1 width=8)
-         Hash Cond: ((NOT (bar.a IS DISTINCT FROM foo_1.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)))
-         ->  GroupAggregate  (cost=0.00..437.00 rows=1 width=8)
-               Group Key: bar.a, foo.b
-               ->  Sort  (cost=0.00..437.00 rows=1 width=8)
-                     Sort Key: bar.a, foo.b
-                     ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
-                           Join Filter: true
-                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Index Scan using foo_pkey on foo  (cost=0.00..6.00 rows=1 width=4)
-                                 Index Cond: (a = bar.a)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: GPORCA
-(15 rows)
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+   |   
+ 1 | 30
+ 1 | 10
+ 2 | 20
+ 2 | 30
+   |  3
+ 2 | 10
+   | 20
+ 3 | 30
+ 1 | 10
+ 1 | 10
+(12 rows)
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  Hash Semi Join  (cost=0.00..868.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-               Hash Key: (row_number() OVER (?))
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-                     Partition By: foo.a, foo.b
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                           Sort Key: foo.a, foo.b
-                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=437.00..437.00 rows=1 width=16)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..437.00 rows=1 width=16)
-                     Hash Key: (row_number() OVER (?))
-                     ->  WindowAgg  (cost=0.00..437.00 rows=1 width=16)
-                           Partition By: bar.a, foo_1.b
-                           ->  Sort  (cost=0.00..437.00 rows=1 width=8)
-                                 Sort Key: bar.a, foo_1.b
-                                 ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
-                                       Join Filter: true
-                                       ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
-                                             Index Cond: (a = bar.a)
- Optimizer: GPORCA
-(23 rows)
-
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  Hash Anti Join  (cost=0.00..868.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)))
-         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=437.00..437.00 rows=1 width=8)
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
-                     Join Filter: true
-                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
-                           Index Cond: (a = bar.a)
- Optimizer: GPORCA
-(11 rows)
-
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
-   ->  Hash Anti Join  (cost=0.00..868.00 rows=1 width=8)
-         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-               Hash Key: (row_number() OVER (?))
-               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
-                     Partition By: foo.a, foo.b
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                           Sort Key: foo.a, foo.b
-                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Hash  (cost=437.00..437.00 rows=1 width=16)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..437.00 rows=1 width=16)
-                     Hash Key: (row_number() OVER (?))
-                     ->  WindowAgg  (cost=0.00..437.00 rows=1 width=16)
-                           Partition By: bar.a, foo_1.b
-                           ->  Sort  (cost=0.00..437.00 rows=1 width=8)
-                                 Sort Key: bar.a, foo_1.b
-                                 ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM foo_1.c)))
+         ->  GroupAggregate
+               Group Key: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: bar.b, foo_1.c
+                     ->  Sort
+                           Sort Key: bar.b, foo_1.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, foo_1.c
+                                 ->  Nested Loop Left Join
                                        Join Filter: true
-                                       ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                                       ->  Seq Scan on bar
+                                       ->  Index Scan using foo_pkey on foo foo_1
                                              Index Cond: (a = bar.a)
  Optimizer: GPORCA
 (23 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+(1 row)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM foo_1.c)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg
+               Partition By: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  WindowAgg
+                     Partition By: bar.b, foo_1.c
+                     ->  Sort
+                           Sort Key: bar.b, foo_1.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, foo_1.c
+                                 ->  Nested Loop Left Join
+                                       Join Filter: true
+                                       ->  Seq Scan on bar
+                                       ->  Index Scan using foo_pkey on foo foo_1
+                                             Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(23 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 1 | 10
+(1 row)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: foo.b, foo.c
+         ->  Sort
+               Sort Key: foo.b, foo.c
+               ->  Hash Anti Join
+                     Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM foo_1.c)))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, foo_1.c
+                                 ->  Nested Loop Left Join
+                                       Join Filter: true
+                                       ->  Seq Scan on bar
+                                       ->  Index Scan using foo_pkey on foo foo_1
+                                             Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(19 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 20
+ 2 | 30
+   |  3
+   |   
+(4 rows)
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: ((NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT (foo.c IS DISTINCT FROM foo_1.c)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg
+               Partition By: foo.b, foo.c
+               ->  Sort
+                     Sort Key: foo.b, foo.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.b, foo.c
+                           ->  Seq Scan on foo
+         ->  Hash
+               ->  WindowAgg
+                     Partition By: bar.b, foo_1.c
+                     ->  Sort
+                           Sort Key: bar.b, foo_1.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: bar.b, foo_1.c
+                                 ->  Nested Loop Left Join
+                                       Join Filter: true
+                                       ->  Seq Scan on bar
+                                       ->  Index Scan using foo_pkey on foo foo_1
+                                             Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(23 rows)
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+ b | c  
+---+----
+ 2 | 30
+ 2 | 30
+   |  3
+   |   
+ 1 | 10
+ 2 | 20
+(6 rows)
 
 drop table foo;
 drop table bar;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -2019,6 +2019,40 @@ explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  Optimizer: GPORCA
 (17 rows)
 
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: foo.a, foo.b
+         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+               Sort Key: foo.a, foo.b
+               ->  Append  (cost=0.00..862.00 rows=1 width=8)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(9 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..868.00 rows=1 width=8)
+         Group Key: foo.a, foo.b
+         ->  Sort  (cost=0.00..868.00 rows=1 width=8)
+               Sort Key: foo.a, foo.b
+               ->  Append  (cost=0.00..868.00 rows=1 width=8)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+                           Join Filter: true
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                                 Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(13 rows)
+
 drop table foo;
 drop table bar;
 -----------------------------------------------------------------

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -2019,6 +2019,7 @@ explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  Optimizer: GPORCA
 (17 rows)
 
+-- join will be pruned
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
 select bar.a,bar.b from bar left join foo on foo.a=bar.a;
                                   QUERY PLAN                                  
@@ -2034,6 +2035,88 @@ select bar.a,bar.b from bar left join foo on foo.a=bar.a;
  Optimizer: GPORCA
 (9 rows)
 
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Append  (cost=0.00..862.00 rows=1 width=8)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(5 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)))
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(7 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+               Partition By: foo.a, foo.b
+               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     Sort Key: foo.a, foo.b
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+                     Partition By: bar.a, bar.b
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: bar.a, bar.b
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(15 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)))
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(7 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM bar.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+               Partition By: foo.a, foo.b
+               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     Sort Key: foo.a, foo.b
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+                     Partition By: bar.a, bar.b
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: bar.a, bar.b
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(15 rows)
+
+-- join will not be pruned
+-- the outer query of union/intersect/except will be pruned but the inner
+-- query will not be pruned.
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
 select bar.a,foo.b from bar left join foo on foo.a=bar.a;
                                                QUERY PLAN                                               
@@ -2052,6 +2135,117 @@ select bar.a,foo.b from bar left join foo on foo.a=bar.a;
                                  Index Cond: (a = bar.a)
  Optimizer: GPORCA
 (13 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  Append  (cost=0.00..868.00 rows=1 width=8)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+               Join Filter: true
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+               ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                     Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(9 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..868.00 rows=1 width=8)
+         Hash Cond: ((NOT (bar.a IS DISTINCT FROM foo_1.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)))
+         ->  GroupAggregate  (cost=0.00..437.00 rows=1 width=8)
+               Group Key: bar.a, foo.b
+               ->  Sort  (cost=0.00..437.00 rows=1 width=8)
+                     Sort Key: bar.a, foo.b
+                     ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+                           Join Filter: true
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Index Scan using foo_pkey on foo  (cost=0.00..6.00 rows=1 width=4)
+                                 Index Cond: (a = bar.a)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(15 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  Hash Semi Join  (cost=0.00..868.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+               Hash Key: (row_number() OVER (?))
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+                     Partition By: foo.a, foo.b
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: foo.a, foo.b
+                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=437.00..437.00 rows=1 width=16)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..437.00 rows=1 width=16)
+                     Hash Key: (row_number() OVER (?))
+                     ->  WindowAgg  (cost=0.00..437.00 rows=1 width=16)
+                           Partition By: bar.a, foo_1.b
+                           ->  Sort  (cost=0.00..437.00 rows=1 width=8)
+                                 Sort Key: bar.a, foo_1.b
+                                 ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+                                       Join Filter: true
+                                       ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                                             Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(23 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  Hash Anti Join  (cost=0.00..868.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)))
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=437.00..437.00 rows=1 width=8)
+               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+                     Join Filter: true
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                           Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(11 rows)
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=8)
+   ->  Hash Anti Join  (cost=0.00..868.00 rows=1 width=8)
+         Hash Cond: ((NOT (foo.a IS DISTINCT FROM bar.a)) AND (NOT (foo.b IS DISTINCT FROM foo_1.b)) AND (NOT ((row_number() OVER (?)) IS DISTINCT FROM (row_number() OVER (?)))))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+               Hash Key: (row_number() OVER (?))
+               ->  WindowAgg  (cost=0.00..431.00 rows=1 width=16)
+                     Partition By: foo.a, foo.b
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                           Sort Key: foo.a, foo.b
+                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=437.00..437.00 rows=1 width=16)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..437.00 rows=1 width=16)
+                     Hash Key: (row_number() OVER (?))
+                     ->  WindowAgg  (cost=0.00..437.00 rows=1 width=16)
+                           Partition By: bar.a, foo_1.b
+                           ->  Sort  (cost=0.00..437.00 rows=1 width=8)
+                                 Sort Key: bar.a, foo_1.b
+                                 ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=8)
+                                       Join Filter: true
+                                       ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Index Scan using foo_pkey on foo foo_1  (cost=0.00..6.00 rows=1 width=4)
+                                             Index Cond: (a = bar.a)
+ Optimizer: GPORCA
+(23 rows)
 
 drop table foo;
 drop table bar;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -2025,7 +2025,14 @@ union select foo.a, bar.b from foo join bar on foo.a = bar.a;
  Optimizer: GPORCA
 (21 rows)
 
--- join will be pruned
+-------------------------------------
+-- CASES WHERE JOIN WILL BE PRUNED --
+-------------------------------------
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                QUERY PLAN                               
@@ -2057,6 +2064,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  3 |   
 (6 rows)
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                 QUERY PLAN                
@@ -2086,6 +2098,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (12 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                              QUERY PLAN                                             
@@ -2120,6 +2137,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 20
 (3 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                                                                    QUERY PLAN                                                                                    
@@ -2155,6 +2177,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
  2 | 20
 (4 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                                    QUERY PLAN                                                   
@@ -2184,6 +2211,11 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
    |  3
 (2 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
                                                                                    QUERY PLAN                                                                                    
@@ -2218,9 +2250,16 @@ select bar.b,bar.c from bar left join foo on foo.a=bar.a;
    |  3
 (3 rows)
 
--- join will not be pruned
--- the outer query of union/intersect/except will be pruned but the inner
--- query will not be pruned.
+------------------------------------------
+-- CASES WHERE JOIN WILL NOT BE PRUNED --
+------------------------------------------
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                  QUERY PLAN                                 
@@ -2259,6 +2298,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
    |   
 (9 rows)
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                         QUERY PLAN                        
@@ -2292,6 +2338,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (12 rows)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                               QUERY PLAN                                              
@@ -2328,6 +2381,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (1 row)
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                                                                     QUERY PLAN                                                                                     
@@ -2364,6 +2424,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
  1 | 10
 (1 row)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                                     QUERY PLAN                                                    
@@ -2399,6 +2466,13 @@ select bar.b,foo.c from bar left join foo on foo.a=bar.a;
    |   
 (4 rows)
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
                                                                                     QUERY PLAN                                                                                     

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -845,76 +845,152 @@ analyze foo,bar;
 explain (costs off) select foo.a, bar.b from foo left join bar on foo.a = bar.a
 union select foo.a, bar.b from foo join bar on foo.a = bar.a;
 
--- join will be pruned
+-------------------------------------
+-- CASES WHERE JOIN WILL BE PRUNED --
+-------------------------------------
+
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query the output columns of both the CLogicalLeftOuterJoin
+-- are from the outer relation, so we can prune both the joins
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
--- join will not be pruned
--- the outer query of union/intersect/except will be pruned but the inner
--- query will not be pruned.
+------------------------------------------
+-- CASES WHERE JOIN WILL NOT BE PRUNED --
+------------------------------------------
+
+--------------------------------------------------------------------------------
+-- join under UNION
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a union
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under UNION ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under INTERSECT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 select foo.b,foo.c from foo left join bar on foo.a=bar.a except
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
+--------------------------------------------------------------------------------
+-- join under EXCEPT ALL
+-- For the below query since for the outer CLogicalLeftOuterJoin, all the output
+-- columns are from the outer relation, the outer join can be pruned but for the
+-- inner CLogicalLeftOuterJoin the output column contains columns from
+-- inner relation.So the inner join can't be pruned.
+--------------------------------------------------------------------------------
 explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
 select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -838,9 +838,17 @@ drop table barJoinPruning;
 --
 create table foo(a int primary key, b int);
 create table bar(a int primary key, b int);
+
 explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  union
    select foo.a, bar.b from foo join bar on foo.a = bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
 drop table foo;
 drop table bar;
 -----------------------------------------------------------------

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -836,52 +836,90 @@ drop table barJoinPruning;
 --
 -- Cases where join under union
 --
-create table foo(a int primary key, b int);
-create table bar(a int primary key, b int);
+create table foo(a int primary key, b int,c int);
+create table bar(a int primary key, b int,c int);
+insert into foo values (1,1,10),(2,1,10),(3,2,20),(4,2,30),(5,2,30),(6,NULL,NULL),(7,NULL,3);
+insert into bar values (1,1,10),(2,2,20),(3,NULL,NULL),(4,3,NULL),(5,1,10);
+analyze foo,bar;
 
-explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
- union
-   select foo.a, bar.b from foo join bar on foo.a = bar.a;
+explain (costs off) select foo.a, bar.b from foo left join bar on foo.a = bar.a
+union select foo.a, bar.b from foo join bar on foo.a = bar.a;
 
 -- join will be pruned
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,bar.c from bar left join foo on foo.a=bar.a;
 
 -- join will not be pruned
 -- the outer query of union/intersect/except will be pruned but the inner
 -- query will not be pruned.
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a union all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
-explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
-select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a intersect all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+explain (costs off) select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
+
+select foo.b,foo.c from foo left join bar on foo.a=bar.a except all
+select bar.b,foo.c from bar left join foo on foo.a=bar.a;
 
 drop table foo;
 drop table bar;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -843,10 +843,44 @@ explain  select foo.a, bar.b from foo left join bar on foo.a = bar.a
  union
    select foo.a, bar.b from foo join bar on foo.a = bar.a;
 
+-- join will be pruned
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
 select bar.a,bar.b from bar left join foo on foo.a=bar.a;
 
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
+select bar.a,bar.b from bar left join foo on foo.a=bar.a;
+
+-- join will not be pruned
+-- the outer query of union/intersect/except will be pruned but the inner
+-- query will not be pruned.
 explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a union all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a intersect all
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except
+select bar.a,foo.b from bar left join foo on foo.a=bar.a;
+
+explain select foo.a,foo.b from foo left join bar on foo.a=bar.a except all
 select bar.a,foo.b from bar left join foo on foo.a=bar.a;
 
 drop table foo;


### PR DESCRIPTION
Fix issue  #16932

## Terminology used:

`Derived Output columns:` Output columns defined by each operator

`Output Columns:` The intersection of the operator's derived output columns and
the operator's parent's combined output pred columns. If the operator is the
root operator, its output columns would be the intersection of the operator's
derived output columns and the query's output columns.

`Combined Output Pred Columns:` A set containing operator's output columns and
its predicate's (if present) derived output columns

## Root Cause Analysis
-------------------------

Consider the below tree
```
+--A(Logical)
   |--B (Logical)
   |  |----C (Logical)
   |  |----D (Logical)
   |  +----E (Scalar)
   |
   +--F (Scalar)
```
In order to perform left join pruning in ORCA, one of the step is that each
operator(Logical) determines two sets. One set containing output columns of the
operator and second set containing combined output pred columns: For e.g. in
the above tree, operator A will create two sets. One set containing output
columns of A (let's call this set S1) and second set containing combined output
pred columns (let's call this set S2). In order to determine those two sets the
below algorithm is employed (Suppose we are determining for operator A)
1.) The operator A will find it's derived output columns and will take a
intersection with the query's output. The common values will be inserted into
set S1 and S2. The set S1 now contains the output columns of operator A.
2.)If a scalar operator is present for operator A then the derived output
columns of the scalar operator are also inserted into the set S2 (In this case
operator F's derived output columns)
3.) Now the set S2 will contain combined output pred columns for operator A.
4.) This set S2 is passed to the next function call in which the output columns
of operator B will be determined.

Now consider the below query:

**Setup:**
```
create table t1(a int primary key, b int) ;
create table t2(a int primary key, b int) ;
```

**Query:**

```
explain select t2.b from t1 left join t2 on t1.a = t2.a union all select t2.b
from t1 left join t2 on t1.a = t2.a;
```

**Algebrized tree:**

```
+--CLogicalUnionAll Output: ("b" (10)), Input: [("b" (10)), ("b" (28))]
   |--CLogicalLeftOuterJoin
   |  |--CLogicalGet "t1" ("t1"), Columns: ["a" (0), "b" (1)]
   |  |--CLogicalGet "t2" ("t2"), Columns: ["a" (9), "b" (10)]
   |  +--CScalarCmp (=)
   |     |--CScalarIdent "a" (0)
   |     +--CScalarIdent "a" (9)
   +--CLogicalLeftOuterJoin
      |--CLogicalGet "t1" ("t1"), Columns: ["a" (18), "b" (19)]
      |--CLogicalGet "t2" ("t2"), Columns: ["a" (27), "b" (28)]
      +--CScalarCmp (=)
         |--CScalarIdent "a" (18)
         +--CScalarIdent "a" (27)
```

Based on the above algorithm mentioned
The derived output columns of CLogicalSetOp
(CLogicalUnion/UnionAll/Intersect/IntersectAll/Except/ExceptAll) are from its
outer child. Based on the algorithm mentioned above, CLogicalUnionAll will
create two sets. One set containing output columns of itself and second set
containing combined output pred columns . The first set will contain b(10) and
the second set will also contain b(10). This second set will be passed to the
outer and inner CLogicalLeftOuterJoin operator for determining there output
columns. The outer CLogicalLeftOuterJoin will find its derived output columns
and will intersect it with the set passed by CLogicalUnionAll containing b(10).
After intersection we will get b(10) as the output column for outer
CLogicalLeftOuterJoin.  Similarly the inner CLogicalLeftOuterJoin will find its
derived output columns and will intersect it with the set passed by
CLogicalUnionAll containing b(10). But here the intersection will lead to a
empty output column set for inner CLogicalLeftOuterJoin. Now for pruning a left
join in a query, one of the condition that ORCA checks is that all output
columns of CLogicalLeftOuterJoin should only belong from the outer relation.
The method performing this check doesn't handle the case when the output
columns set is empty. Due to this all the checks pass in that method and ORCA
proceeds to prune the Join. So basically the issue is that ORCA is not able to
properly determine the output columns for the child operators when the parent
is CLogicalSetOp which is leading to unwanted pruning of joins. A similar issue
was fixed in PR #16690 which ensured that the combined output pred columns of
CLogicalSetOp is not empty because an empty set was leading to unwanted pruning
of left join. But that fix was not complete. It was incorrectly determining
combined output pred columns  of CLogicalSetOp which lead to #16932.

## Fix
--------
Updating the logic for determining the combined output pred columns  of
CLogicalSetOp. Since in the case of CLogicalSetOp, the output columns are from
the outer child, the inner child will always have empty output columns which is
not completely correct. So we need to also include the inner child columns in
the combined output pred columns  for CLogicalSetOP.