### PR TITLE
Fix resource queue slot leaks involving self-deadlocks and termination

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -2116,8 +2116,6 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	uint32		hashcode = locallock->hashcode;
 	LWLockId	partitionLock = LockHashPartitionLock(hashcode);
 
-	bool		selflock = true;		/* initialize result for error. */
-
 	/*
 	 * Don't check my held locks, as we just add at the end of the queue.
 	 */
@@ -2135,16 +2133,6 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	MyProc->waitLockMode = lockmode;
 
 	MyProc->waitStatus = STATUS_WAITING;	/* initialize result for error */
-
-	/* Now check the status of the self lock footgun. */
-	selflock = ResCheckSelfDeadLock(lock, proclock, incrementSet);
-	if (selflock)
-	{
-		LWLockRelease(partitionLock);
-		ereport(ERROR,
-				(errcode(ERRCODE_T_R_DEADLOCK_DETECTED),
-				 errmsg("deadlock detected, locking against self")));
-	}
 
 	/* Mark that we are waiting for a lock */
 	lockAwaited = locallock;

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -2399,6 +2399,8 @@ ResLockWaitCancel(void)
 	timeouts[1].keep_indicator = true;
 	disable_timeouts(timeouts, 2);
 
+	SIMPLE_FAULT_INJECTOR("res_lock_wait_cancel_before_partition_lock");
+
 	/* Unlink myself from the wait queue, if on it  */
 	partitionLock = LockHashPartitionLock(lockAwaited->hashcode);
 	LWLockAcquire(partitionLock, LW_EXCLUSIVE);

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1033,7 +1033,7 @@ ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increment
 	{
 		Assert(limits[0].type == RES_COUNT_LIMIT);
 		elog(LOG,
-			 "Resource queue id: %d, count limit: %f, portal id: %u\n",
+			 "Resource queue id: %u, count limit: %f, portal id: %u\n",
 			 queue->queueid,
 			 limits[0].current_value,
 			 incrementSet->portalId);
@@ -1095,7 +1095,7 @@ ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increment
 ResQueue
 GetResQueueFromLock(LOCK *lock)
 {
-	Assert(LWLockHeldByMeInMode(ResQueueLock, LW_EXCLUSIVE));
+	Assert(LWLockHeldByMe(ResQueueLock));
 
 	ResQueue	queue = ResQueueHashFind(GET_RESOURCE_QUEUEID_FOR_LOCK(lock));
 
@@ -1932,7 +1932,7 @@ ResQueueHashFind(Oid queueid)
 	bool		found;
 	ResQueueData *queue;
 
-	Assert(LWLockHeldByMeInMode(ResQueueLock, LW_EXCLUSIVE));
+	Assert(LWLockHeldByMe(ResQueueLock));
 
 	queue = (ResQueueData *)
 		hash_search(ResQueueHash, (void *) &queueid, HASH_FIND, &found);
@@ -2676,7 +2676,7 @@ void DumpResQueueLockInfo(LOCALLOCK *locallock)
 		LOCK	 *lock = locallock->lock;
 		ResQueue  queue;
 
-		LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
+		LWLockAcquire(ResQueueLock, LW_SHARED);
 		/* Get the queue for this lock. */
 		queue = GetResQueueFromLock(lock);
 		if (queue != NULL)
@@ -2684,7 +2684,7 @@ void DumpResQueueLockInfo(LOCALLOCK *locallock)
 			ResLimit limits  = queue->limits;
 			Assert(limits[0].type == RES_COUNT_LIMIT);
 			elog(LOG,
-				 "Resource queue id: %d, count limit: %f\n",
+				 "Resource queue id: %u, count limit: %f\n",
 				 queue->queueid,
 			limits[0].current_value);
 		}

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1597,6 +1597,12 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 					if (incrementTotals[i] > limits[i].threshold_value)
 					{
 						countThesholdOvercommitted = true;
+						ereport(LOG,
+								(errmsg("count threshold overcommitted"),
+									errdetail("total count %lf exceeds limit %f for resource queue id: %u",
+											  incrementTotals[i],
+											  limits[i].threshold_value,
+											  queue->queueid)));
 					}
 				}
 				break;
@@ -1606,6 +1612,12 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 					if (incrementTotals[i] > limits[i].threshold_value)
 					{
 						costThesholdOvercommitted = true;
+						ereport(LOG,
+								(errmsg("cost threshold overcommitted"),
+									errdetail("total cost %lf exceeds limit %f for resource queue id: %u",
+											  incrementTotals[i],
+											  limits[i].threshold_value,
+											  queue->queueid)));
 					}
 				}
 				break;
@@ -1615,6 +1627,12 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 					if (incrementTotals[i] > limits[i].threshold_value)
 					{
 						memoryThesholdOvercommitted = true;
+						ereport(LOG,
+								(errmsg("memory threshold overcommitted"),
+									errdetail("total memory %lf exceeds limit %f for resource queue id: %u",
+											  incrementTotals[i],
+											  limits[i].threshold_value,
+											  queue->queueid)));
 					}
 				}
 				break;
