### PR TITLE
Handle ICProxy addresses during gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2029,6 +2029,53 @@ class gpexpand:
         else:
             self.logger.info("Heap checksum setting consistent across cluster")
 
+    def validate_icproxy_addr(self, inputFileEntryList):
+        """
+        If we are in icproxy mode: the proxy addresses of newly added segments are still empty after
+        expansion. It will cause queries to hang forever.
+        So, we have to check if the user have already set gp_interconnect_proxy_addresses before.
+        And prompt user to set a proper value via gpconfig before expansion.
+        """
+
+        # get GUC value
+        sql = "show gp_interconnect_proxy_addresses;"
+        conn = dbconn.connect(_gp_expand.dburl, encoding='UTF8')
+        icproxy_addresses_string = dbconn.queryRow(conn, sql)[0].strip()
+        sql = "show gp_interconnect_type;"
+        ic_type = dbconn.queryRow(conn, sql)[0].strip()
+        conn.close()
+
+        # check if newly added dbid exists in gp_interconnect_proxy_addresses
+        need_prompt = False
+        new_addresses_string = icproxy_addresses_string
+        if icproxy_addresses_string:
+            self.logger.info("ICProxy addresses has been set to: %s, start to checking if it contains newly added segs", icproxy_addresses_string)
+
+            dbid_set = set()
+            # icproxy_addresses_string example: 1:-1:gpdb:1432,2:0:gpdb:2000,3:1:gpdb:2001
+            for addr in icproxy_addresses_string.split(','):
+                db_id, content_id, host, port = addr.split(':')
+                dbid_set.add(db_id)
+
+            for seg in inputFileEntryList:
+                if seg.dbid not in dbid_set:
+                    need_prompt = True
+                    new_addresses_string += ",%s:%s:%s:{port}" % (seg.dbid, seg.contentId, seg.hostname.strip())
+                    self.logger.warning(" Missing the address of dbid %s in gp_interconnect_proxy_addresses" % (seg.dbid))
+
+            # prompt user to use gpconfig to set the proper value of gp_interconnect_proxy_addresses
+            if need_prompt:
+                if ic_type == "proxy":
+                    self.logger.error("Please run gpconfig to set gp_interconnect_proxy_addresses (replace the {port} with a proper value):")
+                    self.logger.error(" gpconfig -c gp_interconnect_proxy_addresses -v \"'%s'\" --skipvalidation" % (new_addresses_string))
+                    self.logger.error('then rerun gpexpand -i {input_file}')
+                    raise Exception("Checking ICProxy addresses failed")
+                else:
+                    self.logger.warning("Recommended that run gpconfig to set gp_interconnect_proxy_addresses (replace the {port} with a proper value):")
+                    self.logger.warning(" gpconfig -c gp_interconnect_proxy_addresses -v \"'%s'\" --skipvalidation" % (new_addresses_string))
+            else:
+                self.logger.info("Checking ICProxy addresses passed")
+        return
 
 # -----------------------------------------------
 class ExpandTable():
@@ -2586,6 +2633,7 @@ def main(options, args, parser):
         elif gpexpand_db_status is None and gpexpand_file_status is None and options.filename:
             _gp_expand.validate_heap_checksums()
             newSegList = _gp_expand.read_input_files()
+            _gp_expand.validate_icproxy_addr(newSegList)
             _gp_expand.addNewSegments(newSegList)
             newTableSpaceInfo = _gp_expand.read_tablespace_file()
             _gp_expand.sync_packages()

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -256,6 +256,59 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the tablespace is valid after gpexpand
 
