### PR TITLE
pg_upgrade: Add flag for relocateable output

### DIFF
--- a/doc/src/sgml/ref/pgupgrade.sgml
+++ b/doc/src/sgml/ref/pgupgrade.sgml
@@ -756,7 +756,10 @@ psql --username=postgres --file=script.sql postgres
   <para>
    <application>pg_upgrade</application> creates various working files, such
    as schema dumps, stored within <literal>pg_upgrade_output.d</literal> in
-   the directory of the new cluster.
+   the directory of the new cluster. Each run creates a new subdirectory named
+   with a timestamp formatted as per ISO 8601
+   (<literal>%Y%m%dT%H%M%S</literal>), where all the generated files are
+   stored.
   </para>
 
   <para>

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -238,6 +238,8 @@ report_clusters_compatible(void)
 
 		/* stops new cluster */
 		stop_postmaster(false);
+		cleanup_output_dirs();
+
 		if (get_check_fatal_occurred())
 			exit(1);
 		exit(0);

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -232,7 +232,7 @@ report_clusters_compatible(void)
 				pg_fatal("could not determine current directory: %m\n");
 			canonicalize_path(cwd);
 
-			pg_log(PG_REPORT, "\n*Some cluster objects are not compatible*\n\npg_upgrade check output files are located:\n%s\n\n", cwd);
+			pg_log(PG_REPORT, "\n*Some cluster objects are not compatible*\n\npg_upgrade check output files are located in:\n%s\n\n", log_opts.basedir);
 		} else
 			pg_log(PG_REPORT, "\n*Clusters are compatible*\n");
 
@@ -1126,8 +1126,9 @@ check_for_composite_data_type_usage(ClusterInfo *cluster)
 
 	prep_status("Checking for system-defined composite types in user tables");
 
