### PR TITLE
FIXME: Set correct locus for INSERT RETURNING in a CTE

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -33,10 +33,6 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdbpathlocus.h"	/* me */
 
-static List *cdb_build_distribution_keys(PlannerInfo *root,
-										 Index rti,
-										 GpPolicy *policy);
-
 /*
  * cdbpathlocus_equal
  *

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -388,7 +388,7 @@ bool
 cdbpathlocus_is_valid(CdbPathLocus locus);
 
 List *cdb_build_distribution_keys(struct PlannerInfo *root,
-                                         Index rti,
-                                         struct GpPolicy *policy);
+								  Index				  rti,
+								  struct GpPolicy 	 *policy);
 
 #endif   /* CDBPATHLOCUS_H */

--- a/src/include/cdb/cdbpathlocus.h
+++ b/src/include/cdb/cdbpathlocus.h
@@ -387,4 +387,8 @@ cdbpathlocus_is_hashed_on_relids(CdbPathLocus locus, Bitmapset *relids);
 bool
 cdbpathlocus_is_valid(CdbPathLocus locus);
 
+List *cdb_build_distribution_keys(struct PlannerInfo *root,
+                                         Index rti,
+                                         struct GpPolicy *policy);
+
 #endif   /* CDBPATHLOCUS_H */

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2437,9 +2437,10 @@ select * from with_test;
 drop table with_test;
 -- Check modifytable path: a INSERT RETURNING in a CTE, and check whether locus
 -- of CTE is set correctly, and upper node chooses correct motion.
--- CTE returns one column, which is the dist key
+-- create table cte_t1 with one column
 CREATE TABLE cte_t1(c1 int) DISTRIBUTED BY (c1);
 INSERT INTO cte_t1 SELECT generate_series(1, 100);
+-- CTE returns one column, which is the dist key
 EXPLAIN WITH aa AS (
 	INSERT INTO cte_t1 SELECT generate_series(3,300) RETURNING c1
 )
@@ -2471,3 +2472,102 @@ SELECT count(*) FROM aa, cte_t1 WHERE aa.c1 = cte_t1.c1;
 (1 row)
 
 drop table cte_t1;
