### PR TITLE
gpload.py added "order by" clause in get_table_dist_key method

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2868,7 +2868,8 @@ class gpload:
                 "a.attrelid = p.localoid and " + \
                 "a.attnum = any (p.distkey) and " + \
                 "c.relnamespace = n.oid and " + \
-                "n.nspname = '%s' and c.relname = '%s'; " % (quote_unident(self.schema), quote_unident(self.table))
+                "n.nspname = '%s' and c.relname = '%s' " % (quote_unident(self.schema), quote_unident(self.table)) + \
+                "order by position(concat(' ',a.attnum::text,' ') in concat(' ',p.distkey::text,' ')); "
 
         try:
                 resultList = self.db.query(sql.encode('utf-8')).getresult()


### PR DESCRIPTION
need to restore sorting for distibution key that was implemented  https://github.com/greenplum-db/gpdb/pull/13159 but reverted https://github.com/greenplum-db/gpdb/pull/13465. As far as pg_get_table_distributedby is unavalible it uses simple `order by` clause to get correct order for distibution key columns