### PR TITLE
Fix test case explain_format about hashagg output

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -698,32 +698,16 @@ SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
-explain_filter
-Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-  ->  Finalize HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-        Group Key: a, b, (GROUPINGSET_ID())
-        Planned Partitions: N
-        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-
-        ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-              Hash Key: a, b, (GROUPINGSET_ID())
-              ->  Partial HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-                    Hash Key: a
-                    Hash Key: b
-                    Planned Partitions: N
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-
-                    ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-Optimizer: Postgres-based planner
-Planning Time: N.N ms
-  (sliceN)    Executor memory: NK bytes.
-* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
-* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
-Memory used:  NkB
-Memory wanted:  NkB
-Execution Time: N.N ms
-(23 rows)
+WITH query_plan (et) AS
+(
+	SELECT explain_filter(
+		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
+)
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
+Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+(2 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -641,36 +641,16 @@ CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
-explain_filter
-Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-  ->  Sequence  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-        ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-              ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-        ->  Append  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-                    Group Key: share0_ref2.b
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-
-                    ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-                          Hash Key: share0_ref2.b
-                          ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-                                ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-                    Group Key: share0_ref3.a
-                    Planned Partitions: N
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-
-                    ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
-Optimizer: GPORCA
-Planning Time: N.N ms
-  (sliceN)    Executor memory: NK bytes.
-* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
-  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
-Memory used:  NkB
-Memory wanted:  NkB
-Execution Time: N.N ms
-(27 rows)
+WITH query_plan (et) AS
+(
+	SELECT explain_filter(
+		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
+)
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+explain_info
+Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+(2 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -161,7 +161,12 @@ select explain_filter('EXPLAIN ANALYZE SELECT a, COUNT(DISTINCT b) AS b FROM tes
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
+WITH query_plan (et) AS
+(
+	SELECT explain_filter(
+		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
+)
+SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
 
 RESET optimizer_enable_hashagg;
 RESET statement_mem;


### PR DESCRIPTION
### Error
Test case explain_format failed recently:
```
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/explain_format_optimizer.out /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/explain_format.out
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/explain_format_optimizer.out	2024-01-15 15:50:02.765529591 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/explain_format.out	2024-01-15 15:50:02.813534472 +0000
@@ -708,6 +708,8 @@
                     Group Key: share0_ref2.b
                     Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
                    ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                           Hash Key: share0_ref2.b
                           ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
@@ -717,6 +719,8 @@
                     Planned Partitions: N
                     Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
                     ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
 Planning Time: N.N ms
@@ -726,7 +730,7 @@
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(27 rows)
+(31 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
```
### Root cause
The error was fixed previously by https://github.com/greenplum-db/gpdb/pull/16352

Basically, explain HashAgg occasionally generates an additional line of "Extra Text" which works as design (See PR #16352 for details). So we must use an existing UDF test_util.get_explain_output() to check the result instead of printing out the result directly.

The error was imported again by https://github.com/greenplum-db/gpdb/pull/16843. The PR merged two test helper functions from PG13 that replace changeable output details in the EXPLAIN output. However, the PR didn't consider the "Extra Text" issue so hit the error again.

### Solution
This PR is: keep the using of the helper function explain_filter(), but wrap the result to a CTE and check the result to avoid extra line (by the similar approach of #16352):
```
WITH query_plan (et) AS
(
    SELECT explain_filter(
        'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
)
SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
```