+-- create table cte_t1 with one column
+CREATE TABLE cte_t2(c1 int, c2 int) DISTRIBUTED BY (c1);
+INSERT INTO cte_t2 SELECT generate_series(1, 100), generate_series(1, 100);
+-- CTE returns one column, which is the dist key
+EXPLAIN WITH aa AS (
+	INSERT INTO cte_t2 SELECT generate_series(3,300), generate_series(3,300)  RETURNING c1
+)
+SELECT count(*) FROM aa, cte_t2 WHERE aa.c1 = cte_t2.c1;
+                                                      QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=520.14..520.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=520.08..520.13 rows=3 width=8)
+         ->  Partial Aggregate  (cost=520.08..520.09 rows=1 width=8)
+               ->  Hash Join  (cost=9.71..498.70 rows=8553 width=0)
+                     Hash Cond: (cte_t2.c1 = cte_t2_1.c1)
+                     ->  Seq Scan on cte_t2  (cost=0.00..321.00 rows=28700 width=4)
+                     ->  Hash  (cost=8.46..8.46 rows=99 width=4)
+                           ->  Insert on cte_t2 cte_t2_1  (cost=0.00..8.46 rows=99 width=8)
+                                 ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..8.46 rows=99 width=8)
+                                       Hash Key: (generate_series(3, 300))
+                                       ->  ProjectSet  (cost=0.00..1.51 rows=298 width=8)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+WITH aa AS (
+	INSERT INTO cte_t2 SELECT generate_series(3,300), generate_series(3,300) RETURNING c1
+)
+SELECT count(*) FROM aa, cte_t2 WHERE aa.c1 = cte_t2.c1;
+ count 
+-------
+    98
+(1 row)
+
+-- CTE returns another column, which is not the dist key
+EXPLAIN WITH aa AS (
+	INSERT INTO cte_t2  SELECT generate_series(3,300), generate_series(3,300) RETURNING c2
+)
+SELECT count(*) FROM aa, cte_t2  WHERE aa.c2 = cte_t2.c2;
+                                                         QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=526.60..526.61 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=526.54..526.59 rows=3 width=8)
+         ->  Partial Aggregate  (cost=526.54..526.55 rows=1 width=8)
+               ->  Hash Join  (cost=16.16..505.16 rows=8553 width=0)
+                     Hash Cond: (cte_t2.c2 = cte_t2_1.c2)
+                     ->  Seq Scan on cte_t2  (cost=0.00..321.00 rows=28700 width=4)
+                     ->  Hash  (cost=12.44..12.44 rows=298 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..12.44 rows=298 width=4)
+                                 ->  Insert on cte_t2 cte_t2_1  (cost=0.00..8.46 rows=99 width=8)
+                                       ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..8.46 rows=99 width=8)
+                                             Hash Key: (generate_series(3, 300))
+                                             ->  ProjectSet  (cost=0.00..1.51 rows=298 width=8)
+                                                   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+WITH aa AS (
+	INSERT INTO cte_t2 SELECT generate_series(3,300), generate_series(3,300) RETURNING c2
+)
+SELECT count(*) FROM aa, cte_t2 WHERE aa.c2 = cte_t2.c2;
+ count 
+-------
+   396
+(1 row)
+
+-- CTE returns two columns, one of them is the dist key
+EXPLAIN WITH aa AS (
+	INSERT INTO cte_t2 SELECT generate_series(3,300), generate_series(3,300) RETURNING c1, c2
+)
+SELECT count(*) FROM aa, cte_t2 WHERE aa.c1 = cte_t2.c1;
+                                                         QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=520.14..520.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=520.08..520.13 rows=3 width=8)
+         ->  Partial Aggregate  (cost=520.08..520.09 rows=1 width=8)
+               ->  Hash Join  (cost=9.71..498.70 rows=8553 width=0)
+                     Hash Cond: (cte_t2.c1 = aa.c1)
+                     ->  Seq Scan on cte_t2  (cost=0.00..321.00 rows=28700 width=4)
+                     ->  Hash  (cost=8.46..8.46 rows=99 width=4)
+                           ->  Subquery Scan on aa  (cost=0.00..8.46 rows=99 width=4)
+                                 ->  Insert on cte_t2 cte_t2_1  (cost=0.00..8.46 rows=99 width=8)
+                                       ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..8.46 rows=99 width=8)
+                                             Hash Key: (generate_series(3, 300))
+                                             ->  ProjectSet  (cost=0.00..1.51 rows=298 width=8)
+                                                   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+WITH aa AS (
+	INSERT INTO cte_t2 SELECT generate_series(3,300), generate_series(3,300) RETURNING c1, c2
+)
+SELECT count(*) FROM aa, cte_t2  WHERE aa.c1 = cte_t2.c1;
+ count 
+-------
+   694
+(1 row)
+
+drop table cte_t2;

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2435,3 +2435,39 @@ select * from with_test;
 (1 row)
 
 drop table with_test;
