### PR TITLE
Change compile platform to rhel9 for el9 platforms 

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -115,9 +115,9 @@ def create_pipeline(args, git_remote, git_branch):
         "rhel8" : "rocky8",
         "rocky8": "rocky8",
         "oel8" : "rocky8",
-        "rhel9" : "rocky9",
-        "rocky9": "rocky9",
-        "oel9" : "rocky9"
+        "rhel9" : "rhel9",
+        "rocky9": "rhel9",
+        "oel9" : "rhel9"
     }
     dist = {
         "rhel8" : "el8",

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -458,7 +458,13 @@ resources:
   type: registry-image
   source:
     tag: latest
+  {% if compile_platform == "rhel9" %}
+    repository: gcr.io/data-gpdb-private-images/gpdb7-[[ compile_platform ]]-build
+    username: _json_key
+    password: ((data-gpdb-private-images-container-registry-readonly-service-account-key))
+  {% else %}
     repository: gcr.io/data-gpdb-public-images/gpdb7-[[ compile_platform ]]-build
+  {% endif %}
 {% endif %}
 
 - name: gpdb7-[[ os_type ]]-test

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -125,6 +125,7 @@ rhel7_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_
 rhel8_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
 rocky8_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
 rocky9_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
+rhel9_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
 ol8_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
 ubuntu18.04_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm
 sles12_x86_64_CONFIGFLAGS=--with-gssapi --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml --with-openssl --with-pam --with-ldap --with-uuid=e2fs --with-llvm


### PR DESCRIPTION
Change compile platform to rhel9 for el9 platforms  as llvm 15 is not supported in rocky9 system apps

Tested Pipelines : https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-GPR-1509-rhel9 
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-GPR-1509-oel9 
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-GPR-1509-rocky9 

Authored-by: Anusha Shakarad <shakarada@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
