### PR TITLE
Enable redistribute motions in multi-stage aggs for more cases in Orca

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -438,10 +438,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1426">
+    <dxl:Plan Id="0" SpaceSize="4242">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1389253302320.306396" Rows="1.000000" Width="15"/>
+          <dxl:Cost StartupCost="0" TotalCost="1389253302320.692871" Rows="1.000000" Width="15"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -458,7 +458,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1389253302320.306396" Rows="1.000000" Width="15"/>
+            <dxl:Cost StartupCost="0" TotalCost="1389253302320.692871" Rows="1.000000" Width="15"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -508,27 +508,27 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691816.047135" Rows="5.400000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356691816.047513" Rows="5.400000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691816.047133" Rows="5.400000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356691816.047511" Rows="5.400000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691816.047101" Rows="1.800000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356691816.047478" Rows="1.800000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691816.047101" Rows="1.800000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356691816.047478" Rows="1.800000" Width="1"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -565,7 +565,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356691816.047079" Rows="1.800000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356691816.047456" Rows="1.800000" Width="22"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -602,9 +602,9 @@
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
-                    <dxl:Result>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1356691816.046829" Rows="1.800000" Width="22"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1356691816.047207" Rows="1.800000" Width="22"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="a">
@@ -629,36 +629,44 @@
                           <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                          <dxl:And>
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:Not>
-                                <dxl:IsNull>
-                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                </dxl:IsNull>
-                              </dxl:Not>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                            </dxl:If>
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:Not>
-                                <dxl:IsNull>
-                                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                                </dxl:IsNull>
-                              </dxl:Not>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:If>
-                          </dxl:And>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1356691816.046632" Rows="4.500000" Width="22"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1356691816.047138" Rows="1.800000" Width="22"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="10"/>
+                          <dxl:GroupingColumn ColId="11"/>
+                          <dxl:GroupingColumn ColId="13"/>
+                          <dxl:GroupingColumn ColId="19"/>
+                          <dxl:GroupingColumn ColId="20"/>
+                          <dxl:GroupingColumn ColId="41"/>
+                          <dxl:GroupingColumn ColId="42"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="a">
                             <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
@@ -683,21 +691,10 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.351409" Rows="2.250000" Width="21"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1356691816.047079" Rows="1.800000" Width="22"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="10"/>
-                            <dxl:GroupingColumn ColId="11"/>
-                            <dxl:GroupingColumn ColId="13"/>
-                            <dxl:GroupingColumn ColId="19"/>
-                            <dxl:GroupingColumn ColId="20"/>
-                            <dxl:GroupingColumn ColId="41"/>
-                          </dxl:GroupingColumns>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="10" Alias="a">
                               <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
@@ -717,11 +714,25 @@
                             <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                               <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="42" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324032.351376" Rows="2.250000" Width="21"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1356691816.046829" Rows="1.800000" Width="22"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="10" Alias="a">
@@ -742,21 +753,39 @@
                               <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                 <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                               </dxl:ProjElem>
+                              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                              </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                                <dxl:And>
+                                  <dxl:If TypeMdid="0.16.1.0">
+                                    <dxl:Not>
+                                      <dxl:IsNull>
+                                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
+                                      </dxl:IsNull>
+                                    </dxl:Not>
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                                  </dxl:If>
+                                  <dxl:If TypeMdid="0.16.1.0">
+                                    <dxl:Not>
+                                      <dxl:IsNull>
+                                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                                      </dxl:IsNull>
+                                    </dxl:Not>
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:If>
+                                </dxl:And>
+                                <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324032.351138" Rows="2.250000" Width="21"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1356691816.046632" Rows="4.500000" Width="22"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="10" Alias="a">
@@ -777,32 +806,17 @@
                                 <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                   <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
+                                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:HashExprList>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                </dxl:HashExpr>
-                              </dxl:HashExprList>
+                              <dxl:JoinFilter>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:JoinFilter>
                               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1324032.351084" Rows="2.250000" Width="21"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324032.351409" Rows="2.250000" Width="21"/>
                                 </dxl:Properties>
                                 <dxl:GroupingColumns>
                                   <dxl:GroupingColumn ColId="10"/>
@@ -835,12 +849,9 @@
                                 <dxl:Filter/>
                                 <dxl:Sort SortDiscardDuplicates="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1324032.351016" Rows="6.000000" Width="21"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="1324032.351376" Rows="2.250000" Width="21"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="20" Alias="b">
-                                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                    </dxl:ProjElem>
                                     <dxl:ProjElem ColId="10" Alias="a">
                                       <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
@@ -852,6 +863,9 @@
                                     </dxl:ProjElem>
                                     <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                                       <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="20" Alias="b">
+                                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
                                     </dxl:ProjElem>
                                     <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                       <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
@@ -868,16 +882,11 @@
                                   </dxl:SortingColumnList>
                                   <dxl:LimitCount/>
                                   <dxl:LimitOffset/>
-                                  <dxl:Result>
+                                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1324032.350778" Rows="6.000000" Width="21"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="1324032.351138" Rows="2.250000" Width="21"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
-                                      <dxl:ProjElem ColId="20" Alias="b">
-                                        <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="104">
-                                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                        </dxl:CoerceViaIO>
-                                      </dxl:ProjElem>
                                       <dxl:ProjElem ColId="10" Alias="a">
                                         <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
@@ -890,16 +899,47 @@
                                       <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                                         <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="20" Alias="b">
+                                        <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                                      </dxl:ProjElem>
                                       <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                         <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:SortingColumnList/>
+                                    <dxl:HashExprList>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:HashExpr>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                      </dxl:HashExpr>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      </dxl:HashExpr>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:HashExpr>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                                      </dxl:HashExpr>
+                                      <dxl:HashExpr>
+                                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
+                                      </dxl:HashExpr>
+                                    </dxl:HashExprList>
+                                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="1324032.350736" Rows="6.000000" Width="20"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="1324032.351084" Rows="2.250000" Width="21"/>
                                       </dxl:Properties>
+                                      <dxl:GroupingColumns>
+                                        <dxl:GroupingColumn ColId="10"/>
+                                        <dxl:GroupingColumn ColId="11"/>
+                                        <dxl:GroupingColumn ColId="13"/>
+                                        <dxl:GroupingColumn ColId="19"/>
+                                        <dxl:GroupingColumn ColId="20"/>
+                                        <dxl:GroupingColumn ColId="41"/>
+                                      </dxl:GroupingColumns>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="10" Alias="a">
                                           <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
@@ -913,17 +953,22 @@
                                         <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                                           <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="20" Alias="b">
+                                          <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                                        </dxl:ProjElem>
                                         <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                           <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                                      <dxl:Sort SortDiscardDuplicates="false">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="1324032.350564" Rows="6.000000" Width="20"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="1324032.351016" Rows="6.000000" Width="21"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
+                                          <dxl:ProjElem ColId="20" Alias="b">
+                                            <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                                          </dxl:ProjElem>
                                           <dxl:ProjElem ColId="10" Alias="a">
                                             <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                                           </dxl:ProjElem>
@@ -941,14 +986,26 @@
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:JoinFilter>
-                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                        </dxl:JoinFilter>
-                                        <dxl:TableScan>
+                                        <dxl:SortingColumnList>
+                                          <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                        </dxl:SortingColumnList>
+                                        <dxl:LimitCount/>
+                                        <dxl:LimitOffset/>
+                                        <dxl:Result>
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="19"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="1324032.350778" Rows="6.000000" Width="21"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
+                                            <dxl:ProjElem ColId="20" Alias="b">
+                                              <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="104">
+                                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                              </dxl:CoerceViaIO>
+                                            </dxl:ProjElem>
                                             <dxl:ProjElem ColId="10" Alias="a">
                                               <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                                             </dxl:ProjElem>
@@ -961,140 +1018,214 @@
                                             <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                                               <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                                             </dxl:ProjElem>
-                                          </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                                            <dxl:Columns>
-                                              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                                              <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                              <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                            </dxl:Columns>
-                                          </dxl:TableDescriptor>
-                                        </dxl:TableScan>
-                                        <dxl:Materialize Eager="false">
-                                          <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
-                                          </dxl:Properties>
-                                          <dxl:ProjList>
                                             <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                               <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
-                                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                          <dxl:OneTimeFilter/>
+                                          <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="1324032.350736" Rows="6.000000" Width="20"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
+                                              <dxl:ProjElem ColId="10" Alias="a">
+                                                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="11" Alias="b">
+                                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="13" Alias="ctid">
+                                                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
                                               <dxl:ProjElem ColId="41" Alias="ColRef_0041">
                                                 <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
                                             <dxl:SortingColumnList/>
-                                            <dxl:Result>
+                                            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="1324032.350564" Rows="6.000000" Width="20"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
+                                                <dxl:ProjElem ColId="10" Alias="a">
+                                                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="11" Alias="b">
+                                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="13" Alias="ctid">
+                                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
                                                 <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                               <dxl:Filter/>
-                                              <dxl:OneTimeFilter/>
+                                              <dxl:JoinFilter>
+                                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                              </dxl:JoinFilter>
                                               <dxl:TableScan>
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="19"/>
                                                 </dxl:Properties>
-                                                <dxl:ProjList/>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="10" Alias="a">
+                                                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="11" Alias="b">
+                                                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="13" Alias="ctid">
+                                                    <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                                    <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
                                                 <dxl:Filter/>
-                                                <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                                <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
                                                   <dxl:Columns>
-                                                    <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                                    <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                                   </dxl:Columns>
                                                 </dxl:TableDescriptor>
                                               </dxl:TableScan>
