### PR TITLE
Fix query crash with minus memory_limit value in resgroup

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -57,6 +57,9 @@
 #define RESGROUP_MIN_CPU_WEIGHT	(1)
 #define RESGROUP_MAX_CPU_WEIGHT	(500)
 
+#define RESGROUP_MIN_MEMORY_LIMIT (0)
+#define RESGROUP_DEFAULT_MEMORY_LIMIT (-1)
+
 #define RESGROUP_MIN_MIN_COST		(0)
 static int str2Int(const char *str, const char *prop);
 static ResGroupLimitType getResgroupOptionType(const char* defname);
@@ -940,6 +943,11 @@ checkResgroupCapLimit(ResGroupLimitType type, int value)
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MEMORY_LIMIT:
+				if (value < RESGROUP_MIN_MEMORY_LIMIT && value != RESGROUP_DEFAULT_MEMORY_LIMIT)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("memory_limit range is [%d, INT_MAX] or equals to %d",
+								    RESGROUP_MIN_MEMORY_LIMIT, RESGROUP_DEFAULT_MEMORY_LIMIT)));
 				break;
 
 			case RESGROUP_LIMIT_TYPE_MIN_COST:

--- a/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
@@ -9,6 +9,14 @@ DROP RESOURCE GROUP rg_memory_test;
 CREATE OR REPLACE FUNCTION func_memory_test (text) RETURNS text as /*in func*/ $$ /*in func*/ DECLARE /*in func*/ ln text; /*in func*/ tmp text[]; /*in func*/ match bool := false; /*in func*/ BEGIN /*in func*/ FOR ln IN execute format('explain analyze %s', $1) LOOP /*in func*/ IF NOT match THEN      /*in func*/ tmp := regexp_match(ln, 'Memory used:  (.*)'); /*in func*/ IF tmp IS NOT null THEN /*in func*/ match := true; /*in func*/ END IF; /*in func*/ END IF; /*in func*/ END LOOP; /*in func*/ RETURN tmp[1]; /*in func*/ END; /*in func*/ $$ /*in func*/ LANGUAGE plpgsql;
 CREATE FUNCTION
 
+-- memory_limit range is [0, INT_MAX] or equals to -1
+CREATE RESOURCE GROUP rg_memory_range WITH(memory_limit=-100, cpu_max_percent=20, concurrency=2);
+ERROR:  memory_limit range is [0, INT_MAX] or equals to -1
+CREATE RESOURCE GROUP rg_memory_range WITH(memory_limit=-1, cpu_max_percent=20, concurrency=2);
+CREATE RESOURCE GROUP
+DROP RESOURCE GROUP rg_memory_range;
+DROP RESOURCE GROUP
+
 -- create a resource group with memory limit 100 Mb
 CREATE RESOURCE GROUP rg_memory_test WITH(memory_limit=100, cpu_max_percent=20, concurrency=2);
 CREATE RESOURCE GROUP

--- a/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
@@ -26,6 +26,11 @@ END; /*in func*/
 $$ /*in func*/
 LANGUAGE plpgsql;
 
+-- memory_limit range is [0, INT_MAX] or equals to -1
+CREATE RESOURCE GROUP rg_memory_range WITH(memory_limit=-100, cpu_max_percent=20, concurrency=2);
+CREATE RESOURCE GROUP rg_memory_range WITH(memory_limit=-1, cpu_max_percent=20, concurrency=2);
+DROP RESOURCE GROUP rg_memory_range;
+
 -- create a resource group with memory limit 100 Mb
 CREATE RESOURCE GROUP rg_memory_test WITH(memory_limit=100, cpu_max_percent=20, concurrency=2);
 CREATE ROLE role_memory_test RESOURCE GROUP rg_memory_test;


### PR DESCRIPTION
Resgroup doesn't check memory_limit value when create a resource group, but when execute a query, and set query's memory limit, it will assert memory_limit=-1 if memory_limit < 0.

Set memory_limit range to [0, INT_MAX] or set to default value -1.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
