### PR TITLE
Drop __gpupgrade_tmp if exists during pg_upgrade setup

### DIFF
--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -569,6 +569,8 @@ setup_GPDB6_data_type_checks(ClusterInfo *cluster)
 		DbInfo *active_db = &cluster->dbarr.dbs[dbnum];
 		PGconn *conn = connectToServer(cluster, active_db->db_name);
 		PGresult *res = executeQueryOrDie(conn,
+										  "SET CLIENT_MIN_MESSAGES = WARNING; "
+										  "DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE; "
 										  "CREATE SCHEMA __gpupgrade_tmp; "
 										  "CREATE FUNCTION __gpupgrade_tmp.data_type_checks(base_query TEXT) "
 										  "RETURNS TABLE ( "
@@ -630,7 +632,8 @@ setup_GPDB6_data_type_checks(ClusterInfo *cluster)
 										  "        AND n.nspname !~ '^pg_toast_temp_' "
 										  "        AND n.nspname NOT IN ('pg_catalog', 'information_schema'); "
 										  "END; "
-										  "$$ LANGUAGE plpgsql;");
+										  "$$ LANGUAGE plpgsql; "
+										  "RESET CLIENT_MIN_MESSAGES;");
 
 		PQclear(res);
 		PQfinish(conn);
@@ -650,7 +653,7 @@ teardown_GPDB6_data_type_checks(ClusterInfo *cluster)
 		PGresult *res = executeQueryOrDie(conn,
 										  "SET CLIENT_MIN_MESSAGES = WARNING; "
 										  "DROP SCHEMA __gpupgrade_tmp CASCADE; "
-										  "SET CLIENT_MIN_MESSAGES = NOTICE;");
+										  "RESET CLIENT_MIN_MESSAGES;");
 
 		PQclear(res);
 		PQfinish(conn);


### PR DESCRIPTION
If a check errors out early and `--continue-check-on-fatal` isn't specified, subsequent pg_upgrade runs will hit a `schema __gpupgrade_tmp already exists` error during setup because `teardown_GPDB6_data_type_checks` never executed. 
