### PR TITLE
Optimize DELETEs in Orca to only project necessary columns

### DIFF
--- a/src/backend/access/common/tupconvert.c
+++ b/src/backend/access/common/tupconvert.c
@@ -329,6 +329,86 @@ convert_tuples_by_name_map(TupleDesc indesc,
 }
 
 /*
+ * Return a palloc'd bare attribute map for tuple conversion, matching input
+ * and output columns by name.  (Dropped columns are ignored in both input and
+ * output.)  This is normally a subroutine for convert_tuples_by_name, but can
+ * be used standalone.
+ *
+ * NOTE: this is identical to the above function, but does
+ * not throw an error if an attribute in the outdesc is missing from the indesc.
+ * Future postgres merges will add missing_ok as a parameter to the function and
+ * this can then be removed (commits e1551f9 and ad86d15)
+ */
+AttrNumber *
+convert_tuples_by_name_map_missing_ok(TupleDesc indesc,
+						   TupleDesc outdesc)
+{
+	AttrNumber *attrMap;
+	int			outnatts;
+	int			innatts;
+	int			i;
+	int			nextindesc = -1;
+
+	outnatts = outdesc->natts;
+	innatts = indesc->natts;
+
+	attrMap = (AttrNumber *) palloc0(outnatts * sizeof(AttrNumber));
+	for (i = 0; i < outnatts; i++)
+	{
+		Form_pg_attribute outatt = TupleDescAttr(outdesc, i);
+		char	   *attname;
+		Oid			atttypid;
+		int32		atttypmod;
+		int			j;
+
+		if (outatt->attisdropped)
+			continue;			/* attrMap[i] is already 0 */
+		attname = NameStr(outatt->attname);
+		atttypid = outatt->atttypid;
+		atttypmod = outatt->atttypmod;
+
+		/*
+		 * Now search for an attribute with the same name in the indesc. It
+		 * seems likely that a partitioned table will have the attributes in
+		 * the same order as the partition, so the search below is optimized
+		 * for that case.  It is possible that columns are dropped in one of
+		 * the relations, but not the other, so we use the 'nextindesc'
+		 * counter to track the starting point of the search.  If the inner
+		 * loop encounters dropped columns then it will have to skip over
+		 * them, but it should leave 'nextindesc' at the correct position for
+		 * the next outer loop.
+		 */
+		for (j = 0; j < innatts; j++)
+		{
+			Form_pg_attribute inatt;
+
+			nextindesc++;
+			if (nextindesc >= innatts)
+				nextindesc = 0;
+
+			inatt = TupleDescAttr(indesc, nextindesc);
+			if (inatt->attisdropped)
+				continue;
+			if (strcmp(attname, NameStr(inatt->attname)) == 0)
+			{
+				/* Found it, check type */
+				if (atttypid != inatt->atttypid || atttypmod != inatt->atttypmod)
+					ereport(ERROR,
+							(errcode(ERRCODE_DATATYPE_MISMATCH),
+							 errmsg("could not convert row type"),
+							 errdetail("Attribute \"%s\" of type %s does not match corresponding attribute of type %s.",
+									   attname,
+									   format_type_be(outdesc->tdtypeid),
+									   format_type_be(indesc->tdtypeid))));
+				attrMap[i] = inatt->attnum;
+				break;
+			}
+		}
+	}
+	return attrMap;
+}
+
+/*
  * Returns mapping created by convert_tuples_by_name_map, or NULL if no
  * conversion not required. This is a convenience routine for
  * convert_tuples_by_name() and other functions.

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4735,16 +4735,21 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);
 	child_contexts->Append(&child_context);
 
-	// translate proj list
 	List *dml_target_list =
 		TranslateDXLProjList(project_list_dxlnode,
 							 nullptr,  // translate context for the base table
 							 child_contexts, output_context);
 
-	// pad child plan's target list with NULLs for dropped columns for all DML operator types
-	List *target_list_with_dropped_cols =
-		CreateTargetListWithNullsForDroppedCols(dml_target_list, md_rel);
-	dml_target_list = target_list_with_dropped_cols;
+	// project all columns for intermediate (mid-level) partitions, as we need to pass through the partition keys
+	// but do not have that information for intermediate partitions during Orca's optimization
+	BOOL is_intermediate_part =
+		(md_rel->IsPartitioned() && nullptr != md_rel->MDPartConstraint());
+	if (m_cmd_type != CMD_DELETE || is_intermediate_part)
+	{
+		// pad child plan's target list with NULLs for dropped columns for UPDATE/INSERTs and for DELETEs on intermeidate partitions
+		dml_target_list =
+			CreateTargetListWithNullsForDroppedCols(dml_target_list, md_rel);
+	}
 
 	// Add junk columns to the target list for the 'action', 'ctid',
 	// 'gp_segment_id'. The ModifyTable node will find these based
@@ -4778,7 +4783,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	result_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 	result_plan->lefttree = child_plan;
 
-	result_plan->targetlist = target_list_with_dropped_cols;
+	result_plan->targetlist = dml_target_list;
 	SetParamIds(result_plan);
 
 	child_plan = (Plan *) result;

--- a/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
@@ -308,16 +308,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="150">
-      <dxl:DMLDelete Columns="0" ActionCol="20" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="20" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.023818" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.018603" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="i">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="7" AssignedQueryIdForTargetRel="1">
           <dxl:Columns>
             <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -332,12 +328,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000380" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000374" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="i">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -352,12 +345,9 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="In">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000374" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000369" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -596,17 +596,14 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="139">
-      <dxl:DMLDelete Columns="0,1,2" ActionCol="24" CtidCol="3" SegmentIdCol="9">
+      <dxl:DMLDelete Columns="0,2" ActionCol="24" CtidCol="3" SegmentIdCol="9">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.034376" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.029151" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
             <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="j">
-            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="k">
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -628,14 +625,11 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000521" Rows="1.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000506" Rows="1.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="j">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="k">
               <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -654,14 +648,11 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="In">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000513" Rows="1.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000498" Rows="1.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="k">
                 <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -683,14 +674,11 @@
             </dxl:HashCondList>
             <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="k">
                   <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
@@ -193,19 +193,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="0,1" ActionCol="9" CtidCol="2" SegmentIdCol="8">
+      <dxl:DMLDelete Columns="" ActionCol="9" CtidCol="2" SegmentIdCol="8">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.043023" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.027391" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
           <dxl:Columns>
             <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -221,15 +214,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="ctid">
               <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -244,15 +231,9 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="ctid">
                 <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
@@ -187,16 +187,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="0" ActionCol="8" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="8" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023458" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.018246" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1" LockMode="3">
           <dxl:Columns>
             <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -211,12 +207,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -231,12 +224,9 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
@@ -260,16 +260,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="17">
-      <dxl:DMLDelete Columns="0" ActionCol="16" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="16" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.023911" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.018692" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo" LockMode="3">
           <dxl:Columns>
             <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -284,12 +280,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000463" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -304,12 +297,9 @@
           <dxl:OneTimeFilter/>
           <dxl:RoutedDistributeMotion SegmentIdCol="7" InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000467" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000458" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>
@@ -321,12 +311,9 @@
             <dxl:SortingColumnList/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000453" Rows="1.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000448" Rows="1.000000" Width="10"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="ctid">
                   <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -174,6 +174,9 @@ public:
 	// is column a distribution column?
 	virtual BOOL IsDistCol() const = 0;
 
+	// is column a partition column?
+	virtual BOOL IsPartCol() const = 0;
+
 	// print
 	IOstream &OsPrint(IOstream &) const;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefComputed.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefComputed.h
@@ -66,6 +66,14 @@ public:
 		return false;
 	};
 
+	// is column a partition column?
+	BOOL
+	IsPartCol() const override
+	{
+		// we cannot introduce partition columns as computed column
+		return false;
+	};
+
 
 };	// class CColRefComputed
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefTable.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefTable.h
@@ -48,6 +48,10 @@ private:
 	// is the column a distribution key
 	BOOL m_is_dist_col;
 
+	// is the column a partition key
+	BOOL m_is_part_col;
+
+
 	// width of the column, for instance  char(10) column has width 10
 	ULONG m_width;
 
@@ -101,6 +105,13 @@ public:
 	IsDistCol() const override
 	{
 		return m_is_dist_col;
+	}
+
+	// is column a partition column?
+	BOOL
+	IsPartCol() const override
+	{
+		return m_is_part_col;
 	}
 
 	// width of the column

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
@@ -56,6 +56,9 @@ private:
 	// is the column a distribution col
 	BOOL m_is_dist_col;
 
+	// is the column a partition col
+	BOOL m_is_part_col;
+
 public:
 	// ctor
 	CColumnDescriptor(CMemoryPool *mp, const IMDType *pmdtype,
@@ -121,11 +124,25 @@ public:
 		return m_is_dist_col;
 	}
 
+	// is this a partition column
+	BOOL
+	IsPartCol() const
+	{
+		return m_is_part_col;
+	}
+
 	// set this column as a distribution column
 	void
 	SetAsDistCol()
 	{
 		m_is_dist_col = true;
+	}
+
+	// set this column as a partition column
+	void
+	SetAsPartCol()
+	{
+		m_is_part_col = true;
 	}
 
 	IOstream &OsPrint(IOstream &os) const;

--- a/src/backend/gporca/libgpopt/src/base/CColRefTable.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRefTable.cpp
@@ -39,6 +39,7 @@ CColRefTable::CColRefTable(const CColumnDescriptor *pcoldesc, ULONG id,
 	m_iAttno = pcoldesc->AttrNum();
 	m_is_nullable = pcoldesc->IsNullable();
 	m_is_dist_col = pcoldesc->IsDistCol();
+	m_is_part_col = pcoldesc->IsPartCol();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CColumnDescriptor.cpp
@@ -37,7 +37,9 @@ CColumnDescriptor::CColumnDescriptor(CMemoryPool *mp, const IMDType *pmdtype,
 	  m_iAttno(attno),
 	  m_is_nullable(is_nullable),
 	  m_width(ulWidth),
-	  m_is_dist_col(false)
+	  m_is_dist_col(false),
+	  m_is_part_col(false)
+
 {
 	GPOS_ASSERT(nullptr != pmdtype);
 	GPOS_ASSERT(pmdtype->MDId()->IsValid());

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -212,13 +212,14 @@ CTableDescriptor::AddDistributionColumn(ULONG ulPos, IMDId *opfamily)
 //		CTableDescriptor::AddPartitionColumn
 //
 //	@doc:
-//		Add the column at the specified position to the array of partition column
-//		descriptors
+//		Add the column's position to the array of partition columns
 //
 //---------------------------------------------------------------------------
 void
 CTableDescriptor::AddPartitionColumn(ULONG ulPos)
 {
+	CColumnDescriptor *pcoldesc = (*m_pdrgpcoldesc)[ulPos];
+	pcoldesc->SetAsPartCol();
 	m_pdrgpulPart->Append(GPOS_NEW(m_mp) ULONG(ulPos));
 }
 

--- a/src/include/access/tupconvert.h
+++ b/src/include/access/tupconvert.h
@@ -43,6 +43,8 @@ extern TupleConversionMap *convert_tuples_by_name(TupleDesc indesc,
 extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 											  TupleDesc outdesc,
 											  const char *msg);
+extern AttrNumber *convert_tuples_by_name_map_missing_ok(TupleDesc indesc,
+											  TupleDesc outdesc);
 extern AttrNumber *convert_tuples_by_name_map_if_req(TupleDesc indesc,
 													 TupleDesc outdesc,
 													 const char *msg);

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1681,25 +1681,24 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
 NOTICE:  One or more columns in the following table(s) do not have statistics: tab2
 HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
  Delete on tab1
-   ->  Result
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: tab1.b
-               ->  Hash Join
-                     Hash Cond: (tab2.a = tab1.a)
-                     ->  Seq Scan on tab2
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: tab1.a
-                                 ->  Hash Join
-                                       Hash Cond: (tab3.b = tab1.b)
-                                       ->  Seq Scan on tab3
-                                       ->  Hash
-                                             ->  Seq Scan on tab1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
-(16 rows)
+   ->  Hash Join
+         Hash Cond: (tab3.b = tab1.b)
+         ->  Seq Scan on tab3
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: tab1.b
+                     ->  Hash Join
+                           Hash Cond: (tab2.a = tab1.a)
+                           ->  Seq Scan on tab2
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: tab1.a
+                                       ->  Seq Scan on tab1
+ Optimizer: GPORCA
+(15 rows)
 
 -- ----------------------------------------------------------------------
 -- Test delete on partition table from join on another partition table

--- a/src/test/regress/expected/bfv_dml.out
+++ b/src/test/regress/expected/bfv_dml.out
@@ -663,3 +663,159 @@ explain (analyze, costs off, timing off, summary off) insert into test default v
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- Test delete on partition table with dropped/added columns
+CREATE TABLE part (
+    a int,
+    b int,
+    c text,
+    d numeric)
+DISTRIBUTED BY (b)
+partition by range(a) (
+    start(1) end(6) every(2),
+    default partition def);
+alter table part add column e int;
+insert into part select i, i, 'abc', i*1.01,i from generate_series(1,10)i;
+alter table part drop column b;
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+alter table part set WITH (reorganize=true) distributed by (e);
+-- test delete with dropped column
+explain delete from part where d>9;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Delete on part  (cost=0.00..671.00 rows=14267 width=10)
+   Delete on part_1_prt_2
+   Delete on part_1_prt_3
+   Delete on part_1_prt_4
+   Delete on part_1_prt_def
+   ->  Seq Scan on part_1_prt_2  (cost=0.00..167.75 rows=3567 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_3  (cost=0.00..167.75 rows=3567 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_4  (cost=0.00..167.75 rows=3567 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_def  (cost=0.00..167.75 rows=3567 width=10)
+         Filter: (d > '9'::numeric)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+delete from part where d>9;
+select count(*) from part;
+ count 
+-------
+     8
+(1 row)
+
+-- test delete with added partition key
+explain delete from part where e=3;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Delete on part  (cost=0.00..671.00 rows=43 width=10)
+   Delete on part_1_prt_2
+   Delete on part_1_prt_3
+   Delete on part_1_prt_4
+   Delete on part_1_prt_def
+   ->  Seq Scan on part_1_prt_2  (cost=0.00..167.75 rows=11 width=10)
+         Filter: (e = 3)
+   ->  Seq Scan on part_1_prt_3  (cost=0.00..167.75 rows=11 width=10)
+         Filter: (e = 3)
+   ->  Seq Scan on part_1_prt_4  (cost=0.00..167.75 rows=11 width=10)
+         Filter: (e = 3)
+   ->  Seq Scan on part_1_prt_def  (cost=0.00..167.75 rows=11 width=10)
+         Filter: (e = 3)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+delete from part where e=3;
+select count(*) from part;
+ count 
+-------
+     7
+(1 row)
+
+-- test delete from default partition
+explain delete from part where a=8;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Delete on part  (cost=0.00..167.75 rows=11 width=10)
+   Delete on part_1_prt_def
+   ->  Seq Scan on part_1_prt_def  (cost=0.00..167.75 rows=11 width=10)
+         Filter: (a = 8)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+delete from part where a=8;
+select count(*) from part;
+ count 
+-------
+     6
+(1 row)
+
+DROP TABLE IF EXISTS part;
+CREATE TABLE part (
+    a int,
+    b int,
+    partkey int,
+    c text,
+    d numeric)
+DISTRIBUTED BY (b)
+partition by range(partkey) (
+    start(1) end(6) every(2),
+    default partition def);
+alter table part add column e int;
+insert into part select i, i, i, 'abc', i*1.01,i from generate_series(1,10)i;
+alter table part drop column b;
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+alter table part set WITH (reorganize=true) distributed by (e);
+-- test delete with column order change
+explain delete from part where d>9;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Delete on part  (cost=0.00..649.33 rows=13689 width=10)
+   Delete on part_1_prt_2
+   Delete on part_1_prt_3
+   Delete on part_1_prt_4
+   Delete on part_1_prt_def
+   ->  Seq Scan on part_1_prt_2  (cost=0.00..162.33 rows=3422 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_3  (cost=0.00..162.33 rows=3422 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_4  (cost=0.00..162.33 rows=3422 width=10)
+         Filter: (d > '9'::numeric)
+   ->  Seq Scan on part_1_prt_def  (cost=0.00..162.33 rows=3422 width=10)
+         Filter: (d > '9'::numeric)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+delete from part where d>9;
+select count(*) from part;
+ count 
+-------
+     8
+(1 row)
+
+-- Test delete on mid-level partitions. Ensure Orca properly handles tuple routing
+create table deep_part (
+  i int,
+  j int,
+  k int,
+  s char(5)
+) distributed by (i) partition by list(s) subpartition by range (j) subpartition template (
+  start(1) end(3) every(1)
+) (
+  partition p1
+  values
+    ('A'),
+    partition p2
+  values
+    ('B')
+);
+insert into deep_part values (1,1,1,'A');
+delete from deep_part_1_prt_p1 where j=1;

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -660,3 +660,132 @@ explain (analyze, costs off, timing off, summary off) insert into test default v
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
+-- Test delete on partition table with dropped/added columns
+CREATE TABLE part (
+    a int,
+    b int,
+    c text,
+    d numeric)
+DISTRIBUTED BY (b)
+partition by range(a) (
+    start(1) end(6) every(2),
+    default partition def);
+alter table part add column e int;
+insert into part select i, i, 'abc', i*1.01,i from generate_series(1,10)i;
+alter table part drop column b;
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+alter table part set WITH (reorganize=true) distributed by (e);
+-- test delete with dropped column
+explain delete from part where d>9;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Delete on part  (cost=0.00..431.03 rows=1 width=1)
+   ->  Dynamic Seq Scan on part  (cost=0.00..431.00 rows=1 width=26)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (d > '9'::numeric)
+ Optimizer: GPORCA
+(5 rows)
+
+delete from part where d>9;
+select count(*) from part;
+ count 
+-------
+     8
+(1 row)
+
+-- test delete with added partition key
+explain delete from part where e=3;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Delete on part  (cost=0.00..431.03 rows=1 width=1)
+   ->  Dynamic Seq Scan on part  (cost=0.00..431.00 rows=1 width=18)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (e = 3)
+ Optimizer: GPORCA
+(5 rows)
+
+delete from part where e=3;
+select count(*) from part;
+ count 
+-------
+     7
+(1 row)
+
+-- test delete from default partition
+explain delete from part where a=8;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Delete on part  (cost=0.00..431.03 rows=1 width=1)
+   ->  Dynamic Seq Scan on part  (cost=0.00..431.00 rows=1 width=18)
+         Number of partitions to scan: 1 (out of 4)
+         Filter: (a = 8)
+ Optimizer: GPORCA
+(5 rows)
+
+delete from part where a=8;
+select count(*) from part;
+ count 
+-------
+     6
+(1 row)
+
+DROP TABLE IF EXISTS part;
+CREATE TABLE part (
+    a int,
+    b int,
+    partkey int,
+    c text,
+    d numeric)
+DISTRIBUTED BY (b)
+partition by range(partkey) (
+    start(1) end(6) every(2),
+    default partition def);
+alter table part add column e int;
+insert into part select i, i, i, 'abc', i*1.01,i from generate_series(1,10)i;
+alter table part drop column b;
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
+alter table part set WITH (reorganize=true) distributed by (e);
+-- test delete with column order change
+explain delete from part where d>9;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Delete on part  (cost=0.00..431.03 rows=1 width=1)
+   ->  Dynamic Seq Scan on part  (cost=0.00..431.00 rows=1 width=26)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (d > '9'::numeric)
+ Optimizer: GPORCA
+(5 rows)
+
+delete from part where d>9;
+select count(*) from part;
+ count 
+-------
+     8
+(1 row)
+
+-- Test delete on mid-level partitions. Ensure Orca properly handles tuple routing
+create table deep_part (
+  i int,
+  j int,
+  k int,
+  s char(5)
+) distributed by (i) partition by list(s) subpartition by range (j) subpartition template (
+  start(1) end(3) every(1)
+) (
+  partition p1
+  values
+    ('A'),
+    partition p2
+  values
+    ('B')
+);
+insert into deep_part values (1,1,1,'A');
+delete from deep_part_1_prt_p1 where j=1;


### PR DESCRIPTION
Currently, ORCA projects all columns for DML operations, which means that deleting a row requires populating all of the columns in the targetlist. For deletes, the only necessary columns are the ctid and gp_segment_id in the executor. This performance difference is especially evident for CO tables

Things are more complicated due to how Orca handles partitioned tables. Orca produces DynamicScan nodes, which scan the necessary partitions and pass those tuples to the DML operator. While planner uses separate scan and each partition corresponds to a delete operator, for Orca the DML operator needs to figure out which partition to delete from for each tuple. It does this through tuple routing logic in the executor. Because of this, Orca needs to project the partition key and include additional mapping logic to remap this partition key to fit the existing tuple routing framework. Additionally, internally Orca needs the distribution key to figure out which segment to use for direct dispatch.

Performance numbers:

Using the setup from https://github.com/greenplum-db/gpdb/issues/16755.

```
CREATE TABLE wide_table(i int, j int, k int, l int, m int, n int, o int)
WITH(appendonly=true,orientation=column,compresstype=zlib,compresslevel=5);
INSERT INTO wide_table SELECT g, g+1, g+2, g+3, g+4, g+5, g+6 FROM
generate_series(1, 100000000) g; begin; explain (analyze, verbose)
delete from wide_table; rollback;
```

Before: 10.2s
After: 6.4s

Fixes https://github.com/greenplum-db/gpdb/issues/16755