-                                            </dxl:Result>
-                                          </dxl:BroadcastMotion>
-                                        </dxl:Materialize>
-                                      </dxl:NestedLoopJoin>
-                                    </dxl:RandomMotion>
-                                  </dxl:Result>
+                                              <dxl:Materialize Eager="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                                                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                                                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList/>
+                                                  <dxl:Result>
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:OneTimeFilter/>
+                                                    <dxl:TableScan>
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList/>
+                                                      <dxl:Filter/>
+                                                      <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                                        <dxl:Columns>
+                                                          <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                          <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                          <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                        </dxl:Columns>
+                                                      </dxl:TableDescriptor>
+                                                    </dxl:TableScan>
+                                                  </dxl:Result>
+                                                </dxl:BroadcastMotion>
+                                              </dxl:Materialize>
+                                            </dxl:NestedLoopJoin>
+                                          </dxl:RandomMotion>
+                                        </dxl:Result>
+                                      </dxl:Sort>
+                                    </dxl:Aggregate>
+                                  </dxl:RedistributeMotion>
                                 </dxl:Sort>
                               </dxl:Aggregate>
-                            </dxl:RedistributeMotion>
-                          </dxl:Sort>
-                        </dxl:Aggregate>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:TableScan>
+                              <dxl:Materialize Eager="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
                                 </dxl:Properties>
-                                <dxl:ProjList/>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Result>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:NestedLoopJoin>
-                    </dxl:Result>
+                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:TableScan>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList/>
+                                      <dxl:Filter/>
+                                      <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
+                                        <dxl:Columns>
+                                          <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                          <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        </dxl:Columns>
+                                      </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                  </dxl:Result>
+                                </dxl:BroadcastMotion>
+                              </dxl:Materialize>
+                            </dxl:NestedLoopJoin>
+                          </dxl:Result>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:RedistributeMotion>
                   </dxl:Sort>
                 </dxl:Aggregate>
               </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -418,10 +418,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="182">
+    <dxl:Plan Id="0" SpaceSize="534">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691815.597956" Rows="1.000000" Width="15"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356691815.977601" Rows="1.000000" Width="15"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -438,7 +438,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691815.597900" Rows="1.000000" Width="15"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356691815.977545" Rows="1.000000" Width="15"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -488,27 +488,27 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.351131" Rows="6.750000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.351501" Rows="6.750000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.351128" Rows="6.750000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.351499" Rows="6.750000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.351088" Rows="2.250000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.351459" Rows="2.250000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.351088" Rows="2.250000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.351459" Rows="2.250000" Width="1"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -541,7 +541,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.351063" Rows="2.400000" Width="21"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.351437" Rows="2.250000" Width="21"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -574,9 +574,9 @@
                     </dxl:SortingColumnList>
                     <dxl:LimitCount/>
                     <dxl:LimitOffset/>
-                    <dxl:Result>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.350824" Rows="2.400000" Width="21"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.351199" Rows="2.250000" Width="21"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="a">
@@ -598,31 +598,41 @@
                           <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                          <dxl:If TypeMdid="0.16.1.0">
-                            <dxl:Not>
-                              <dxl:IsNull>
-                                <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                              </dxl:IsNull>
-                            </dxl:Not>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:If>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.350627" Rows="6.000000" Width="21"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.351128" Rows="2.250000" Width="21"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="10"/>
+                          <dxl:GroupingColumn ColId="11"/>
+                          <dxl:GroupingColumn ColId="13"/>
+                          <dxl:GroupingColumn ColId="19"/>
+                          <dxl:GroupingColumn ColId="20"/>
+                          <dxl:GroupingColumn ColId="31"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="20" Alias="b">
-                            <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="74">
-                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                            </dxl:CoerceViaIO>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="10" Alias="a">
                             <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
@@ -635,15 +645,17 @@
                           <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                             <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="20" Alias="b">
+                            <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                             <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                        <dxl:Sort SortDiscardDuplicates="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.350564" Rows="6.000000" Width="20"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.351063" Rows="2.400000" Width="21"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="10" Alias="a">
@@ -658,17 +670,27 @@
                             <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                               <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="20" Alias="b">
+                              <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                               <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:JoinFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:JoinFilter>
-                          <dxl:TableScan>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="31" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="19"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324032.350824" Rows="2.400000" Width="21"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="10" Alias="a">
@@ -683,79 +705,174 @@
                               <dxl:ProjElem ColId="19" Alias="gp_segment_id">
                                 <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                              <dxl:Columns>
-                                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                          <dxl:Materialize Eager="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="b">
+                                <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                                 <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                                <dxl:If TypeMdid="0.16.1.0">
+                                  <dxl:Not>
+                                    <dxl:IsNull>
+                                      <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                                    </dxl:IsNull>
+                                  </dxl:Not>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                </dxl:If>
+                                <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1324032.350627" Rows="6.000000" Width="21"/>
                               </dxl:Properties>
                               <dxl:ProjList>
+                                <dxl:ProjElem ColId="20" Alias="b">
+                                  <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="74">
+                                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                  </dxl:CoerceViaIO>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="10" Alias="a">
+                                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="11" Alias="b">
+                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="13" Alias="ctid">
+                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                                   <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:Result>
+                              <dxl:OneTimeFilter/>
+                              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324032.350564" Rows="6.000000" Width="20"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="10" Alias="a">
+                                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="11" Alias="b">
+                                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="13" Alias="ctid">
+                                    <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
+                                <dxl:JoinFilter>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                </dxl:JoinFilter>
                                 <dxl:TableScan>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="19"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList/>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="10" Alias="a">
+                                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="11" Alias="b">
+                                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="13" Alias="ctid">
+                                      <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                      <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                  <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
                                     <dxl:Columns>
-                                      <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
-                              </dxl:Result>
-                            </dxl:BroadcastMotion>
-                          </dxl:Materialize>
-                        </dxl:NestedLoopJoin>
-                      </dxl:Result>
-                    </dxl:Result>
+                                <dxl:Materialize Eager="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                      <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                        <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList/>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                            <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:Materialize>
+                              </dxl:NestedLoopJoin>
+                            </dxl:Result>
+                          </dxl:Result>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:RedistributeMotion>
                   </dxl:Sort>
                 </dxl:Aggregate>
               </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds1.mdp
@@ -223,7 +223,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12648">
+    <dxl:Plan Id="0" SpaceSize="32040">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.000700" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
@@ -249,7 +249,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5110770">
+    <dxl:Plan Id="0" SpaceSize="5514354">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.000859" Rows="3.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -404,7 +404,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="155744591272">
+    <dxl:Plan Id="0" SpaceSize="159264362144">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250698.553699" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-MultipleColumn.mdp
@@ -343,7 +343,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="400">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="434.387393" Rows="10000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseGb-With-Agg-Funcs.mdp
@@ -234,7 +234,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="50">
+    <dxl:Plan Id="0" SpaceSize="210">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000347" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -1,49 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
-  <!--
-CREATE TABLE inverse (cidr inet);
-SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
--->
+  <dxl:Comment><![CDATA[
+	set optimizer_force_multistage_agg=on;
+	CREATE TABLE inverse (cidr inet);
+	SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+	test=# explain SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
+                                                                                                                QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.93 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.93 rows=1 width=1)
+         ->  Result  (cost=0.00..1324032.93 rows=1 width=1)
+               Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((inverse_1.cidr <<= inverse.cidr) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
+               ->  Finalize HashAggregate  (cost=0.00..1324032.93 rows=1 width=16)
+                     Group Key: inverse_1.cidr, inverse_1.ctid, inverse_1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324032.93 rows=1 width=34)
+                           Hash Key: inverse_1.cidr, inverse_1.ctid, inverse_1.gp_segment_id
+                           ->  Streaming Partial HashAggregate  (cost=0.00..1324032.93 rows=1 width=34)
+                                 Group Key: inverse_1.cidr, inverse_1.ctid, inverse_1.gp_segment_id
+                                 ->  Result  (cost=0.00..1324032.93 rows=1 width=23)
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324032.93 rows=1 width=27)
+                                             ->  Nested Loop Left Join  (cost=0.00..1324032.93 rows=1 width=27)
+                                                   Join Filter: ((inverse_1.cidr <<= inverse.cidr) IS NOT FALSE)
+                                                   ->  Seq Scan on inverse inverse_1  (cost=0.00..431.00 rows=1 width=18)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=9)
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Seq Scan on inverse  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: GPORCA
+(20 rows)
+
+Time: 87.591 ms
+
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
-          <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104004,104005"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:RelationStatistics Mdid="2.660032.1.1" Name="inverse" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.660032.1.1" Name="inverse" IsTemporary="false" Rows="0.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
-        <dxl:Columns>
-          <dxl:Column Name="cidr" Attno="1" Mdid="0.869.1.0" Nullable="true" ColWidth="8">
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.0" Name="cidr" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:ColumnStatistics Mdid="1.3718553.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.3718553.1.0" Name="inverse"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -58,7 +68,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.410.1.0"/>
         <dxl:InequalityOp Mdid="0.411.1.0"/>
         <dxl:LessThanOp Mdid="0.412.1.0"/>
@@ -73,7 +86,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -88,20 +104,27 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.20.1.0"/>
         <dxl:RightType Mdid="0.20.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.467.1.0"/>
         <dxl:Commutator Mdid="0.410.1.0"/>
         <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.3028.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -110,13 +133,16 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
         <dxl:ComparisonOp Mdid="0.356.1.0"/>
         <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -131,7 +157,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.20.1.0"/>
         <dxl:RightType Mdid="0.20.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -140,10 +166,12 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:InverseOp Mdid="0.414.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3028.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -158,9 +186,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -173,41 +202,33 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.932.1.0" Name="&lt;&lt;=" ComparisonType="Other" ReturnsNullOnNullInput="true">
