### PR TITLE
[6X backport] Improve performance of pgarch_readyXlog() with many failed status file and history file prioritization

### DIFF
--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -30,10 +30,12 @@
 #include <time.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
+#include "lib/binaryheap.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "pgstat.h"
@@ -67,6 +69,10 @@
 
 #define NUM_ARCHIVE_RETRIES 3
 
+/*
+ * Maximum number of .ready files to gather per directory scan.
+ */
+#define NUM_FILES_PER_DIRECTORY_SCAN 64
 
 /* ----------
  * Local data
@@ -74,6 +80,22 @@
  */
 static time_t last_pgarch_start_time;
 static time_t last_sigterm_time = 0;
+
+/*
+ * Stuff for tracking multiple files to archive from each scan of
+ * archive_status.  Minimizing the number of directory scans when there are
+ * many files to archive can significantly improve archival rate.
+ *
+ * arch_heap is a max-heap that is used during the directory scan to track
+ * the highest-priority files to archive.  After the directory scan
+ * completes, the file names are stored in ascending order of priority in
+ * arch_files.  pgarch_readyXlog() returns files from arch_files until it
+ * is empty, at which point another directory scan must be performed.
+ */
+static binaryheap *arch_heap = NULL;
+static char arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS];
+static char *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
+static int arch_files_size = 0;
 
 /*
  * Flags set by interrupt handlers for later service in the main loop.
@@ -107,7 +129,7 @@ static void pgarch_ArchiverCopyLoop(void);
 static bool pgarch_archiveXlog(char *xlog);
 static bool pgarch_readyXlog(char *xlog);
 static void pgarch_archiveDone(char *xlog);
-
+static int ready_file_comparator(Datum a, Datum b, void *arg);
 
 /* ------------------------------------------------------------
  * Public functions called from postmaster follow
@@ -268,6 +290,10 @@ PgArchiverMain(int argc, char *argv[])
 	 * Identify myself via ps
 	 */
 	init_ps_display("archiver process", "", "", "");
+
+	/* Initialize our max-heap for prioritizing files to archive. */
+	arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
+									ready_file_comparator, NULL);
 
 	pgarch_MainLoop();
 
@@ -445,6 +471,9 @@ static void
 pgarch_ArchiverCopyLoop(void)
 {
 	char		xlog[MAX_XFN_CHARS + 1];
+
+	/* force directory scan in the first call to pgarch_readyXlog() */
+	arch_files_size = 0;
 
 	/*
 	 * loop through all xlogs with archive_status of .ready and archive
@@ -701,18 +730,41 @@ pgarch_archiveXlog(char *xlog)
 static bool
 pgarch_readyXlog(char *xlog)
 {
-	/*
-	 * open xlog status directory and read through list of xlogs that have the
-	 * .ready suffix, looking for earliest file. It is possible to optimise
-	 * this code, though only a single file is expected on the vast majority
-	 * of calls, so....
-	 */
 	char		XLogArchiveStatusDir[MAXPGPATH];
 	DIR		   *rldir;
 	struct dirent *rlde;
-	bool		found = false;
-	bool		historyFound = false;
 
+	/*
+	 * If we still have stored file names from the previous directory scan,
+	 * try to return one of those.  We check to make sure the status file
+	 * is still present, as the archive_command for a previous file may
+	 * have already marked it done.
+	 */
+	while (arch_files_size > 0)
+	{
+		struct stat	st;
+		char		status_file[MAXPGPATH];
+		char	   *arch_file;
+
+		arch_files_size--;
+		arch_file = arch_files[arch_files_size];
+		StatusFilePath(status_file, arch_file, ".ready");
+
+		if (stat(status_file, &st) == 0)
+		{
+			strcpy(xlog, arch_file);
+			return true;
+		}
+		else if (errno != ENOENT)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not stat file \"%s\": %m", status_file)));
+	}
+
+	/*
+	 * Open the archive status directory and read through the list of files
+	 * with the .ready suffix, looking for the earliest files.
+	 */
 	snprintf(XLogArchiveStatusDir, MAXPGPATH, XLOGDIR "/archive_status");
 	rldir = AllocateDir(XLogArchiveStatusDir);
 	if (rldir == NULL)
