### PR TITLE
Fix "unrecognized join type" error with LASJ Not-In and network types

### DIFF
--- a/src/backend/utils/adt/network_selfuncs.c
+++ b/src/backend/utils/adt/network_selfuncs.c
@@ -224,6 +224,7 @@ networkjoinsel(PG_FUNCTION_ARGS)
 			break;
 		case JOIN_SEMI:
 		case JOIN_ANTI:
+		case JOIN_LASJ_NOTIN:
 			/* Here, it's important that we pass the outer var on the left. */
 			if (!join_is_reversed)
 				selec = networkjoinsel_semi(operator, &vardata1, &vardata2);

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -3048,3 +3048,24 @@ drop table if exists repli_t1_pk;
 drop table if exists repli_t2_pk;
 drop table if exists repli_t3_pk;
 drop table if exists repli_t4_pk;
+-- Test that left-anti-semi-join not-in works with netowrk types
+CREATE TABLE inverse (cidr inet);
+INSERT INTO inverse values ('192.168.100.199');
+explain SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10027702610.21 rows=16 width=4)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10027702610.00 rows=5 width=4)
+         Join Filter: (inverse.cidr <<= inverse_1.cidr)
+         ->  Seq Scan on inverse  (cost=0.00..210.00 rows=17600 width=32)
+         ->  Materialize  (cost=0.00..1178.00 rows=52800 width=32)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..914.00 rows=52800 width=32)
+                     ->  Seq Scan on inverse inverse_1  (cost=0.00..210.00 rows=17600 width=32)
+ Optimizer: Postgres-based planner
+(8 rows)
+
+SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+ ?column? 
+----------
+(0 rows)
+

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -2950,3 +2950,32 @@ drop table if exists repli_t1_pk;
 drop table if exists repli_t2_pk;
 drop table if exists repli_t3_pk;
 drop table if exists repli_t4_pk;
+-- Test that left-anti-semi-join not-in works with netowrk types
+CREATE TABLE inverse (cidr inet);
+INSERT INTO inverse values ('192.168.100.199');
+explain SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.93 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.93 rows=1 width=1)
+         ->  Result  (cost=0.00..1324032.93 rows=1 width=1)
+               Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((inverse_1.cidr <<= inverse.cidr) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
+               ->  GroupAggregate  (cost=0.00..1324032.93 rows=1 width=16)
+                     Group Key: inverse_1.cidr, inverse_1.ctid, inverse_1.gp_segment_id
+                     ->  Sort  (cost=0.00..1324032.93 rows=1 width=23)
+                           Sort Key: inverse_1.cidr, inverse_1.ctid, inverse_1.gp_segment_id
+                           ->  Nested Loop Left Join  (cost=0.00..1324032.93 rows=1 width=27)
+                                 Join Filter: ((inverse_1.cidr <<= inverse.cidr) IS NOT FALSE)
+                                 ->  Seq Scan on inverse inverse_1  (cost=0.00..431.00 rows=1 width=18)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
+                                       ->  Result  (cost=0.00..431.00 rows=1 width=9)
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Seq Scan on inverse  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(16 rows)
+
+SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+ ?column? 
+----------
+(0 rows)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -1112,3 +1112,9 @@ drop table if exists repli_t1_pk;
 drop table if exists repli_t2_pk;
 drop table if exists repli_t3_pk;
 drop table if exists repli_t4_pk;
+
+-- Test that left-anti-semi-join not-in works with netowrk types
+CREATE TABLE inverse (cidr inet);
+INSERT INTO inverse values ('192.168.100.199');
+explain SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));


### PR DESCRIPTION
During the GP7 merge, separate join selectivity functions were added for network types. However, GPDB has a separate join, JOIN_LASJ_NOTIN, that does not exist in Postgres and thus was not added as a possible case.

I followed the same pattern in selfuncs.c, treating it as a semi/anti join for calculating the selectivity.

Fixes https://github.com/greenplum-db/gpdb/issues/16997