### PR TITLE
Make archiver process as auxiliary process and Improve performance of pgarch_readyXlog() with many failed status file 

### DIFF
--- a/.abi-check/7.0.0/postgres.symbols.ignore
+++ b/.abi-check/7.0.0/postgres.symbols.ignore
@@ -7,3 +7,4 @@ createDir
 generatePartitions
 MergeAttributes
 makePartitionCreateStmt
+pgarch_start

--- a/.abi-check/7.0.0/postgres.types.ignore
+++ b/.abi-check/7.0.0/postgres.types.ignore
@@ -7,3 +7,4 @@ struct AOCSWriteColumnDescData
 struct AppendOnlyFetchDescData
 struct AppendOnlyInsertDescData
 struct CreateForeignTableStmt
+enum PMSignalReason

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -559,6 +559,20 @@ XLogArchiveNotify(const char *xlog)
 		return;
 	}
 
+	/*
+	 * Timeline history files are given the highest archival priority to
+	 * lower the chance that a promoted standby will choose a timeline that
+	 * is already in use.  However, the archiver ordinarily tries to gather
+	 * multiple files to archive from each scan of the archive_status
+	 * directory, which means that newly created timeline history files
+	 * could be left unarchived for a while.  To ensure that the archiver
+	 * picks up timeline history files as soon as possible, we force the
+	 * archiver to scan the archive_status directory the next time it looks
+	 * for a file to archive.
+	 */
+	if (IsTLHistoryFileName(xlog))
+		PgArchForceDirScan();
+
 	/* Notify archiver that it's got something to do */
 	if (IsUnderPostmaster)
 		PgArchWakeup();

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -23,11 +23,11 @@
 #include "access/xlog_internal.h"
 #include "miscadmin.h"
 #include "postmaster/startup.h"
+#include "postmaster/pgarch.h"
 #include "replication/walsender.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
 #include "storage/lwlock.h"
-#include "storage/pmsignal.h"
 
 /*
  * GPDB specific imports:
@@ -561,7 +561,7 @@ XLogArchiveNotify(const char *xlog)
 
 	/* Notify archiver that it's got something to do */
 	if (IsUnderPostmaster)
-		SendPostmasterSignal(PMSIGNAL_WAKEN_ARCHIVER);
+		PgArchWakeup();
 }
 
 /*

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -328,6 +328,9 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			case StartupProcess:
 				statmsg = pgstat_get_backend_desc(B_STARTUP);
 				break;
+			case ArchiverProcess:
+				statmsg = pgstat_get_backend_desc(B_ARCHIVER);
+				break;
 			case BgWriterProcess:
 				statmsg = pgstat_get_backend_desc(B_BG_WRITER);
 				break;
@@ -456,30 +459,29 @@ AuxiliaryProcessMain(int argc, char *argv[])
 			proc_exit(1);		/* should never return */
 
 		case StartupProcess:
-			/* don't set signals, startup process has its own agenda */
 			StartupProcessMain();
-			proc_exit(1);		/* should never return */
+			proc_exit(1);
+
+		case ArchiverProcess:
+			PgArchiverMain();
+			proc_exit(1);
 
 		case BgWriterProcess:
-			/* don't set signals, bgwriter has its own agenda */
 			BackgroundWriterMain();
-			proc_exit(1);		/* should never return */
+			proc_exit(1);
 
 		case CheckpointerProcess:
-			/* don't set signals, checkpointer has its own agenda */
 			CheckpointerMain();
-			proc_exit(1);		/* should never return */
+			proc_exit(1);
 
 		case WalWriterProcess:
-			/* don't set signals, walwriter has its own agenda */
 			InitXLOGAccess();
 			WalWriterMain();
-			proc_exit(1);		/* should never return */
+			proc_exit(1);
 
 		case WalReceiverProcess:
-			/* don't set signals, walreceiver has its own agenda */
 			WalReceiverMain();
-			proc_exit(1);		/* should never return */
+			proc_exit(1);
 
 		default:
 			elog(PANIC, "unrecognized process type: %d", (int) MyAuxProcType);

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -35,6 +35,7 @@
 
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
+#include "lib/binaryheap.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "pgstat.h"
@@ -44,6 +45,7 @@
 #include "storage/latch.h"
 #include "storage/pmsignal.h"
 #include "storage/procsignal.h"
+#include "storage/spin.h"
 #include "utils/guc.h"
 #include "utils/ps_status.h"
 
@@ -74,10 +76,23 @@
  */
 #define NUM_ORPHAN_CLEANUP_RETRIES 3
 
+/*
+ * Maximum number of .ready files to gather per directory scan.
+ */
+#define NUM_FILES_PER_DIRECTORY_SCAN 64
+
 /* Shared memory area for archiver process */
 typedef struct PgArchData
 {
 	int			pgprocno;		/* pgprocno of archiver process */
+
+	/*
+	 * Forces a directory scan in pgarch_readyXlog().  Protected by
+	 * arch_lck.
+	 */
+	bool		force_dir_scan;
+
+	slock_t		arch_lck;
 } PgArchData;
 
 
@@ -87,6 +102,22 @@ typedef struct PgArchData
  */
 static time_t last_sigterm_time = 0;
 static PgArchData *PgArch = NULL;
+
+/*
+ * Stuff for tracking multiple files to archive from each scan of
+ * archive_status.  Minimizing the number of directory scans when there are
+ * many files to archive can significantly improve archival rate.
+ *
+ * arch_heap is a max-heap that is used during the directory scan to track
+ * the highest-priority files to archive.  After the directory scan
+ * completes, the file names are stored in ascending order of priority in
+ * arch_files.  pgarch_readyXlog() returns files from arch_files until it
+ * is empty, at which point another directory scan must be performed.
+ */
+static binaryheap *arch_heap = NULL;
+static char arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS];
+static char *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
+static int arch_files_size = 0;
 
 /*
  * Flags set by interrupt handlers for later service in the main loop.
@@ -109,6 +140,7 @@ static bool pgarch_archiveXlog(char *xlog);
 static bool pgarch_readyXlog(char *xlog);
 static void pgarch_archiveDone(char *xlog);
 static void pgarch_die(int code, Datum arg);
+static int ready_file_comparator(Datum a, Datum b, void *arg);
 
 /* Report shared memory space needed by PgArchShmemInit */
 Size
@@ -135,6 +167,7 @@ PgArchShmemInit(void)
 		/* First time through, so initialize */
 		MemSet(PgArch, 0, PgArchShmemSize());
 		PgArch->pgprocno = INVALID_PGPROCNO;
+		SpinLockInit(&PgArch->arch_lck);
 	}
 }
 
@@ -203,6 +236,10 @@ PgArchiverMain(void)
 	 * while we're sleeping.
 	 */
 	PgArch->pgprocno = MyProc->pgprocno;
+
+	/* Initialize our max-heap for prioritizing files to archive. */
+	arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
+									ready_file_comparator, NULL);
 
 	pgarch_MainLoop();
 
