### PR TITLE
[6X] pg_dump: fix --function-oid when --relation-oid is also used

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -69,6 +69,12 @@ def before_feature(context, feature):
         dbconn.execSQL(context.conn, 'insert into t1 values(1, 2)')
         dbconn.execSQL(context.conn, 'insert into t2 values(1, 3)')
         dbconn.execSQL(context.conn, 'insert into t3 values(1, 4)')
+        # minirepro tests require statistical data about the contents of the database
+        # we should execute 'ANALYZE' to fill the pg_statistic catalog table.
+        dbconn.execSQL(context.conn, 'analyze t1')
+        dbconn.execSQL(context.conn, 'analyze t2')
+        dbconn.execSQL(context.conn, 'analyze t3')
+        dbconn.execSQL(context.conn, 'create or replace function select_one() returns integer as $$ select 1 $$ language sql')
         context.conn.commit()
 
     if 'gppkg' in feature.tags:

--- a/gpMgmt/test/behave/mgmt_utils/minirepro.feature
+++ b/gpMgmt/test/behave/mgmt_utils/minirepro.feature
@@ -263,3 +263,15 @@ Feature: Dump minimum database objects that is related to the query
       And the output file "/tmp/out.sql" should contain "Table: t3, Attribute: f"
       And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
       And the file "/tmp/in.sql" should be executed in database "minidb_tmp" without error
+
+    @minirepro_core
+    Scenario: Dump database objects of only functions
+      Given the file "/tmp/in.sql" exists and contains "SELECT select_one()"
+      And the file "/tmp/out.sql" does not exist
+      When the user runs "minirepro minireprodb -q /tmp/in.sql -f /tmp/out.sql"
+      Then the output file "/tmp/out.sql" should exist
+      And the output file "/tmp/out.sql" should contain "CREATE FUNCTION public.select_one() RETURNS integer"
+      And the output file "/tmp/out.sql" should contain "LANGUAGE sql"
+      And the output file "/tmp/out.sql" should contain "AS $$ select 1 $$;"
+      And the output file "/tmp/out.sql" should be loaded to database "minidb_tmp" without error
+      And the file "/tmp/in.sql" should be executed in database "minidb_tmp" without error


### PR DESCRIPTION
This is a backport of 7X commits 992b4dd and 9a36a39 with minor modifications to account for differences in pg_dump code between 6X and 7X.

Original commit message follows:

pg_dump does not correctly dump functions when both greenplum specific
internal flags `--function-oid` and `--relation-oid` are used at the
same time. This is because functions are being marked dumpable or not
twice. The first time is by selectDumpableFunction and then again by
selectDumpableObject. When `--relation-oid` is used, all namespaces are
marked not dumpable which is why selectDumpableObject will mark the
function to not be dumped.

This must be a regression. The original commit that introduces greenplum
specific selectDumpableFunction removes the usage of the more generic
selectDumpableObject.

selectDumpableFunction reference commit:
318b86a

selectDumpableAggregate was created so aggregate dumping works as intended when
using --function-oid on an aggregate function. This is necessary because
pg_dump treats aggregates separately from functions. See the comment in getFuncs
for details.

Co-Authored By: Kevin Yeap <kyeap@vmware.com>