### PR TITLE
Ignore symbol ConfigureNamesInt_gp in base 6.26.1

### DIFF
--- a/.abi-check/6.26.1/postgres.symbols.ignore
+++ b/.abi-check/6.26.1/postgres.symbols.ignore
@@ -1,1 +1,2 @@
 ConfigureNamesBool_gp
+ConfigureNamesInt_gp


### PR DESCRIPTION
ABI problems with the symbol ConfigureNamesInt_gp:

> Size of this global data has been changed from 18880 bytes to 19040 bytes.

The reason is that an additional GUC is added in this PR #16957 [file](https://github.com/greenplum-db/gpdb/pull/16957/files#diff-3d03368dae4bd5ea009d6cdc0ce2ddc4620e2b776429532d32fde1c3ba63c515R4677) since 6.26.1

Currently, we can ignore this symbol in the ABI check-ignore list.

Similar PR: #16992

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