@@ -725,7 +777,7 @@ pgarch_readyXlog(char *xlog)
 	{
 		int			basenamelen = (int) strlen(rlde->d_name) - 6;
 		char		basename[MAX_XFN_CHARS + 1];
-		bool		ishistory;
+		char	   *arch_file;
 
 		/* Ignore entries with unexpected number of characters */
 		if (basenamelen < MIN_XFN_CHARS ||
@@ -744,32 +796,82 @@ pgarch_readyXlog(char *xlog)
 		memcpy(basename, rlde->d_name, basenamelen);
 		basename[basenamelen] = '\0';
 
-		/* Is this a history file? */
-		ishistory = IsTLHistoryFileName(basename);
-
 		/*
-		 * Consume the file to archive.  History files have the highest
-		 * priority.  If this is the first file or the first history file
-		 * ever, copy it.  In the presence of a history file already chosen as
-		 * target, ignore all other files except history files which have been
-		 * generated for an older timeline than what is already chosen as
-		 * target to archive.
+		 * Store the file in our max-heap if it has a high enough priority.
 		 */
-		if (!found || (ishistory && !historyFound))
+		if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
 		{
-			strcpy(xlog, basename);
-			found = true;
-			historyFound = ishistory;
+			/* If the heap isn't full yet, quickly add it. */
+			arch_file = arch_filenames[arch_heap->bh_size];
+			strcpy(arch_file, basename);
+			binaryheap_add_unordered(arch_heap, CStringGetDatum(arch_file));
+
+			/* If we just filled the heap, make it a valid one. */
+			if (arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
+				binaryheap_build(arch_heap);
 		}
-		else if (ishistory || !historyFound)
+		else if (ready_file_comparator(binaryheap_first(arch_heap),
+									   CStringGetDatum(basename), NULL) > 0)
 		{
-			if (strcmp(basename, xlog) < 0)
-				strcpy(xlog, basename);
+			/*
+			 * Remove the lowest priority file and add the current one to
+			 * the heap.
+			 */
+			arch_file = DatumGetCString(binaryheap_remove_first(arch_heap));
+			strcpy(arch_file, basename);
+			binaryheap_add(arch_heap, CStringGetDatum(arch_file));
 		}
 	}
 	FreeDir(rldir);
 
-	return found;
+	/* If no files were found, simply return. */
+	if (arch_heap->bh_size == 0)
+		return false;
+
+	/*
+	 * If we didn't fill the heap, we didn't make it a valid one.  Do that
+	 * now.
+	 */
+	if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		binaryheap_build(arch_heap);
+
+	/*
+	 * Fill arch_files array with the files to archive in ascending order
+	 * of priority.
+	 */
+	arch_files_size = arch_heap->bh_size;
+	for (int i = 0; i < arch_files_size; i++)
+		arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_heap));
+
+	/* Return the highest priority file. */
+	arch_files_size--;
+	strcpy(xlog, arch_files[arch_files_size]);
+
+	return true;
+}
+
+/*
+ * ready_file_comparator
+ *
+ * Compares the archival priority of the given files to archive.  If "a"
+ * has a higher priority than "b", a negative value will be returned.  If
+ * "b" has a higher priority than "a", a positive value will be returned.
+ * If "a" and "b" have equivalent values, 0 will be returned.
+ */
+static int
+ready_file_comparator(Datum a, Datum b, void *arg)
+{
+	char *a_str = DatumGetCString(a);
+	char *b_str = DatumGetCString(b);
+	bool a_history = IsTLHistoryFileName(a_str);
+	bool b_history = IsTLHistoryFileName(b_str);
+
+	/* Timeline history files always have the highest priority. */
+	if (a_history != b_history)
+		return a_history ? -1 : 1;
+
+	/* Priority is given to older files. */
+	return strcmp(a_str, b_str);
 }
 
 /*

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -91,11 +91,20 @@ static time_t last_sigterm_time = 0;
  * completes, the file names are stored in ascending order of priority in
  * arch_files.  pgarch_readyXlog() returns files from arch_files until it
  * is empty, at which point another directory scan must be performed.
+ *
+ * We only need this data in the archiver process, so make it a palloc'd
+ * struct rather than a bunch of static arrays.
  */
-static binaryheap *arch_heap = NULL;
-static char arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS];
-static char *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
-static int arch_files_size = 0;
+struct arch_files_state
+{
+	binaryheap *arch_heap;
+	int			arch_files_size;	/* number of live entries in arch_files[] */
+	char	   *arch_files[NUM_FILES_PER_DIRECTORY_SCAN];
+	/* buffers underlying heap, and later arch_files[], entries: */
+	char		arch_filenames[NUM_FILES_PER_DIRECTORY_SCAN][MAX_XFN_CHARS + 1];
+};
+
+static struct arch_files_state *arch_files = NULL;
 
 /*
  * Flags set by interrupt handlers for later service in the main loop.
@@ -291,9 +300,13 @@ PgArchiverMain(int argc, char *argv[])
 	 */
 	init_ps_display("archiver process", "", "", "");
 
