### PR TITLE
pg_upgrade: Re-add AO matview check call

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -169,6 +169,12 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 		old_cluster.controldata.cat_ver < JSONB_FORMAT_CHANGE_CAT_VER)
 		check_for_jsonb_9_4_usage(&old_cluster);
 
+	/* For now, the issue exists only for Greenplum 6.x/PostgreSQL 9.4 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) == 904)
+	{
+		check_for_appendonly_materialized_view_with_relfrozenxid(&old_cluster);
+	}
+
 	teardown_GPDB6_data_type_checks(&old_cluster);
 
 dump_old_cluster:


### PR DESCRIPTION
Commit bb4f0754efbc8661033110ce44c9b94922e5d632 was a bit overzealous in removing checks. The AO matview check is required for a 6X source cluster.