+      <dxl:GPDBFunc Mdid="0.928.1.0" Name="network_subeq" ReturnsSet="false" Stability="Immutable" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.16.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBScalarOp Mdid="0.932.1.0" Name="&lt;&lt;=" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.869.1.0"/>
         <dxl:RightType Mdid="0.869.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.928.1.0"/>
         <dxl:Commutator Mdid="0.934.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.928.1.0" Name="network_subeq" ReturnsSet="false" Stability="Immutable" IsStrict="true">
-	    <dxl:ResultType Mdid="0.16.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.3" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.2" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.5" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.4" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.66.1.0"/>
-        <dxl:Commutator Mdid="0.521.1.0"/>
-        <dxl:InverseOp Mdid="0.525.1.0"/>
         <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.3550.1.0"/>
+          <dxl:Opfamily Mdid="0.3794.1.0"/>
+          <dxl:Opfamily Mdid="0.4102.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.869.1.0" Name="inet" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.869.1.0" Name="inet" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1975.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7120.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1974.1.0"/>
         <dxl:EqualityOp Mdid="0.1201.1.0"/>
         <dxl:InequalityOp Mdid="0.1202.1.0"/>
         <dxl:LessThanOp Mdid="0.1203.1.0"/>
@@ -216,26 +237,33 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:GreaterThanEqualsOp Mdid="0.1206.1.0"/>
         <dxl:ComparisonOp Mdid="0.926.1.0"/>
         <dxl:ArrayType Mdid="0.1041.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.3565.1.0"/>
+        <dxl:MaxAgg Mdid="0.3564.1.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.660032.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.27.1.0"/>
-        <dxl:RightType Mdid="0.27.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.2791.1.0"/>
-        <dxl:Commutator Mdid="0.2800.1.0"/>
-        <dxl:InverseOp Mdid="0.2802.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.2789.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+      <dxl:ColumnStatistics Mdid="1.3718553.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.3718553.1.0.0" Name="cidr" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.3718553.1.0" Name="inverse" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.3718553.1.0" Name="inverse" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="cidr" Attno="1" Mdid="0.869.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1975.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
@@ -256,42 +284,42 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
             <dxl:SubqueryAny OperatorName="&lt;&lt;=" OperatorMdid="0.932.1.0" ColId="9">
               <dxl:Ident ColId="1" ColName="cidr" TypeMdid="0.869.1.0"/>
               <dxl:LogicalGet>
-                <dxl:TableDescriptor Mdid="6.660032.1.1" TableName="inverse">
+                <dxl:TableDescriptor Mdid="6.3718553.1.0" TableName="inverse" LockMode="1" AclMode="2">
                   <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="9" Attno="1" ColName="cidr" TypeMdid="0.869.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:LogicalGet>
             </dxl:SubqueryAny>
           </dxl:Not>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.660032.1.1" TableName="inverse">
+            <dxl:TableDescriptor Mdid="6.3718553.1.0" TableName="inverse" LockMode="1" AclMode="2">
               <dxl:Columns>
-                <dxl:Column ColId="1" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="1" ColName="cidr" TypeMdid="0.869.1.0" ColWidth="8"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:LogicalGet>
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="66">
+    <dxl:Plan Id="0" SpaceSize="204">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001770" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.926893" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="16" Alias="?column?">
@@ -302,14 +330,14 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001766" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.926889" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001763" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.926885" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter>
@@ -332,9 +360,9 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
               </dxl:Not>
             </dxl:Filter>
             <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001741" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.926863" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -345,7 +373,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 <dxl:ProjElem ColId="18" Alias="ColRef_0018">
                   <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -355,7 +383,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -373,9 +401,9 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.001704" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.926495" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cidr">
@@ -387,23 +415,29 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                     <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-                    <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                    <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                    <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                    <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1975.1.0">
+                    <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.2227.1.0">
+                    <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.001318" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.926441" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="cidr">
@@ -415,28 +449,45 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                     <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                       <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-                      <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                      <dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                      <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                      <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.001212" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.926441" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="0"/>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="7"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="26" Alias="ColRef_0026">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="0" Alias="cidr">
                         <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
                       </dxl:ProjElem>
@@ -446,44 +497,24 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                         <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-                        <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                        <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.001212" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.926298" Rows="1.000000" Width="23"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="0"/>
-                        <dxl:GroupingColumn ColId="1"/>
-                        <dxl:GroupingColumn ColId="7"/>
-                      </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
+                        <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                          <dxl:If TypeMdid="0.23.1.0">
+                            <dxl:IsNull>
+                              <dxl:Comparison ComparisonOperator="&lt;&lt;=" OperatorMdid="0.932.1.0">
+                                <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                                <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:IsNull>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          </dxl:If>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="0" Alias="cidr">
                           <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
@@ -494,25 +525,17 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                         <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                           <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                          <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Result>
+                      <dxl:OneTimeFilter/>
+                      <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.001132" Rows="1.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.926290" Rows="1.000000" Width="27"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                            <dxl:If TypeMdid="0.23.1.0">
-                              <dxl:IsNull>
-                                <dxl:Comparison ComparisonOperator="&lt;&lt;=" OperatorMdid="0.932.1.0">
-                                  <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-                                  <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                            </dxl:If>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="0" Alias="cidr">
                             <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
                           </dxl:ProjElem>
@@ -522,15 +545,18 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                           <dxl:ProjElem ColId="7" Alias="gp_segment_id">
                             <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="8" Alias="cidr">
+                            <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="17" Alias="ColRef_0017">
                             <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
+                        <dxl:SortingColumnList/>
                         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.001109" Rows="1.000000" Width="27"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.926220" Rows="1.000000" Width="27"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="cidr">
@@ -558,9 +584,9 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                               </dxl:Comparison>
                             </dxl:IsNotFalse>
                           </dxl:JoinFilter>
-                          <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000258" Rows="1.000000" Width="18"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="cidr">
@@ -574,42 +600,19 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="cidr">
-                                  <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="1" Alias="ctid">
-                                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-                                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.660032.1.1" TableName="inverse">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-                                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:Sort>
+                            <dxl:TableDescriptor Mdid="6.3718553.1.0" TableName="inverse" LockMode="1" AclMode="2">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="cidr" TypeMdid="0.869.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
                           <dxl:Materialize Eager="false">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000483" Rows="3.000000" Width="9"/>
@@ -658,16 +661,16 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="6.660032.1.1" TableName="inverse">
+                                  <dxl:TableDescriptor Mdid="6.3718553.1.0" TableName="inverse" LockMode="1" AclMode="2">
                                     <dxl:Columns>
-                                      <dxl:Column ColId="8" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-                                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="8" Attno="1" ColName="cidr" TypeMdid="0.869.1.0" ColWidth="8"/>
+                                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
@@ -675,11 +678,11 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                             </dxl:Result>
                           </dxl:Materialize>
                         </dxl:NestedLoopJoin>
-                      </dxl:Result>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
+                      </dxl:RandomMotion>
+                    </dxl:Result>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
             </dxl:Aggregate>
           </dxl:Result>
         </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-2.mdp
@@ -1054,7 +1054,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="432.918520" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-3.mdp
@@ -1008,7 +1008,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.928371" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-4.mdp
@@ -2250,7 +2250,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="444.634909" Rows="1000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct-5.mdp
@@ -1043,7 +1043,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="440.328864" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-Stat-NDistinct.mdp
@@ -1037,7 +1037,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.928371" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
@@ -333,7 +333,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="126">
+    <dxl:Plan Id="0" SpaceSize="462">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324039.770556" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate2.mdp
@@ -287,7 +287,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.002979" Rows="4.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -446,7 +446,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="68">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.007060" Rows="10.000001" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -307,7 +307,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="120">
+    <dxl:Plan Id="0" SpaceSize="184">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000721" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
@@ -356,7 +356,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30320">
+    <dxl:Plan Id="0" SpaceSize="31040">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.237175" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -408,10 +408,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="77">
+    <dxl:Plan Id="0" SpaceSize="109">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691750.443794" Rows="1.600000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356691750.865775" Rows="1.600000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -428,7 +428,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691750.443717" Rows="1.600000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356691750.865698" Rows="1.600000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -445,7 +445,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691750.443717" Rows="1.600000" Width="13"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356691750.865698" Rows="1.600000" Width="13"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -482,7 +482,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691750.443688" Rows="1.600000" Width="25"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356691750.865669" Rows="1.600000" Width="25"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -519,9 +519,9 @@
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
-              <dxl:Result>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691750.443405" Rows="1.600000" Width="25"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356691750.865386" Rows="1.600000" Width="25"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -546,38 +546,44 @@
                     <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                    <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="32">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:CoerceViaIO>
