### PR TITLE
pg_dumpall: Fix syntax error when dumping RGs

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -865,7 +865,7 @@ dumpResGroups(PGconn *conn)
 			else
 			{
 				printfPQExpBuffer(buf, "CREATE RESOURCE GROUP %s WITH ("
-									   "concurrency=%s, cpu_set=%s);\n",
+									   "concurrency=%s, cpuset=%s);\n",
 								  fmtId(groupname), concurrency, cpuset);
 			}
 


### PR DESCRIPTION
`cpu_set` causes a syntax error