@@ -1649,6 +1667,10 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 		if (lock->nRequested > lock->nGranted)
 		{
 			/* we're no longer waiting. */
+			ereport(LOG,
+					(errmsg("granting ourselves the resource queue lock in the self-deadlock check"),
+						errdetail("resource queue id: %u, portal id: %u",
+								  queue->queueid, incrementSet->portalId)));
 			pgstat_report_wait_end();
 			ResGrantLock(lock, proclock);
 			ResLockUpdateLimit(lock, proclock, incrementSet, true, true);

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -835,8 +835,13 @@ ResUnLockPortal(Portal portal)
 
 		ResLockRelease(&tag, portal->portalId);
 
-		/* Count holdable cursors.*/
-		if (portal->cursorOptions & CURSOR_OPT_HOLD)
+		/*
+		 * Count holdable cursors.
+		 * Note: there is an edge case when we are unlocking a portal with a
+		 * dangling increment set. Such a portal was not counted as a holdable
+		 * portal, so don't un-count it.
+		 */
+		if ((portal->cursorOptions & CURSOR_OPT_HOLD) && portal->hasResQueueLock)
 		{
 			Assert(numHoldPortals > 0);
 			numHoldPortals--;

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -159,7 +159,11 @@ typedef struct PortalData
 	bool		portalPinned;	/* a pinned portal can't be dropped */
 	bool		autoHeld;		/* was automatically converted from pinned to
 								 * held (see HoldPinnedPortals()) */
-	bool		hasResQueueLock;	/* true => resscheduler lock must be released */
+	/*
+	 * true => resscheduler lock must be released. Set to true at the end of
+	 * successful reslock acquisition in ResLockPortal() and ResLockUtilityPortal().
+	 */
+	bool		hasResQueueLock;
 
 	/* If not NULL, Executor is active; call ExecutorEnd eventually: */
 	QueryDesc  *queryDesc;		/* info needed for executor invocation */

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -146,6 +146,7 @@ extern void				ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode);
 extern bool				ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incSet);
 
 extern ResPortalIncrement	*ResIncrementFind(ResPortalTag *portaltag);
+extern bool 				ResPortalHasDanglingIncrement(Portal portal);
 
 extern bool					ResPortalIncrementHashTableInit(void);
 

--- a/src/test/isolation2/expected/resource_queue_alter.out
+++ b/src/test/isolation2/expected/resource_queue_alter.out
@@ -1,0 +1,133 @@
+-- Behavioral tests to showcase what happens when resource queue limits are
+-- altered concurrently with active and waiting statements.
+
+0:CREATE RESOURCE QUEUE rq_alter WITH (active_statements = 1);
+CREATE QUEUE
+0:CREATE ROLE rq_alter_role RESOURCE QUEUE rq_alter;
+CREATE ROLE
+
+--
+-- Scenario 1: Bumping the resource queue limit
+--
+1:SET ROLE rq_alter_role;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+2:SET ROLE rq_alter_role;
+SET
+2:BEGIN;
+BEGIN
+-- The following will block waiting for the resource queue slot.
+2&:DECLARE c2 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- Inflate the limit.
+0:ALTER RESOURCE QUEUE rq_alter WITH (active_statements = 2);
+ALTER QUEUE
+-- The limit has been bumped. However we still see that Session 2 is waiting.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+ ?column? | lorrsqname | lorlocktype    | lormode       | lorgranted 
+----------+------------+----------------+---------------+------------
+ t        | rq_alter   | resource queue | ExclusiveLock | t          
+ t        | rq_alter   | resource queue | ExclusiveLock | f          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+ rsqname  | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+----------+---------------+---------------+------------+------------
+ rq_alter | 2             | 1             | 1          | 1          
+(1 row)
+
+-- New statements actually can get into the queue ahead of Session 2!
+1:DECLARE c3 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+-- Only once a statement completes (or ERRORs out) is Session 2 woken up, and
+-- can complete acquiring the lock for portal c2.
+1:CLOSE c1;
+CLOSE CURSOR
+2<:  <... completed>
+DECLARE CURSOR
+1q: ... <quitting>
+2q: ... <quitting>
+
+--
+-- Scenario 2: Decreasing the resource queue limit
+--
+1:SET ROLE rq_alter_role;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+-- The following will block waiting for the resource queue slot.
+2:SET ROLE rq_alter_role;
+SET
+2:BEGIN;
+BEGIN
+2&:DECLARE c3 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- The current situation:
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+ ?column? | lorrsqname | lorlocktype    | lormode       | lorgranted 
+----------+------------+----------------+---------------+------------
+ t        | rq_alter   | resource queue | ExclusiveLock | t          
+ t        | rq_alter   | resource queue | ExclusiveLock | f          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+ rsqname  | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+----------+---------------+---------------+------------+------------
+ rq_alter | 2             | 2             | 1          | 2          
+(1 row)
+
+-- Decrease the limit
+0:ALTER RESOURCE QUEUE rq_alter WITH (active_statements = 1);
+ALTER QUEUE
+
+-- Nothing changes, current holders and waiters continue as they were. However,
+-- do note that now we have a situation where rsqcountvalue > rsqcountlimit.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+ ?column? | lorrsqname | lorlocktype    | lormode       | lorgranted 
+----------+------------+----------------+---------------+------------
+ t        | rq_alter   | resource queue | ExclusiveLock | t          
+ t        | rq_alter   | resource queue | ExclusiveLock | f          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+ rsqname  | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+----------+---------------+---------------+------------+------------
+ rq_alter | 1             | 2             | 1          | 2          
+(1 row)
+
+-- The following will NOT wake up Session 2, as we would exceed the limit if we
+-- were to do so.
+1:CLOSE c1;
+CLOSE CURSOR
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+ ?column? | lorrsqname | lorlocktype    | lormode       | lorgranted 
+----------+------------+----------------+---------------+------------
+ t        | rq_alter   | resource queue | ExclusiveLock | t          
+ t        | rq_alter   | resource queue | ExclusiveLock | f          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+ rsqname  | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+----------+---------------+---------------+------------+------------
+ rq_alter | 1             | 1             | 1          | 1          
+(1 row)
+
+-- Now this will wake up Session 2
+1:CLOSE c2;
+CLOSE CURSOR
+2<:  <... completed>
+DECLARE CURSOR
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+0:DROP ROLE rq_alter_role;
+DROP ROLE
+0:DROP RESOURCE QUEUE rq_alter;
+DROP QUEUE

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -149,6 +149,8 @@ DECLARE CURSOR
 
 -- There should now only be one active statement, following the abort of session
 -- 1's transaction. The active statement is contributed by session 2.
