### PR TITLE
fix the value of `TUPLE_CHUNK_HEADER_SIZE`

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -165,10 +165,10 @@ createMotionLayerState(int maxMotNodeID)
 		return NULL;
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
-		Gp_max_tuple_chunk_size = Gp_max_packet_size - sizeof(struct icpkthdr) - TUPLE_CHUNK_HEADER_SIZE;
+		Gp_max_tuple_chunk_size = Gp_max_packet_size - sizeof(struct icpkthdr);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
 			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
-		Gp_max_tuple_chunk_size = Gp_max_packet_size - PACKET_HEADER_SIZE - TUPLE_CHUNK_HEADER_SIZE;
+		Gp_max_tuple_chunk_size = Gp_max_packet_size - PACKET_HEADER_SIZE;
 
 	/*
 	 * Use the statically allocated chunk that is intended for sending end-of-


### PR DESCRIPTION
This PR is trying to fix the problem that there are 4 bytes in IC package that are never used.

When we set `gp_max_packet_size` to the minimum value of 512 and put a breakpoint in 
QD's `RecvTupleChunk` function, we can find that the value of `conn->msgSize` is only 508, 
and the correct value should be 512. This is because when calculating the longest tuple length, 
an additional `TUPLE_CHUNK_HEADER_SIZE` is subtracted, which is 4 bytes:

```
Thread 1 "postgres" hit Breakpoint 1, RecvTupleChunk () at ic_common.c:93
(gdb) n
(gdb) p conn->msgSize
$10 = 508
(gdb) n
(gdb) p tcSize
$11 = 444
```
