### PR TITLE
pg_upgrade: Add check for functions dependent on plpython2

### DIFF
--- a/src/bin/pg_upgrade/function.c
+++ b/src/bin/pg_upgrade/function.c
@@ -68,13 +68,17 @@ get_loadable_libraries(void)
 
 		/*
 		 * Fetch all libraries containing non-built-in C functions in this DB.
+		 * GPDB: $libdir/plpython2 was removed with GP7, which only supports
+		 * plpython3. The target GP7 cluster is not expected to have the
+		 * library, so it's excluded from the check.
 		 */
 		ress[dbnum] = executeQueryOrDie(conn,
 										"SELECT DISTINCT probin "
 										"FROM pg_catalog.pg_proc "
 										"WHERE prolang = %u AND "
 										"probin IS NOT NULL AND "
-										"oid >= %u;",
+										"probin != '$libdir/plpython2' "
+										"AND oid >= %u;",
 										ClanguageId,
 										FirstNormalObjectId);
 		totaltups += PQntuples(ress[dbnum]);

--- a/src/bin/pg_upgrade/function.c
+++ b/src/bin/pg_upgrade/function.c
@@ -56,7 +56,6 @@ get_loadable_libraries(void)
 	PGresult  **ress;
 	int			totaltups;
 	int			dbnum;
-	bool		found_public_plpython_handler = false;
 
 	ress = (PGresult **) pg_malloc(old_cluster.dbarr.ndbs * sizeof(PGresult *));
 	totaltups = 0;
@@ -82,9 +81,6 @@ get_loadable_libraries(void)
 
 		PQfinish(conn);
 	}
-
-	if (found_public_plpython_handler)
-		pg_fatal("Remove the problem functions from the old cluster to continue.\n");
 
 	os_info.libraries = (LibraryInfo *) pg_malloc(totaltups * sizeof(LibraryInfo));
 	totaltups = 0;


### PR DESCRIPTION
GP7 does not  support plpython2, so any functions using it on GP6 will fail to upgrade. 
Provide a check to output the offending functions.
