### PR TITLE
fix gpload create staging table with wrong distribution key order

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2862,7 +2862,7 @@ class gpload:
                 "a.attnum = any (p.attrnums) and " + \
                 "c.relnamespace = n.oid and " + \
                 "n.nspname = '%s' and c.relname = '%s' " % (quote_unident(self.schema), quote_unident(self.table)) + \
-                "order by position(a.attnum::text in array_to_string(attrnums,','));"
+                "order by position(' '||a.attnum::text||' ' in ' '||array_to_string(attrnums,' ')||' ') ;"
         else:
             sql = "select attname from pg_attribute a, gp_distribution_policy p , pg_class c, pg_namespace n "+ \
                 "where a.attrelid = c.oid and " + \

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2856,19 +2856,21 @@ class gpload:
         # NOTE: this query should be re-written better. the problem is that it is
         # not possible to perform a cast on a table name with spaces...
         if withGpVersion and self.gpdb_version < "6.0.0":
-            sql = "select attname from pg_attribute a, gp_distribution_policy p , pg_class c, pg_namespace n "+\
+            sql = "select attname from pg_attribute a, gp_distribution_policy p , pg_class c, pg_namespace n " + \
                 "where a.attrelid = c.oid and " + \
                 "a.attrelid = p.localoid and " + \
                 "a.attnum = any (p.attrnums) and " + \
                 "c.relnamespace = n.oid and " + \
-                "n.nspname = '%s' and c.relname = '%s'; " % (quote_unident(self.schema), quote_unident(self.table))
+                "n.nspname = '%s' and c.relname = '%s' " % (quote_unident(self.schema), quote_unident(self.table)) + \
+                "order by position(a.attnum::text in array_to_string(attrnums,','));"
         else:
-            sql = "select attname from pg_attribute a, gp_distribution_policy p , pg_class c, pg_namespace n "+\
+            sql = "select attname from pg_attribute a, gp_distribution_policy p , pg_class c, pg_namespace n "+ \
                 "where a.attrelid = c.oid and " + \
                 "a.attrelid = p.localoid and " + \
                 "a.attnum = any (p.distkey) and " + \
                 "c.relnamespace = n.oid and " + \
-                "n.nspname = '%s' and c.relname = '%s'; " % (quote_unident(self.schema), quote_unident(self.table))
+                "n.nspname = '%s' and c.relname = '%s' " % (quote_unident(self.schema), quote_unident(self.table)) + \
+                "order by position(concat(' ',a.attnum::text,' ') in concat(' ',p.distkey::text,' '));"
 
         try:
                 resultList = self.db.query(sql.encode('utf-8')).getresult()

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -481,6 +481,7 @@ def test_263_gpload_tabel_distributed_key():
     f.close()
 
 
+# For more info, please refer to https://github.com/greenplum-db/gpdb/issues/16959
 @pytest.mark.order(264)
 @prepare_before_test(num=264)
 def test_264_gpload_tabel_distributed_key():

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -479,3 +479,23 @@ def test_263_gpload_tabel_distributed_key():
     f = open(mkpath('query263.sql'),'a')
     f.write("""\\! psql -d reuse_gptest -c '\d staging_gpload_*'""")
     f.close()
+
+
+@pytest.mark.order(264)
+@prepare_before_test(num=264)
+def test_264_gpload_tabel_distributed_key():
+    "264 test gpload create staging table distributed by target table columns special order"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_262.txt','data_file.txt')
+    match_col = ["c1"]
+    update_col = ["'\"C#3\"'"]
+    write_config_file(mode='merge', 
+                      match_columns=match_col, 
+                      update_columns=update_col, 
+                      file='data_file.txt', 
+                      table='testdk3')
+    f = open(mkpath('query264.sql'),'a')
+    f.write("""\\! psql -d reuse_gptest -c '\d staging_gpload_*'""")
+    f.close()
+

--- a/gpMgmt/bin/gpload_test/gpload2/query264.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query264.ans
@@ -1,0 +1,28 @@
+2024-01-23 16:34:32|INFO|gpload session started 2024-01-23 16:34:32
+2024-01-23 16:34:32|INFO|setting schema 'public' for table 'testdk3'
+2024-01-23 16:34:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2024-01-23 16:34:32|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_82c905028bb7dd459ff776534b584ac4
+2024-01-23 16:34:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3b2e8ace_b9ca_11ee_8ffa_0050569ea4ff
+2024-01-23 16:34:32|INFO|running time: 0.08 seconds
+2024-01-23 16:34:32|INFO|rows Inserted          = 3
+2024-01-23 16:34:32|INFO|rows Updated           = 0
+2024-01-23 16:34:32|INFO|data formatting errors = 0
+2024-01-23 16:34:32|INFO|gpload succeeded
+2024-01-23 16:34:32|INFO|gpload session started 2024-01-23 16:34:32
+2024-01-23 16:34:32|INFO|setting schema 'public' for table 'testdk3'
+2024-01-23 16:34:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2024-01-23 16:34:32|INFO|reusing staging table staging_gpload_reusable_82c905028bb7dd459ff776534b584ac4
+2024-01-23 16:34:32|INFO|reusing external table ext_gpload_reusable_3b2e8ace_b9ca_11ee_8ffa_0050569ea4ff
+2024-01-23 16:34:32|INFO|running time: 0.06 seconds
+2024-01-23 16:34:32|INFO|rows Inserted          = 0
+2024-01-23 16:34:32|INFO|rows Updated           = 3
+2024-01-23 16:34:32|INFO|data formatting errors = 0
+2024-01-23 16:34:32|INFO|gpload succeeded
+Table "public.staging_gpload_reusable_82c905028bb7dd459ff776534b584ac4"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ c1     | integer | 
+ C#2    | text    | 
+ C#3    | text    | 
+Distributed by: ("C#2", c1)
+

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -73,3 +73,5 @@ CREATE TABLE testdk1 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED BY ("C#2");
 CREATE TABLE
 CREATE TABLE testdk2 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED REPLICATED;
 CREATE TABLE
+CREATE TABLE testdk3 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED BY ("C#2", "c1");
+CREATE TABLE

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -48,3 +48,4 @@ INSERT INTO testtruncate VALUES('ttt','ttgt','shpits', '2011-06-01 12:30:30',16,
 CREATE TABLE prices (itemnumber integer, price decimal ) DISTRIBUTED BY (itemnumber);
 CREATE TABLE testdk1 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED BY ("C#2");
 CREATE TABLE testdk2 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED REPLICATED;
+CREATE TABLE testdk3 (c1 int, "C#2" text, "C#3" text) DISTRIBUTED BY ("C#2", "c1");


### PR DESCRIPTION
This PR fixes issue https://github.com/greenplum-db/gpdb/issues/16959

gpload needs to create a staging table for update and merge.
The staging table's distribution key should be the same as the target table.
When the target table doesn't have distribution key (distributed random or replicated), the distribution key of staging table should be the same as `MATCH_COLUMNS` in the gpload config file.

In the before code, when the target table has distribution key with special order like:`distributed by (col2, col1, col3)`
Gpload will create staging table `distributed by ( col1, col2, col3)`, which is the wrong order.
In this PR, we fix this wrong distribution key order.

We don't use the function `pg_get_table_distributedby` because gpload6 needs to support gpdb5, and gpdb5 doesn't have this function.

Add test case 264 to test special distribution key order.

Co-authored-by: TimonSP <https://github.com/TimonSP>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