@@ -381,6 +418,9 @@ static void
 pgarch_ArchiverCopyLoop(void)
 {
 	char		xlog[MAX_XFN_CHARS + 1];
+
+	/* force directory scan in the first call to pgarch_readyXlog() */
+	arch_files_size = 0;
 
 	/*
 	 * loop through all xlogs with archive_status of .ready and archive
@@ -671,18 +711,54 @@ pgarch_archiveXlog(char *xlog)
 static bool
 pgarch_readyXlog(char *xlog)
 {
-	/*
-	 * open xlog status directory and read through list of xlogs that have the
-	 * .ready suffix, looking for earliest file. It is possible to optimise
-	 * this code, though only a single file is expected on the vast majority
-	 * of calls, so....
-	 */
 	char		XLogArchiveStatusDir[MAXPGPATH];
 	DIR		   *rldir;
 	struct dirent *rlde;
-	bool		found = false;
-	bool		historyFound = false;
+	bool		force_dir_scan;
 
+	/*
+	 * If a directory scan was requested, clear the stored file names and
+	 * proceed.
+	 */
+	SpinLockAcquire(&PgArch->arch_lck);
+	force_dir_scan = PgArch->force_dir_scan;
+	PgArch->force_dir_scan = false;
+	SpinLockRelease(&PgArch->arch_lck);
+
+	if (force_dir_scan)
+		arch_files_size = 0;
+
+	/*
+	 * If we still have stored file names from the previous directory scan,
+	 * try to return one of those.  We check to make sure the status file
+	 * is still present, as the archive_command for a previous file may
+	 * have already marked it done.
+	 */
+	while (arch_files_size > 0)
+	{
+		struct stat	st;
+		char		status_file[MAXPGPATH];
+		char	   *arch_file;
+
+		arch_files_size--;
+		arch_file = arch_files[arch_files_size];
+		StatusFilePath(status_file, arch_file, ".ready");
+
+		if (stat(status_file, &st) == 0)
+		{
+			strcpy(xlog, arch_file);
+			return true;
+		}
+		else if (errno != ENOENT)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not stat file \"%s\": %m", status_file)));
+	}
+
+	/*
+	 * Open the archive status directory and read through the list of files
+	 * with the .ready suffix, looking for the earliest files.
+	 */
 	snprintf(XLogArchiveStatusDir, MAXPGPATH, XLOGDIR "/archive_status");
 	rldir = AllocateDir(XLogArchiveStatusDir);
 
@@ -690,7 +766,7 @@ pgarch_readyXlog(char *xlog)
 	{
 		int			basenamelen = (int) strlen(rlde->d_name) - 6;
 		char		basename[MAX_XFN_CHARS + 1];
-		bool		ishistory;
+		char	   *arch_file;
 
 		/* Ignore entries with unexpected number of characters */
 		if (basenamelen < MIN_XFN_CHARS ||
@@ -709,32 +785,97 @@ pgarch_readyXlog(char *xlog)
 		memcpy(basename, rlde->d_name, basenamelen);
 		basename[basenamelen] = '\0';
 
-		/* Is this a history file? */
-		ishistory = IsTLHistoryFileName(basename);
-
 		/*
-		 * Consume the file to archive.  History files have the highest
-		 * priority.  If this is the first file or the first history file
-		 * ever, copy it.  In the presence of a history file already chosen as
-		 * target, ignore all other files except history files which have been
-		 * generated for an older timeline than what is already chosen as
-		 * target to archive.
+		 * Store the file in our max-heap if it has a high enough priority.
 		 */
-		if (!found || (ishistory && !historyFound))
+		if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
 		{
-			strcpy(xlog, basename);
-			found = true;
-			historyFound = ishistory;
+			/* If the heap isn't full yet, quickly add it. */
+			arch_file = arch_filenames[arch_heap->bh_size];
+			strcpy(arch_file, basename);
+			binaryheap_add_unordered(arch_heap, CStringGetDatum(arch_file));
+
+			/* If we just filled the heap, make it a valid one. */
+			if (arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
+				binaryheap_build(arch_heap);
 		}
-		else if (ishistory || !historyFound)
+		else if (ready_file_comparator(binaryheap_first(arch_heap),
+									   CStringGetDatum(basename), NULL) > 0)
 		{
-			if (strcmp(basename, xlog) < 0)
-				strcpy(xlog, basename);
+			/*
+			 * Remove the lowest priority file and add the current one to
+			 * the heap.
+			 */
+			arch_file = DatumGetCString(binaryheap_remove_first(arch_heap));
+			strcpy(arch_file, basename);
+			binaryheap_add(arch_heap, CStringGetDatum(arch_file));
 		}
 	}
 	FreeDir(rldir);
 
-	return found;
+	/* If no files were found, simply return. */
+	if (arch_heap->bh_size == 0)
+		return false;
+
+	/*
+	 * If we didn't fill the heap, we didn't make it a valid one.  Do that
+	 * now.
+	 */
+	if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		binaryheap_build(arch_heap);
+
+	/*
+	 * Fill arch_files array with the files to archive in ascending order
+	 * of priority.
+	 */
+	arch_files_size = arch_heap->bh_size;
+	for (int i = 0; i < arch_files_size; i++)
+		arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_heap));
+
+	/* Return the highest priority file. */
+	arch_files_size--;
+	strcpy(xlog, arch_files[arch_files_size]);
+
+	return true;
+}
+
+/*
+ * ready_file_comparator
+ *
+ * Compares the archival priority of the given files to archive.  If "a"
+ * has a higher priority than "b", a negative value will be returned.  If
+ * "b" has a higher priority than "a", a positive value will be returned.
+ * If "a" and "b" have equivalent values, 0 will be returned.
+ */
+static int
+ready_file_comparator(Datum a, Datum b, void *arg)
+{
+	char *a_str = DatumGetCString(a);
+	char *b_str = DatumGetCString(b);
+	bool a_history = IsTLHistoryFileName(a_str);
+	bool b_history = IsTLHistoryFileName(b_str);
+
+	/* Timeline history files always have the highest priority. */
+	if (a_history != b_history)
+		return a_history ? -1 : 1;
+
+	/* Priority is given to older files. */
+	return strcmp(a_str, b_str);
+}
+
+/*
+ * PgArchForceDirScan
+ *
+ * When called, the next call to pgarch_readyXlog() will perform a
+ * directory scan.  This is useful for ensuring that important files such
+ * as timeline history files are archived as quickly as possible.
+ */
+void
+PgArchForceDirScan(void)
+{
+	SpinLockAcquire(&PgArch->arch_lck);
+	PgArch->force_dir_scan = true;
+	SpinLockRelease(&PgArch->arch_lck);
 }
 
 /*

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -113,11 +113,20 @@ static PgArchData *PgArch = NULL;
  * completes, the file names are stored in ascending order of priority in
  * arch_files.  pgarch_readyXlog() returns files from arch_files until it
  * is empty, at which point another directory scan must be performed.
+ *
+ * We only need this data in the archiver process, so make it a palloc'd
+ * struct rather than a bunch of static arrays.
  */