-                    <dxl:And>
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Not>
-                          <dxl:IsNull>
-                            <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                          </dxl:IsNull>
-                        </dxl:Not>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:If>
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Not>
-                          <dxl:IsNull>
-                            <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                          </dxl:IsNull>
-                        </dxl:Not>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:If>
-                    </dxl:And>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691750.443207" Rows="4.000000" Width="25"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356691750.865307" Rows="1.600000" Width="25"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="0"/>
+                    <dxl:GroupingColumn ColId="1"/>
+                    <dxl:GroupingColumn ColId="2"/>
+                    <dxl:GroupingColumn ColId="3"/>
+                    <dxl:GroupingColumn ColId="9"/>
+                    <dxl:GroupingColumn ColId="30"/>
+                    <dxl:GroupingColumn ColId="31"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -602,21 +608,10 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.287320" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356691750.865240" Rows="1.600000" Width="25"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="0"/>
-                      <dxl:GroupingColumn ColId="1"/>
-                      <dxl:GroupingColumn ColId="2"/>
-                      <dxl:GroupingColumn ColId="3"/>
-                      <dxl:GroupingColumn ColId="9"/>
-                      <dxl:GroupingColumn ColId="30"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -636,11 +631,25 @@
                       <dxl:ProjElem ColId="30" Alias="ColRef_0030">
                         <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                        <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="31" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.287259" Rows="4.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1356691750.864957" Rows="1.600000" Width="25"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">
@@ -661,21 +670,41 @@
                         <dxl:ProjElem ColId="30" Alias="ColRef_0030">
                           <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                          <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                          <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="32">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                          </dxl:CoerceViaIO>
+                          <dxl:And>
+                            <dxl:If TypeMdid="0.16.1.0">
+                              <dxl:Not>
+                                <dxl:IsNull>
+                                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                </dxl:IsNull>
+                              </dxl:Not>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                            </dxl:If>
+                            <dxl:If TypeMdid="0.16.1.0">
+                              <dxl:Not>
+                                <dxl:IsNull>
+                                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                                </dxl:IsNull>
+                              </dxl:Not>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:If>
+                          </dxl:And>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.286987" Rows="4.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1356691750.864759" Rows="4.000000" Width="25"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
@@ -696,15 +725,26 @@
                           <dxl:ProjElem ColId="30" Alias="ColRef_0030">
                             <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                            <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
+                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:JoinFilter>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:JoinFilter>
-                        <dxl:TableScan>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.287732" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="0"/>
+                            <dxl:GroupingColumn ColId="1"/>
+                            <dxl:GroupingColumn ColId="2"/>
+                            <dxl:GroupingColumn ColId="3"/>
+                            <dxl:GroupingColumn ColId="9"/>
+                            <dxl:GroupingColumn ColId="30"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="a">
                               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -721,30 +761,292 @@
                             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                              <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
+                          <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="1324032.287694" Rows="2.000000" Width="24"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="a">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="2" Alias="c">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="3" Alias="ctid">
+                                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1324032.287422" Rows="2.000000" Width="24"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="0" Alias="a">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="1" Alias="b">
+                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="2" Alias="c">
+                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="3" Alias="ctid">
+                                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr>
+                                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324032.287347" Rows="2.000000" Width="24"/>
+                                </dxl:Properties>
+                                <dxl:GroupingColumns>
+                                  <dxl:GroupingColumn ColId="0"/>
+                                  <dxl:GroupingColumn ColId="1"/>
+                                  <dxl:GroupingColumn ColId="2"/>
+                                  <dxl:GroupingColumn ColId="3"/>
+                                  <dxl:GroupingColumn ColId="9"/>
+                                  <dxl:GroupingColumn ColId="30"/>
+                                </dxl:GroupingColumns>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="0" Alias="a">
+                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="1" Alias="b">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="2" Alias="c">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="3" Alias="ctid">
+                                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:Sort SortDiscardDuplicates="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="1324032.287259" Rows="4.000000" Width="24"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="a">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="1" Alias="b">
+                                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="2" Alias="c">
+                                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="3" Alias="ctid">
+                                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList>
+                                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                  </dxl:SortingColumnList>
+                                  <dxl:LimitCount/>
+                                  <dxl:LimitOffset/>
+                                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="1324032.286987" Rows="4.000000" Width="24"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="0" Alias="a">
+                                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="1" Alias="b">
+                                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="2" Alias="c">
+                                        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="3" Alias="ctid">
+                                        <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                        <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:JoinFilter>
+                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    </dxl:JoinFilter>
+                                    <dxl:TableScan>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="0" Alias="a">
+                                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="1" Alias="b">
+                                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="2" Alias="c">
+                                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="3" Alias="ctid">
+                                          <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
+                                        <dxl:Columns>
+                                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                          <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        </dxl:Columns>
+                                      </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                    <dxl:Materialize Eager="false">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                          <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                            <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:SortingColumnList/>
+                                        <dxl:Result>
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:OneTimeFilter/>
+                                          <dxl:TableScan>
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList/>
+                                            <dxl:Filter/>
+                                            <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                              <dxl:Columns>
+                                                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                              </dxl:Columns>
+                                            </dxl:TableDescriptor>
+                                          </dxl:TableScan>
+                                        </dxl:Result>
+                                      </dxl:BroadcastMotion>
+                                    </dxl:Materialize>
+                                  </dxl:NestedLoopJoin>
+                                </dxl:Sort>
+                              </dxl:Aggregate>
+                            </dxl:RedistributeMotion>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
                         <dxl:Materialize Eager="false">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                              <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                              <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
@@ -753,8 +1055,8 @@
                               <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
+                              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                                <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
@@ -764,7 +1066,7 @@
                                 <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                <dxl:ProjElem ColId="31" Alias="ColRef_0031">
                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
@@ -776,16 +1078,16 @@
                                 </dxl:Properties>
                                 <dxl:ProjList/>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
                                   <dxl:Columns>
-                                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                   </dxl:Columns>
                                 </dxl:TableDescriptor>
                               </dxl:TableScan>
@@ -793,64 +1095,10 @@
                           </dxl:BroadcastMotion>
                         </dxl:Materialize>
                       </dxl:NestedLoopJoin>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                  <dxl:Materialize Eager="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                        <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                          <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
-                            <dxl:Columns>
-                              <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Result>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:RedistributeMotion>
             </dxl:Sort>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
@@ -314,10 +314,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.404298" Rows="2.250000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.404722" Rows="2.250000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -334,7 +334,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.404189" Rows="2.250000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.404613" Rows="2.250000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -351,7 +351,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.404189" Rows="2.250000" Width="13"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.404613" Rows="2.250000" Width="13"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -384,7 +384,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.404155" Rows="2.400000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.404583" Rows="2.250000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -417,9 +417,9 @@
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
-              <dxl:Result>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.403882" Rows="2.400000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.404311" Rows="2.250000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -441,27 +441,40 @@
                     <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                    <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="24">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:CoerceViaIO>
-                    <dxl:If TypeMdid="0.16.1.0">
-                      <dxl:Not>
-                        <dxl:IsNull>
-                          <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
-                        </dxl:IsNull>
-                      </dxl:Not>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                    </dxl:If>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.403685" Rows="6.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.404229" Rows="2.250000" Width="24"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="0"/>
+                    <dxl:GroupingColumn ColId="1"/>
+                    <dxl:GroupingColumn ColId="2"/>
+                    <dxl:GroupingColumn ColId="3"/>
+                    <dxl:GroupingColumn ColId="9"/>
+                    <dxl:GroupingColumn ColId="20"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -483,12 +496,9 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:TableScan>
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.404155" Rows="2.400000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -506,79 +516,186 @@
                       <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                         <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                        <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                  <dxl:Materialize Eager="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                         <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.403882" Rows="2.400000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="c">
+                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="3" Alias="ctid">
+                          <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                           <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                          <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="24">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                          </dxl:CoerceViaIO>
+                          <dxl:If TypeMdid="0.16.1.0">
+                            <dxl:Not>
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
+                              </dxl:IsNull>
+                            </dxl:Not>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                          </dxl:If>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.403685" Rows="6.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="c">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="3" Alias="ctid">
+                            <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
+                        <dxl:JoinFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:JoinFilter>
                         <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
                           </dxl:Properties>
-                          <dxl:ProjList/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="c">
+                              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="3" Alias="ctid">
+                              <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                              <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
                             <dxl:Columns>
-                              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
-                      </dxl:Result>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
+                        <dxl:Materialize Eager="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:Result>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
+                                </dxl:Properties>
+                                <dxl:ProjList/>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Result>
+                          </dxl:BroadcastMotion>
+                        </dxl:Materialize>
+                      </dxl:NestedLoopJoin>
+                    </dxl:Result>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:RedistributeMotion>
             </dxl:Sort>
           </dxl:Aggregate>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -475,10 +475,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1390">
+    <dxl:Plan Id="0" SpaceSize="2430">
       <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="867.148180" Rows="96.000000" Width="36"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -516,7 +516,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.122533" Rows="96.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.148180" Rows="96.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="38" Alias="?column?">
@@ -548,7 +548,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.118053" Rows="96.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.143700" Rows="96.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="lang_count">
@@ -576,7 +576,7 @@
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.114848" Rows="96.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.140495" Rows="96.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="19" Alias="lang_count">
@@ -599,7 +599,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.114848" Rows="96.000000" Width="32"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.140495" Rows="96.000000" Width="32"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="38" Alias="?column?">
@@ -622,7 +622,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.113824" Rows="96.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.139471" Rows="96.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="20"/>
@@ -630,8 +630,10 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="lang_count">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                        </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
                         <dxl:ValuesList ParamType="aggdistinct"/>
@@ -645,9 +647,9 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:HashJoin JoinType="Inner">
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.094337" Rows="240.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.119984" Rows="240.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="20" Alias="code">
@@ -656,84 +658,154 @@
                       <dxl:ProjElem ColId="21" Alias="countrycode">
                         <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+                        <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                        <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                      </dxl:HashExpr>
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                        <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.015820" Rows="1000.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="countrycode">
-                          <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.009167" Rows="1000.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="countrycode">
-                            <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="6.57366.1.0" TableName="countrylanguage">
-                          <dxl:Columns>
-                            <dxl:Column ColId="21" Attno="1" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7" ColWidth="4"/>
-                            <dxl:Column ColId="30" Attno="2" ColName="language" TypeMdid="0.25.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.001672" Rows="240.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.115977" Rows="240.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="20" Alias="code">
                           <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="21" Alias="countrycode">