+-- Check modifytable path: a INSERT RETURNING in a CTE, and check whether locus
+-- of CTE is set correctly, and upper node chooses correct motion.
+-- CTE returns one column, which is the dist key
+CREATE TABLE cte_t1(c1 int) DISTRIBUTED BY (c1);
+INSERT INTO cte_t1 SELECT generate_series(1, 100);
+EXPLAIN WITH aa AS (
+	INSERT INTO cte_t1 SELECT generate_series(3,300) RETURNING c1
+)
+SELECT count(*) FROM aa, cte_t1 WHERE aa.c1 = cte_t1.c1;
+                                                      QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=576.57..576.58 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=576.51..576.56 rows=3 width=8)
+         ->  Partial Aggregate  (cost=576.51..576.52 rows=1 width=8)
+               ->  Hash Join  (cost=9.70..552.60 rows=9566 width=0)
+                     Hash Cond: (cte_t1.c1 = cte_t1_1.c1)
+                     ->  Seq Scan on cte_t1  (cost=0.00..355.00 rows=32100 width=4)
+                     ->  Hash  (cost=8.46..8.46 rows=99 width=4)
+                           ->  Insert on cte_t1 cte_t1_1  (cost=0.00..8.46 rows=99 width=4)
+                                 ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..8.46 rows=99 width=4)
+                                       Hash Key: (generate_series(3, 300))
+                                       ->  ProjectSet  (cost=0.00..1.51 rows=298 width=4)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+WITH aa AS (
+	INSERT INTO cte_t1 SELECT generate_series(3,300) RETURNING c1
+)
+SELECT count(*) FROM aa, cte_t1 WHERE aa.c1 = cte_t1.c1;
+ count 
+-------
+    98
+(1 row)
+
+drop table cte_t1;


### PR DESCRIPTION
### Brief

For statement of INSERT RETURNING in a CTE, existing code always sets locus to Strewn, which causes that an extra Redistribute Motion is always needed even when the distribution of the CTE is compatible to upper node. The fix is to set correct locus according to the distribution of RETURNING of the CTE, so extra Redistribute Motion may be avoided for the case.

### Background

It's from a FIXME at /src/backend/optimizer/util/pathnode.c:5408:
```
    /*   
     * Set the distribution of the ModifyTable node itself. If there is only
     * one subplan, or all the subplans have a compatible distribution, then
     * we could mark the ModifyTable with the same distribution key. However,
     * currently, because a ModifyTable node can only be at the top of the
     * plan, it won't make any difference to the overall plan.
     *
     * GPDB_96_MERGE_FIXME: it might with e.g. a INSERT RETURNING in a CTE
     * I tried here, the locus setting is quite simple, but failed if it's not
     * in a CTE and the locus is General. Haven't figured out how to create
     * flow in that case.
     * Example:
     * CREATE TABLE cte_returning_locus(c1 int) DISTRIBUTED BY (c1);
     * COPY cte_returning_locus FROM PROGRAM 'seq 1 100';
     * EXPLAIN WITH aa AS (
     *        INSERT INTO cte_returning_locus SELECT generate_series(3,300) RETURNING c1
     * )
     * SELECT count(*) FROM aa,cte_returning_locus WHERE aa.c1 = cte_returning_locus.c1;
     *
     * The returning doesn't need a motion to be hash joined, works fine. But
     * without the WITH, what is the proper flow? FLOW_SINGLETON returns
     * nothing, FLOW_PARTITIONED without hashExprs(General locus has no
     * distkeys) returns duplication.
     *
     * GPDB_90_MERGE_FIXME: I've hacked a basic implementation of the above for
     * the case where all the subplans are POLICYTYPE_ENTRY, but it seems like
     * there should be a more general way to do this.
     */
```
And the issue actually comes from two separated commits:
https://github.com/greenplum-db/gpdb/pull/8955/commits/4e712e3fdc7c8e1d671a80217a85f028597a39dc by Adam
https://github.com/greenplum-db/gpdb/pull/8955/commits/2a864ff1421a631be1ebd2fb68f93cdfb8df09a4 by Heikki


### Example