-static binaryheap *arch_heap = NULL;
-static char arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS];
-static char *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
-static int arch_files_size = 0;
+struct arch_files_state
+{
+	binaryheap *arch_heap;
+	int			arch_files_size;	/* number of live entries in arch_files[] */
+	char	   *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
+	/* buffers underlying heap, and later arch_files[], entries: */
+	char		arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS + 1];
+};
+
+static struct arch_files_state *arch_files = NULL;
 
 /*
  * Flags set by interrupt handlers for later service in the main loop.
@@ -237,9 +246,13 @@ PgArchiverMain(void)
 	 */
 	PgArch->pgprocno = MyProc->pgprocno;
 
+	/* Create workspace for pgarch_readyXlog() */
+	arch_files = palloc(sizeof(struct arch_files_state));
+	arch_files->arch_files_size = 0;
+
 	/* Initialize our max-heap for prioritizing files to archive. */
-	arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
-									ready_file_comparator, NULL);
+	arch_files->arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
+												ready_file_comparator, NULL);
 
 	pgarch_MainLoop();
 
@@ -420,7 +433,7 @@ pgarch_ArchiverCopyLoop(void)
 	char		xlog[MAX_XFN_CHARS + 1];
 
 	/* force directory scan in the first call to pgarch_readyXlog() */
-	arch_files_size = 0;
+	arch_files->arch_files_size = 0;
 
 	/*
 	 * loop through all xlogs with archive_status of .ready and archive
@@ -726,7 +739,7 @@ pgarch_readyXlog(char *xlog)
 	SpinLockRelease(&PgArch->arch_lck);
 
 	if (force_dir_scan)
-		arch_files_size = 0;
+		arch_files->arch_files_size = 0;
 
 	/*
 	 * If we still have stored file names from the previous directory scan,
@@ -734,14 +747,14 @@ pgarch_readyXlog(char *xlog)
 	 * is still present, as the archive_command for a previous file may
 	 * have already marked it done.
 	 */
-	while (arch_files_size > 0)
+	while (arch_files->arch_files_size > 0)
 	{
 		struct stat	st;
 		char		status_file[MAXPGPATH];
 		char	   *arch_file;
 
-		arch_files_size--;
-		arch_file = arch_files[arch_files_size];
+		arch_files->arch_files_size--;
+		arch_file = arch_files->arch_files[arch_files->arch_files_size];
 		StatusFilePath(status_file, arch_file, ".ready");
 
 		if (stat(status_file, &st) == 0)
@@ -754,6 +767,9 @@ pgarch_readyXlog(char *xlog)
 					(errcode_for_file_access(),
 					 errmsg("could not stat file \"%s\": %m", status_file)));
 	}
+
+	/* arch_heap is probably empty, but let's make sure */
+	binaryheap_reset(arch_files->arch_heap);
 
 	/*
 	 * Open the archive status directory and read through the list of files
@@ -788,53 +804,53 @@ pgarch_readyXlog(char *xlog)
 		/*
 		 * Store the file in our max-heap if it has a high enough priority.
 		 */
-		if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		if (arch_files->arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
 		{
 			/* If the heap isn't full yet, quickly add it. */
-			arch_file = arch_filenames[arch_heap->bh_size];
+			arch_file = arch_files->arch_filenames[arch_files->arch_heap->bh_size];
 			strcpy(arch_file, basename);
-			binaryheap_add_unordered(arch_heap, CStringGetDatum(arch_file));
+			binaryheap_add_unordered(arch_files->arch_heap, CStringGetDatum(arch_file));
 
 			/* If we just filled the heap, make it a valid one. */
-			if (arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
-				binaryheap_build(arch_heap);
+			if (arch_files->arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
+				binaryheap_build(arch_files->arch_heap);
 		}
-		else if (ready_file_comparator(binaryheap_first(arch_heap),
+		else if (ready_file_comparator(binaryheap_first(arch_files->arch_heap),
 									   CStringGetDatum(basename), NULL) > 0)
 		{
 			/*
 			 * Remove the lowest priority file and add the current one to
 			 * the heap.
 			 */
-			arch_file = DatumGetCString(binaryheap_remove_first(arch_heap));
+			arch_file = DatumGetCString(binaryheap_remove_first(arch_files->arch_heap));
 			strcpy(arch_file, basename);
-			binaryheap_add(arch_heap, CStringGetDatum(arch_file));
+			binaryheap_add(arch_files->arch_heap, CStringGetDatum(arch_file));
 		}
 	}
 	FreeDir(rldir);
 
 	/* If no files were found, simply return. */
-	if (arch_heap->bh_size == 0)
+	if (arch_files->arch_heap->bh_size == 0)
 		return false;
 
 	/*
 	 * If we didn't fill the heap, we didn't make it a valid one.  Do that
 	 * now.
 	 */
-	if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
-		binaryheap_build(arch_heap);
+	if (arch_files->arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		binaryheap_build(arch_files->arch_heap);
 
 	/*
 	 * Fill arch_files array with the files to archive in ascending order
 	 * of priority.
 	 */
-	arch_files_size = arch_heap->bh_size;
-	for (int i = 0; i < arch_files_size; i++)
-		arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_heap));
+	arch_files->arch_files_size = arch_files->arch_heap->bh_size;
+	for (int i = 0; i < arch_files->arch_files_size; i++)
+		arch_files->arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_files->arch_heap));
 
 	/* Return the highest priority file. */
-	arch_files_size--;
-	strcpy(xlog, arch_files[arch_files_size]);
+	arch_files->arch_files_size--;
+	strcpy(xlog, arch_files->arch_files[arch_files->arch_files_size]);
 
 	return true;
 }

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -38,15 +38,12 @@
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "pgstat.h"
-#include "postmaster/fork_process.h"
 #include "postmaster/pgarch.h"
-#include "postmaster/postmaster.h"
-#include "storage/dsm.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
 #include "storage/latch.h"
-#include "storage/pg_shmem.h"
 #include "storage/pmsignal.h"
+#include "storage/procsignal.h"
 #include "utils/guc.h"
 #include "utils/ps_status.h"
 
@@ -77,158 +74,104 @@
  */
 #define NUM_ORPHAN_CLEANUP_RETRIES 3
 
+/* Shared memory area for archiver process */
+typedef struct PgArchData
+{
+	int			pgprocno;		/* pgprocno of archiver process */
+} PgArchData;
+
 
 /* ----------
  * Local data
  * ----------
  */
-static time_t last_pgarch_start_time;
 static time_t last_sigterm_time = 0;
+static PgArchData *PgArch = NULL;
 
 /*
  * Flags set by interrupt handlers for later service in the main loop.
  */
 static volatile sig_atomic_t got_SIGHUP = false;
 static volatile sig_atomic_t got_SIGTERM = false;
-static volatile sig_atomic_t wakened = false;
 static volatile sig_atomic_t ready_to_stop = false;
 
 /* ----------
  * Local function forward declarations
  * ----------
  */
-#ifdef EXEC_BACKEND
-static pid_t pgarch_forkexec(void);
-#endif
-
-NON_EXEC_STATIC void PgArchiverMain(int argc, char *argv[]) pg_attribute_noreturn();
 static void pgarch_exit(SIGNAL_ARGS);
 static void ArchSigHupHandler(SIGNAL_ARGS);
 static void ArchSigTermHandler(SIGNAL_ARGS);