+                          <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+                          <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.57345.1.0" TableName="country">
-                        <dxl:Columns>
-                          <dxl:Column ColId="20" Attno="1" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7" ColWidth="4"/>
-                          <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:HashJoin>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="862.115977" Rows="240.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="20"/>
+                          <dxl:GroupingColumn ColId="21"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                              <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="20" Alias="code">
+                            <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="21" Alias="countrycode">
+                            <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:HashJoin JoinType="Inner">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="862.094337" Rows="240.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="code">
+                              <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="21" Alias="countrycode">
+                              <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:JoinFilter/>
+                          <dxl:HashCondList>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                              <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                              <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                              <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                              <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                            </dxl:Comparison>
+                          </dxl:HashCondList>
+                          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.015820" Rows="1000.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="21" Alias="countrycode">
+                                <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.009167" Rows="1000.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="21" Alias="countrycode">
+                                  <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="6.57366.1.0" TableName="countrylanguage">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="21" Attno="1" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7" ColWidth="4"/>
+                                  <dxl:Column ColId="30" Attno="2" ColName="language" TypeMdid="0.25.1.0" ColWidth="16"/>
+                                  <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                  <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:RedistributeMotion>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.001672" Rows="240.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="code">
+                                <dxl:Ident ColId="20" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.57345.1.0" TableName="country">
+                              <dxl:Columns>
+                                <dxl:Column ColId="20" Attno="1" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7" ColWidth="4"/>
+                                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:HashJoin>
+                      </dxl:Aggregate>
+                    </dxl:Result>
+                  </dxl:RedistributeMotion>
                 </dxl:Aggregate>
               </dxl:Result>
             </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -763,7 +763,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21488">
+    <dxl:Plan Id="0" SpaceSize="29144">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -789,7 +789,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52597280">
+    <dxl:Plan Id="0" SpaceSize="102007712">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -280,7 +280,7 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6334">
+    <dxl:Plan Id="0" SpaceSize="23038">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003186" Rows="2.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -454,7 +454,7 @@ SQL:
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9296">
+    <dxl:Plan Id="0" SpaceSize="16496">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.104458" Rows="10.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
@@ -445,7 +445,7 @@ SQL:
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8288">
+    <dxl:Plan Id="0" SpaceSize="13184">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.076760" Rows="111.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -498,10 +498,10 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="398361600">
+    <dxl:Plan Id="0" SpaceSize="34258338816">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2586.144639" Rows="134.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.174907" Rows="134.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -518,7 +518,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2586.132606" Rows="134.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.162874" Rows="134.000000" Width="20"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -537,9 +537,9 @@ select a,count(distinct a), count(distinct b) from t1 group by a
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Append IsTarget="false" IsZapped="false">
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2586.107284" Rows="134.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.137552" Rows="134.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -553,10 +553,27 @@ select a,count(distinct a), count(distinct b) from t1 group by a
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Sequence>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="2586.133357" Rows="134.000000" Width="20"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="0"/>
+                <dxl:GroupingColumn ColId="9"/>
+                <dxl:GroupingColumn ColId="10"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -568,91 +585,10 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:CTEProducer CTEId="1" Columns="42,43,44,45,46,47,48,49,50">
+              <dxl:Filter/>
+              <dxl:Append IsTarget="false" IsZapped="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="42" Alias="a">
-                    <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="43" Alias="b">
-                    <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="44" Alias="ctid">
-                    <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="45" Alias="xmin">
-                    <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="46" Alias="cmin">
-                    <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="47" Alias="xmax">
-                    <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="48" Alias="cmax">
-                    <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="49" Alias="tableoid">
-                    <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="50" Alias="gp_segment_id">
-                    <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="42" Alias="a">
-                      <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="43" Alias="b">
-                      <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="44" Alias="ctid">
-                      <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="45" Alias="xmin">
-                      <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="46" Alias="cmin">
-                      <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="47" Alias="xmax">
-                      <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="48" Alias="cmax">
-                      <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="49" Alias="tableoid">
-                      <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="gp_segment_id">
-                      <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="42" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="43" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:CTEProducer>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.060544" Rows="111.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2586.107284" Rows="134.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -666,444 +602,277 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Not>
-                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:IsDistinctFrom>
-                  </dxl:Not>
-                </dxl:HashCondList>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.008771" Rows="111.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="0"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="9" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="count">
+                      <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="count">
+                      <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:CTEProducer CTEId="1" Columns="42,43,44,45,46,47,48,49,50">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.008175" Rows="111.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="0"/>
-                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="42" Alias="a">
+                        <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="43" Alias="b">
+                        <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="44" Alias="ctid">
+                        <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="45" Alias="xmin">
+                        <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="46" Alias="cmin">
+                        <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="47" Alias="xmax">
+                        <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="48" Alias="cmax">
+                        <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="49" Alias="tableoid">
+                        <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="50" Alias="gp_segment_id">
+                        <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="a">
+                          <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="43" Alias="b">
+                          <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="44" Alias="ctid">
+                          <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="45" Alias="xmin">
+                          <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="46" Alias="cmin">
+                          <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="47" Alias="xmax">
+                          <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="48" Alias="cmax">
+                          <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="49" Alias="tableoid">
+                          <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="50" Alias="gp_segment_id">
+                          <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="42" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="43" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:CTEProducer>
+                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.060544" Rows="111.000000" Width="20"/>
+                    </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="count">
+                        <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="count">
+                        <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Not>
+                        <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:IsDistinctFrom>
+                      </dxl:Not>
+                    </dxl:HashCondList>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008771" Rows="111.000000" Width="12"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="0"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="0" Alias="a">
                           <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="xmin">
-                          <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="4" Alias="cmin">
-                          <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="xmax">
-                          <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="cmax">
-                          <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="tableoid">
-                          <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8">
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.008175" Rows="111.000000" Width="4"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="0"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="xmin">
-                            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="4" Alias="cmin">
-                            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="5" Alias="xmax">
-                            <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="cmax">
-                            <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="7" Alias="tableoid">
-                            <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Aggregate>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="51"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="a">
-                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="51"/>
-                      <dxl:GroupingColumn ColId="52"/>
-                    </dxl:GroupingColumns>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="51" Alias="a">
-                        <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="52" Alias="b">
-                        <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="ctid">
+                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="3" Alias="xmin">
+                              <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="4" Alias="cmin">
+                              <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="5" Alias="xmax">
+                              <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="6" Alias="cmax">
+                              <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="7" Alias="tableoid">
+                              <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="a">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="2" Alias="ctid">
+                                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="3" Alias="xmin">
+                                <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="4" Alias="cmin">
+                                <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="5" Alias="xmax">
+                                <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="6" Alias="cmax">
+                                <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="7" Alias="tableoid">
+                                <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:Aggregate>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="51"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="51" Alias="a">
                           <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="52" Alias="b">
-                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="53" Alias="ctid">
-                          <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="54" Alias="xmin">
-                          <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="55" Alias="cmin">
-                          <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="56" Alias="xmax">
-                          <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="57" Alias="cmax">
-                          <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="58" Alias="tableoid">
-                          <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="59" Alias="gp_segment_id">
-                          <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="51" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="52" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:CTEConsumer CTEId="1" Columns="51,52,53,54,55,56,57,58,59">
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="51"/>
+                          <dxl:GroupingColumn ColId="52"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="51" Alias="a">
                             <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="52" Alias="b">
                             <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="53" Alias="ctid">
-                            <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="54" Alias="xmin">
-                            <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="55" Alias="cmin">
-                            <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="56" Alias="xmax">
-                            <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="57" Alias="cmax">
-                            <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="58" Alias="tableoid">
-                            <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="59" Alias="gp_segment_id">
-                            <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Aggregate>
-              </dxl:HashJoin>
-            </dxl:Sequence>
-            <dxl:Sequence>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.039152" Rows="23.000000" Width="20"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="12" Alias="b">
-                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="count">
-                  <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="count">
-                  <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="22" Alias="a">
-                    <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="23" Alias="b">
-                    <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="24" Alias="ctid">
-                    <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="25" Alias="xmin">
-                    <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="cmin">
-                    <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="27" Alias="xmax">
-                    <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="cmax">
-                    <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="29" Alias="tableoid">
-                    <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="gp_segment_id">
-                    <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="a">
-                      <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="23" Alias="b">
-                      <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="ctid">
-                      <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="xmin">
-                      <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="cmin">
-                      <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="xmax">
-                      <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="cmax">
-                      <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="tableoid">
-                      <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="gp_segment_id">
-                      <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:CTEProducer>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.033784" Rows="23.000000" Width="20"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="12" Alias="b">
-                    <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="count">
-                    <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="21" Alias="count">
-                    <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Not>
-                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:IsDistinctFrom>
-                  </dxl:Not>
-                </dxl:HashCondList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.018084" Rows="23.000000" Width="12"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="12"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="12" Alias="b">
-                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.016611" Rows="23.000000" Width="12"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="12" Alias="b">
-                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="12" Alias="b">
-                          <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="12"/>
-                        </dxl:GroupingColumns>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="12" Alias="b">
-                            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
@@ -1112,202 +881,484 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                             <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="11" Alias="a">
-                              <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="51" Alias="a">
+                              <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="12" Alias="b">
-                              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="52" Alias="b">
+                              <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="13" Alias="ctid">
-                              <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:ProjElem ColId="53" Alias="ctid">
+                              <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="14" Alias="xmin">
-                              <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:ProjElem ColId="54" Alias="xmin">
+                              <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="15" Alias="cmin">
-                              <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:ProjElem ColId="55" Alias="cmin">
+                              <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="16" Alias="xmax">
-                              <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:ProjElem ColId="56" Alias="xmax">
+                              <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="17" Alias="cmax">
-                              <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:ProjElem ColId="57" Alias="cmax">
+                              <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="18" Alias="tableoid">
-                              <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:ProjElem ColId="58" Alias="tableoid">
+                              <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                              <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="59" Alias="gp_segment_id">
+                              <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="51" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="52" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           </dxl:SortingColumnList>
                           <dxl:LimitCount/>
                           <dxl:LimitOffset/>
