### PR TITLE
Fix the failed unit test of mgmt

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2595,8 +2595,8 @@ def main(options, args, parser):
         elif gpexpand_db_status is None and gpexpand_file_status is None and options.filename:
             _gp_expand.validate_heap_checksums()
             newSegList = _gp_expand.read_input_files()
-            _gp_expand.validate_icproxy_addr(newSegList)
             _gp_expand.addNewSegments(newSegList)
+            _gp_expand.validate_icproxy_addr(newSegList)
             newTableSpaceInfo = _gp_expand.read_tablespace_file()
             _gp_expand.sync_packages()
             _gp_expand.start_prepare()


### PR DESCRIPTION
My previous commit ceb66bab5a17c69a637cc3f20db14873a1129215 break a unit test of mgmt:
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_main/jobs/unit_tests_gpmgmt_rocky8/builds/293

Fixed it in this PR, sorry for unnoticed it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
