### PR TITLE
Docs postgresml train

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
@@ -72,10 +72,11 @@ in **every** database in which you registered/use the extension.
 
 The `postgresml` extension currently supports just a subset of all of the user-defined functions provided by PostgresML. They are these three:
 
-- `pgml.load_dataset()`: Loads a dataset into tables in VMware Greenplum using the `INSERT` SQL command. Read more about loading data [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/).
-- `pgml.embed()` - Generates an embedding for the dataset. Read more about PostgresML embeddings [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/embeddings). 
-- `pgml.transform()`: Applies a pre-trained transformer to process data. Read more about PostgresML pre-trained models [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/).
-- `pgml.train()`: Handles different training tasks which are configurable with the function parameters.
+- `pgml.load_dataset()`: Loads a dataset into tables in VMware Greenplum using the `INSERT` SQL command. Read more about loading data [here](https://postgresml.org/docs/use-cases/natural-language-processing).
+- `pgml.embed()` - Generates an embedding for the dataset. Read more about PostgresML embeddings [here](https://postgresml.org/docs/use-cases/embeddings/). 
+- `pgml.transform()`: Applies a pre-trained transformer to process data. Read more about PostgresML pre-trained models [here](https://postgresml.org/docs/use-cases/natural-language-processing).
+- `pgml.train()`: Handles different training tasks which are configurable with the function parameters. Read more about supervised learning [here](https://postgresml.org/docs/use-cases/supervised-learning).
+- `pgml.predict()`: Provides online predictions using the best, automatically deployed model for a project. Read more about supervised learning [here](https://postgresml.org/docs/use-cases/supervised-learning).
 
 VMware anticipates adding support for the additional PostgresML functions in future releases. 
 
@@ -163,7 +164,7 @@ pgml.train(
 where
 
 - `project_name` is an easily recognizable identifier to organize your work.
-- `task` is the objective of the experiment: `regression`, `classification` or `cluster`.
+- `task` is the objective of the experiment: `regression`, `classification`, or `cluster`.
 - `relation_name` is the Postgres table or view where the training data is stored or defined.
 - `y_column_name` is the name of the label column in the training table.
 - `algorithm` is the algorithm to train on the dataset, the available algorithms are `regression`, `classification`, and `clustering`.
@@ -177,7 +178,23 @@ where
 
 For more information about the available algorithms, hyperparameter search, and data pre-processing, visit the official [PostgresML Documentation](https://postgresml.org/docs/introduction/apis/sql-extensions/pgml.train/).
 
-## <a id="Example"></a>Example
+### <a id="pgml_predict"></a>pgml.predict()
+
+#### Syntax
+
+```
+select pgml.predict (
+    project_name TEXT,
+    features REAL[]
+)
+```
+
+where
+
+- `project_name` is the project name used to train models in [pgml.train()](#pgml.train).
+- `features` is an aggregate of feature vectors used to predict novel data points
+
+## <a id="Example"></a>Examples
 
 The following example:
 
@@ -217,3 +234,35 @@ SELECT pgml.transform(
     ] 
 ) AS french; 
 ```
+
+The following example:
+
+1. Obtains training data.
+2. Trains a model.
+3. Performs a prediction.
+
+```
+# Obtain training data from a dataset
+
+SELECT * FROM pgml.load_dataset('digits');
+SELECT target, image
+FROM pgml.digits LIMIT 5;
+
+# Train a model using an algorithm using the default linear algorithm 
+
+SELECT * FROM pgml.train(
+'Handwritten Digit Image Classifier',
+'classification',
+'pgml.digits',
+'target'
+);
+
+# Predict
+
+SELECT
+target,
+pgml.predict('Handwritten Digit Image Classifier', image) AS prediction
+FROM pgml.digits
+LIMIT 10;
+```
+

--- a/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
@@ -58,6 +58,16 @@ CREATE EXTENSION pgml;
 
 Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
 
+## <a id="topic_upgrading"></a>Upgrading the Module
+
+The `PostgresML` module is installed when you install or upgrade Greenplum Database. A previous version of the extension will continue to work in existing databases after you upgrade Greenplum. To upgrade to the most recent version of the extension, you must:
+
+```
+ALTER EXTENSION pgml UPDATE TO '2.7.13+greenplum.1.0.0';
+```
+
+in **every** database in which you registered/use the extension.
+
 ## <a id="UDF_summary"></a>User-Defined Functions
 
 The `postgresml` extension currently supports just a subset of all of the user-defined functions provided by PostgresML. They are these three:
@@ -65,6 +75,7 @@ The `postgresml` extension currently supports just a subset of all of the user-d
 - `pgml.load_dataset()`: Loads a dataset into tables in VMware Greenplum using the `INSERT` SQL command. Read more about loading data [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/).
 - `pgml.embed()` - Generates an embedding for the dataset. Read more about PostgresML embeddings [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/embeddings). 
 - `pgml.transform()`: Applies a pre-trained transformer to process data. Read more about PostgresML pre-trained models [here](https://postgresml.org/docs/guides/machine-learning/natural-language-processing/).
+- `pgml.train()`: Handles different training tasks which are configurable with the function parameters.
 
 VMware anticipates adding support for the additional PostgresML functions in future releases. 
 
@@ -127,6 +138,66 @@ where:
 
 >**Note**
 >You must explicitly specify a model when calling `pgml.transform()`; default models are not yet supported.
+
+### <a id="pgml_train"></a>pgml.train()
+
+#### Syntax
+
+```
+pgml.train(
+    project_name TEXT,
+    task TEXT DEFAULT NULL,
+    relation_name TEXT DEFAULT NULL,
+    y_column_name TEXT DEFAULT NULL,
+    algorithm TEXT DEFAULT 'linear',
+    hyperparams JSONB DEFAULT '{}'::JSONB,
+    search TEXT DEFAULT NULL,
+    search_params JSONB DEFAULT '{}'::JSONB,
+    search_args JSONB DEFAULT '{}'::JSONB,
+    test_size REAL DEFAULT 0.25,
+    test_sampling TEXT DEFAULT 'random',
+    preprocess JSONB DEFAULT '{}'::JSONB
+)
+```
+
+where
+
+- `project_name` is an easily recognizable identifier to organize your work.
+- `task` is the objective of the experiment: `regression`, `classification` or `cluster`.
+- `relation_name` is the Postgres table or view where the training data is stored or defined.
+- `y_column_name` is the name of the label column in the training table.
+- `algorithm` is the algorithm to train on the dataset, see the task specific pages for available algorithms: [regression](#pgml_train_algorithms_regression), [classification](#pgml_train_algorithms_classification), [clustering](#pgml_train_algorithms_clustering).
+- `hyperparams` are the hyperparameters to pass to the algorithm for training, JSON formatted.
+- `search` indicates, if set, whether or not PostgresML performs a hyperparameter search to find the best hyperparameters for the algorithm. See [Hyperparameter Search](#pgml_train_hyperparameter) for details.
+- `search_params` are the search parameters used in the `hyperparameter` search, using the scikit-learn notation, JSON formatted.
+- `search_args` are the configuration parameters for the `search`, JSON formatted. Currently only `n_iter` is supported for `random` search.
+- `test_size` is the fraction of the dataset to use for the test set and algorithm validation.
+- `test_sampling` is the algorithm used to fetch test data from the dataset: `random`, `first`, or `last`.
+- `preprocess` are the preprocessing steps to impute NULLS, encode categoricals and scale inputs. See [Data Pre-Processing](#pgml_train_datapreproc) for details.
+
+#### <a id="pgml_train_algorithms"></a>Algorithms
+
+##### <a id="pgml_train_algorithms_regression"></a>Regression
+
+PostgresML currently supports regression algorithms from [scikit-learn](https://scikit-learn.org/), [XGBoost](https://xgboost.readthedocs.io/), [LightGBM](https://lightgbm.readthedocs.io/) and [Catboost](https://catboost.ai/).
+
+##### <a id="pgml_train_algorithms_classification"></a>Classification
+
+This technique assigns new observations to categorical labels or classes based on a model built from labeled training data.
+
+##### <a id="pgml_train_algorithms_clustering"></a>Clustering
+
+You can train models using `pgml.train` on unlabeled data to identify groups within the data. To build clusters on a given dataset, you can use the table or a view. Since clustering is an unsupervised algorithm, you do not need a column that represents a label as one of the inputs to `pgml.train`.
+
+#### <a id="pgml_train_hyperparameter"></a>Hyperparameter Search
+
+You can further refine the models by using hyperparameter search and cross validation. PostgresML currently supports `random` and `grid` search algorithms, and `k-fold` cross validation.
+
+#### <a id="pgml_train_datapreproc"></a>Data Pre-Processing
+
+The training function also provides the option to pre-process data with the `preprocess` parameter. You can configure the pre-processors on a per-column basis for the training data set. There are currently three types of preprocessing available, for both categorical and quantitative variables. Below is a brief example for training data to learn a model of whether we should carry an umbrella or not.
+
+Preprocessing steps are saved after training, and repeated identically for future calls to `pgml.predict()`.
 
 ## <a id="Example"></a>Example
 

--- a/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/postgresml.html.md
@@ -166,38 +166,16 @@ where
 - `task` is the objective of the experiment: `regression`, `classification` or `cluster`.
 - `relation_name` is the Postgres table or view where the training data is stored or defined.
 - `y_column_name` is the name of the label column in the training table.
-- `algorithm` is the algorithm to train on the dataset, see the task specific pages for available algorithms: [regression](#pgml_train_algorithms_regression), [classification](#pgml_train_algorithms_classification), [clustering](#pgml_train_algorithms_clustering).
+- `algorithm` is the algorithm to train on the dataset, the available algorithms are `regression`, `classification`, and `clustering`.
 - `hyperparams` are the hyperparameters to pass to the algorithm for training, JSON formatted.
-- `search` indicates, if set, whether or not PostgresML performs a hyperparameter search to find the best hyperparameters for the algorithm. See [Hyperparameter Search](#pgml_train_hyperparameter) for details.
+- `search` indicates, if set, whether or not PostgresML performs a hyperparameter search to find the best hyperparameters for the algorithm. 
 - `search_params` are the search parameters used in the `hyperparameter` search, using the scikit-learn notation, JSON formatted.
 - `search_args` are the configuration parameters for the `search`, JSON formatted. Currently only `n_iter` is supported for `random` search.
 - `test_size` is the fraction of the dataset to use for the test set and algorithm validation.
 - `test_sampling` is the algorithm used to fetch test data from the dataset: `random`, `first`, or `last`.
-- `preprocess` are the preprocessing steps to impute NULLS, encode categoricals and scale inputs. See [Data Pre-Processing](#pgml_train_datapreproc) for details.
+- `preprocess` are the preprocessing steps to impute NULLS, encode categoricals and scale inputs. 
 
-#### <a id="pgml_train_algorithms"></a>Algorithms
-
-##### <a id="pgml_train_algorithms_regression"></a>Regression
-
-PostgresML currently supports regression algorithms from [scikit-learn](https://scikit-learn.org/), [XGBoost](https://xgboost.readthedocs.io/), [LightGBM](https://lightgbm.readthedocs.io/) and [Catboost](https://catboost.ai/).
-
-##### <a id="pgml_train_algorithms_classification"></a>Classification
-
-This technique assigns new observations to categorical labels or classes based on a model built from labeled training data.
-
-##### <a id="pgml_train_algorithms_clustering"></a>Clustering
-
-You can train models using `pgml.train` on unlabeled data to identify groups within the data. To build clusters on a given dataset, you can use the table or a view. Since clustering is an unsupervised algorithm, you do not need a column that represents a label as one of the inputs to `pgml.train`.
-
-#### <a id="pgml_train_hyperparameter"></a>Hyperparameter Search
-
-You can further refine the models by using hyperparameter search and cross validation. PostgresML currently supports `random` and `grid` search algorithms, and `k-fold` cross validation.
-
-#### <a id="pgml_train_datapreproc"></a>Data Pre-Processing
-
-The training function also provides the option to pre-process data with the `preprocess` parameter. You can configure the pre-processors on a per-column basis for the training data set. There are currently three types of preprocessing available, for both categorical and quantitative variables. Below is a brief example for training data to learn a model of whether we should carry an umbrella or not.
-
-Preprocessing steps are saved after training, and repeated identically for future calls to `pgml.predict()`.
+For more information about the available algorithms, hyperparameter search, and data pre-processing, visit the official [PostgresML Documentation](https://postgresml.org/docs/introduction/apis/sql-extensions/pgml.train/).
 
 ## <a id="Example"></a>Example
 


### PR DESCRIPTION
This PR adds the function `pgml.train` to the existing PostgresML reference page. 
@radarwave @yihong0618 could you help with an example for the last section, can anything be added to the existing example that uses the `pgml.train` function? Thanks.

Edit: it now also includes `pgml.predict` and an example at the end of the page.

Review site: 
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-pgml/greenplum-database/ref_guide-modules-postgresml.html