-static void pgarch_waken(SIGNAL_ARGS);
 static void pgarch_waken_stop(SIGNAL_ARGS);
 static void pgarch_MainLoop(void);
 static void pgarch_ArchiverCopyLoop(void);
 static bool pgarch_archiveXlog(char *xlog);
 static bool pgarch_readyXlog(char *xlog);
 static void pgarch_archiveDone(char *xlog);
+static void pgarch_die(int code, Datum arg);
 
+/* Report shared memory space needed by PgArchShmemInit */
+Size
+PgArchShmemSize(void)
+{
+	Size		size = 0;
 
-/* ------------------------------------------------------------
- * Public functions called from postmaster follow
- * ------------------------------------------------------------
- */
+	size = add_size(size, sizeof(PgArchData));
+
+	return size;
+}
+
+/* Allocate and initialize archiver-related shared memory */
+void
+PgArchShmemInit(void)
+{
+	bool		found;
+
+	PgArch = (PgArchData *)
+		ShmemInitStruct("Archiver Data", PgArchShmemSize(), &found);
+
+	if (!found)
+	{
+		/* First time through, so initialize */
+		MemSet(PgArch, 0, PgArchShmemSize());
+		PgArch->pgprocno = INVALID_PGPROCNO;
+	}
+}
 
 /*
- * pgarch_start
+ * PgArchCanRestart
  *
- *	Called from postmaster at startup or after an existing archiver
- *	died.  Attempt to fire up a fresh archiver process.
+ * Return true and archiver is allowed to restart if enough time has
+ * passed since it was launched last to reach PGARCH_RESTART_INTERVAL.
+ * Otherwise return false.
  *
- *	Returns PID of child process, or 0 if fail.
- *
- *	Note: if fail, we will be called again from the postmaster main loop.
+ * This is a safety valve to protect against continuous respawn attempts if the
+ * archiver is dying immediately at launch. Note that since we will retry to
+ * launch the archiver from the postmaster main loop, we will get another
+ * chance later.
  */
-int
-pgarch_start(void)
+bool
+PgArchCanRestart(void)
 {
-	time_t		curtime;
-	pid_t		pgArchPid;
+	static time_t last_pgarch_start_time = 0;
+	time_t		curtime = time(NULL);
 
 	/*
-	 * Do nothing if no archiver needed
+	 * Return false and don't restart archiver if too soon since last archiver
+	 * start.
 	 */
-	if (!XLogArchivingActive())
-		return 0;
-
-	/*
-	 * Do nothing if too soon since last archiver start.  This is a safety
-	 * valve to protect against continuous respawn attempts if the archiver is
-	 * dying immediately at launch. Note that since we will be re-called from
-	 * the postmaster main loop, we will get another chance later.
-	 */
-	curtime = time(NULL);
 	if ((unsigned int) (curtime - last_pgarch_start_time) <
 		(unsigned int) PGARCH_RESTART_INTERVAL)
-		return 0;
+		return false;
+
 	last_pgarch_start_time = curtime;
-
-#ifdef EXEC_BACKEND
-	switch ((pgArchPid = pgarch_forkexec()))
-#else
-	switch ((pgArchPid = fork_process()))
-#endif
-	{
-		case -1:
-			ereport(LOG,
-					(errmsg("could not fork archiver: %m")));
-			return 0;
-
-#ifndef EXEC_BACKEND
-		case 0:
-			/* in postmaster child ... */
-			InitPostmasterChild();
-
-			/* Close the postmaster's sockets */
-			ClosePostmasterPorts(false);
-
-			/* Drop our connection to postmaster's shared memory, as well */
-			dsm_detach_all();
-			PGSharedMemoryDetach();
-
-			PgArchiverMain(0, NULL);
-			break;
-#endif
-
-		default:
-			return (int) pgArchPid;
-	}
-
-	/* shouldn't get here */
-	return 0;
+	return true;
 }
 
-/* ------------------------------------------------------------
- * Local functions called by archiver follow
- * ------------------------------------------------------------
- */
 
-
-#ifdef EXEC_BACKEND
-
-/*
- * pgarch_forkexec() -
- *
- * Format up the arglist for, then fork and exec, archive process
- */
-static pid_t
-pgarch_forkexec(void)
-{
-	char	   *av[10];
-	int			ac = 0;
-
-	av[ac++] = "postgres";
-
-	av[ac++] = "--forkarch";
-
-	av[ac++] = NULL;			/* filled in by postmaster_forkexec */
-
-	av[ac] = NULL;
-	Assert(ac < lengthof(av));
-
-	return postmaster_forkexec(ac, av);
-}
-#endif							/* EXEC_BACKEND */
-
-
-/*
- * PgArchiverMain
- *
- *	The argc/argv parameters are valid only in EXEC_BACKEND case.  However,
- *	since we don't use 'em, it hardly matters...
- */
-NON_EXEC_STATIC void
-PgArchiverMain(int argc, char *argv[])
+/* Main entry point for archiver process */
+void
+PgArchiverMain(void)
 {
 	/*
 	 * Ignore all signals usually bound to some action in the postmaster,
@@ -240,20 +183,30 @@ PgArchiverMain(int argc, char *argv[])
 	pqsignal(SIGQUIT, pgarch_exit);
 	pqsignal(SIGALRM, SIG_IGN);
 	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, pgarch_waken);
+	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 	pqsignal(SIGUSR2, pgarch_waken_stop);
+
 	/* Reset some signals that are accepted by postmaster but not here */
 	pqsignal(SIGCHLD, SIG_DFL);
+
+	/* Unblock signals (they were blocked when the postmaster forked us) */
 	PG_SETMASK(&UnBlockSig);
 
+	/* We shouldn't be launched unnecessarily. */
+	Assert(XLogArchivingActive());
+
+	/* Arrange to clean up at archiver exit */
+	on_shmem_exit(pgarch_die, 0);
+
 	/*
-	 * Identify myself via ps
+	 * Advertise our pgprocno so that backends can use our latch to wake us up
+	 * while we're sleeping.
 	 */
-	init_ps_display("archiver", "", "", "");
+	PgArch->pgprocno = MyProc->pgprocno;
 
 	pgarch_MainLoop();
 
-	exit(0);
+	proc_exit(0);
 }
 
 /* SIGQUIT signal handler for archiver process */
@@ -303,18 +256,24 @@ ArchSigTermHandler(SIGNAL_ARGS)
 	errno = save_errno;
 }
 
-/* SIGUSR1 signal handler for archiver process */
-static void
-pgarch_waken(SIGNAL_ARGS)
+/*
+ * Wake up the archiver
+ */
+void
+PgArchWakeup(void)
 {
-	int			save_errno = errno;
+	int			arch_pgprocno = PgArch->pgprocno;
 
-	/* set flag that there is work to be done */
-	wakened = true;
-	SetLatch(MyLatch);
-
-	errno = save_errno;
+	/*
+	 * We don't acquire ProcArrayLock here.  It's actually fine because
+	 * procLatch isn't ever freed, so we just can potentially set the wrong
+	 * process' (or no process') latch.  Even in that case the archiver will
+	 * be relaunched shortly and will start archiving.
+	 */
+	if (arch_pgprocno != INVALID_PGPROCNO)
+		SetLatch(&ProcGlobal->allProcs[arch_pgprocno].procLatch);
 }