-                          <dxl:CTEConsumer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+                          <dxl:CTEConsumer CTEId="1" Columns="51,52,53,54,55,56,57,58,59">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="11" Alias="a">
-                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="51" Alias="a">
+                                <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="12" Alias="b">
-                                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="52" Alias="b">
+                                <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="13" Alias="ctid">
-                                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:ProjElem ColId="53" Alias="ctid">
+                                <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="14" Alias="xmin">
-                                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:ProjElem ColId="54" Alias="xmin">
+                                <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="15" Alias="cmin">
-                                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:ProjElem ColId="55" Alias="cmin">
+                                <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="16" Alias="xmax">
-                                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:ProjElem ColId="56" Alias="xmax">
+                                <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="17" Alias="cmax">
-                                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:ProjElem ColId="57" Alias="cmax">
+                                <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="18" Alias="tableoid">
-                                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:ProjElem ColId="58" Alias="tableoid">
+                                <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="59" Alias="gp_segment_id">
+                                <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                           </dxl:CTEConsumer>
                         </dxl:Sort>
                       </dxl:Aggregate>
-                    </dxl:Result>
-                  </dxl:RedistributeMotion>
-                </dxl:Aggregate>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    </dxl:Aggregate>
+                  </dxl:HashJoin>
+                </dxl:Sequence>
+                <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.008530" Rows="23.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.039152" Rows="23.000000" Width="20"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="32"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="21" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="12" Alias="b">
+                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="32" Alias="b">
-                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="20" Alias="count">
+                      <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="count">
+                      <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.008406" Rows="23.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="32"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="32" Alias="b">
-                        <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="22" Alias="a">
+                        <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="23" Alias="b">
+                        <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="24" Alias="ctid">
+                        <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="25" Alias="xmin">
+                        <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="26" Alias="cmin">
+                        <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="27" Alias="xmax">
+                        <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="cmax">
+                        <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="29" Alias="tableoid">
+                        <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                        <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.008334" Rows="23.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="32" Alias="b">
-                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="22" Alias="a">
+                          <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="23" Alias="b">
+                          <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="24" Alias="ctid">
+                          <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="25" Alias="xmin">
+                          <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="26" Alias="cmin">
+                          <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="27" Alias="xmax">
+                          <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="cmax">
+                          <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="29" Alias="tableoid">
+                          <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                          <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
+                      <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:CTEProducer>
+                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.033784" Rows="23.000000" Width="20"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="12" Alias="b">
+                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="count">
+                        <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="count">
+                        <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Not>
+                        <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:IsDistinctFrom>
+                      </dxl:Not>
+                    </dxl:HashCondList>
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.018084" Rows="23.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="12"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="12" Alias="b">
+                          <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.007415" Rows="23.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.016611" Rows="23.000000" Width="12"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="32" Alias="b">
-                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="12" Alias="b">
+                            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                            <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
                           <dxl:HashExpr>
-                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.007271" Rows="23.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="32"/>
-                          </dxl:GroupingColumns>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="12" Alias="b">
+                              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                              <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
+                            </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="12"/>
+                            </dxl:GroupingColumns>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="12" Alias="b">
+                                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="11" Alias="a">
+                                  <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="12" Alias="b">
+                                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="13" Alias="ctid">
+                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="14" Alias="xmin">
+                                  <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="15" Alias="cmin">
+                                  <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="16" Alias="xmax">
+                                  <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="17" Alias="cmax">
+                                  <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="18" Alias="tableoid">
+                                  <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:CTEConsumer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="11" Alias="a">
+                                    <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="12" Alias="b">
+                                    <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="13" Alias="ctid">
+                                    <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="14" Alias="xmin">
+                                    <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="15" Alias="cmin">
+                                    <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="16" Alias="xmax">
+                                    <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="17" Alias="cmax">
+                                    <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="18" Alias="tableoid">
+                                    <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                              </dxl:CTEConsumer>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:RedistributeMotion>
+                    </dxl:Aggregate>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008530" Rows="23.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="32"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="21" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="b">
+                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.008406" Rows="23.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="32"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="32" Alias="b">
+                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.008334" Rows="23.000000" Width="4"/>
+                          </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="32" Alias="b">
                               <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="31,32,33,34,35,36,37,38,39">
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.007415" Rows="23.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="31" Alias="a">
-                                <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="32" Alias="b">
                                 <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="33" Alias="ctid">
-                                <dxl:Ident ColId="33" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="34" Alias="xmin">
-                                <dxl:Ident ColId="34" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="35" Alias="cmin">
-                                <dxl:Ident ColId="35" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="36" Alias="xmax">
-                                <dxl:Ident ColId="36" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="37" Alias="cmax">
-                                <dxl:Ident ColId="37" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="38" Alias="tableoid">
-                                <dxl:Ident ColId="38" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="39" Alias="gp_segment_id">
-                                <dxl:Ident ColId="39" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                             </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Aggregate>
-                      </dxl:RedistributeMotion>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Aggregate>
-              </dxl:HashJoin>
-            </dxl:Sequence>
-          </dxl:Append>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.007271" Rows="23.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="32"/>
+                              </dxl:GroupingColumns>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="32" Alias="b">
+                                  <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:CTEConsumer CTEId="0" Columns="31,32,33,34,35,36,37,38,39">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="31" Alias="a">
+                                    <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="32" Alias="b">
+                                    <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="33" Alias="ctid">
+                                    <dxl:Ident ColId="33" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="34" Alias="xmin">
+                                    <dxl:Ident ColId="34" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="35" Alias="cmin">
+                                    <dxl:Ident ColId="35" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="36" Alias="xmax">
+                                    <dxl:Ident ColId="36" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="37" Alias="cmax">
+                                    <dxl:Ident ColId="37" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="38" Alias="tableoid">
+                                    <dxl:Ident ColId="38" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="39" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="39" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                              </dxl:CTEConsumer>
+                            </dxl:Aggregate>
+                          </dxl:RedistributeMotion>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:Aggregate>
+                  </dxl:HashJoin>
+                </dxl:Sequence>
+              </dxl:Append>
+            </dxl:Aggregate>
+          </dxl:RedistributeMotion>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.006109" Rows="10.000001" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1170,7 +1170,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="163431">
+    <dxl:Plan Id="0" SpaceSize="547857">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops.mdp
@@ -306,7 +306,7 @@
         </dxl:LogicalGet>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5318">
+    <dxl:Plan Id="0" SpaceSize="31686">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000742" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
@@ -710,7 +710,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2585">
+    <dxl:Plan Id="0" SpaceSize="3996">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="14873.784860" Rows="400.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
@@ -499,10 +499,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="100">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001122" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001629" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -520,7 +520,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.001121" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001628" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="ColRef_0026">
@@ -531,7 +531,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.001091" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001598" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -561,7 +561,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.001091" Rows="1.000000" Width="9"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.001597" Rows="1.000000" Width="9"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -598,7 +598,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.001066" Rows="2.000000" Width="35"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001561" Rows="1.000000" Width="35"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="c">
@@ -635,9 +635,9 @@
                 </dxl:SortingColumnList>
                 <dxl:LimitCount/>
                 <dxl:LimitOffset/>
-                <dxl:HashJoin JoinType="Left">
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000669" Rows="2.000000" Width="35"/>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001164" Rows="1.000000" Width="35"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c">
@@ -663,17 +663,43 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                      <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.16.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.001109" Rows="1.000000" Width="35"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="0"/>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="2"/>
+                      <dxl:GroupingColumn ColId="4"/>
+                      <dxl:GroupingColumn ColId="9"/>
+                      <dxl:GroupingColumn ColId="10"/>
+                      <dxl:GroupingColumn ColId="23"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c">
                         <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
@@ -693,17 +719,14 @@
                       <dxl:ProjElem ColId="10" Alias="gp_segment_id">
                         <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                        <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:DynamicTableScan SelectorIds="">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.001066" Rows="2.000000" Width="35"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="c">
@@ -724,88 +747,196 @@
                         <dxl:ProjElem ColId="10" Alias="gp_segment_id">
                           <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Partitions>
