### PR TITLE
[6X] Fix query with DynamicBitmap scan crash when QueryFinishPending is true

### DIFF
--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -148,6 +148,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 			else
 			{
 				tbm_intersect(hbm, (TIDBitmap *)subresult);
+				tbm_generic_free(subresult);
 			}
 
 			/*
@@ -159,13 +160,6 @@ MultiExecBitmapAnd(BitmapAndState *node)
 			 */
 			if (tbm_is_empty(hbm))
 			{
-				/*
-				 * GPDB_84_MERGE_FIXME: If we saw any StreamBitmap inputs, we
-				 * will create an OpStream to AND the empty result with the
-				 * StreamBitmaps we saw already. We could just close them now,
-				 * and return an empty hash bitmap here, but I'm not sure how
-				 * to close the already-opened stream bitmaps correctly.
-				 */
 				empty = true;
 				break;
 			}
@@ -182,6 +176,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
    				{
 	   				StreamBitmap *s = (StreamBitmap *)subresult;
 	   				stream_move_node((StreamBitmap *)node->bitmap, s, BMS_AND);
+					tbm_generic_free(subresult);
 			   	}
 			}
    			else

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -111,9 +111,6 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 		if (node->ss.ps.instrument && (node->ss.ps.instrument)->need_cdb)
 			tbm_generic_set_instrument(bitmap, node->ss.ps.instrument);
 
-		if (node->biss_result == NULL)
-			node->biss_result = (Node *) bitmap;
-
 		doscan = ExecIndexAdvanceArrayKeys(node->biss_ArrayKeys,
 										   node->biss_NumArrayKeys);
 		if (doscan)				/* reset index scan */
@@ -178,21 +175,6 @@ ExecReScanBitmapIndexScan(BitmapIndexScanState *node)
 		index_rescan(node->biss_ScanDesc,
 					 node->biss_ScanKeys, node->biss_NumScanKeys,
 					 NULL, 0);
-
-	/* Sanity check */
-	if (node->biss_result &&
-		(!IsA(node->biss_result, TIDBitmap) && !IsA(node->biss_result, StreamBitmap)))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("the returning bitmap in nodeBitmapIndexScan is invalid")));
-	}
-
-	if (NULL != node->biss_result)
-	{
-		tbm_generic_free(node->biss_result);
-		node->biss_result = NULL;
-	}
 }
 
 /* ----------------------------------------------------------------
@@ -229,9 +211,6 @@ ExecEndBitmapIndexScan(BitmapIndexScanState *node)
 		index_endscan(indexScanDesc);
 	if (indexRelationDesc)
 		index_close(indexRelationDesc, NoLock);
-
-	tbm_generic_free(node->biss_result);
-	node->biss_result = NULL;
 
 	EndPlanStateGpmonPkt(&node->ss.ps);
 }

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -145,6 +145,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 			else
 			{
 				tbm_union(hbm, (TIDBitmap *)subresult);
+				tbm_generic_free(subresult);
 			}
 		}
 		else
@@ -154,7 +155,9 @@ MultiExecBitmapOr(BitmapOrState *node)
 				if(node->bitmap != subresult)
 				{
 					StreamBitmap *s = (StreamBitmap *)subresult;
-					stream_move_node((StreamBitmap *)node->bitmap, s, BMS_OR);				}
+					stream_move_node((StreamBitmap *)node->bitmap, s, BMS_OR);
+					tbm_generic_free(subresult);
+				}
 			}
 			else
 				node->bitmap = subresult;

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -1453,11 +1453,9 @@ tbm_stream_block(StreamBMIterator *iterator, PagetableEntry *e)
 static void
 tbm_stream_free(StreamNode *self)
 {
-	/*
-	 * self->opaque is actually a reference to node->bitmap from BitmapIndexScanState
-	 * BitmapIndexScanState would have freed the self->opaque already so we shouldn't
-	 * access now.
-	 */
+	TIDBitmap *tbm = self->opaque;
+	Assert(self->type == BMS_INDEX);
+	tbm_free(tbm);
 	pfree(self);
 }
 

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -114,6 +114,7 @@ select gp_inject_fault('execshare_input_next', 'status', 2);
 (1 row)
 
 reset gp_enable_mk_sort;
+reset optimizer;
 -- Disable faultinjectors
 select gp_inject_fault('execsort_mksort_mergeruns', 'reset', 2);
  gp_inject_fault 
@@ -209,3 +210,42 @@ select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'reset', dbid)
 (3 rows)
 
 drop table _tmp_table3;
+-- test if a query with dynamic bitmapscan plan does not crash when QueryFinishPending set to true
+-- Planner doesn't generate dynamic bitmap heap scan plan for below query.
+create table t1_bm(a int, b int, c text, d int)
+distributed randomly
+partition by range(a)
+(
+   start (1) end (10) every (1),
+   default partition extra
+);
+create table t2_bm(b int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index idx1_bm ON t1_bm USING bitmap (b);
+set optimizer_enable_hashjoin = off;
+set optimizer_enable_materialize = off;
+-- set QueryFinishPending to true befor bitmap heap scan retrieve results from bitmap
+select gp_inject_fault('before_retrieve_from_bitmap', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select count(distinct a.d) from t1_bm a, t2_bm b
+where a.c = b.c and a.b < 10 and b.b < 10;
+ count 
+-------
+     0
+(1 row)
+
+select gp_inject_fault('before_retrieve_from_bitmap', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+reset optimizer_enable_hashjoin;
+reset optimizer_enable_materialize;
+drop table t1_bm;
+drop table t2_bm;


### PR DESCRIPTION
Previously, BitmapIndexScan create and free the bitmap memory. When BitmapHeapScan retrieves all tuples, it will free the bitmapstate's memory(tbmiterator, don't free bitmap), and the next relation's (of the same dynamic scan) BitmapHeapScan will first rescan the child node BitmapIndexScan which will free the bitmap memory.

But if QueryFinishPending is true when iteration over the bitmap, it will return null without free the bitmapstate, and next bitmapheap scan still need to do the rescan and free the bitmap memory. Finally when ExecEndBitmapHeapScan free bitmap iterator will access to a freed bitmap.

We don't have need to let BitmapIndexScan free bitmap memory, free bitmap iterator and bitmap memory together.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