+    @gpexpand_icproxy
+    Scenario: Cluster expansion failed (no new proxy address) with IC proxy mode enabled
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And the user runs command "rm -rf /data/gpdata/gpexpand/*"
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with no mirrors on "cdw" and "sdw1"
+        And the coordinator pid has been saved
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is running in IC proxy mode
+        And the cluster is setup for an expansion on hosts "cdw"
+        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignore.host"
+        And the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        Then gpexpand should return a return code of 3
+        And gpexpand should print "Checking ICProxy addresses failed" to stdout
+
+    @gpexpand_icproxy
+    Scenario: Cluster expansion failed (bind an wrong proxy address) with IC proxy mode enabled
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And the user runs command "rm -rf /data/gpdata/gpexpand/*"
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with no mirrors on "cdw" and "sdw1"
+        And the coordinator pid has been saved
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is running in IC proxy mode with new proxy address 4:2:cdw:16502
+        And the cluster is setup for an expansion on hosts "cdw"
+        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignore.host"
+        And the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        Then gpexpand should return a return code of 3
+        And gpexpand should print "The ic_proxy process failed to bind or listen" to stdout
+
+    @gpexpand_icproxy
+    Scenario: Cluster expansion successful with IC proxy mode enabled
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And the user runs command "rm -rf /data/gpdata/gpexpand/*"
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with no mirrors on "cdw" and "sdw1"
+        And the coordinator pid has been saved
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is running in IC proxy mode with new proxy address 4:2:sdw1:16502
+        And the cluster is setup for an expansion on hosts "cdw"
+        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignore.host"
+        And the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile without ret code check
+        Then gpexpand should return a return code of 0
+
     @gpexpand_verify_redistribution
     Scenario: Verify data is correctly redistributed after expansion
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4378,3 +4378,53 @@ def verify_elements_in_file(filename, elements):
 
         return True
 
+def set_ic_proxy_and_address(context, new_addr):
+    """
+        set the proper proxy addresses and enable proxy mode
+    """
+    with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
+        # get segment_configuration
+        sql = "SELECT dbid, content, address, port FROM gp_segment_configuration order by dbid"
+        rows = dbconn.query(conn, sql).fetchall()
+        if len(rows) <= 0:
+            raise Exception("Found no entries in gp_segment_configuration table")
+
+        # generate the proper proxy addresses by segment_configuration
+        cmd = "gpconfig -c gp_interconnect_proxy_addresses -v \"'"
+        for row in rows:
+            delta = 4000
+            dbid = row[0]
+            contentid = row[1]
+            host = row[2].strip()
+            port = int(row[3]) - delta
+            # an icproxy_addresses_string example: 1:-1:gpdb:1432,2:0:gpdb:2000,3:1:gpdb:2001
+            if dbid != 1:
+                cmd += ","
+            cmd += "%d:%d:%s:%d" % (dbid, contentid, host, port)
+        # append new address
+        if new_addr:
+            cmd += ","
+            cmd += new_addr
+        cmd += "'\" --skipvalidation"
+        run_command(context, cmd)
+        if context.ret_code != 0:
+            raise Exception("cannot run %s: %s, stdout: %s" % (cmd, context.error_message, context.stdout_message))
+
+        # set interconnect_type to proxy
+        cmd = "gpconfig -c gp_interconnect_type -v proxy"
+        run_command(context, cmd)
+        if context.ret_code != 0:
+            raise Exception("cannot run %s: %s, stdout: %s" % (cmd, context.error_message, context.stdout_message))
+        # let all config take effects
+        cmd = "gpstop -u"
+        run_command(context, cmd)
+        if context.ret_code != 0:
+            raise Exception("cannot run %s: %s, stdout: %s" % (cmd, context.error_message, context.stdout_message))
+
+@given(u'the cluster is running in IC proxy mode')
+def step_impl(context):
+    set_ic_proxy_and_address(context, "")
+
+@given(u'the cluster is running in IC proxy mode with new proxy address {address}')
+def step_impl(context, address):
+    set_ic_proxy_and_address(context, address)


### PR DESCRIPTION
Current gpexpand doesn't handle the ICProxy addresses. So, if we are in icproxy mode: the proxy addresses of newly added segments are still empty after expansion. This causes queries to hang forever.

We have to check if the user has already set gp_interconnect_proxy_addresses before and prompt them to set a proper value via gpconfig before expansion.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
