### PR TITLE
Delay setting the current user until the CREATE SCHEMA is dispatched

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -168,18 +168,6 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 		}
 	}
 
-	/*
-	 * If the requested authorization is different from the current user,
-	 * temporarily set the current user so that the object(s) will be created
-	 * with the correct ownership.
-	 *
-	 * (The setting will be restored at the end of this routine, or in case of
-	 * error, transaction abort will clean things up.)
-	 */
-	if (saved_uid != owner_uid)
-		SetUserIdAndSecContext(owner_uid,
-							   save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
-
 	/* Create the schema's namespace */
 	if (shouldDispatch || Gp_role != GP_ROLE_EXECUTE)
 	{
@@ -214,6 +202,21 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 	{
 		namespaceId = NamespaceCreate(schemaName, owner_uid, false);
 	}
+
+	/*
+	 * If the requested authorization is different from the current user,
+	 * temporarily set the current user so that the object(s) will be created
+	 * with the correct ownership.
+	 *
+	 * (The setting will be restored at the end of this routine, or in case of
+	 * error, transaction abort will clean things up.)
+	 *
+	 * Greenplum delays setting the current user until the query is dispatched
+	 * to QEs.
+	 */
+	if (saved_uid != owner_uid)
+		SetUserIdAndSecContext(owner_uid,
+							   save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
 
 	/* Advance cmd counter to make the namespace visible */
 	CommandCounterIncrement();

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -2552,6 +2552,9 @@ LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should pass
 COMMIT;
 \c
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
+-- regression test: superuser create a schema and authorize it to a non-superuser
+CREATE ROLE "non_superuser_schema";
+CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
 -- clean up
 DROP TABLE lock_table;
 DROP USER regress_locktable_user;

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -2553,6 +2553,7 @@ COMMIT;
 \c
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
 -- regression test: superuser create a schema and authorize it to a non-superuser
+DROP ROLE IF EXISTS "non_superuser_schema";
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
 -- clean up

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -2599,6 +2599,10 @@ LOCK TABLE lock_table IN ACCESS EXCLUSIVE MODE; -- should pass
 COMMIT;
 \c
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
+-- regression test: superuser create a schema and authorize it to a non-superuser
+DROP ROLE IF EXISTS "non_superuser_schema";
+CREATE ROLE "non_superuser_schema";
+CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
 -- clean up
 DROP TABLE lock_table;
 DROP USER regress_locktable_user;

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1589,6 +1589,7 @@ COMMIT;
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
 
 -- regression test: superuser create a schema and authorize it to a non-superuser
+DROP ROLE IF EXISTS "non_superuser_schema";
 CREATE ROLE "non_superuser_schema";
 CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
 

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1588,6 +1588,10 @@ COMMIT;
 \c
 REVOKE TRUNCATE ON lock_table FROM regress_locktable_user;
 
+-- regression test: superuser create a schema and authorize it to a non-superuser
+CREATE ROLE "non_superuser_schema";
+CREATE SCHEMA test_non_superuser_schema AUTHORIZATION "non_superuser_schema";
+
 -- clean up
 DROP TABLE lock_table;
 DROP USER regress_locktable_user;


### PR DESCRIPTION
We lost this code change and its test in an upstream merge, get it back.

	commit c5d6078de405cfeb66a35192efd16c4298220d82
	Author: Pengzhou Tang <ptang@pivotal.io>
	Date:   Thu Apr 25 19:52:42 2019 -0400

	    Fix a permission denied issue

	    Assume user1 has the privilege to database db1 and user2 has not, when
	    user1 try to create a schema in db1 and authorize it to user2, a
	    permission denied error is reported in QE. The RCA is QD set current
	    user to user2 before dispatching the query to QEs, so QE will also
	    set current user to user2, however, user2 has no provilege to create
	    schema in database db1.

	    To fix this, we delay setting the current user to user2 until the query
	    is dispatched to QEs.

Fix #16988

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