+1<:  <... completed>
+ERROR:  canceling statement due to user request
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
  rsqcountlimit | rsqcountvalue 
 ---------------+---------------
@@ -161,8 +163,6 @@ DECLARE CURSOR
 (1 row)
 
 -- After ending the transactions, there should be 0 active statements.
-1<:  <... completed>
-ERROR:  canceling statement due to user request
 1:END;
 ROLLBACK
 2:END;

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -135,6 +135,7 @@ DECLARE CURSOR
 -- its transaction.
 1:DECLARE c3 CURSOR FOR SELECT 1;
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 585193, portal id: 3
 
 -- There should be 0 active statements following the transaction abort.
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -12,6 +12,36 @@ SET
 SET
 
 --
+-- Scenario 0:
+-- Multiple explicit cursors active in the same session.
+--
+
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+-- Shows 1 lock on the resource queue, with 2 holders (one for each cursor).
+-- Note: In the gp_locks_on_resqueue view, we show that lorusename as the
+-- session_user (and not the current_user 'role_multi_portal', which determines
+-- the queue for the statement).
+0:SELECT lorusename=session_user, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname='rq_multi_portal';
+ ?column? | lorlocktype    | lormode       | lorgranted 
+----------+----------------+---------------+------------
+ t        | resource queue | ExclusiveLock | t          
+(1 row)
+0:SELECT rsqcountlimit, rsqcountvalue,rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname='rq_multi_portal';
+ rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+---------------+---------------+------------+------------
+ 2             | 2             | 0          | 2          
+(1 row)
+
+1:END;
+COMMIT
+
+--
 -- Scenario 1:
 -- Multiple explicit cursors active in the same session with a deadlock.
 --

--- a/src/test/isolation2/expected/resource_queue_role.out
+++ b/src/test/isolation2/expected/resource_queue_role.out
@@ -1,0 +1,136 @@
+-- Behavioral tests to showcase that we always use the current_user to determine
+-- which resource queue that the statement should belong to. Also, even though
+-- we may use the current_user to route the statement, we may still use the
+-- session_user in resource queue views.
+
+0:CREATE RESOURCE QUEUE rq_role_test1 WITH (active_statements = 2);
+CREATE QUEUE
+0:CREATE RESOURCE QUEUE rq_role_test2 WITH (active_statements = 2);
+CREATE QUEUE
+0:CREATE ROLE rq_role_test_role1 RESOURCE QUEUE rq_role_test1;
+CREATE ROLE
+0:CREATE ROLE rq_role_test_role2 RESOURCE QUEUE rq_role_test2;
+CREATE ROLE
+
+--
+-- SET ROLE
+--
+
+1:SET ROLE rq_role_test_role1;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+1:SET ROLE rq_role_test_role2;
+SET
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+-- We should see 1 lock each on each queue, with 1 holder, with 1 active
+-- statement in queue. The lorusename in gp_locks_on_resqueue will be the session_user
+-- as opposed to the current_user 'rq_role_test_role1' or 'rq_role_test_role2' (which we
+-- use to find the destination queue)
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+ ?column? | lorrsqname    | lorlocktype    | lormode       | lorgranted 
+----------+---------------+----------------+---------------+------------
+ t        | rq_role_test2 | resource queue | ExclusiveLock | t          
+ t        | rq_role_test1 | resource queue | ExclusiveLock | t          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+ rsqname       | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+---------------+---------------+---------------+------------+------------
+ rq_role_test1 | 2             | 1             | 0          | 1          
+ rq_role_test2 | 2             | 1             | 0          | 1          
+(2 rows)
+
+1:END;
+COMMIT
+1q: ... <quitting>
+
+--
+-- SET SESSION AUTHORIZATION
+--
+
+1:SET SESSION AUTHORIZATION rq_role_test_role1;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+1:SET SESSION AUTHORIZATION  rq_role_test_role2;
+SET
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+-- We should see 1 lock each on each queue, with 1 holder, with 1 active
+-- statement in queue. The lorusename in gp_locks_on_resqueue will be the session_user
+-- as opposed to the current_user 'rq_role_test_role1' or 'rq_role_test_role2' (which we
+-- use to find the destination queue)
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+ ?column? | lorrsqname    | lorlocktype    | lormode       | lorgranted 
+----------+---------------+----------------+---------------+------------
+ t        | rq_role_test2 | resource queue | ExclusiveLock | t          
+ t        | rq_role_test1 | resource queue | ExclusiveLock | t          
+(2 rows)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+ rsqname       | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+---------------+---------------+---------------+------------+------------
+ rq_role_test1 | 2             | 1             | 0          | 1          
+ rq_role_test2 | 2             | 1             | 0          | 1          
+(2 rows)
+
+1:END;
+COMMIT
+1q: ... <quitting>
+
+--
+-- Executing a SECURITY DEFINER function
+--
+
+1:SET ROLE rq_role_test_role2;
+SET
+1:CREATE FUNCTION rq_run_as_secd() RETURNS VOID AS 'SELECT pg_sleep(10000000);' LANGUAGE SQL SECURITY DEFINER;
+CREATE FUNCTION
+1:SET ROLE rq_role_test_role1;
+SET
+1&:SELECT rq_run_as_secd();  <waiting ...>
+
+-- It may seem that because rq_run_as_secd() is to be executed as
+-- rq_role_test_role2, the owner of rq_run_as_secd(), that it will be allocated
+-- to rq_role_test1. However, since the portal is created prior to the
+-- current_user switch for SECURITY DEFINER in the function manager, we end up
+-- allocating the statement to rq_role_test1, according to the "current" current_user.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+ ?column? | lorrsqname    | lorlocktype    | lormode       | lorgranted 
+----------+---------------+----------------+---------------+------------
+ t        | rq_role_test1 | resource queue | ExclusiveLock | t          
+(1 row)
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+ rsqname       | rsqcountlimit | rsqcountvalue | rsqwaiters | rsqholders 
+---------------+---------------+---------------+------------+------------
+ rq_role_test2 | 2             | 0             | 0          | 0          
+ rq_role_test1 | 2             | 1             | 0          | 1          
+(2 rows)
+
+-- Terminate the function
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT rq_run_as_secd();';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+CONTEXT:  SQL function "rq_run_as_secd" statement 1
+
+-- Cleanup
+0:DROP FUNCTION rq_run_as_secd();
+DROP FUNCTION
+0:DROP ROLE rq_role_test_role1;
+DROP ROLE
+0:DROP RESOURCE QUEUE rq_role_test1;
+DROP QUEUE
+0:DROP ROLE rq_role_test_role2;
+DROP ROLE
+0:DROP RESOURCE QUEUE rq_role_test2;
+DROP QUEUE