-                        <dxl:Partition Mdid="6.423243001.1.0"/>
-                        <dxl:Partition Mdid="6.423243002.1.0"/>
-                      </dxl:Partitions>
-                      <dxl:TableDescriptor Mdid="6.423243.1.0" TableName="bar">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="2" Attno="3" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
-                          <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:DynamicTableScan>
-                  </dxl:RedistributeMotion>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="2.000000" Width="3"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="13" Alias="c">
-                        <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="2"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="13" Alias="c">
-                          <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                        <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                          <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.16.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="2" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="4" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="23" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:HashJoin JoinType="Left">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="2"/>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000669" Rows="2.000000" Width="35"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="13" Alias="c">
-                            <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                          <dxl:ProjElem ColId="0" Alias="c">
+                            <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="d">
+                            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="e">
+                            <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="4" Alias="ctid">
+                            <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="9" Alias="tableoid">
+                            <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                            <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                            <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="6.423237.1.0" TableName="foo">
-                          <dxl:Columns>
-                            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
-                            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
-                  </dxl:Result>
-                </dxl:HashJoin>
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                            <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="1.000000" Width="34"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="c">
+                              <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="d">
+                              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="e">
+                              <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="4" Alias="ctid">
+                              <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="9" Alias="tableoid">
+                              <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                              <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:DynamicTableScan SelectorIds="">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="34"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="c">
+                                <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="d">
+                                <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="2" Alias="e">
+                                <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="4" Alias="ctid">
+                                <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="tableoid">
+                                <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                                <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:Partitions>
+                              <dxl:Partition Mdid="6.423243001.1.0"/>
+                              <dxl:Partition Mdid="6.423243002.1.0"/>
+                            </dxl:Partitions>
+                            <dxl:TableDescriptor Mdid="6.423243.1.0" TableName="bar">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="2" Attno="3" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+                                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:DynamicTableScan>
+                        </dxl:RedistributeMotion>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="2.000000" Width="3"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="21" Alias="?column?">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="13" Alias="c">
+                              <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="2"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="13" Alias="c">
+                                <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:HashExprList>
+                              <dxl:HashExpr>
+                                <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                              </dxl:HashExpr>
+                            </dxl:HashExprList>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="2"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="13" Alias="c">
+                                  <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="6.423237.1.0" TableName="foo">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+                                  <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                  <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:RedistributeMotion>
+                        </dxl:Result>
+                      </dxl:HashJoin>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:RedistributeMotion>
               </dxl:Sort>
             </dxl:Aggregate>
           </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1658,7 +1658,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="103">
+    <dxl:Plan Id="0" SpaceSize="348">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1298.385913" Rows="4000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1658,7 +1658,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="680">
+    <dxl:Plan Id="0" SpaceSize="13848">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Push-Subplan-Below-Union.mdp
@@ -614,7 +614,7 @@ union
         </dxl:LogicalSelect>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="203400432">
+    <dxl:Plan Id="0" SpaceSize="1385319984">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="7327.003376" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -674,7 +674,7 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8566">
+    <dxl:Plan Id="0" SpaceSize="86022">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="907.697100" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -5283,7 +5283,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23688">
+    <dxl:Plan Id="0" SpaceSize="30648">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="25984.123228" Rows="60175000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RollupNoAgg.mdp
@@ -218,7 +218,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="100">
+    <dxl:Plan Id="0" SpaceSize="116">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000192" Rows="3.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
+	  set optimizer_force_multistage_agg=on;
 	  create table t1 (a int, b text, c int);
 	  create table t2 (a int, b int, c int);
 	  create table t3 (a int, b text, c int);
@@ -16,7 +17,7 @@
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
@@ -24,66 +25,14 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
-      <dxl:TraceFlags Value="102001,102002,102003,102074,102120,102144,103001,103015,103022,103027,103033,104003,104004,104005,105000"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t1" Rows="2.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.16385.1.0" Name="t1" IsTemporary="false" Rows="2.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="5">
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.16391.1.0" Name="t2" Rows="1.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.16391.1.0" Name="t2" IsTemporary="false" Rows="1.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.16391.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -98,7 +47,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.410.1.0"/>
         <dxl:InequalityOp Mdid="0.411.1.0"/>
         <dxl:LessThanOp Mdid="0.412.1.0"/>
@@ -113,7 +65,11 @@
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:RelationExtendedStatistics Mdid="10.3694084.1.0" Name="t1"/>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -128,7 +84,24 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.664.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.740.1.0"/>
+        <dxl:Commutator Mdid="0.666.1.0"/>
+        <dxl:InverseOp Mdid="0.667.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
         <dxl:EqualityOp Mdid="0.98.1.0"/>
         <dxl:InequalityOp Mdid="0.531.1.0"/>
         <dxl:LessThanOp Mdid="0.664.1.0"/>
@@ -143,28 +116,31 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.1" Name="b" Width="5.000000" NullFreq="0.000000" NdvRemain="2.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="1.000000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:RelationExtendedStatistics Mdid="10.3694089.1.0" Name="t2"/>
+      <dxl:ColumnStatistics Mdid="1.3694084.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.3694084.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.3694084.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.20.1.0"/>
         <dxl:RightType Mdid="0.20.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.467.1.0"/>
         <dxl:Commutator Mdid="0.410.1.0"/>
         <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -173,13 +149,16 @@
         <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
         <dxl:ComparisonOp Mdid="0.356.1.0"/>
         <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -194,7 +173,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.20.1.0"/>
         <dxl:RightType Mdid="0.20.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -203,10 +182,12 @@
         <dxl:InverseOp Mdid="0.414.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -221,9 +202,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -236,36 +218,34 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.16391.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="2.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="1.000000" DistinctValues="2.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true">
+      <dxl:ColumnStatistics Mdid="1.3694084.1.0.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.3694084.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.16.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="1"/>
+      <dxl:ColumnStatistics Mdid="1.3694089.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.16.1.0"/>
         <dxl:RightType Mdid="0.16.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.60.1.0"/>
         <dxl:Commutator Mdid="0.91.1.0"/>
         <dxl:InverseOp Mdid="0.85.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7124.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.424.1.0"/>
           <dxl:Opfamily Mdid="0.2222.1.0"/>
-          <dxl:Opfamily Mdid="0.7017.1.0"/>
+          <dxl:Opfamily Mdid="0.7124.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -274,26 +254,32 @@
         <dxl:InverseOp Mdid="0.525.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.65.1.0"/>
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" IsStrict="true">
-	    <dxl:ResultType Mdid="0.16.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.27.1.0"/>
         <dxl:RightType Mdid="0.27.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -302,12 +288,55 @@
         <dxl:InverseOp Mdid="0.2802.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2789.1.0"/>
+          <dxl:Opfamily Mdid="0.4069.1.0"/>
+          <dxl:Opfamily Mdid="0.10025.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.3694084.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.3694084.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.3694089.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.3694089.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.3694089.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -324,45 +353,45 @@
           <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="13">
             <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+              <dxl:TableDescriptor Mdid="6.3694089.1.0" TableName="t2" LockMode="1" AclMode="2">
                 <dxl:Columns>
                   <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:LogicalGet>
           </dxl:SubqueryAny>
         </dxl:Comparison>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
+          <dxl:TableDescriptor Mdid="6.3694084.1.0" TableName="t1" LockMode="1" AclMode="2">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
               <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="34">
+    <dxl:Plan Id="0" SpaceSize="102">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.645539" Rows="2.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.555423" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -379,7 +408,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.645442" Rows="2.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.555364" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -417,7 +446,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.645376" Rows="2.000000" Width="29"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.555331" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -430,7 +459,7 @@
               <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                 <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
                   <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -440,7 +469,7 @@
               <dxl:ProjElem ColId="23" Alias="ColRef_0023">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                   <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -466,7 +495,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.645326" Rows="2.000000" Width="39"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.555283" Rows="1.000000" Width="42"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -484,15 +513,18 @@
                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                  <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
               </dxl:SortingColumnList>
@@ -500,7 +532,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.644884" Rows="2.000000" Width="39"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.554807" Rows="1.000000" Width="42"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -518,26 +550,35 @@
                   <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                    <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                    <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1995.1.0">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.2227.1.0">
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.644762" Rows="2.000000" Width="39"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.554740" Rows="1.000000" Width="42"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -555,18 +596,18 @@
                     <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                      <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                      <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                      <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.644762" Rows="2.000000" Width="39"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.554740" Rows="1.000000" Width="42"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -576,7 +617,7 @@
                       <dxl:GroupingColumn ColId="9"/>
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
+                      <dxl:ProjElem ColId="29" Alias="ColRef_0029">
                         <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
@@ -586,7 +627,7 @@
                           <dxl:ValuesList ParamType="aggdistinct"/>
                         </dxl:AggFunc>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
                         <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
@@ -613,13 +654,22 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.644641" Rows="4.000000" Width="28"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.554509" Rows="1.000000" Width="31"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                          <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                          <dxl:If TypeMdid="0.23.1.0">
+                            <dxl:IsNull>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:IsNull>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          </dxl:If>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="0" Alias="a">
                           <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -641,29 +691,12 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:Result>
+                      <dxl:OneTimeFilter/>
+                      <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.644323" Rows="4.000000" Width="28"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.554499" Rows="1.000000" Width="31"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                            <dxl:If TypeMdid="0.23.1.0">
-                              <dxl:IsNull>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                            </dxl:If>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="0" Alias="a">
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
@@ -679,15 +712,18 @@
                           <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                             <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="c">
+                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="20" Alias="ColRef_0020">
                             <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
+                        <dxl:SortingColumnList/>
                         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.644267" Rows="4.000000" Width="28"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324032.554418" Rows="1.000000" Width="31"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="a">
@@ -723,7 +759,7 @@
                           </dxl:JoinFilter>
                           <dxl:TableScan>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="26"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -743,18 +779,18 @@
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
+                            <dxl:TableDescriptor Mdid="6.3694084.1.0" TableName="t1" LockMode="1" AclMode="2">
                               <dxl:Columns>
                                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
                                 <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                                 <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
