### PR TITLE
Fix an edge case bug of repositioning in AOCO partition scan

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -721,6 +721,17 @@ aocs_positionscan(AOCSScanDesc scan,
 		}
 	}
 
+	if (beginFileOffset == 0)
+	{
+		/* 
+		 * If we intend to position to the 1st varblock in the segfile,
+		 * we are already done, as open_scan_seg() always reads the 1st
+		 * block in the file, so there is no additional positioning
+		 * necessary.
+		 */
+		return true;
+	}
+
 	/* The datum stream array is always of length relnatts */
 	dsIdx = scan->columnScanInfo.proj_atts[colIdx];
 	Assert(dsIdx >= 0 && dsIdx < RelationGetNumberOfAttributes(scan->rs_base.rs_rd));
@@ -733,8 +744,8 @@ aocs_positionscan(AOCSScanDesc scan,
 	}
 
 	AppendOnlyStorageRead_SetTemporaryStart(&ds->ao_read,
-											beginFileOffset,
-											afterFileOffset);
+												beginFileOffset,
+												afterFileOffset);
 
 	return true;
 }

--- a/src/test/isolation2/expected/ao_partial_scan.out
+++ b/src/test/isolation2/expected/ao_partial_scan.out
@@ -774,10 +774,6 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 ----                          ao_column tables
 --------------------------------------------------------------------------------
 
--- Note: for AOCO tables, there is 1 additional varblock read reported by the
--- fault point per column (the initial open_scan_seg() results in the additional
--- read being counted)
-
 CREATE TABLE aoco_partial_scan1(i int, j int2, k int) USING ao_column;
 CREATE TABLE
 
@@ -953,7 +949,7 @@ SELECT brin_summarize_range('aoco_partial_scan1_i_j_idx', 33554432);
 SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault                                                                                                                                                                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'21' 
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'20' 
  
 (1 row)
 SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
@@ -1368,7 +1364,7 @@ SELECT brin_summarize_range('aoco_partial_scan2_i_j_idx', 33554432);
 SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault                                                                                                                                                                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'12' 
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
  
 (1 row)
 SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';

--- a/src/test/isolation2/sql/ao_partial_scan.sql
+++ b/src/test/isolation2/sql/ao_partial_scan.sql
@@ -267,10 +267,6 @@ SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', d
 ----                          ao_column tables
 --------------------------------------------------------------------------------
 
--- Note: for AOCO tables, there is 1 additional varblock read reported by the
--- fault point per column (the initial open_scan_seg() results in the additional
--- read being counted)
-
 CREATE TABLE aoco_partial_scan1(i int, j int2, k int) USING ao_column;
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
In AO/CO partial scan, we reposition to read block from a desired file offset. There is an edge case bug where if we intend to read from start of the file of a CO table, we might end up reading the first block of the file twice. The reason is that, when opening file segments for CO tables (open_scan_seg()), we would read ahead the first blocks of the files. So, if we re-position to the start of the file, after we scanned all the rows of the read-ahead blocks, we would read in the first blocks again, and end up scanning the same blocks twice. This was found when looking at some incoherent numbers in ao_partial_scan regress test. Fixing the issue now, and correcting the test output.

Co-authored-by: Soumyadeep Chakraborty <soumyadeepc@vmware.com>

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/ao-partial-scan-bug

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