-	snprintf(output_path, sizeof(output_path), "tables_using_composite.txt");
-
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "tables_using_composite.txt");
 	/*
 	 * Look for composite types that were made during initdb *or* belong to
 	 * information_schema; that's important in case information_schema was
@@ -1184,7 +1185,9 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 
 	prep_status("Checking for reg* data types in user tables");
 
-	snprintf(output_path, sizeof(output_path), "tables_using_reg.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "tables_using_reg.txt");
 
 	/*
 	 * Note: older servers will not have all of these reg* types, so we have
@@ -1241,7 +1244,8 @@ check_for_removed_data_type_usage(ClusterInfo *cluster, const char *version,
 	prep_status("Checking for removed \"%s\" data type in user tables",
 				datatype);
 
-	snprintf(output_path, sizeof(output_path), "tables_using_%s.txt",
+	snprintf(output_path, sizeof(output_path), "%s/tables_using_%s.txt",
+			 log_opts.basedir,
 			 datatype);
 	snprintf(typename, sizeof(typename), "pg_catalog.%s", datatype);
 
@@ -1273,7 +1277,9 @@ check_for_jsonb_9_4_usage(ClusterInfo *cluster)
 
 	prep_status("Checking for incompatible \"jsonb\" data type");
 
-	snprintf(output_path, sizeof(output_path), "tables_using_jsonb.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "tables_using_jsonb.txt");
 
 	if (check_for_data_type_usage(cluster, "pg_catalog.jsonb", output_path))
 	{

--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -144,7 +144,9 @@ check_external_partition(void)
 
 	prep_status("Checking for external tables used in partitioning");
 
-	snprintf(output_path, sizeof(output_path), "external_partitions.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "external_partitions.txt");
+
 	/*
 	 * We need to query the inheritance catalog rather than the partitioning
 	 * catalogs since they are not available on the segments.
@@ -251,7 +253,8 @@ check_covering_aoindex(void)
 
 	prep_status("Checking for non-covering indexes on partitioned AO tables");
 
-	snprintf(output_path, sizeof(output_path), "mismatched_aopartition_indexes.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "mismatched_aopartition_indexes.txt");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{
@@ -322,7 +325,8 @@ check_orphaned_toastrels(void)
 
 	prep_status("Checking for orphaned TOAST relations");
 
-	snprintf(output_path, sizeof(output_path), "orphaned_toast_tables.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "orphaned_toast_tables.txt");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{
@@ -405,7 +409,8 @@ check_partition_indexes(void)
 
 	prep_status("Checking for indexes on partitioned tables");
 
-	snprintf(output_path, sizeof(output_path), "partitioned_tables_indexes.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "partitioned_tables_indexes.txt");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{

--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -1,3 +1,5 @@
+#include "postgres_fe.h"
+
 #include "pg_upgrade_greenplum.h"
 
 typedef enum
@@ -12,6 +14,7 @@ typedef struct {
 	bool continue_check_on_fatal;
 	bool skip_target_check;
 	bool skip_checks;
+	char *output_dir;
 } GreenplumUserOpts;
 
 static GreenplumUserOpts greenplum_user_opts;
@@ -24,6 +27,7 @@ initialize_greenplum_user_options(void)
 	greenplum_user_opts.continue_check_on_fatal = false;
 	greenplum_user_opts.skip_target_check = false;
 	greenplum_user_opts.skip_checks = false;
+	greenplum_user_opts.output_dir = NULL;
 }
 
 bool
@@ -76,6 +80,10 @@ process_greenplum_option(greenplumOption option)
 			greenplum_user_opts.skip_checks = true;
 			break;
 
+		case GREENPLUM_OUTPUT_DIR:
+			greenplum_user_opts.output_dir = pg_strdup(optarg);
+			break;
+
 		default:
 			return false;
 	}
@@ -123,4 +131,10 @@ bool
 skip_checks(void)
 {
 	return greenplum_user_opts.skip_checks;
+}
+
+char*
+get_output_dir(void)
+{
+	return greenplum_user_opts.output_dir;
 }

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -36,7 +36,8 @@ typedef enum {
 	GREENPLUM_PROGRESS_OPTION = 11,
 	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 12,
 	GREENPLUM_SKIP_TARGET_CHECK = 13,
-	GREENPLUM_SKIP_CHECKS = 14
+	GREENPLUM_SKIP_CHECKS = 14,
+	GREENPLUM_OUTPUT_DIR = 15
 } greenplumOption;
 
 #define GREENPLUM_OPTIONS \
@@ -44,7 +45,8 @@ typedef enum {
 	{"progress", no_argument, NULL, GREENPLUM_PROGRESS_OPTION}, \
 	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
 	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK}, \
-	{"skip-checks", no_argument, NULL, GREENPLUM_SKIP_CHECKS},
+	{"skip-checks", no_argument, NULL, GREENPLUM_SKIP_CHECKS}, \
+	{"output-dir", required_argument, NULL, GREENPLUM_OUTPUT_DIR},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
@@ -52,6 +54,7 @@ typedef enum {
       --continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
       --skip-target-check       skip all checks on new/target cluster\n\
       --skip-checks             skip all checks\n\
+      --output-dir              directory to output logs. Default=\"COORDINATOR_DATA_DIRECTORY/pg_upgrade.d\"\n\
 "
 
 /* option_gp.c */
@@ -64,6 +67,7 @@ void set_check_fatal_occured(void);
 bool get_check_fatal_occurred(void);
 bool is_skip_target_check(void);
 bool skip_checks(void);
