### PR TITLE
Docs: added gp_get_suboverflowed_backends to index

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-functions.html.md
@@ -4,6 +4,7 @@ Greenplum Database provides the following system catalog functions:
 
 > **Note** This list is provisional and may be incomplete.
 
+-   [gp_get_suboverflowed_backends](#gp_get_suboverflowed_backends)
 -   [pg_stat_get_backend_subxact](#pg_stat_get_backend_subxact)
 
 ## <a id="statistics"></a>Statistics Functions


### PR DESCRIPTION
This is a follow up PR to https://github.com/greenplum-db/gpdb/pull/16854. I forgot to add the function `gp_get_suboverflowed_backends` to the initial page index. I just need a quick approval. Thanks.