### PR TITLE
Fix regression: listen all listen_addresses with the specified family

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -367,21 +367,21 @@ Feature: gpinitsystem tests
         And the user runs command "mv ../gpAux/gpdemo/clusterConfigFile.bak ../gpAux/gpdemo/clusterConfigFile"
 
     @postmaster
-    Scenario: gpinitsystem creates a cluster with GUC gp_postmaster_inet_address_family
+    Scenario: gpinitsystem creates a cluster with GUC gp_postmaster_address_family
         Given the database is initialized with checksum "off"
-        When the user runs "gpconfig -s gp_postmaster_inet_address_family"
+        When the user runs "gpconfig -s gp_postmaster_address_family"
         Then gpconfig should return a return code of 0
         And gpconfig should print "Coordinator value: auto" to stdout
         And gpconfig should print "Segment     value: auto" to stdout
-        When the user runs "gpconfig --skipvalidation -c gp_postmaster_inet_address_family -v ipv4"
+        When the user runs "gpconfig --skipvalidation -c gp_postmaster_address_family -v ipv4"
         Then gpconfig should return a return code of 0
         When the user runs "gpstop -ar"
         Then gpstop should return a return code of 0
-        When the user runs "gpconfig -s gp_postmaster_inet_address_family"
+        When the user runs "gpconfig -s gp_postmaster_address_family"
         Then gpconfig should return a return code of 0
         And gpconfig should print "Coordinator value: ipv4" to stdout
         And gpconfig should print "Segment     value: ipv4" to stdout
-        When the user runs "gpconfig --skipvalidation -c gp_postmaster_inet_address_family -v auto"
+        When the user runs "gpconfig --skipvalidation -c gp_postmaster_address_family -v auto"
         Then gpconfig should return a return code of 0
         When the user runs "gpstop -ar"
         Then gpstop should return a return code of 0

--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -643,10 +643,6 @@ StreamServerPort(int family, char *hostName, unsigned short portNumber,
 
 		ListenSocket[listen_index] = fd;
 		added++;
-
-		/* Forced address family, no more tries. */
-		if (!IS_AF_UNIX(addr->ai_family) && Gp_postmaster_address_family_type)
-			break;
 	}
 
 	pg_freeaddrinfo_all(hint.ai_family, addrs);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4949,7 +4949,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	},
 
 	{
-		{"gp_postmaster_inet_address_family", PGC_POSTMASTER, CUSTOM_OPTIONS,
+		{"gp_postmaster_address_family", PGC_POSTMASTER, CUSTOM_OPTIONS,
 			gettext_noop("Specifies the address family used by postmaster listener sockets."),
 			gettext_noop("Valid values are auto, ipv4 and ipv6."), 
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -205,7 +205,7 @@
 		"gp_max_system_slices",
 		"gp_motion_cost_per_row",
 		"gp_pause_on_restore_point_replay",
-		"gp_postmaster_inet_address_family",
+		"gp_postmaster_address_family",
 		"gp_print_create_gang_time",
 		"gp_qd_hostname",
 		"gp_qd_port",


### PR DESCRIPTION
For instance, the default `listen_addresses` is set to `*` (all), it
should not break right after the first good address.