### PR TITLE
[ORCA] Fill Agg argtypes as optimizer_enable_eageragg is on

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
@@ -251,7 +251,7 @@
           </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="21" Alias="min">
-              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -348,7 +348,7 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="min">
-              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -433,7 +433,7 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                      <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                      <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                         <dxl:ValuesList ParamType="aggargs">
                           <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggExpression.mdp
@@ -3252,7 +3252,7 @@
         </dxl:GroupingColumns>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="min">
-            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
                 <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
@@ -3337,7 +3337,7 @@
             </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="20" Alias="min">
-                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
@@ -3420,7 +3420,7 @@
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                        <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                        <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
                               <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -248,7 +248,7 @@
         </dxl:GroupingColumns>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="max">
-            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -341,7 +341,7 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -417,7 +417,7 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                         <dxl:ValuesList ParamType="aggargs">
                           <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
@@ -250,7 +250,7 @@
           </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="21" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -347,7 +347,7 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -432,7 +432,7 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                         <dxl:ValuesList ParamType="aggargs">
                           <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
@@ -4186,7 +4186,7 @@
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                         <dxl:ProjElem Alias="max" ColId="31">
-                            <dxl:AggFunc AggDistinct="false" AggMdid="0.2116.1.0" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:AggFunc AggDistinct="false" AggMdid="0.2116.1.0" AggStage="Normal" AggKind="n" AggArgTypes="23">
                               <dxl:ValuesList ParamType="aggargs">
                                 <dxl:Ident ColId="13" ColName="s1" TypeMdid="0.23.1.0"/>
                               </dxl:ValuesList>
@@ -4299,7 +4299,7 @@
               <dxl:Ident ColId="1" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="30" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -4384,7 +4384,7 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                         <dxl:ValuesList ParamType="aggargs">
                           <dxl:Ident ColId="12" ColName="s1" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMinMax.mdp
@@ -3252,7 +3252,7 @@
         </dxl:GroupingColumns>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="min">
-            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -3262,7 +3262,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="22" Alias="max">
-            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -3350,7 +3350,7 @@
             </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="20" Alias="min">
-                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
@@ -3360,7 +3360,7 @@
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="21" Alias="max">
-                <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                   </dxl:ValuesList>
@@ -3452,7 +3452,7 @@
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                        <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                        <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
@@ -3462,7 +3462,7 @@
                         </dxl:AggFunc>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
@@ -285,7 +285,7 @@
         </dxl:GroupingColumns>
         <dxl:ProjList>
           <dxl:ProjElem ColId="31" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -390,7 +390,7 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="30" Alias="sum">
-              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
@@ -520,7 +520,7 @@
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
@@ -3273,7 +3273,7 @@
         </dxl:GroupingColumns>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="min">
-            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -3283,7 +3283,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="22" Alias="max">
-            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:Ident ColId="3" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:ValuesList>
@@ -3293,7 +3293,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="23" Alias="count2">
-            <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+            <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="20">
               <dxl:ValuesList ParamType="aggargs">
               <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
@@ -3381,7 +3381,7 @@
               <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="min">
-              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -3391,7 +3391,7 @@
               </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="21" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -3401,7 +3401,7 @@
               </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="22" Alias="count2">
-              <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+              <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="20">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
@@ -3466,7 +3466,7 @@
                 </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                    <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                    <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                       <dxl:ValuesList ParamType="aggargs">
                         <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
@@ -3476,7 +3476,7 @@
                     </dxl:AggFunc>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                       <dxl:ValuesList ParamType="aggargs">
                         <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
@@ -3486,7 +3486,7 @@
                     </dxl:AggFunc>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="25" Alias="ColRef_0025">
-                    <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                    <dxl:AggFunc AggMdid="0.32851.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="20">
                       <dxl:ValuesList ParamType="aggargs">
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                           <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
@@ -101,7 +101,7 @@ private:
 		CMemoryPool *mp,  // memory pool
 		IMDId *agg_mdid,  // original global aggregate function
 		CWStringConst *agg_name, CExpressionArray *agg_arg_array,
