### PR TITLE
Ignore symbol ConfigureNamesBool_gp in base 6.26.1

### DIFF
--- a/.abi-check/6.26.1/postgres.symbols.ignore
+++ b/.abi-check/6.26.1/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp


### PR DESCRIPTION
ABI problems with the symbol `ConfigureNamesBool_gp`:

> Size of this global data has been changed from 38304 bytes to 38456 bytes.

The reason is that an additional GUC is added in this commit: https://github.com/greenplum-db/gpdb/pull/16887/files#diff-3d03368dae4bd5ea009d6cdc0ce2ddc4620e2b776429532d32fde1c3ba63c515R3292 since 6.26.1

Currently, we can ignore this symbol in the ABI check.

Related PR: #16887

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