+	/* Create workspace for pgarch_readyXlog() */
+	arch_files = palloc(sizeof(struct arch_files_state));
+	arch_files->arch_files_size = 0;
+
 	/* Initialize our max-heap for prioritizing files to archive. */
-	arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
-									ready_file_comparator, NULL);
+	arch_files->arch_heap = binaryheap_allocate(NUM_FILES_PER_DIRECTORY_SCAN,
+												ready_file_comparator, NULL);
 
 	pgarch_MainLoop();
 
@@ -473,7 +486,7 @@ pgarch_ArchiverCopyLoop(void)
 	char		xlog[MAX_XFN_CHARS + 1];
 
 	/* force directory scan in the first call to pgarch_readyXlog() */
-	arch_files_size = 0;
+	arch_files->arch_files_size = 0;
 
 	/*
 	 * loop through all xlogs with archive_status of .ready and archive
@@ -740,14 +753,14 @@ pgarch_readyXlog(char *xlog)
 	 * is still present, as the archive_command for a previous file may
 	 * have already marked it done.
 	 */
-	while (arch_files_size > 0)
+	while (arch_files->arch_files_size > 0)
 	{
 		struct stat	st;
 		char		status_file[MAXPGPATH];
 		char	   *arch_file;
 
-		arch_files_size--;
-		arch_file = arch_files[arch_files_size];
+		arch_files->arch_files_size--;
+		arch_file = arch_files->arch_files[arch_files->arch_files_size];
 		StatusFilePath(status_file, arch_file, ".ready");
 
 		if (stat(status_file, &st) == 0)
@@ -760,6 +773,9 @@ pgarch_readyXlog(char *xlog)
 					(errcode_for_file_access(),
 					 errmsg("could not stat file \"%s\": %m", status_file)));
 	}
+
+	/* arch_heap is probably empty, but let's make sure */
+	binaryheap_reset(arch_files->arch_heap);
 
 	/*
 	 * Open the archive status directory and read through the list of files
@@ -799,53 +815,53 @@ pgarch_readyXlog(char *xlog)
 		/*
 		 * Store the file in our max-heap if it has a high enough priority.
 		 */
-		if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		if (arch_files->arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
 		{
 			/* If the heap isn't full yet, quickly add it. */
-			arch_file = arch_filenames[arch_heap->bh_size];
+			arch_file = arch_files->arch_filenames[arch_files->arch_heap->bh_size];
 			strcpy(arch_file, basename);
-			binaryheap_add_unordered(arch_heap, CStringGetDatum(arch_file));
+			binaryheap_add_unordered(arch_files->arch_heap, CStringGetDatum(arch_file));
 
 			/* If we just filled the heap, make it a valid one. */
-			if (arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
-				binaryheap_build(arch_heap);
+			if (arch_files->arch_heap->bh_size == NUM_FILES_PER_DIRECTORY_SCAN)
+				binaryheap_build(arch_files->arch_heap);
 		}
-		else if (ready_file_comparator(binaryheap_first(arch_heap),
+		else if (ready_file_comparator(binaryheap_first(arch_files->arch_heap),
 									   CStringGetDatum(basename), NULL) > 0)
 		{
 			/*
 			 * Remove the lowest priority file and add the current one to
 			 * the heap.
 			 */
-			arch_file = DatumGetCString(binaryheap_remove_first(arch_heap));
+			arch_file = DatumGetCString(binaryheap_remove_first(arch_files->arch_heap));
 			strcpy(arch_file, basename);
-			binaryheap_add(arch_heap, CStringGetDatum(arch_file));
+			binaryheap_add(arch_files->arch_heap, CStringGetDatum(arch_file));
 		}
 	}
 	FreeDir(rldir);
 
 	/* If no files were found, simply return. */
-	if (arch_heap->bh_size == 0)
+	if (arch_files->arch_heap->bh_size == 0)
 		return false;
 
 	/*
 	 * If we didn't fill the heap, we didn't make it a valid one.  Do that
 	 * now.
 	 */
-	if (arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
-		binaryheap_build(arch_heap);
+	if (arch_files->arch_heap->bh_size < NUM_FILES_PER_DIRECTORY_SCAN)
+		binaryheap_build(arch_files->arch_heap);
 
 	/*
 	 * Fill arch_files array with the files to archive in ascending order
 	 * of priority.
 	 */
-	arch_files_size = arch_heap->bh_size;
-	for (int i = 0; i < arch_files_size; i++)
-		arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_heap));
+	arch_files->arch_files_size = arch_files->arch_heap->bh_size;
+	for (int i = 0; i < arch_files->arch_files_size; i++)
+		arch_files->arch_files[i] = DatumGetCString(binaryheap_remove_first(arch_files->arch_heap));
 
 	/* Return the highest priority file. */
-	arch_files_size--;
-	strcpy(xlog, arch_files[arch_files_size]);
+	arch_files->arch_files_size--;
+	strcpy(xlog, arch_files->arch_files[arch_files->arch_files_size]);
 
 	return true;
 }

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -691,11 +691,12 @@ pgarch_archiveXlog(char *xlog)
  * 2) because the oldest ones will sooner become candidates for
  * recycling at time of checkpoint
  *
