### PR TITLE
fix the potential integer overflow problem at InterConnect Tuple Chunk

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -165,10 +165,10 @@ createMotionLayerState(int maxMotNodeID)
 		return NULL;
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
-		Gp_max_tuple_chunk_size = Gp_max_packet_size - sizeof(struct icpkthdr) - TUPLE_CHUNK_HEADER_SIZE;
+		Gp_max_tuple_chunk_size = Gp_max_packet_size - sizeof(struct icpkthdr);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
 			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
-		Gp_max_tuple_chunk_size = Gp_max_packet_size - PACKET_HEADER_SIZE - TUPLE_CHUNK_HEADER_SIZE;
+		Gp_max_tuple_chunk_size = Gp_max_packet_size - PACKET_HEADER_SIZE;
 
 	/*
 	 * Use the statically allocated chunk that is intended for sending end-of-
@@ -181,8 +181,10 @@ createMotionLayerState(int maxMotNodeID)
 
 	pData = s_eos_chunk_data->chunk_data;
 
-	SetChunkDataSize(pData, 0);
+	InitializeChunkHeader(pData);
 	SetChunkType(pData, TC_END_OF_STREAM);
+	SetChunkDataSize(pData, 0);
+	SetChunkTupleSize(pData, 0);
 
 	/*
 	 * Create the memory-contexts that we will use within the Motion Layer.

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -25,6 +25,7 @@
 #include "cdb/ml_ipc.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp.h"
+#include "cdb/tupchunk.h"
 
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -130,7 +131,8 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 							   conn->msgSize, bytesProcessed, TUPLE_CHUNK_HEADER_SIZE)));
 		}
 
-		tcSize = TUPLE_CHUNK_HEADER_SIZE + (*(uint16 *) (conn->msgPos + bytesProcessed));
+		GetChunkDataSize(conn->msgPos + bytesProcessed, &tcSize);
+		tcSize += TUPLE_CHUNK_HEADER_SIZE;
 
 		/* sanity check */
 		if (tcSize > Gp_max_packet_size)

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -538,7 +538,7 @@ startOutgoingConnections(ChunkTransportState *transportStates,
 		if (cdbProc)
 		{
 			conn->cdbProc = cdbProc;
-			conn->pBuff = palloc(Gp_max_packet_size);
+			conn->pBuff = palloc0(Gp_max_packet_size);
 			conn->state = mcsSetupOutgoingConnection;
 			(*pOutgoingCount)++;
 		}
@@ -1200,7 +1200,7 @@ acceptIncomingConnection(void)
 	 */
 	conn = palloc0(sizeof(MotionConn));
 	conn->sockfd = newsockfd;
-	conn->pBuff = palloc(Gp_max_packet_size);
+	conn->pBuff = palloc0(Gp_max_packet_size);
 	conn->msgSize = 0;
 	conn->recvBytes = 0;
 	conn->msgPos = 0;


### PR DESCRIPTION
This PR is trying to fix 2 problems:

1. The potential integer overflow problem at Tuple Chunk data size.
2. There are 4 bytes in IC package that are never used.

---

For the problem 1, we design the tuple chunk into the below structure:

<img width="550" alt="image" src="https://github.com/greenplum-db/gpdb/assets/30709931/0b17214c-354d-43b9-a127-15a008e6125c">

we used 16bits space to store the length of tuple, but we allow the max size of the interconnect 
package to 65507, which is `MAX_PACKET_SIZE`. And that value could not be stored at 16bits, 
so I use 20bits to save it, and the left 12bits to save the chunk type, just like:

<img width="1088" alt="image" src="https://github.com/greenplum-db/gpdb/assets/30709931/0f4a62b9-a32d-4293-947e-22ffb2bfcf3a">

Currently, Greenplum only has 6 types of chunks, and 12bits is completely sufficient.

----

For the problem 2, there are 4 bytes in IC package that are never used.

When we set `gp_max_packet_size` to the minimum value of 512 and put a breakpoint in 
QD's `RecvTupleChunk` function, we can find that the value of `conn->msgSize` is only 508, 
and the correct value should be 512. This is because when calculating the longest tuple length, 
an additional `TUPLE_CHUNK_HEADER_SIZE` is subtracted, which is 4 bytes:

```
Thread 1 "postgres" hit Breakpoint 1, RecvTupleChunk () at ic_common.c:93
(gdb) n
(gdb) p conn->msgSize
$10 = 508
(gdb) n
(gdb) p tcSize
$11 = 444
```