--- a/src/test/isolation2/expected/resource_queue_self_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_self_deadlock.out
@@ -63,6 +63,7 @@ ERROR:  canceling statement due to user request
 
 1<:  <... completed>
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 585195, portal id: 2
 
 -- Sanity check: Ensure that the resource queue is now empty.
 0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_self';

--- a/src/test/isolation2/expected/resource_queue_self_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_self_deadlock.out
@@ -1,0 +1,78 @@
+-- This test is used to test if waiting on a resource queue lock will trigger a
+-- self deadlock detection and if we will properly clean up (preventing nasty
+-- race conditions)
+
+0: CREATE RESOURCE QUEUE rq_self WITH (active_statements = 1);
+CREATE QUEUE
+0: CREATE ROLE r_self RESOURCE QUEUE rq_self;
+CREATE ROLE
+
+1: SET ROLE r_self;
+SET
+1: BEGIN;
+BEGIN
+1: DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE CURSOR
+
+0: SELECT gp_inject_fault_infinite('res_lock_acquire_self_deadlock_error', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+0&: SELECT gp_wait_until_triggered_fault('res_lock_acquire_self_deadlock_error', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';  <waiting ...>
+-- Will trip a self-deadlock and the backend will be suspended.
+1&: DECLARE c2 CURSOR FOR SELECT 1;  <waiting ...>
+
+2: SET ROLE r_self;
+SET
+-- Will wait for a slot in the queue.
+2&: SELECT 33176;  <waiting ...>
+
+-- Now inflate the active statement count for the queue.
+0<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+0: ALTER RESOURCE QUEUE rq_self WITH (active_statements = 5);
+ALTER QUEUE
+
+-- Cancellation of the backend should not lead to us doing an extra grant to the
+-- process undergoing self-deadlock. Doing so, leads to an assertion failure:
+-- FailedAssertion("!(lock->nGranted <= lock->nRequested)", File: "resqueue.c", Line: 1086)
+-- ResGrantLock resqueue.c:1086
+-- ResProcLockRemoveSelfAndWakeup resqueue.c:1361
+-- ResCleanUpLock resqueue.c:1215
+-- ResRemoveFromWaitQueue resqueue.c:1473
+-- ResLockWaitCancel proc.c:2102
+-- ResLockPortal resscheduler.c:695
+-- ...
+3: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query='SELECT 33176;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+
+0: SELECT gp_inject_fault('res_lock_acquire_self_deadlock_error', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ERROR:  deadlock detected, locking against self
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_self';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 5             | 0             
+(1 row)
+
+-- Clean up the test
+0: DROP ROLE r_self;
+DROP ROLE
+0: DROP RESOURCE QUEUE rq_self;
+DROP QUEUE

--- a/src/test/isolation2/expected/resource_queue_terminate.out
+++ b/src/test/isolation2/expected/resource_queue_terminate.out
@@ -120,6 +120,139 @@ COMMIT
  1             | 0             
 (1 row)
 
+--
+-- Scenario 5: Race during termination of session having a waiting portal with
+-- another session waking up the same one. This can happen if the waiter during
+-- termination, hasn't yet removed itself from the wait queue in
+-- AbortOutOfAnyTransaction() -> .. -> ResLockWaitCancel(), and another session
+-- sees it on the wait queue, does an external grant and wakeup. This causes a
+-- leak, as the external grant is never cleaned up. In an asserts build we see:
+-- FailedAssertion(""!(SHMQueueEmpty(&(MyProc->myProcLocks[i])))"", File: ""proc.c", Line: 1031
+--
+7:SET ROLE role_terminate;
+SET
+7:BEGIN;
+BEGIN
+7:DECLARE cs6 CURSOR FOR SELECT 0;
+DECLARE CURSOR
+8:SET ROLE role_terminate;
+SET
+8&:SELECT 331765;  <waiting ...>
+
+0:SELECT gp_inject_fault('res_lock_wait_cancel_before_partition_lock', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fire the termination first and it will be stuck in the middle of aborting.
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='SELECT 331765;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+0:SELECT gp_wait_until_triggered_fault('res_lock_wait_cancel_before_partition_lock', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Now perform the external grant (as a part of relinquishing a spot in the queue)
+7:CLOSE cs6;
+CLOSE CURSOR
+
+-- Sanity check: Ensure that the resource queue now has 1 active statement (from
+-- the external grant).
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 1             
+(1 row)
+
+0:SELECT gp_inject_fault('res_lock_wait_cancel_before_partition_lock', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+8<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+7:END;
+COMMIT
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+--
+-- Scenario 6: Same as 5, except the statement being terminated is a holdable cursor.
+--
+9:SET ROLE role_terminate;
+SET
+9:BEGIN;
+BEGIN
+9:DECLARE cs7 CURSOR FOR SELECT 0;
+DECLARE CURSOR
+10:SET ROLE role_terminate;
+SET
+10&:DECLARE cs8 CURSOR WITH HOLD FOR SELECT 0;  <waiting ...>
+
+0:SELECT gp_inject_fault('res_lock_wait_cancel_before_partition_lock', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fire the termination first and it will be stuck in the middle of aborting.
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='DECLARE cs8 CURSOR WITH HOLD FOR SELECT 0;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+0:SELECT gp_wait_until_triggered_fault('res_lock_wait_cancel_before_partition_lock', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Now perform the external grant (as a part of relinquishing a spot in the queue)
+9:CLOSE cs6;
+ERROR:  cursor "cs6" does not exist
+
+-- Sanity check: Ensure that the resource queue now has 1 active statement (from
+-- the external grant).
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 1             
+(1 row)
+
+0:SELECT gp_inject_fault('res_lock_wait_cancel_before_partition_lock', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+10<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+9:END;
+ROLLBACK
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
 
 -- Cleanup
 0:DROP ROLE role_terminate;

--- a/src/test/isolation2/expected/resource_queue_terminate.out
+++ b/src/test/isolation2/expected/resource_queue_terminate.out
@@ -1,0 +1,128 @@
+-- Test various scenarios with respect to backend termination.
+
+0:CREATE RESOURCE QUEUE rq_terminate WITH (active_statements = 1);
+CREATE QUEUE
+0:CREATE ROLE role_terminate RESOURCE QUEUE rq_terminate;
+CREATE ROLE
+
+--
+-- Scenario 1: Terminate a backend with a regular open cursor
+--
+1:SET ROLE role_terminate;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE cs1 CURSOR FOR SELECT 0;
+DECLARE CURSOR
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='DECLARE cs1 CURSOR FOR SELECT 0;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+1<:  <... completed>
+FAILED:  Execution failed
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+--
+-- Scenario 2: Terminate a backend with a holdable open cursor that has been
+-- persisted.
+--
+2:SET ROLE role_terminate;
+SET
+2:DECLARE cs2 CURSOR WITH HOLD FOR SELECT 0;
+DECLARE CURSOR
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='DECLARE cs2 CURSOR WITH HOLD FOR SELECT 0;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+2<:  <... completed>
+FAILED:  Execution failed
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+--
+-- Scenario 3: Terminate a backend with a waiting statement
+--
+3:SET ROLE role_terminate;
+SET
+3:BEGIN;
+BEGIN
+3:DECLARE cs3 CURSOR FOR SELECT 0;
+DECLARE CURSOR
+4:SET ROLE role_terminate;
+SET
+4&:SELECT 331763;  <waiting ...>
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='SELECT 331763;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+4<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+3:END;
+COMMIT
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+--
+-- Scenario 4: Terminate a backend with a waiting holdable cursor
+--
+5:SET ROLE role_terminate;
+SET
+5:BEGIN;
+BEGIN
+5:DECLARE cs4 CURSOR FOR SELECT 0;
+DECLARE CURSOR
+6:SET ROLE role_terminate;
+SET
+6&:DECLARE cs5 CURSOR WITH HOLD FOR SELECT 0;  <waiting ...>
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query='DECLARE cs5 CURSOR WITH HOLD FOR SELECT 0;';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+6<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+5:END;
+COMMIT
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+
+-- Cleanup
+0:DROP ROLE role_terminate;
+DROP ROLE
+0:DROP RESOURCE QUEUE rq_terminate;
+DROP QUEUE

--- a/src/test/isolation2/isolation2_resqueue_schedule
+++ b/src/test/isolation2/isolation2_resqueue_schedule
@@ -3,4 +3,5 @@ test: resource_queue
 test: resource_queue_cancel
 test: resource_queue_deadlock
 test: resource_queue_multi_portal
+test: resource_queue_role
 test: resource_manager_restore_to_none

--- a/src/test/isolation2/isolation2_resqueue_schedule
+++ b/src/test/isolation2/isolation2_resqueue_schedule
@@ -6,4 +6,5 @@ test: resource_queue_multi_portal
 test: resource_queue_role
 test: resource_queue_alter
 test: resource_queue_self_deadlock
+test: resource_queue_terminate
 test: resource_manager_restore_to_none

--- a/src/test/isolation2/isolation2_resqueue_schedule
+++ b/src/test/isolation2/isolation2_resqueue_schedule
@@ -4,4 +4,5 @@ test: resource_queue_cancel
 test: resource_queue_deadlock
 test: resource_queue_multi_portal
 test: resource_queue_role
+test: resource_queue_alter
 test: resource_manager_restore_to_none

--- a/src/test/isolation2/isolation2_resqueue_schedule
+++ b/src/test/isolation2/isolation2_resqueue_schedule
@@ -5,4 +5,5 @@ test: resource_queue_deadlock
 test: resource_queue_multi_portal
 test: resource_queue_role
 test: resource_queue_alter
+test: resource_queue_self_deadlock
 test: resource_manager_restore_to_none

--- a/src/test/isolation2/sql/resource_queue_alter.sql
+++ b/src/test/isolation2/sql/resource_queue_alter.sql
@@ -1,0 +1,82 @@
+-- Behavioral tests to showcase what happens when resource queue limits are
+-- altered concurrently with active and waiting statements.
+
+0:CREATE RESOURCE QUEUE rq_alter WITH (active_statements = 1);
+0:CREATE ROLE rq_alter_role RESOURCE QUEUE rq_alter;
+
+--
+-- Scenario 1: Bumping the resource queue limit
+--
+1:SET ROLE rq_alter_role;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+
+2:SET ROLE rq_alter_role;
+2:BEGIN;
+-- The following will block waiting for the resource queue slot.
+2&:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- Inflate the limit.
+0:ALTER RESOURCE QUEUE rq_alter WITH (active_statements = 2);
+-- The limit has been bumped. However we still see that Session 2 is waiting.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+
+-- New statements actually can get into the queue ahead of Session 2!
+1:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- Only once a statement completes (or ERRORs out) is Session 2 woken up, and
+-- can complete acquiring the lock for portal c2.
+1:CLOSE c1;
+2<:
+1q:
+2q:
+
+--
+-- Scenario 2: Decreasing the resource queue limit
+--
+1:SET ROLE rq_alter_role;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- The following will block waiting for the resource queue slot.
+2:SET ROLE rq_alter_role;
+2:BEGIN;
+2&:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- The current situation:
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+
+-- Decrease the limit
+0:ALTER RESOURCE QUEUE rq_alter WITH (active_statements = 1);
+
+-- Nothing changes, current holders and waiters continue as they were. However,
+-- do note that now we have a situation where rsqcountvalue > rsqcountlimit.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+
+-- The following will NOT wake up Session 2, as we would exceed the limit if we
+-- were to do so.
+1:CLOSE c1;
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname ='rq_alter';
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname = 'rq_alter';
+
+-- Now this will wake up Session 2
+1:CLOSE c2;
+2<:
+
+1q:
+2q:
+
+0:DROP ROLE rq_alter_role;
+0:DROP RESOURCE QUEUE rq_alter;

--- a/src/test/isolation2/sql/resource_queue_multi_portal.sql
+++ b/src/test/isolation2/sql/resource_queue_multi_portal.sql
@@ -8,6 +8,26 @@
 2:SET ROLE role_multi_portal;
 
 --
+-- Scenario 0:
+-- Multiple explicit cursors active in the same session.
+--
+
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- Shows 1 lock on the resource queue, with 2 holders (one for each cursor).
+-- Note: In the gp_locks_on_resqueue view, we show that lorusename as the
+-- session_user (and not the current_user 'role_multi_portal', which determines
+-- the queue for the statement).
+0:SELECT lorusename=session_user, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname='rq_multi_portal';
+0:SELECT rsqcountlimit, rsqcountvalue,rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname='rq_multi_portal';
+
+1:END;
+
+--
 -- Scenario 1:
 -- Multiple explicit cursors active in the same session with a deadlock.
 --

--- a/src/test/isolation2/sql/resource_queue_multi_portal.sql
+++ b/src/test/isolation2/sql/resource_queue_multi_portal.sql
@@ -88,12 +88,12 @@
 
 -- There should now only be one active statement, following the abort of session
 -- 1's transaction. The active statement is contributed by session 2.
+1<:
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
 0:SELECT query, state from pg_stat_activity
   WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
 
 -- After ending the transactions, there should be 0 active statements.
-1<:
 1:END;
 2:END;
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';

--- a/src/test/isolation2/sql/resource_queue_role.sql
+++ b/src/test/isolation2/sql/resource_queue_role.sql
@@ -1,0 +1,84 @@
+-- Behavioral tests to showcase that we always use the current_user to determine
+-- which resource queue that the statement should belong to. Also, even though
+-- we may use the current_user to route the statement, we may still use the
+-- session_user in resource queue views.
+
+0:CREATE RESOURCE QUEUE rq_role_test1 WITH (active_statements = 2);
+0:CREATE RESOURCE QUEUE rq_role_test2 WITH (active_statements = 2);
+0:CREATE ROLE rq_role_test_role1 RESOURCE QUEUE rq_role_test1;
+0:CREATE ROLE rq_role_test_role2 RESOURCE QUEUE rq_role_test2;
+
+--
+-- SET ROLE
+--
+
+1:SET ROLE rq_role_test_role1;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:SET ROLE rq_role_test_role2;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- We should see 1 lock each on each queue, with 1 holder, with 1 active
+-- statement in queue. The lorusename in gp_locks_on_resqueue will be the session_user
+-- as opposed to the current_user 'rq_role_test_role1' or 'rq_role_test_role2' (which we
+-- use to find the destination queue)
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+
+1:END;
+1q:
+
+--
+-- SET SESSION AUTHORIZATION
+--
+
+1:SET SESSION AUTHORIZATION rq_role_test_role1;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:SET SESSION AUTHORIZATION  rq_role_test_role2;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- We should see 1 lock each on each queue, with 1 holder, with 1 active
+-- statement in queue. The lorusename in gp_locks_on_resqueue will be the session_user
+-- as opposed to the current_user 'rq_role_test_role1' or 'rq_role_test_role2' (which we
+-- use to find the destination queue)
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+
+1:END;
+1q:
+
+--
+-- Executing a SECURITY DEFINER function
+--
+
+1:SET ROLE rq_role_test_role2;
+1:CREATE FUNCTION rq_run_as_secd() RETURNS VOID AS 'SELECT pg_sleep(10000000);'
+    LANGUAGE SQL SECURITY DEFINER;
+1:SET ROLE rq_role_test_role1;
+1&:SELECT rq_run_as_secd();
+
+-- It may seem that because rq_run_as_secd() is to be executed as
+-- rq_role_test_role2, the owner of rq_run_as_secd(), that it will be allocated
+-- to rq_role_test1. However, since the portal is created prior to the
+-- current_user switch for SECURITY DEFINER in the function manager, we end up
+-- allocating the statement to rq_role_test1, according to the "current" current_user.
+0:SELECT lorusename=session_user, lorrsqname, lorlocktype, lormode, lorgranted
+  FROM gp_toolkit.gp_locks_on_resqueue WHERE lorrsqname IN ('rq_role_test1', 'rq_role_test2');
+0:SELECT rsqname, rsqcountlimit, rsqcountvalue, rsqwaiters, rsqholders
+  FROM gp_toolkit.gp_resqueue_status WHERE rsqname IN ('rq_role_test1', 'rq_role_test2');
+
+-- Terminate the function
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT rq_run_as_secd();';
+1<:
+
+-- Cleanup
+0:DROP FUNCTION rq_run_as_secd();
+0:DROP ROLE rq_role_test_role1;
+0:DROP RESOURCE QUEUE rq_role_test1;
+0:DROP ROLE rq_role_test_role2;
+0:DROP RESOURCE QUEUE rq_role_test2;

--- a/src/test/isolation2/sql/resource_queue_self_deadlock.sql
+++ b/src/test/isolation2/sql/resource_queue_self_deadlock.sql
@@ -1,0 +1,50 @@
+-- This test is used to test if waiting on a resource queue lock will trigger a
+-- self deadlock detection and if we will properly clean up (preventing nasty
+-- race conditions)
+
+0: CREATE RESOURCE QUEUE rq_self WITH (active_statements = 1);
+0: CREATE ROLE r_self RESOURCE QUEUE rq_self;
+
+1: SET ROLE r_self;
+1: BEGIN;
+1: DECLARE c1 CURSOR FOR SELECT 1;
+
+0: SELECT gp_inject_fault_infinite('res_lock_acquire_self_deadlock_error', 'suspend', dbid) FROM
+    gp_segment_configuration WHERE content = -1 AND role = 'p';
+0&: SELECT gp_wait_until_triggered_fault('res_lock_acquire_self_deadlock_error', 1, dbid)
+    FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+-- Will trip a self-deadlock and the backend will be suspended.
+1&: DECLARE c2 CURSOR FOR SELECT 1;
+
+2: SET ROLE r_self;
+-- Will wait for a slot in the queue.
+2&: SELECT 33176;
+
+-- Now inflate the active statement count for the queue.
+0<:
+0: ALTER RESOURCE QUEUE rq_self WITH (active_statements = 5);
+
+-- Cancellation of the backend should not lead to us doing an extra grant to the
+-- process undergoing self-deadlock. Doing so, leads to an assertion failure:
+-- FailedAssertion("!(lock->nGranted <= lock->nRequested)", File: "resqueue.c", Line: 1086)
+-- ResGrantLock resqueue.c:1086
+-- ResProcLockRemoveSelfAndWakeup resqueue.c:1361
+-- ResCleanUpLock resqueue.c:1215
+-- ResRemoveFromWaitQueue resqueue.c:1473
+-- ResLockWaitCancel proc.c:2102
+-- ResLockPortal resscheduler.c:695
+-- ...
+3: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query='SELECT 33176;';
+2<:
+
+0: SELECT gp_inject_fault('res_lock_acquire_self_deadlock_error', 'reset', dbid) FROM
+    gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+1<:
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_self';
+
+-- Clean up the test
+0: DROP ROLE r_self;
+0: DROP RESOURCE QUEUE rq_self;

--- a/src/test/isolation2/sql/resource_queue_terminate.sql
+++ b/src/test/isolation2/sql/resource_queue_terminate.sql
@@ -1,0 +1,71 @@
+-- Test various scenarios with respect to backend termination.
+
+0:CREATE RESOURCE QUEUE rq_terminate WITH (active_statements = 1);
+0:CREATE ROLE role_terminate RESOURCE QUEUE rq_terminate;
+
+--
+-- Scenario 1: Terminate a backend with a regular open cursor
+--
+1:SET ROLE role_terminate;
+1:BEGIN;
+1:DECLARE cs1 CURSOR FOR SELECT 0;
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE query='DECLARE cs1 CURSOR FOR SELECT 0;';
+
+1<:
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+
+--
+-- Scenario 2: Terminate a backend with a holdable open cursor that has been
+-- persisted.
+--
+2:SET ROLE role_terminate;
+2:DECLARE cs2 CURSOR WITH HOLD FOR SELECT 0;
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE query='DECLARE cs2 CURSOR WITH HOLD FOR SELECT 0;';
+
+2<:
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+
+--
+-- Scenario 3: Terminate a backend with a waiting statement
+--
+3:SET ROLE role_terminate;
+3:BEGIN;
+3:DECLARE cs3 CURSOR FOR SELECT 0;
+4:SET ROLE role_terminate;
+4&:SELECT 331763;
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE query='SELECT 331763;';
+
+4<:
+3:END;
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+
+--
+-- Scenario 4: Terminate a backend with a waiting holdable cursor
+--
+5:SET ROLE role_terminate;
+5:BEGIN;
+5:DECLARE cs4 CURSOR FOR SELECT 0;
+6:SET ROLE role_terminate;
+6&:DECLARE cs5 CURSOR WITH HOLD FOR SELECT 0;
+
+0:SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE query='DECLARE cs5 CURSOR WITH HOLD FOR SELECT 0;';
+
+6<:
+5:END;
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_terminate';
+
+
+-- Cleanup
+0:DROP ROLE role_terminate;
+0:DROP RESOURCE QUEUE rq_terminate;

--- a/src/test/regress/expected/resource_queue.out
+++ b/src/test/regress/expected/resource_queue.out
@@ -272,6 +272,7 @@ DECLARE c1 CURSOR FOR SELECT 1 FROM tenk1;
 DECLARE c2 CURSOR FOR SELECT 2 FROM tenk1;
 DECLARE c3 CURSOR FOR SELECT 3 FROM tenk1; -- should detect deadlock
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 576196, portal id: 3
 END;
 -- track cursor open/close count (should not deadlock)
 BEGIN;
@@ -338,6 +339,7 @@ SELECT rsqname, rsqcostlimit, rsqwaiters, rsqholders FROM pg_resqueue_status WHE
 
 DECLARE c3 CURSOR FOR SELECT * FROM tenk1 a, tenk1 b;
 ERROR:  statement requires more resources than resource queue allows
+DETAIL:  resource queue id: 625696, portal id: 3
 SELECT rsqname, rsqcostlimit, rsqwaiters, rsqholders FROM pg_resqueue_status WHERE rsqcostvalue > 0;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 DECLARE c4 CURSOR FOR SELECT * FROM tenk1 a, tenk1 b, tenk1 c;
@@ -448,6 +450,7 @@ fetch c0;
 
 select * from rq_product;
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 576200, portal id: 0
 fetch c0;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 abort;
@@ -479,6 +482,7 @@ fetch c0;
 
 select * from rq_product;
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 576200, portal id: 0
 fetch c0;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 abort;
@@ -529,6 +533,7 @@ fetch c0;
 
 select * from rq_product;
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 576200, portal id: 0
 fetch c0;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 abort;
@@ -580,6 +585,7 @@ fetch c0;
 
 select * from rq_product;
 ERROR:  deadlock detected, locking against self
+DETAIL:  resource queue id: 576200, portal id: 0
 fetch c0;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 abort;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -204,4 +204,8 @@ s/^------------+\s*$/------------\n/
 -- s/Heap Blocks: exact=\d+/Heap Blocks: exact=###/
 -- m/Heap Blocks: lossy=\d+/
 -- s/Heap Blocks: lossy=\d+/Heap Blocks: lossy=###/
+
+# ignore resource queue ids
+m/resource queue id: \d+/
+s/resource queue id: \d+/resource queue id: XXXX/
 -- end_matchsubs

--- a/src/test/regress/output/resource_queue_function.source
+++ b/src/test/regress/output/resource_queue_function.source
@@ -21,7 +21,7 @@ SET ROLE test_role;
 -- query should be assigned 125MB, but queue only allows 10MB 
 SELECT count(*) FROM test_table; 
 ERROR:  deadlock detected, locking against self
-HINT:  It is likely that a query is waiting on itself for resources. Check resource queue limits.
+DETAIL:  resource queue id: 581950, portal id: 0
 RESET ROLE;
 -- should return true
 select checkResourceQueueMemoryLimits('test_q'); 


### PR DESCRIPTION
This PR consists of:

1) Tests adding coverage and documentation for resource queue behavior
2) The fix for the statement leak involving self-deadlocks
3) The fix for the statement leak involving termination
4) Logging improvements

Please review commits individually

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/resq_self