- * NOTE: the "oldest" comparison will presently consider all segments of
- * a timeline with a smaller ID to be older than all segments of a timeline
- * with a larger ID; the net result being that past timelines are given
- * higher priority for archiving.  This seems okay, or at least not
- * obviously worth changing.
+ * NOTE: the "oldest" comparison will consider any .history file to be older
+ * than any other file except another .history file.  Segments on a timeline
+ * with a smaller ID will be older than all segments on a timeline with a
+ * larger ID; the net result being that past timelines are given higher
+ * priority for archiving.  This seems okay, or at least not obviously worth
+ * changing.
  */
 static bool
 pgarch_readyXlog(char *xlog)
@@ -707,10 +708,10 @@ pgarch_readyXlog(char *xlog)
 	 * of calls, so....
 	 */
 	char		XLogArchiveStatusDir[MAXPGPATH];
-	char		newxlog[MAX_XFN_CHARS + 6 + 1];
 	DIR		   *rldir;
 	struct dirent *rlde;
 	bool		found = false;
+	bool		historyFound = false;
 
 	snprintf(XLogArchiveStatusDir, MAXPGPATH, XLOGDIR "/archive_status");
 	rldir = AllocateDir(XLogArchiveStatusDir);
@@ -723,32 +724,51 @@ pgarch_readyXlog(char *xlog)
 	while ((rlde = ReadDir(rldir, XLogArchiveStatusDir)) != NULL)
 	{
 		int			basenamelen = (int) strlen(rlde->d_name) - 6;
+		char		basename[MAX_XFN_CHARS + 1];
+		bool		ishistory;
 
-		if (basenamelen >= MIN_XFN_CHARS &&
-			basenamelen <= MAX_XFN_CHARS &&
-			strspn(rlde->d_name, VALID_XFN_CHARS) >= basenamelen &&
-			strcmp(rlde->d_name + basenamelen, ".ready") == 0)
+		/* Ignore entries with unexpected number of characters */
+		if (basenamelen < MIN_XFN_CHARS ||
+			basenamelen > MAX_XFN_CHARS)
+			continue;
+
+		/* Ignore entries with unexpected characters */
+		if (strspn(rlde->d_name, VALID_XFN_CHARS) < basenamelen)
+			continue;
+
+		/* Ignore anything not suffixed with .ready */
+		if (strcmp(rlde->d_name + basenamelen, ".ready") != 0)
+			continue;
+
+		/* Truncate off the .ready */
+		memcpy(basename, rlde->d_name, basenamelen);
+		basename[basenamelen] = '\0';
+
+		/* Is this a history file? */
+		ishistory = IsTLHistoryFileName(basename);
+
+		/*
+		 * Consume the file to archive.  History files have the highest
+		 * priority.  If this is the first file or the first history file
+		 * ever, copy it.  In the presence of a history file already chosen as
+		 * target, ignore all other files except history files which have been
+		 * generated for an older timeline than what is already chosen as
+		 * target to archive.
+		 */
+		if (!found || (ishistory && !historyFound))
 		{
-			if (!found)
-			{
-				strcpy(newxlog, rlde->d_name);
-				found = true;
-			}
-			else
-			{
-				if (strcmp(rlde->d_name, newxlog) < 0)
-					strcpy(newxlog, rlde->d_name);
-			}
+			strcpy(xlog, basename);
+			found = true;
+			historyFound = ishistory;
+		}
+		else if (ishistory || !historyFound)
+		{
+			if (strcmp(basename, xlog) < 0)
+				strcpy(xlog, basename);
 		}
 	}
 	FreeDir(rldir);
 