-		BOOL is_distinct,
+		BOOL is_distinct, ULongPtrArray *arg_types,
 		CExpression **lower_proj_elem_expr	// output project element of the new
 											// lower aggregate
 	);
@@ -111,7 +111,7 @@ private:
 		CMemoryPool *mp,  // memory pool
 		IMDId *agg_mdid,  // aggregate mdid to create
 		CWStringConst *agg_name, CColRef *lower_colref, CColRef *output_colref,
-		BOOL is_distinct,
+		BOOL is_distinct, ULongPtrArray *arg_types,
 		CExpression **upper_proj_elem_expr	// output project element of the new
 											// upper aggregate
 	);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
@@ -280,7 +280,7 @@ CXformEagerAgg::PopulateLowerUpperProjectList(
 			GPOS_NEW(mp)
 				CWStringConst(mp, orig_agg_func->PstrAggFunc()->GetBuffer()),
 			orig_agg_expr->PdrgPexpr(), orig_agg_func->IsDistinct(),
-			&lower_proj_elem_expr);
+			orig_agg_func->GetArgTypes(), &lower_proj_elem_expr);
 		lower_proj_elem_array->Append(lower_proj_elem_expr);
 
 		CExpression *upper_proj_elem_expr = nullptr;
@@ -291,7 +291,7 @@ CXformEagerAgg::PopulateLowerUpperProjectList(
 			CScalarProjectElement::PopConvert(lower_proj_elem_expr->Pop())
 				->Pcr(),
 			orig_proj_elem->Pcr(), orig_agg_func->IsDistinct(),
-			&upper_proj_elem_expr);
+			orig_agg_func->GetArgTypes(), &upper_proj_elem_expr);
 		upper_proj_elem_array->Append(upper_proj_elem_expr);
 	}  // end of loop over each project element
 
@@ -310,6 +310,7 @@ CXformEagerAgg::PopulateLowerProjectElement(
 	CMemoryPool *mp,  // memory pool
 	IMDId *agg_mdid,  // original global aggregate function
 	CWStringConst *agg_name, CExpressionArray *agg_arg_array, BOOL is_distinct,
+	ULongPtrArray *arg_types,
 	CExpression **
 		lower_proj_elem_expr  // output project element of the new lower aggregate
 )
@@ -318,9 +319,10 @@ CXformEagerAgg::PopulateLowerProjectElement(
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 
 	agg_mdid->AddRef();
+	arg_types->AddRef();
 	CScalarAggFunc *lower_agg_func = CUtils::PopAggFunc(
 		mp, agg_mdid, agg_name, is_distinct, EaggfuncstageLocal, true, nullptr,
-		EaggfunckindNormal, GPOS_NEW(mp) ULongPtrArray(mp), false);
+		EaggfunckindNormal, arg_types, false);
 	// add the arguments for the lower aggregate function, which is
 	// going to be the same as the original aggregate function
 	agg_arg_array->AddRef();
@@ -348,16 +350,17 @@ CXformEagerAgg::PopulateUpperProjectElement(
 	CMemoryPool *mp,  // memory pool
 	IMDId *agg_mdid,  // original global aggregate function
 	CWStringConst *agg_name, CColRef *lower_colref, CColRef *output_colref,
-	BOOL is_distinct,
+	BOOL is_distinct, ULongPtrArray *arg_types,
 	CExpression **
 		upper_proj_elem_expr  // output project element of the new lower aggregate
 )
 {
 	// create a new operator
 	agg_mdid->AddRef();
+	arg_types->AddRef();
 	CScalarAggFunc *upper_agg_func = CUtils::PopAggFunc(
 		mp, agg_mdid, agg_name, is_distinct, EaggfuncstageGlobal, true, nullptr,
-		EaggfunckindNormal, GPOS_NEW(mp) ULongPtrArray(mp), false);
+		EaggfunckindNormal, arg_types, false);
 
 	// populate the argument list for the upper aggregate function
 	CExpressionArray *upper_agg_arg_array = GPOS_NEW(mp) CExpressionArray(mp);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14840,6 +14840,43 @@ explain select * from DatumSortedSet_core where b in (NULL, NULL);
 (4 rows)
 
 ---------------------------------------------------------------------------------