+
 
 /* SIGUSR2 signal handler for archiver process */
 static void
@@ -339,14 +298,6 @@ pgarch_MainLoop(void)
 {
 	pg_time_t	last_copy_time = 0;
 	bool		time_to_stop;
-
-	/*
-	 * We run the copy loop immediately upon entry, in case there are
-	 * unarchived files left over from a previous database run (or maybe the
-	 * archiver died unexpectedly).  After that we wait for a signal or
-	 * timeout before doing more.
-	 */
-	wakened = true;
 
 	/*
 	 * There shouldn't be anything for the archiver to do except to wait for a
@@ -386,12 +337,8 @@ pgarch_MainLoop(void)
 		}
 
 		/* Do what we're here for */
-		if (wakened || time_to_stop)
-		{
-			wakened = false;
-			pgarch_ArchiverCopyLoop();
-			last_copy_time = time(NULL);
-		}
+		pgarch_ArchiverCopyLoop();
+		last_copy_time = time(NULL);
 
 		/*
 		 * Sleep until a signal is received, or until a poll is forced by
@@ -412,13 +359,9 @@ pgarch_MainLoop(void)
 							   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 							   timeout * 1000L,
 							   WAIT_EVENT_ARCHIVER_MAIN);
-				if (rc & WL_TIMEOUT)
-					wakened = true;
 				if (rc & WL_POSTMASTER_DEATH)
 					time_to_stop = true;
 			}
-			else
-				wakened = true;
 		}
 
 		/*
@@ -811,4 +754,16 @@ pgarch_archiveDone(char *xlog)
 	StatusFilePath(rlogready, xlog, ".ready");
 	StatusFilePath(rlogdone, xlog, ".done");
 	(void) durable_rename(rlogready, rlogdone, WARNING);
+}
+
+
+/*
+ * pgarch_die
+ *
+ * Exit-time cleanup handler
+ */
+static void
+pgarch_die(int code, Datum arg)
+{
+	PgArch->pgprocno = INVALID_PGPROCNO;
 }

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3103,6 +3103,9 @@ pgstat_bestart(void)
 			case WalReceiverProcess:
 				lbeentry.st_backendType = B_WAL_RECEIVER;
 				break;
+			case ArchiverProcess:
+				lbeentry.st_backendType = B_ARCHIVER;
+				break;
 			default:
 				elog(FATAL, "unrecognized process type: %d",
 					 (int) MyAuxProcType);
@@ -4576,6 +4579,9 @@ pgstat_get_backend_desc(BackendType backendType)
 			break;
 		case B_WAL_WRITER:
 			backendDesc = "walwriter";
+			break;
+		case B_ARCHIVER:
+			backendDesc = "archiver";
 			break;
 	}
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -544,9 +544,10 @@ static void getLogDirectoryAbsolutePath(char *out_buf, size_t len);
  * even during recovery.
  */
 #define PgArchStartupAllowed()	\
-	((XLogArchivingActive() && pmState == PM_RUN) ||	\
-	 (XLogArchivingAlways() &&	\
-	  (pmState == PM_RECOVERY || pmState == PM_HOT_STANDBY)))
+	(((XLogArchivingActive() && pmState == PM_RUN) ||			\
+	  (XLogArchivingAlways() &&									  \
+	   (pmState == PM_RECOVERY || pmState == PM_HOT_STANDBY))) && \
+	 PgArchCanRestart())
 
 bool isAuxiliaryBgWorker(BackgroundWorker *worker);
 
@@ -653,6 +654,7 @@ static void ShmemBackendArrayRemove(Backend *bn);
 #endif							/* EXEC_BACKEND */
 
 #define StartupDataBase()		StartChildProcess(StartupProcess)
+#define StartArchiver()			StartChildProcess(ArchiverProcess)
 #define StartBackgroundWriter() StartChildProcess(BgWriterProcess)
 #define StartCheckpointer()		StartChildProcess(CheckpointerProcess)
 #define StartWalWriter()		StartChildProcess(WalWriterProcess)
@@ -2072,7 +2074,7 @@ ServerLoop(void)
 
 		/* If we have lost the archiver, try to start a new one. */
 		if (PgArchPID == 0 && PgArchStartupAllowed())
-			PgArchPID = pgarch_start();
+			PgArchPID = StartArchiver();
 
 		/* If we need to signal the autovacuum launcher, do so now */
 		if (avlauncher_needs_signal)
@@ -3501,7 +3503,7 @@ reaper(SIGNAL_ARGS)
 			if (!IsBinaryUpgrade && AutoVacuumingActive() && AutoVacPID == 0)
 				AutoVacPID = StartAutoVacLauncher();
 			if (PgArchStartupAllowed() && PgArchPID == 0)
-				PgArchPID = pgarch_start();
+				PgArchPID = StartArchiver();
 			if (PgStatPID == 0)
 				PgStatPID = pgstat_start();
 
@@ -3651,20 +3653,22 @@ reaper(SIGNAL_ARGS)
 		}
 
 		/*
-		 * Was it the archiver?  If so, just try to start a new one; no need
-		 * to force reset of the rest of the system.  (If fail, we'll try
-		 * again in future cycles of the main loop.).  Unless we were waiting
-		 * for it to shut down; don't restart it in that case, and
+		 * Was it the archiver?  If exit status is zero (normal) or one (FATAL
+		 * exit), we assume everything is all right just like normal backends
+		 * and just try to restart a new one so that we immediately retry
+		 * archiving remaining files. (If fail, we'll try again in future
+		 * cycles of the postmaster's main loop.) Unless we were waiting for
+		 * it to shut down; don't restart it in that case, and
 		 * PostmasterStateMachine() will advance to the next shutdown step.
 		 */
 		if (pid == PgArchPID)
 		{
 			PgArchPID = 0;
-			if (!EXIT_STATUS_0(exitstatus))
-				LogChildExit(LOG, _("archiver process"),
-							 pid, exitstatus);
+			if (!EXIT_STATUS_0(exitstatus) && !EXIT_STATUS_1(exitstatus))
+				HandleChildCrash(pid, exitstatus,
+								 _("archiver process"));
 			if (PgArchStartupAllowed())
-				PgArchPID = pgarch_start();
+				PgArchPID = StartArchiver();
 			continue;
 		}
 