-	if (found)
-	{
-		/* truncate off the .ready */
-		newxlog[strlen(newxlog) - 6] = '\0';
-		strcpy(xlog, newxlog);
-	}
 	return found;
 }
 

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -332,4 +332,9 @@ extern bool XLogArchiveIsReady(const char *xlog);
 extern bool XLogArchiveIsReadyOrDone(const char *xlog);
 extern void XLogArchiveCleanup(const char *xlog);
 
+#define IsTLHistoryFileName(fname)	\
+	(strlen(fname) == 8 + strlen(".history") &&		\
+	 strspn(fname, "0123456789ABCDEF") == 8 &&		\
+	 strcmp((fname) + 8, ".history") == 0)
+
 #endif   /* XLOG_INTERNAL_H */


### PR DESCRIPTION
> [!NOTE]
> This PR is the Partial Backport of GPDB PR https://github.com/greenplum-db/gpdb/pull/16984

### Backporting Below Upstream Commit:
1. https://github.com/postgres/postgres/commit/b981df4cc09aca978c5ce55e437a74913d09cccc
2. https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d
3. https://github.com/postgres/postgres/commit/1fb17b1903414676bd371068739549cd2966fe87
*<sub>_For more information on actual changes please refer to the relevant commit message._</sub>

<details> 
<summary> 

#### Original Commit Message:
</summary>