+char *get_output_dir(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_master_data(void);

--- a/src/bin/pg_upgrade/greenplum/version_gp.c
+++ b/src/bin/pg_upgrade/greenplum/version_gp.c
@@ -39,7 +39,8 @@ check_hash_partition_usage(void)
 
 	prep_status("Checking for hash partitioned tables");
 
-	snprintf(output_path, sizeof(output_path), "hash_partitioned_tables.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "hash_partitioned_tables.txt");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{
@@ -113,7 +114,8 @@ old_GPDB6_check_for_unsupported_sha256_password_hashes(void)
 
 	prep_status("Checking for SHA-256 hashed passwords");
 
-	snprintf(output_path, sizeof(output_path), "roles_using_sha256_passwords.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "roles_using_sha256_passwords.txt");
 
 	/* It's enough to check this in one database, pg_authid is a shared catalog. */
 	{

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -98,6 +98,7 @@ main(int argc, char **argv)
 	char       *sequence_script_file_name = NULL;
 	char	   *analyze_script_file_name = NULL;
 	char	   *deletion_script_file_name = NULL;
+	char	   *output_dir = NULL;
 	bool		live_check = false;
 
 	pg_logging_init(argv[0]);
@@ -128,8 +129,13 @@ main(int argc, char **argv)
 	/*
 	 * This needs to happen after adjusting the data directory of the new
 	 * cluster in adjust_data_dir().
+	 *
+	 * GPDB allows for relocateable output with the --output-dir flag
 	 */
-	make_outputdirs(new_cluster.pgdata);
+	if ((output_dir = get_output_dir()) != NULL)
+		make_outputdirs(output_dir);
+	else
+		make_outputdirs(new_cluster.pgdata);
 
 	setup(argv[0], &live_check);
 

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -59,7 +59,6 @@ static void copy_xact_xlog_xid(void);
 static void set_frozenxids(bool minmxid_only);
 static void make_outputdirs(char *pgdata);
 static void setup(char *argv0, bool *live_check);
-static void cleanup(void);
 
 static void copy_subdir_files(const char *old_subdir, const char *new_subdir);
 
@@ -278,7 +277,7 @@ main(int argc, char **argv)
 	pg_free(analyze_script_file_name);
 	pg_free(deletion_script_file_name);
 
-	cleanup();
+	cleanup_output_dirs();
 
 	return 0;
 }
@@ -404,19 +403,54 @@ make_outputdirs(char *pgdata)
 	char	  **filename;
 	time_t		run_time = time(NULL);
 	char		filename_path[MAXPGPATH];
+	char		timebuf[128];
+	struct timeval time;
+	time_t		tt;
+	int			len;
 
-	log_opts.basedir = (char *) pg_malloc(MAXPGPATH);
-	snprintf(log_opts.basedir, MAXPGPATH, "%s/%s", pgdata, BASE_OUTPUTDIR);
-	log_opts.dumpdir = (char *) pg_malloc(MAXPGPATH);
-	snprintf(log_opts.dumpdir, MAXPGPATH, "%s/%s", pgdata, DUMP_OUTPUTDIR);
-	log_opts.logdir = (char *) pg_malloc(MAXPGPATH);
-	snprintf(log_opts.logdir, MAXPGPATH, "%s/%s", pgdata, LOG_OUTPUTDIR);
+	log_opts.rootdir = (char *) pg_malloc0(MAXPGPATH);
+	len = snprintf(log_opts.rootdir, MAXPGPATH, "%s/%s", pgdata, BASE_OUTPUTDIR);
+	if (len >= MAXPGPATH)
+		pg_fatal("buffer for root directory too small");
 
-	if (mkdir(log_opts.basedir, pg_dir_create_mode))
+	/* BASE_OUTPUTDIR/$timestamp/ */
+	gettimeofday(&time, NULL);
+	tt = (time_t) time.tv_sec;
+	strftime(timebuf, sizeof(timebuf), "%Y%m%dT%H%M%S", localtime(&tt));
+	/* append milliseconds */
+	snprintf(timebuf + strlen(timebuf), sizeof(timebuf) - strlen(timebuf),
+			 ".%03d", (int) (time.tv_usec / 1000));
+	log_opts.basedir = (char *) pg_malloc0(MAXPGPATH);
+	len = snprintf(log_opts.basedir, MAXPGPATH, "%s/%s", log_opts.rootdir,
+				   timebuf);
+	if (len >= MAXPGPATH)
+		pg_fatal("buffer for base directory too small");
+
+	/* BASE_OUTPUTDIR/$timestamp/dump/ */
+	log_opts.dumpdir = (char *) pg_malloc0(MAXPGPATH);
+	len = snprintf(log_opts.dumpdir, MAXPGPATH, "%s/%s/%s", log_opts.rootdir,
+				   timebuf, DUMP_OUTPUTDIR);
+	if (len >= MAXPGPATH)
+		pg_fatal("buffer for dump directory too small");
+
+	/* BASE_OUTPUTDIR/$timestamp/log/ */
+	log_opts.logdir = (char *) pg_malloc0(MAXPGPATH);
+	len = snprintf(log_opts.logdir, MAXPGPATH, "%s/%s/%s", log_opts.rootdir,
+				   timebuf, LOG_OUTPUTDIR);
+	if (len >= MAXPGPATH)
+		pg_fatal("buffer for log directory too small");
+
+	/*
+	 * Ignore the error case where the root path exists, as it is kept the
+	 * same across runs.
+	 */
+	if (mkdir(log_opts.rootdir, pg_dir_create_mode) < 0 && errno != EEXIST)
+		pg_fatal("could not create directory \"%s\": %m\n", log_opts.rootdir);
+	if (mkdir(log_opts.basedir, pg_dir_create_mode) < 0)
 		pg_fatal("could not create directory \"%s\": %m\n", log_opts.basedir);
-	if (mkdir(log_opts.dumpdir, pg_dir_create_mode))
+	if (mkdir(log_opts.dumpdir, pg_dir_create_mode) < 0)
 		pg_fatal("could not create directory \"%s\": %m\n", log_opts.dumpdir);
-	if (mkdir(log_opts.logdir, pg_dir_create_mode))
+	if (mkdir(log_opts.logdir, pg_dir_create_mode) < 0)
 		pg_fatal("could not create directory \"%s\": %m\n", log_opts.logdir);
 
 	snprintf(filename_path, sizeof(filename_path), "%s/%s", log_opts.logdir,
@@ -982,14 +1016,4 @@ set_frozenxids(bool minmxid_only)
 	PQfinish(conn_template1);
 
 	check_ok();
-}
-
-static void
-cleanup(void)
-{
-	fclose(log_opts.internal);
-
-	/* Remove dump and log files? */
-	if (!log_opts.retain)
-		rmtree(log_opts.basedir, true);
 }

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -411,7 +411,7 @@ make_outputdirs(char *pgdata)
 	log_opts.rootdir = (char *) pg_malloc0(MAXPGPATH);
 	len = snprintf(log_opts.rootdir, MAXPGPATH, "%s/%s", pgdata, BASE_OUTPUTDIR);
 	if (len >= MAXPGPATH)
-		pg_fatal("buffer for root directory too small");
+		pg_fatal("directory path for new cluster is too long\n");
 
 	/* BASE_OUTPUTDIR/$timestamp/ */
 	gettimeofday(&time, NULL);
@@ -424,21 +424,21 @@ make_outputdirs(char *pgdata)
 	len = snprintf(log_opts.basedir, MAXPGPATH, "%s/%s", log_opts.rootdir,
 				   timebuf);
 	if (len >= MAXPGPATH)
-		pg_fatal("buffer for base directory too small");
+		pg_fatal("directory path for new cluster is too long\n");
 
 	/* BASE_OUTPUTDIR/$timestamp/dump/ */
 	log_opts.dumpdir = (char *) pg_malloc0(MAXPGPATH);
 	len = snprintf(log_opts.dumpdir, MAXPGPATH, "%s/%s/%s", log_opts.rootdir,
 				   timebuf, DUMP_OUTPUTDIR);
 	if (len >= MAXPGPATH)
-		pg_fatal("buffer for dump directory too small");
+		pg_fatal("directory path for new cluster is too long\n");
 
 	/* BASE_OUTPUTDIR/$timestamp/log/ */
 	log_opts.logdir = (char *) pg_malloc0(MAXPGPATH);
 	len = snprintf(log_opts.logdir, MAXPGPATH, "%s/%s/%s", log_opts.rootdir,
 				   timebuf, LOG_OUTPUTDIR);
 	if (len >= MAXPGPATH)
-		pg_fatal("buffer for log directory too small");
+		pg_fatal("directory path for new cluster is too long\n");
 
 	/*
 	 * Ignore the error case where the root path exists, as it is kept the
@@ -453,21 +453,25 @@ make_outputdirs(char *pgdata)
 	if (mkdir(log_opts.logdir, pg_dir_create_mode) < 0)
 		pg_fatal("could not create directory \"%s\": %m\n", log_opts.logdir);
 
-	snprintf(filename_path, sizeof(filename_path), "%s/%s", log_opts.logdir,
-			 INTERNAL_LOG_FILE);
+	len = snprintf(filename_path, sizeof(filename_path), "%s/%s",
+				   log_opts.logdir, INTERNAL_LOG_FILE);
+	if (len >= sizeof(filename_path))
+		pg_fatal("directory path for new cluster is too long\n");
+
 	if ((log_opts.internal = fopen_priv(filename_path, "a")) == NULL)
 		pg_fatal("could not open log file \"%s\": %m\n", filename_path);
 
 	/* label start of upgrade in logfiles */
 	for (filename = output_files; *filename != NULL; filename++)
 	{
-		snprintf(filename_path, sizeof(filename_path), "%s/%s",
-				 log_opts.logdir, *filename);
+		len = snprintf(filename_path, sizeof(filename_path), "%s/%s",
+					   log_opts.logdir, *filename);
+		if (len >= sizeof(filename_path))
+			pg_fatal("directory path for new cluster is too long\n");
 		if ((fp = fopen_priv(filename_path, "a")) == NULL)
 			pg_fatal("could not write to log file \"%s\": %m\n", filename_path);
 
-		/* Start with newline because we might be appending to a file. */
-		fprintf(fp, "\n"
+		fprintf(fp,
 				"-----------------------------------------------------------------\n"
 				"  pg_upgrade run on %s"
 				"-----------------------------------------------------------------\n\n",

--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -38,12 +38,14 @@
 #define DB_DUMP_FILE_MASK	"pg_upgrade_dump_%u.custom"
 
 /*
- * Base directories that include all the files generated internally,
- * from the root path of the new cluster.
+ * Base directories that include all the files generated internally, from the
+ * root path of the new cluster.  The paths are dynamically built as of
+ * BASE_OUTPUTDIR/$timestamp/{LOG_OUTPUTDIR,DUMP_OUTPUTDIR} to ensure their
+ * uniqueness in each run.
  */
 #define BASE_OUTPUTDIR		"pg_upgrade_output.d"
-#define LOG_OUTPUTDIR		BASE_OUTPUTDIR "/log"
-#define DUMP_OUTPUTDIR		BASE_OUTPUTDIR "/dump"
+#define LOG_OUTPUTDIR		 "log"
+#define DUMP_OUTPUTDIR		 "dump"
 
 #define DB_DUMP_LOG_FILE_MASK	"pg_upgrade_dump_%u.log"
 #define SERVER_LOG_FILE		"pg_upgrade_server.log"
@@ -386,7 +388,8 @@ typedef struct
 	bool		verbose;		/* true -> be verbose in messages */
 	bool		retain;			/* retain log files on success */
 	/* Set of internal directories for output files */
-	char	   *basedir;		/* Base output directory */
+	char	   *rootdir;		/* Root directory, aka pg_upgrade_output.d */
+	char	   *basedir;		/* Base output directory, with timestamp */
 	char	   *dumpdir;		/* Dumps */
 	char	   *logdir;			/* Log files */
 	bool		isatty;			/* is stdout a tty */
@@ -547,6 +550,7 @@ void		report_status(eLogType type, const char *fmt,...) pg_attribute_printf(2, 3
 void		pg_log(eLogType type, const char *fmt,...) pg_attribute_printf(2, 3);
 void		pg_fatal(const char *fmt,...) pg_attribute_printf(1, 2) pg_attribute_noreturn();
 void		end_progress_output(void);
+void		cleanup_output_dirs(void);
 void		prep_status(const char *fmt,...) pg_attribute_printf(1, 2);
 void		prep_status_progress(const char *fmt,...) pg_attribute_printf(1, 2);
 unsigned int str2uint(const char *str);

--- a/src/bin/pg_upgrade/util.c
+++ b/src/bin/pg_upgrade/util.c
@@ -54,6 +54,48 @@ end_progress_output(void)
 		pg_log(PG_REPORT, "%-*s", MESSAGE_WIDTH, "");
 }
 
+/*
+ * Remove any logs generated internally.  To be used once when exiting.
+ */
+void
+cleanup_output_dirs(void)
+{
+	fclose(log_opts.internal);
+
+	/* Remove dump and log files? */
+	if (log_opts.retain)
+		return;
+
+	(void) rmtree(log_opts.basedir, true);
+
+	/* Remove pg_upgrade_output.d only if empty */
+	switch (pg_check_dir(log_opts.rootdir))
+	{
+		case 0:					/* non-existent */
+		case 3:					/* exists and contains a mount point */
+			Assert(false);
+			break;
+
+		case 1:					/* exists and empty */
+		case 2:					/* exists and contains only dot files */
+			(void) rmtree(log_opts.rootdir, true);
+			break;
+
+		case 4:					/* exists */
+
+			/*
+			 * Keep the root directory as this includes some past log
+			 * activity.
+			 */
+			break;
+
+		default:
+			/* different failure, just report it */
+			pg_log(PG_WARNING, "could not access directory \"%s\": %m",
+				   log_opts.rootdir);
+			break;
+	}
+}
 
 /*
  * prep_status

--- a/src/bin/pg_upgrade/version.c
+++ b/src/bin/pg_upgrade/version.c
@@ -209,7 +209,9 @@ old_9_6_check_for_unknown_data_type_usage(ClusterInfo *cluster)
 
 	prep_status("Checking for invalid \"unknown\" user columns");
 
-	snprintf(output_path, sizeof(output_path), "tables_using_unknown.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+				 log_opts.basedir,
+				 "tables_using_unknown.txt");
 
 	if (check_for_data_type_usage(cluster, "pg_catalog.unknown", output_path))
 	{
@@ -352,7 +354,8 @@ old_11_check_for_sql_identifier_data_type_usage(ClusterInfo *cluster)
 
 	prep_status("Checking for invalid \"sql_identifier\" user columns");
 
-	snprintf(output_path, sizeof(output_path), "tables_using_sql_identifier.txt");
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir, "tables_using_sql_identifier.txt");
 
 	if (check_for_data_type_usage(cluster, "information_schema.sql_identifier",
 								  output_path))


### PR DESCRIPTION
This PR backports some QOL improvements for `pg_upgrade` output, then adds a new pg_upgrade flag, `--output-dir`.

Currently, `pg_upgrade` output (checks, logs, schema dump) is sent to the target cluster's data directory in `pg_upgrade.d` by default. The new flag allows the user to redirect the output. For example, during `pg_upgrade` checks, users may want to send the check output files to `gpAdminLogs` instead of the target data directory. This will be a likely use-case for gpupgrade.

As a note, output files are always removed unless the `-r, --retain` flag is set, which seems to me an odd choice when `pg_upgrade` fails. Since this is the case in upstream and gpupgrade always sets `--retain` flag, leave this as is.

Example:
GP6 -> GP7 check run
```
pg_upgrade -c --continue-check-on-fatal --retain --output-dir ~/gpAdminLogs -d /home/bdoil/workspace/gpdb6/gpAux/gpdemo/datadirs/qddir/demoDataDir-1 -D /home/bdoil/workspace/gpdb7/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/ -b /usr/local/gpdb6/bin -B /usr/local/gpdb7/bin -p 6000 -P 7000
```
Failed check
```
Checking for presence of required libraries                 fatal
| Your installation references loadable libraries that are missing from the
| new installation.  You can add these libraries to the new installation,
| or remove the functions using them from the old installation.  A list of
| problem libraries is in the file:
|     /home/bdoil/gpAdminLogs/pg_upgrade_output.d/20240125T022501.730/loadable_libraries.txt
```
Output
```
# bdoil @ bdoil-ub in ~/gpAdminLogs/pg_upgrade_output.d/20240125T022501.730 [2:26:48] 
$ ll -rth
total 24K
drwx------ 2 bdoil bdoil 4.0K Jan 25 02:25 log
drwx------ 2 bdoil bdoil 4.0K Jan 25 02:25 dump
-rw------- 1 bdoil bdoil   62 Jan 25 02:25 tables_using_abstime.txt
-rw------- 1 bdoil bdoil   64 Jan 25 02:25 tables_using_tinterval.txt
-rw------- 1 bdoil bdoil   72 Jan 25 02:25 tables_using_unknown.txt
-rw------- 1 bdoil bdoil  173 Jan 25 02:25 loadable_libraries.txt
```