+-- Test fill argtypes of PopAggFunc
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+set optimizer_enable_eageragg = on;
+create table foo (j1 int, g1 int, s1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'j1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo select i%10, i %10, i from generate_series(1,100) i;
+create table bar (j2 int, g2 int, s2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'j2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar select i%1, i %10, i from generate_series(1,10) i;
+analyze foo;
+analyze bar;
+explain (costs off) select max(s1) from foo inner join bar on j1 = j2 group by g1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: foo.g1
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: foo.g1
+               ->  Partial HashAggregate
+                     Group Key: foo.g1
+                     ->  Hash Join
+                           Hash Cond: (foo.j1 = bar.j2)
+                           ->  Seq Scan on foo
+                           ->  Hash
+                                 ->  Seq Scan on bar
+ Optimizer: Postgres-based planner
+(13 rows)
+
+drop table foo;
+drop table bar;
+reset optimizer_enable_eageragg;
 -- Testcases to validate the behavior of the GUC gp_max_system_slices
 -- start_ignore
 drop table if exists foo;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14929,6 +14929,45 @@ explain select * from DatumSortedSet_core where b in (NULL, NULL);
 (3 rows)
 
 ---------------------------------------------------------------------------------
+-- Test fill argtypes of PopAggFunc
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+set optimizer_enable_eageragg = on;
+create table foo (j1 int, g1 int, s1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'j1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo select i%10, i %10, i from generate_series(1,100) i;
+create table bar (j2 int, g2 int, s2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'j2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar select i%1, i %10, i from generate_series(1,10) i;
+analyze foo;
+analyze bar;
+explain (costs off) select max(s1) from foo inner join bar on j1 = j2 group by g1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize GroupAggregate
+         Group Key: foo.g1
+         ->  Sort
+               Sort Key: foo.g1
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: foo.g1
+                     ->  Streaming Partial HashAggregate
+                           Group Key: foo.g1
+                           ->  Hash Join
+                                 Hash Cond: (foo.j1 = bar.j2)
+                                 ->  Seq Scan on foo
+                                 ->  Hash
+                                       ->  Seq Scan on bar
+ Optimizer: GPORCA
+(15 rows)
+
+drop table foo;
+drop table bar;
+reset optimizer_enable_eageragg;
 -- Testcases to validate the behavior of the GUC gp_max_system_slices
 -- start_ignore
 drop table if exists foo;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3638,6 +3638,25 @@ create table DatumSortedSet_core (a int, b character varying NOT NULL) distribut
 explain select * from DatumSortedSet_core where b in (NULL, NULL);
 ---------------------------------------------------------------------------------
 
+-- Test fill argtypes of PopAggFunc
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+-- end_ignore
+
+set optimizer_enable_eageragg = on;
+create table foo (j1 int, g1 int, s1 int);
+insert into foo select i%10, i %10, i from generate_series(1,100) i;
+create table bar (j2 int, g2 int, s2 int);
+insert into bar select i%1, i %10, i from generate_series(1,10) i;
+analyze foo;
+analyze bar;
+
+explain (costs off) select max(s1) from foo inner join bar on j1 = j2 group by g1;
+drop table foo;
+drop table bar;
+reset optimizer_enable_eageragg;
+
 -- Testcases to validate the behavior of the GUC gp_max_system_slices
 
 -- start_ignore


### PR DESCRIPTION
To Fix issue https://github.com/greenplum-db/gpdb/issues/16978, In CXformEagerAgg rule, we chould fill argtypes of CLogicalAgg, which used for filling Aggref in finla Plan.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