Script:
```
CREATE TABLE cte_returning_locus(c1 int) DISTRIBUTED BY (c1);
COPY cte_returning_locus FROM PROGRAM 'seq 1 100';
EXPLAIN WITH aa AS (
  INSERT INTO cte_returning_locus SELECT generate_series(3,300)
  RETURNING c1)
SELECT count(*) FROM aa,cte_returning_locus
  WHERE aa.c1 = cte_returning_locus.c1;
```
The plan for existing code:
```
testdb=# explain verbose WITH aa AS (
testdb(# INSERT INTO cte_returning_locus SELECT generate_series(3,300) RETURNING c1
testdb(# )
testdb-# SELECT count(*) FROM aa,cte_returning_locus WHERE aa.c1 = cte_returning_locus.c1;
                                                            QUERY PLAN-------------------------------------------------------------------------------------------------------------
----------------------
 Finalize Aggregate  (cost=18.96..18.97 rows=1 width=8)
   Output: count(*)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=18.90..18.95 rows=3 width=8)
         Output: (PARTIAL count(*))
         ->  Partial Aggregate  (cost=18.90..18.91 rows=1 width=8)
               Output: PARTIAL count(*)
               ->  Hash Join  (cost=11.69..18.41 rows=199 width=0)
                     Hash Cond: (cte_returning_locus.c1 = cte_returning_locus_1.c1)
                     ->  Seq Scan on public.cte_returning_locus  (cost=0.00..3.99 rows=199 width=4)
                           Output: cte_returning_locus.c1
                     ->  Hash  (cost=10.45..10.45 rows=99 width=4)
                           Output: cte_returning_locus_1.c1
                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..10.45 rows=99 widt
h=4)
                                 Output: cte_returning_locus_1.c1
                                 Hash Key: cte_returning_locus_1.c1
                                 ->  Insert on public.cte_returning_locus cte_returning_locus_1  (cost=0.00..
8.46 rows=99 width=4)
                                       Output: cte_returning_locus_1.c1
                                       ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..8.46 r
ows=99 width=4)
                                             Output: (generate_series(3, 300))
                                             Hash Key: (generate_series(3, 300))
                                             ->  ProjectSet  (cost=0.00..1.51 rows=298 width=4)
                                                   Output: generate_series(3, 300)
                                                   ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres-based planner
 Settings: optimizer = 'off'
(25 rows) 
```
We can see there is Redistribute Motion (3:3) in front of the Insert node.

With the fix:
```
testdb=# EXPLAIN verbose WITH aa AS (
testdb(#   INSERT INTO cte_returning_locus SELECT generate_series(3,300)
testdb(#   RETURNING c1)
testdb-# SELECT count(*) FROM aa,cte_returning_locus
testdb-#   WHERE aa.c1 = cte_returning_locus.c1;
                                                         QUERY PLAN

-----------------------------------------------------------------------------------------
------------------------------------
 Finalize Aggregate  (cost=16.83..16.84 rows=1 width=8)
   Output: count(*)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=16.77..16.82 rows=3 width=8)
         Output: (PARTIAL count(*))
         ->  Partial Aggregate  (cost=16.77..16.78 rows=1 width=8)
               Output: PARTIAL count(*)
               ->  Hash Join  (cost=9.70..16.20 rows=230 width=0)
                     Hash Cond: (cte_returning_locus.c1 = cte_returning_locus_1.c1)
                     ->  Seq Scan on public.cte_returning_locus  (cost=0.00..3.32 rows=23
2 width=4)
                           Output: cte_returning_locus.c1
                     ->  Hash  (cost=8.46..8.46 rows=99 width=4)
                           Output: cte_returning_locus_1.c1
                           ->  Insert on public.cte_returning_locus cte_returning_locus_1
  (cost=0.00..8.46 rows=99 width=4)
                                 Output: cte_returning_locus_1.c1
                                 ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cos
t=0.00..8.46 rows=99 width=4)
                                       Output: (generate_series(3, 300))
                                       Hash Key: (generate_series(3, 300))
                                       ->  ProjectSet  (cost=0.00..1.51 rows=298 width=4)
                                             Output: generate_series(3, 300)
                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres-based planner
(21 rows)
```
The extra Redistribute Motion is gone because of the correct locus.

### Notes

Please note the assumption that for a INSERT there must be only one sub path (and one item in returningLists). I didn't find any negative example, but I am not very sure about the assumption. Please help to confirm it. Thanks!