### PR TITLE
Docs: document guc debug_shareinput_xslice

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -359,6 +359,14 @@ For each query run, prints the Greenplum query slice plan. *client\_min\_message
 |-----------|-------|-------------------|
 |Boolean|off|coordinator, session, reload|
 
+## <a id="debug_shareinput_xslice"></a>debug_shareinput_xslice
+
+Prints cross-slice share input scan information to the server log.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|off|coordinator, session, reload, superuser|
+
 ## <a id="default_statistics_target"></a>default\_statistics\_target 
 
 Sets the default statistics sampling target \(the number of values that are stored in the list of common values\) for table columns that have not had a column-specific target set via `ALTER TABLE SET STATISTICS`. Larger values may improve the quality of the Postgres-based planner estimates, particularly for columns with irregular data distributions, at the expense of consuming more space in `pg_statistic` and slightly more time to compute the estimates. Conversely, a lower limit might be sufficient for columns with simple data distributions. The default is 100.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -278,6 +278,7 @@ These configuration parameters control Greenplum Database logging.
 - [debug_print_prelim_plan](guc-list.html#debug_print_prelim_plan)
 - [debug_print_rewritten](guc-list.html#debug_print_rewritten)
 - [debug_print_slice_table](guc-list.html#debug_print_slice_table)
+- [debug_shareinput_xslice](guc-list.html#debug_shareinput_xslice)
 - [log_autostats](guc-list.html#log_autostats)
 - [log_connections](guc-list.html#log_connections)
 - [log_directory](guc-list.html#log_directory)


### PR DESCRIPTION
This PR adds the guc `debug_shareinput_xslice` to the documentation reference pages.