@@ -3912,7 +3916,7 @@ CleanupBackend(int pid,
 
 /*
  * HandleChildCrash -- cleanup after failed backend, bgwriter, checkpointer,
- * walwriter, autovacuum, or background worker.
+ * walwriter, autovacuum, archiver or background worker.
  *
  * The objectives here are to clean up our local state about the child
  * process, and to signal all other remaining children to quickdie.
@@ -4117,19 +4121,16 @@ HandleChildCrash(int pid, int exitstatus, const char *procname)
 		signal_child(AutoVacPID, (SendStop ? SIGSTOP : SIGQUIT));
 	}
 
-	/*
-	 * Force a power-cycle of the pgarch process too.  (This isn't absolutely
-	 * necessary, but it seems like a good idea for robustness, and it
-	 * simplifies the state-machine logic in the case where a shutdown request
-	 * arrives during crash processing.)
-	 */
-	if (PgArchPID != 0 && take_action)
+	/* Take care of the archiver too */
+	if (pid == PgArchPID)
+		PgArchPID = 0;
+	else if (PgArchPID != 0 && take_action)
 	{
 		ereport(DEBUG2,
 				(errmsg_internal("sending %s to process %d",
-								 "SIGQUIT",
+								 (SendStop ? "SIGSTOP" : "SIGQUIT"),
 								 (int) PgArchPID)));
-		signal_child(PgArchPID, SIGQUIT);
+		signal_child(PgArchPID, (SendStop ? SIGSTOP : SIGQUIT));
 	}
 
 	/*
@@ -4312,12 +4313,11 @@ PostmasterStateMachine(void)
 		 * (including autovac workers), no bgworkers (including unconnected
 		 * ones), and no walwriter, autovac launcher or bgwriter.  If we are
 		 * doing crash recovery or an immediate shutdown then we expect the
-		 * checkpointer to exit as well, otherwise not. The archiver, stats,
-		 * and syslogger processes are disregarded since they are not
-		 * connected to shared memory; we also disregard dead_end children
-		 * here. Walsenders are also disregarded, they will be terminated
-		 * later after writing the checkpoint record, like the archiver
-		 * process.
+		 * checkpointer to exit as well, otherwise not. The stats and
+		 * syslogger processes are disregarded since they are not connected to
+		 * shared memory; we also disregard dead_end children here. Walsenders
+		 * and archiver are also disregarded, they will be terminated later
+		 * after writing the checkpoint record.
 		 */
 		if (CountChildren(BACKEND_TYPE_ALL - BACKEND_TYPE_WALSND) == 0 &&
 			StartupPID == 0 &&
@@ -4420,6 +4420,7 @@ PostmasterStateMachine(void)
 			Assert(CheckpointerPID == 0);
 			Assert(WalWriterPID == 0);
 			Assert(AutoVacPID == 0);
+			Assert(PgArchPID == 0);
 			/* syslogger is not considered here */
 			pmState = PM_NO_CHILDREN;
 		}
@@ -5599,12 +5600,6 @@ SubPostmasterMain(int argc, char *argv[])
 
 		StartBackgroundWorker();
 	}
-	if (strcmp(argv[1], "--forkarch") == 0)
-	{
-		/* Do not want to attach to shared memory */
-
-		PgArchiverMain(argc, argv); /* does not return */
-	}
 	if (strcmp(argv[1], "--forkcol") == 0)
 	{
 		/* Do not want to attach to shared memory */
@@ -5704,7 +5699,7 @@ sigusr1_handler(SIGNAL_ARGS)
 		 */
 		Assert(PgArchPID == 0);
 		if (XLogArchivingAlways())
-			PgArchPID = pgarch_start();
+			PgArchPID = StartArchiver();
 
 		/*
 		 * GPDB: if promote trigger file exist we don't wish to convey
@@ -5782,16 +5777,6 @@ sigusr1_handler(SIGNAL_ARGS)
 
 	if (StartWorkerNeeded || HaveCrashedWorker)
 		maybe_start_bgworkers();
-
-	if (CheckPostmasterSignal(PMSIGNAL_WAKEN_ARCHIVER) &&
-		PgArchPID != 0)
-	{
-		/*
-		 * Send SIGUSR1 to archiver process, to wake it up and begin archiving
-		 * next WAL file.
-		 */
-		signal_child(PgArchPID, SIGUSR1);
-	}
 
 	/* Tell syslogger to rotate logfile if requested */
 	if (SysLoggerPID != 0)
@@ -6076,6 +6061,10 @@ StartChildProcess(AuxProcType type)
 			case StartupProcess:
 				ereport(LOG,
 						(errmsg("could not fork startup process: %m")));
+				break;
+			case ArchiverProcess:
+				ereport(LOG,
+						(errmsg("could not fork archiver process: %m")));
 				break;
 			case BgWriterProcess:
 				ereport(LOG,

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -182,6 +182,7 @@ CreateSharedMemoryAndSemaphores(int port)
 		size = add_size(size, ReplicationOriginShmemSize());
 		size = add_size(size, WalSndShmemSize());
 		size = add_size(size, WalRcvShmemSize());
+		size = add_size(size, PgArchShmemSize());
 		size = add_size(size, ApplyLauncherShmemSize());
 		size = add_size(size, FTSReplicationStatusShmemSize());
 		size = add_size(size, SnapMgrShmemSize());
@@ -353,6 +354,7 @@ CreateSharedMemoryAndSemaphores(int port)
 	ReplicationOriginShmemInit();
 	WalSndShmemInit();
 	WalRcvShmemInit();
+	PgArchShmemInit();
 	ApplyLauncherShmemInit();
 	FTSReplicationStatusShmemInit();
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -518,6 +518,7 @@ typedef enum
 	CheckpointerProcess,
 	WalWriterProcess,
 	WalReceiverProcess,
+	ArchiverProcess,
 
 	NUM_AUXPROCTYPES			/* Must be last! */
 } AuxProcType;
@@ -527,6 +528,7 @@ extern AuxProcType MyAuxProcType;
 #define AmBootstrapProcess()		(MyAuxProcType == BootstrapProcess)
 #define AmStartupProcess()			(MyAuxProcType == StartupProcess)
 #define AmBackgroundWriterProcess() (MyAuxProcType == BgWriterProcess)
+#define AmArchiverProcess()			(MyAuxProcType == ArchiverProcess)
 #define AmCheckpointerProcess()		(MyAuxProcType == CheckpointerProcess)
 #define AmWalWriterProcess()		(MyAuxProcType == WalWriterProcess)
 #define AmWalReceiverProcess()		(MyAuxProcType == WalReceiverProcess)

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -874,7 +874,8 @@ typedef enum BackendType
 	B_STARTUP,
 	B_WAL_RECEIVER,
 	B_WAL_SENDER,
-	B_WAL_WRITER
+	B_WAL_WRITER,
+	B_ARCHIVER
 } BackendType;
 
 

--- a/src/include/postmaster/pgarch.h
+++ b/src/include/postmaster/pgarch.h
@@ -31,5 +31,6 @@ extern void PgArchShmemInit(void);
 extern bool PgArchCanRestart(void);
 extern void PgArchiverMain(void) pg_attribute_noreturn();
 extern void PgArchWakeup(void);
+extern void PgArchForceDirScan(void);
 
 #endif							/* _PGARCH_H */

--- a/src/include/postmaster/pgarch.h
+++ b/src/include/postmaster/pgarch.h
@@ -26,14 +26,10 @@
 #define MAX_XFN_CHARS	40
 #define VALID_XFN_CHARS "0123456789ABCDEF.history.backup.partial"
 