[Prioritize history files when archiving](https://github.com/postgres/postgres/commit/b981df4cc09aca978c5ce55e437a74913d09cccc)
```
Prioritize history files when archiving

At the end of recovery for the post-promotion process, a new history
file is created followed by the last partial segment of the previous
timeline.  Based on the timing, the archiver would first try to archive
the last partial segment and then the history file.  This can delay the
detection of a new timeline taken, particularly depending on the time it
takes to transfer the last partial segment as it delays the moment the
history file of the new timeline gets archived.  This can cause promoted
standbys to use the same timeline as one already taken depending on the
circumstances if multiple instances look at archives at the same
location.

This commit changes the order of archiving so as history files are
archived in priority over other file types, which reduces the likelihood
of the same timeline being taken (still not reducing the window to
zero), and it makes the archiver behave more consistently with the
startup process doing its post-promotion business.

Author: David Steele
Reviewed-by: Michael Paquier, Kyotaro Horiguchi
Discussion: https://postgr.es/m/929068cf-69e1-bba2-9dc0-e05986aed471@pgmasters.net
Backpatch-through: 9.5
```

[Performance improvement of archive_status directory scan with many failed status files](https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d)
```
Improve performance of pgarch_readyXlog() with many status files.

Presently, the archive_status directory was scanned for each file to
archive.  When there are many status files, say because archive_command
has been failing for a long time, these directory scans can get very
slow.  With this change, the archiver remembers several files to archive
during each directory scan, speeding things up.

To ensure timeline history files are archived as quickly as possible,
XLogArchiveNotify() forces the archiver to do a new directory scan as
soon as the .ready file for one is created.

Nathan Bossart, per a long discussion involving many people. It is
not clear to me exactly who out of all those people reviewed this
particular patch.

Discussion: http://postgr.es/m/CA+TgmobhAbs2yabTuTRkJTq_kkC80-+jw=pfpypdOJ7+gAbQbw@mail.gmail.com
Discussion: http://postgr.es/m/620F3CE1-0255-4D66-9D87-0EADE866985A@amazon.com
```

[Archiver Crash fix due to corrupted status file name](https://github.com/postgres/postgres/commit/1fb17b1903414676bd371068739549cd2966fe87)
```
Fix issues in pgarch's new directory-scanning logic.

The arch_filenames[] array elements were one byte too small, so that
a maximum-length filename would get corrupted if another entry
were made after it.  (Noted by Thomas Munro, fix by Nathan Bossart.)

Move these arrays into a palloc'd struct, so that we aren't wasting
a few kilobytes of static data in each non-archiver process.

Add a binaryheap_reset() call to make it plain that we start the
directory scan with an empty heap.  I don't think there's any live
bug of that sort, but it seems fragile, and this is very cheap
insurance.

Cleanup for commit https://github.com/postgres/postgres/commit/beb4e9ba1652a04f66ff20261444d06f678c0b2d, so no back-patch needed.

Discussion: https://postgr.es/m/CA+hUKGLHAjHuKuwtzsW7uMJF4BVPcQRL-UMZG_HM-g0y7yLkUg@mail.gmail.com
```

</details>

---

<!-- ### Summary: -->
## ${\color{RoyalBlue} \underline{\textbf{Summary:}} }$
In brief this PR introduces following changes
    ▪︎ History file Prioritization when pushing status file to archive location
    ▪︎ Reduce archive_status dir scan when multiple .ready file exists
    
***This improves the performance because When there are many failed status files, say because archive_command
has been failing for a long time, these directory scans can get very slow(cloud storage like S3, GCP, Azure, NFS). With this change, the archiver remembers several files to archive during each directory scan, speeding things up.***
   
---
## ${\color{RoyalBlue} \underline{\textbf{Testing:}}}$
- Manullay Verified the changes
- Some basic  sanity test 


#### Log Snippet:
<details><summary><i>
Previous Behaviour:</i>
</summary>

Scan the archive_status directory every time to fetch the status file name without any prioritization.
```

2024-01-22 12:18:09.983240 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN...",,,,,,,0,,"pgarch.c",722,
2024-01-22 12:18:09.983336 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Scanning archive_status directory",,,,,,,0,,"pgarch.c",727,
2024-01-22 12:18:09.983492 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: READDIR Found status file  00000002.history.ready",,,,,,,0,,"pgarch.c",736,
2024-01-22 12:18:09.984954 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: READDIR Found status file  000000020000000000000005.ready ",,,,,,,0,,"pgarch.c",741,
2024-01-22 12:18:09.985043 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: READDIR Found status file  000000010000000000000005.partial.ready",,,,,,,0,,"pgarch.c",741,
2024-01-22 12:18:09.985082 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: END... Returning status file 000000010000000000000005.partial",,,,,,,0,,"pgarch.c",755,

2024-01-22 12:18:12.114753 IST,,,p89087,th-492510976,,,,0,,,seg0,,,,,"WARNING","01000","archiving transaction log file ""000000010000000000000005.partial"" failed too many times, will try again later",,,,,,,0,,"pgarch.c",515,
```  

</details>

<details >
<summary>

#### _New Behaviour_:
</summary>

Utilize the cached status file directory entries to feed the archiver command.
```

2024-01-21 13:53:51.001047 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:0 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.001824 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002008 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002061 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002368 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002415 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000020000000000000008 ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.002473 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002525 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002568 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 00000002.history ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.002612 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002662 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000010000000000000002 ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.002706 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002751 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000010000000000000006.partial ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.002800 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.002846 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000020000000000000009 ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.003117 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.003170 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000020000000000000007 ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.003246 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,
2024-01-21 13:53:51.003289 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir found 000000020000000000000006 ",,,,,,,0,,"pgarch.c",834,
2024-01-21 13:53:51.003341 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: END... XLOG File 00000002.history   files remaining:6 ",,,,,,,0,,"pgarch.c",874,

<<<<<<<<<< 00000002.history  file archive is successful

2024-01-21 13:53:51.030751 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:6 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.030840 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.030895 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000010000000000000002 ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.053162 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:5 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.053367 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.053441 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000010000000000000006.partial ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.073236 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:4 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.073332 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.073374 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000020000000000000006 ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.097333 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:3 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.097438 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.097478 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000020000000000000007 ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.117122 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:2 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.117949 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.118003 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000020000000000000008 ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.138403 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:1 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.138531 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Found Cached Xlog status file details ",,,,,,,0,,"pgarch.c",760,
2024-01-21 13:53:51.138580 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: Returning Cached XLOG File 000000020000000000000009 ",,,,,,,0,,"pgarch.c",772,

2024-01-21 13:53:51.151769 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug: BEGIN... files remaining:0 ",,,,,,,0,,"pgarch.c",750,
2024-01-21 13:53:51.151988 IST,,,p25877,th-492510976,,,,0,,,seg0,,,,,"LOG","00000","Backport Debug:ReadDir Scanning archive_status directory ",,,,,,,0,,"pgarch.c",798,

```

</details>


#### Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [X] Document changes
- [ ] Communicate in the mailing list if needed
- [X] Pass `make installcheck`
- [ ] Review a PR in return to support the community
