### PR TITLE
[6X][backport] Fix FTS PROBE process memory leak

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -3176,6 +3176,8 @@ freePGconn(PGconn *conn)
 		free(conn->krbsrvname);
 	if (conn->gsslib)
 		free(conn->gsslib);
+	if (conn->gpconntype)
+		free(conn->gpconntype);
 	if (conn->gpqeid)			/* CDB */
 		free(conn->gpqeid);
 	/* Note that conn->Pfdebug is not ours to close or free */


### PR DESCRIPTION
Note that f86af5e introduces `gpconntype` in `pg_conn`, but this field won't be freed in `freePGconn`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