-/* ----------
- * Functions called from postmaster
- * ----------
- */
-extern int	pgarch_start(void);
-
-#ifdef EXEC_BACKEND
-extern void PgArchiverMain(int argc, char *argv[]) pg_attribute_noreturn();
-#endif
+extern Size PgArchShmemSize(void);
+extern void PgArchShmemInit(void);
+extern bool PgArchCanRestart(void);
+extern void PgArchiverMain(void) pg_attribute_noreturn();
+extern void PgArchWakeup(void);
 
 #endif							/* _PGARCH_H */

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -34,7 +34,6 @@ typedef enum
 {
 	PMSIGNAL_RECOVERY_STARTED,	/* recovery has started */
 	PMSIGNAL_BEGIN_HOT_STANDBY, /* begin Hot Standby */
-	PMSIGNAL_WAKEN_ARCHIVER,	/* send a NOTIFY signal to xlog archiver */
 	PMSIGNAL_ROTATE_LOGFILE,	/* send SIGUSR1 to syslogger to rotate logfile */
 	PMSIGNAL_START_AUTOVAC_LAUNCHER,	/* start an autovacuum launcher */
 	PMSIGNAL_START_AUTOVAC_WORKER,	/* start an autovacuum worker */

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -371,11 +371,11 @@ extern PGPROC *PreparedXactProcs;
  * We set aside some extra PGPROC structures for auxiliary processes,
  * ie things that aren't full-fledged backends but need shmem access.
  *
- * Background writer, checkpointer and WAL writer run during normal operation.
- * Startup process and WAL receiver also consume 2 slots, but WAL writer is
- * launched only after startup has exited, so we only need 4 slots.
+ * Background writer, checkpointer, WAL writer and archiver run during normal
+ * operation.  Startup process and WAL receiver also consume 2 slots, but WAL
+ * writer is launched only after startup has exited, so we only need 5 slots.
  */
-#define NUM_AUXILIARY_PROCS		4
+#define NUM_AUXILIARY_PROCS		5
 
 /* configurable options */
 extern PGDLLIMPORT int DeadlockTimeout;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1509,6 +1509,7 @@ PGresAttValue
 PGresParamDesc
 PGresult
 PGresult_data
+PgArchData
 PHANDLE
 PLAINTREE
 PLTemplate


### PR DESCRIPTION
> [!IMPORTANT]
>  Backporting Upstream Postgres Commit to GPDB main
>         - https://github.com/postgres/postgres/commit/d75288fb27b8fe0a926aaab7d75816f091ecdc27 (Make archiver process an auxiliary process.) (PG14)
>         - https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d (Improve performance of pgarch_readyXlog() with many status files.) (PG15)
>        - https://github.com/postgres/postgres/commit/1fb17b1903414676bd371068739549cd2966fe87 (Fix issues in pgarch's new directory-scanning logic.) (PG15)

Original Commit Message:
--------------------------
[Archiver Process as an Auxiliary Process](https://github.com/postgres/postgres/commit/d75288fb27b8fe0a926aaab7d75816f091ecdc27)
```
Make archiver process an auxiliary process.

This commit changes WAL archiver process so that it's treated as
an auxiliary process and can use shared memory. This is an infrastructure
patch required for upcoming shared-memory based stats collector patch
series. These patch series basically need any processes including archiver
that can report the statistics to access to shared memory. Since this patch
itself is useful to simplify the code and when users monitor the status of
archiver, it's committed separately in advance.

This commit simplifies the code for WAL archiving. For example, previously
backends need to signal to archiver via postmaster when they notify
archiver that there are some WAL files to archive. On the other hand,
this commit removes that signal to postmaster and enables backends to
notify archier directly using shared latch.

Also, as the side of this change, the information about archiver process
becomes viewable at pg_stat_activity view.

Author: Kyotaro Horiguchi
Reviewed-by: Andres Freund, Álvaro Herrera, Julien Rouhaud, Tomas Vondra, Arthur Zakirov, Fujii Masao
Discussion: https://postgr.es/m/20180629.173418.190173462.horiguchi.kyotaro@lab.ntt.co.jp
```

[Performance improvement of archive_status directory scan with many failed status files](https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d)
```
Improve the performance of pgarch_readyXlog() with many status files.

Presently, the archive_status directory is scanned for each file to
archive.  When there are many status files, say because archive_command
has been failing for a long time, these directory scans can get very
slow.  With this change, the archiver remembers several files to archive
during each directory scan, speeding things up.

To ensure timeline history files are archived as quickly as possible,
XLogArchiveNotify() forces the archiver to do a new directory scan as
soon as the .ready file for one is created.

Nathan Bossart, per a long discussion involving many people. It is
not clear to me exactly who out of all those people reviewed this
particular patch.

Discussion: http://postgr.es/m/CA+TgmobhAbs2yabTuTRkJTq_kkC80-+jw=pfpypdOJ7+gAbQbw@mail.gmail.com
Discussion: http://postgr.es/m/620F3CE1-0255-4D66-9D87-0EADE866985A@amazon.com
```


[Archiver Crash fix due to corrupted status file name](https://github.com/postgres/postgres/commit/1fb17b1903414676bd371068739549cd2966fe87)

```
Fix issues in pgarch's new directory-scanning logic.

The arch_filenames[] array elements were one byte too small, so that
a maximum-length filename would get corrupted if another entry
were made after it.  (Noted by Thomas Munro, fix by Nathan Bossart.)

Move these arrays into a palloc'd struct, so that we aren't wasting
a few kilobytes of static data in each non-archiver process.

Add a binaryheap_reset() call to make it plain that we start the
directory scan with an empty heap.  I don't think there's any live
bug of that sort, but it seems fragile, and this is very cheap
insurance.

Cleanup for commit https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d, so no back-patch needed.

Discussion: https://postgr.es/m/CA+hUKGLHAjHuKuwtzsW7uMJF4BVPcQRL-UMZG_HM-g0y7yLkUg@mail.gmail.com
```

Summary:
----------
In brief, this PR introduces the following changes
    ▪︎ Modifying the existing archiver process as an Auxiliary process.
    ▪︎ Identify Archiver as an Auxiliary process in pgstat.
    ▪︎ Improve the performance of pgarch_readyXlog() to avoid scanning multiple failed status files in archive_status  directory.
    ▪︎ Optimize the above performance to give high priority to the .history file and force scan the directory if any new .history status file is created.     
     ▪︎ Dynamic memory allocation to store status filename to  avoid wasting a few kilobytes of static data in each non-archiver process and to fix filename corruption.

_**This improves the performance because When there are many failed status files, say because archive_command
has been failing for a long time, these directory scans can get very slow(cloud storage like S3, GCP, Azure, NFS).  With this change, the archiver remembers several files to archive during each directory scan, speeding things up.**_

_**Making Archiver an Auxiliary process provides benefits to utilize Postgres auxiliary process framework like shared memory**_

#### Testing :
✓ Manually verified the directory scan optimization 
  `    *`The archive_status directory is scanned once.
  `    *` A force scan is triggered when a new .history file is created during Primary failover scenario.
  `    *` Xlog status files are returned from the binary heap context without scanning the directory.
✓ Autorestart of Auxiliary process on SIGTERM
✓ Archiver process name showing as "archiver" in the process list
✓ Archiver crash fix due to status filename corruption
✓ Some basic sanity test on this build

#### Log Snippet:
**Directory Scan Optimization->**
```
2024-01-10 14:47:17.300261 IST,,,p2529,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","received SIGHUP, reloading configuration files",,,,,,,0,,"postmaster.c",3175,
2024-01-10 14:47:17.421286 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:0 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,
2024-01-10 14:47:17.421323 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000013",,,,,,,0,,"pgarch.c",799,
2024-01-10 14:47:17.421337 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000011",,,,,,,0,,"pgarch.c",799,
2024-01-10 14:47:17.421356 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000015",,,,,,,0,,"pgarch.c",799,
2024-01-10 14:47:17.421372 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000012",,,,,,,0,,"pgarch.c",799,
2024-01-10 14:47:17.421383 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000014",,,,,,,0,,"pgarch.c",799,
2024-01-10 14:47:17.421405 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Exiting Value: arch_files_size:4 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",854,

2024-01-10 14:47:17.462800 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:4 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,
2024-01-10 14:47:17.462995 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Returning Cached File  000000010000000000000012",,,,,,,0,,"pgarch.c",758,
2024-01-10 14:47:17.486119 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:3 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,
2024-01-10 14:47:17.486145 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Returning Cached File  000000010000000000000013",,,,,,,0,,"pgarch.c",758,
2024-01-10 14:47:17.512169 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:2 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,
2024-01-10 14:47:17.512194 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Returning Cached File  000000010000000000000014",,,,,,,0,,"pgarch.c",758,
2024-01-10 14:47:17.533613 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:1 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,
2024-01-10 14:47:17.533649 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug : Returning Cached File  000000010000000000000015",,,,,,,0,,"pgarch.c",758,
2024-01-10 14:47:17.569804 IST,,,p4518,th-430595840,,,,0,,,seg-1,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:0 force_dir_scan 0 ",,,,,,,0,,"pgarch.c",734,

```


**History file Optimization (force_dir_scan 1) using shared memory ->**
```
2024-01-10 20:35:31.215617 IST,,,p44104,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found History File 00000003.history, force directory scan",,,,,,,0,,"xlogarchive.c",575,
2024-01-10 20:35:31.215640 IST,,,p44104,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Initialized force directory scan",,,,,,,0,,"pgarch.c",889,
2024-01-10 20:35:31.226317 IST,,,p44104,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","latest completed transaction id is 531 and next transaction id is 532",,,,,,,0,,"xlog.c",8180,
2024-01-10 20:35:31.230507 IST,,,p44104,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","database system is ready",,,,,,,0,,"xlog.c",8206,
2024-01-10 20:35:31.234014 IST,,,p44102,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","PostgreSQL 12.12 (Greenplum Database 7.0.0+dev.261.g663088a09bf build dev) on arm-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.0.40.1), 64-bit compiled on Jan 10 2024 12:36:11 (with assert checking)",,,,,,,0,,"postmaster.c",3523,
2024-01-10 20:35:31.234052 IST,,,p44102,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","database system is ready to accept connections","PostgreSQL 12.12 (Greenplum Database 7.0.0+dev.261.g663088a09bf build dev) on arm-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.0.40.1), 64-bit compiled on Jan 10 2024 12:36:11 (with assert checking)",,,,,,0,,"postmaster.c",3527,
2024-01-10 20:35:31.234507 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug - Initial Value: arch_files_size:0 force_dir_scan 1 ",,,,,,,0,,"pgarch.c",729,
2024-01-10 20:35:31.236140 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000020000000000000017",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236165 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000020000000000000019.partial",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236200 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  00000002.history",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236216 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000010000000000000016.partial",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236232 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  000000020000000000000016",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236251 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug : Reading archive_status and Found File  00000003.history",,,,,,,0,,"pgarch.c",794,
2024-01-10 20:35:31.236266 IST,,,p44751,th-430595840,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug - Exiting Value:  arch_files_size:5 force_dir_scan 1 returning xlog:00000002.history ",,,,,,,0,,"pgarch.c",849,

```



Archiver Crash Validation->
```
2024-01-15 15:39:16.051686 IST,,,p81993,th-503521024,,,,0,,,seg-1,,,,,"LOG","00000","PostgreSQL 12.12 (Greenplum Database 7.0.0+dev.335.g842d2830a1c build dev) on arm-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.0.40.1), 64-bit compiled on Jan 15 2024 10:09:00 (with assert checking)",,,,,,,0,,"postmaster.c",3523,
2024-01-15 15:39:16.051730 IST,,,p81993,th-503521024,,,,0,,,seg-1,,,,,"LOG","00000","database system is ready to accept connections","PostgreSQL 12.12 (Greenplum Database 7.0.0+dev.335.g842d2830a1c build dev) on arm-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.0.40.1), 64-bit compiled on Jan 15 2024 10:09:00 (with assert checking)",,,,,,0,,"postmaster.c",3527,
2024-01-15 15:39:16.231574 IST,"sunils3",,p89086,th-503521024,"127.0.0.1","50222",2024-01-15 15:39:16 IST,0,,,seg-1,,,,,"LOG","00000","standby ""gp_walreceiver"" is now a synchronous standby with priority 1",,,,,,"START_REPLICATION 0/40000000 TIMELINE 1",0,,"syncrep.c",595,
2024-01-15 15:39:16.251667 IST,,,p89080,th-503521024,,,,0,con2,,seg-1,,,,sx1,"LOG","00000","DTM Started",,,,,,,0,,"cdbdtxrecovery.c",165,
2024-01-15 15:39:28.457808 IST,,,p89132,th-503521024,,,,0,,,seg-1,,,,,"WARNING","01000","removal of orphan archive status file ""pg_wal/archive_status/00000001000000000000000A.00000028.backup00000001000000000000000C.00000028.backup.ready"" failed too many times, will try again later",,,,,,,0,,"pgarch.c",507,
2024-01-15 15:39:28.471088 IST,,,p81993,th-503521024,,,,0,,,seg-1,,,,,"LOG","00000","archiver process (PID 89132) was terminated by signal 6: Abort trap: 6",,,,,,,0,,"postmaster.c",4221,
2024-01-15 15:39:28.471220 IST,,,p81993,th-503521024,,,,0,,,seg-1,,,,,"LOG","00000","terminating any other active server processes",,,,,,,0,,"postmaster.c",3945,
2024-01-15 15:39:28.471569 IST,"sunils3",,p89086,th-503521024,"127.0.0.1","50222",2024-01-15 15:39:16 IST,0,,,seg-1,,,,,"WARNING","57P02","terminating connection because of crash of another server process","The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.","In a moment you should be able to reconnect to the database and repeat your command.",,,,,0,,"postgres.c",3507,

```






#### Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