@@ -806,17 +842,17 @@
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                  <dxl:TableDescriptor Mdid="6.3694089.1.0" TableName="t2" LockMode="1" AclMode="2">
                                     <dxl:Columns>
                                       <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                                       <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                                       <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
@@ -824,8 +860,8 @@
                             </dxl:Result>
                           </dxl:Materialize>
                         </dxl:NestedLoopJoin>
-                      </dxl:Result>
-                    </dxl:Sort>
+                      </dxl:RandomMotion>
+                    </dxl:Result>
                   </dxl:Aggregate>
                 </dxl:Result>
               </dxl:RedistributeMotion>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -426,7 +426,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22142">
+    <dxl:Plan Id="0" SpaceSize="143490">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001518" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -401,7 +401,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="150026">
+    <dxl:Plan Id="0" SpaceSize="728714">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008270" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -488,7 +488,7 @@ ON a = c
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36848">
+    <dxl:Plan Id="0" SpaceSize="48688">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2206721.811317" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -504,7 +504,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="439">
+    <dxl:Plan Id="0" SpaceSize="691">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356698084.004784" Rows="1.000000" Width="16"/>
@@ -721,7 +721,7 @@
                 <dxl:ProjElem ColId="30" Alias="ColRef_0030">
                   <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -731,7 +731,7 @@
                 <dxl:ProjElem ColId="32" Alias="ColRef_0032">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -769,15 +769,17 @@
                   <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                    <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                    <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                    <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 </dxl:SortingColumnList>
@@ -800,16 +802,22 @@
                     <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                      <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                      <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
                     <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
@@ -834,11 +842,11 @@
                       <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                         <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                        <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                        <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                        <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -854,7 +862,7 @@
                         <dxl:GroupingColumn ColId="8"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                        <dxl:ProjElem ColId="38" Alias="ColRef_0038">
                           <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
@@ -864,7 +872,7 @@
                             <dxl:ValuesList ParamType="aggdistinct"/>
                           </dxl:AggFunc>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:ProjElem ColId="39" Alias="ColRef_0039">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
@@ -914,6 +922,8 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                         </dxl:SortingColumnList>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -568,7 +568,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="449">
+    <dxl:Plan Id="0" SpaceSize="701">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356695751.048855" Rows="1.000000" Width="16"/>
@@ -785,7 +785,7 @@
                 <dxl:ProjElem ColId="40" Alias="ColRef_0040">
                   <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -795,7 +795,7 @@
                 <dxl:ProjElem ColId="42" Alias="ColRef_0042">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -833,15 +833,17 @@
                   <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                    <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+                    <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                    <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="49" Alias="ColRef_0049">
+                    <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 </dxl:SortingColumnList>
@@ -864,16 +866,22 @@
                     <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                      <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+                      <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                      <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="49" Alias="ColRef_0049">
+                      <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
                     <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
@@ -898,11 +906,11 @@
                       <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                         <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                        <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+                        <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                        <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="49" Alias="ColRef_0049">
+                        <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -918,7 +926,7 @@
                         <dxl:GroupingColumn ColId="8"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="50" Alias="ColRef_0050">
+                        <dxl:ProjElem ColId="48" Alias="ColRef_0048">
                           <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
@@ -928,7 +936,7 @@
                             <dxl:ValuesList ParamType="aggdistinct"/>
                           </dxl:AggFunc>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="51" Alias="ColRef_0051">
+                        <dxl:ProjElem ColId="49" Alias="ColRef_0049">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.23.1.0"/>
@@ -978,6 +986,8 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                         </dxl:SortingColumnList>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -635,7 +635,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3143">
+    <dxl:Plan Id="0" SpaceSize="4907">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712065392.598691" Rows="1.000000" Width="16"/>
@@ -931,7 +931,7 @@
                 <dxl:ProjElem ColId="49" Alias="ColRef_0049">
                   <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -941,7 +941,7 @@
                 <dxl:ProjElem ColId="51" Alias="ColRef_0051">
                   <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -979,15 +979,17 @@
                   <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                    <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                    <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                    <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                    <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 </dxl:SortingColumnList>
@@ -1010,16 +1012,22 @@
                     <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                      <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                      <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                      <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                      <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
                     <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
@@ -1044,11 +1052,11 @@
                       <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                         <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                        <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="57" Alias="ColRef_0057">
+                        <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                        <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="58" Alias="ColRef_0058">
+                        <dxl:Ident ColId="58" ColName="ColRef_0058" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -1064,7 +1072,7 @@
                         <dxl:GroupingColumn ColId="8"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="59" Alias="ColRef_0059">
+                        <dxl:ProjElem ColId="57" Alias="ColRef_0057">
                           <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
@@ -1074,7 +1082,7 @@
                             <dxl:ValuesList ParamType="aggdistinct"/>
                           </dxl:AggFunc>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="60" Alias="ColRef_0060">
+                        <dxl:ProjElem ColId="58" Alias="ColRef_0058">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.23.1.0"/>
@@ -1124,6 +1132,8 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                           <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                         </dxl:SortingColumnList>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2429,7 +2429,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3334">
+    <dxl:Plan Id="0" SpaceSize="4462">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionGbSubquery.mdp
@@ -228,7 +228,7 @@
         </dxl:Union>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14301">
+    <dxl:Plan Id="0" SpaceSize="60405">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -394,7 +394,7 @@
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="92610">
+    <dxl:Plan Id="0" SpaceSize="1670490">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.002353" Rows="13.000000" Width="8"/>

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14923,3 +14923,29 @@ ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
 drop user ruser;
 drop table foo, bar;
+-- ensure we choose a redistribute instead of a gather motion when optimizer_force_multistage_agg enabled
+create table foo (a int, b int, c int, d date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (a int, b int, c int, d date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo select i,i,i from generate_series(1,10)i;
+insert into bar select i,i,i from generate_series(1,10)i;
+analyze foo;
+analyze bar;
+set optimizer_force_multistage_agg=on;
+explain (COSTS OFF) create table jazz as select foo.a, foo.d, (clock_timestamp() at time zone 'America/Chicago')::Date as create_date from foo join bar on foo.a=bar.a group by 1,2,3 distributed by (a);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ HashAggregate
+   Group Key: foo.a, foo.d, (timezone('America/Chicago'::text, clock_timestamp()))::date
+   ->  Hash Join
+         Hash Cond: (foo.a = bar.a)
+         ->  Seq Scan on foo
+         ->  Hash
+               ->  Seq Scan on bar
+ Optimizer: Postgres-based planner
+(8 rows)
+
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15018,3 +15018,40 @@ ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
 drop user ruser;
 drop table foo, bar;
+-- ensure we choose a redistribute instead of a gather motion when optimizer_force_multistage_agg enabled
+create table foo (a int, b int, c int, d date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar (a int, b int, c int, d date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo select i,i,i from generate_series(1,10)i;
+insert into bar select i,i,i from generate_series(1,10)i;
+analyze foo;
+analyze bar;
+set optimizer_force_multistage_agg=on;
+explain (COSTS OFF) create table jazz as select foo.a, foo.d, (clock_timestamp() at time zone 'America/Chicago')::Date as create_date from foo join bar on foo.a=bar.a group by 1,2,3 distributed by (a);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: foo.a
+         ->  GroupAggregate
+               Group Key: foo.a, foo.d, (date(timezone('America/Chicago'::text, clock_timestamp())))
+               ->  Sort
+                     Sort Key: foo.a, foo.d, (date(timezone('America/Chicago'::text, clock_timestamp())))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: foo.a, foo.d, (date(timezone('America/Chicago'::text, clock_timestamp())))
+                           ->  GroupAggregate
+                                 Group Key: foo.a, foo.d, (date(timezone('America/Chicago'::text, clock_timestamp())))
+                                 ->  Sort
+                                       Sort Key: foo.a, foo.d, (date(timezone('America/Chicago'::text, clock_timestamp())))
+                                       ->  Hash Join
+                                             Hash Cond: (foo.a = bar.a)
+                                             ->  Seq Scan on foo
+                                             ->  Hash
+                                                   ->  Seq Scan on bar
+ Optimizer: GPORCA
+(19 rows)
+
+reset optimizer_force_multistage_agg;


### PR DESCRIPTION
Orca has a function, FValidContext(), which invalidates optimization contexts where both the motion and the motion's child distribution request satisfy the current distribution request. This would imply that the motion is redundant and unnecessary, and thus by invalidating this request we can reduce the search space.

However, for multi-stage aggs, such a plan may be better in certain cases. Consider the case where there is a request to be distributed on 1 column, and the table is distributed on 3 columns. For a single stage agg, we would not need a motion. A multi-stage agg would introduce a motion, but would be performing the aggregate with data that may exist on other segments as well, thus possibly reducing the work in the final agg on the coordinator.

This issue manifested with a CTAS query when
optimizer_force_multistage_agg is enabled (off by default). The plan generated a gather motion, and then redistributed the data instead of having 2 redistributes. Doing 2 redistrubtes instead is much better in this case, and the cost model will choose this plan.

Note: This commit will almost exclusively impact plans that set `optimizer_force_multistage_agg` to on. It will also cause more of these plans to have a multistage agg alternative. This may cause some plans (which didn't have a valid multistage alternative) to now select a multistage alternative when this GUC is enabled, and this multistage plan may be worse than the single stage selected previously.

The plan changes in the below plans are all with `optimizer_force_multistage_agg=on`. 
Additionally, we expect the theoretical exploration space to increase as we're enabling new alternatives, 
but I did not see any increase in actual planning time.