### PR TITLE
Fix CTAS crash.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -307,7 +307,7 @@ get_partitioned_policy_from_path(PlannerInfo *root, Path *path)
  * returned in that case.
  *
  * TODO: This only handles a few cases. For example, INSERT INTO SELECT ...
- * is not handled, because the parser injects a subquery for ti which makes
+ * is not handled, because the parser injects a subquery for it which makes
  * it tricky.
  */
 CdbPathLocus

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2403,7 +2403,15 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 			}
 
 		}
-		subpath = cdbpath_create_broadcast_motion_path(root, subpath, policy->numsegments);
+
+		/*
+		 * planner may have add a top Motion eariler.
+		 * Create table t1(id int) distributed randomly;
+		 * Create table t2 as select random() from t1 distributed replicated;
+		 * Avoid Motion if there already was.
+		 */
+		if (!CdbPathLocus_IsReplicated(subpath->locus))
+			subpath = cdbpath_create_broadcast_motion_path(root, subpath, policy->numsegments);
 	}
 	else
 		elog(ERROR, "unrecognized policy type %u", policyType);

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -663,6 +663,8 @@ select count(distinct nextval) from gp_dist_random('t_rep4');
 (1 row)
 
 drop table rep_tbl, t_rep4;
+create table t_random(id int) distributed randomly;
+create table t_replicated as select random() from t_random distributed replicated;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -681,6 +681,8 @@ select count(distinct nextval) from gp_dist_random('t_rep4');
 (1 row)
 
 drop table rep_tbl, t_rep4;
+create table t_random(id int) distributed randomly;
+create table t_replicated as select random() from t_random distributed replicated;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -345,6 +345,9 @@ select count(*) from gp_dist_random('t_rep4');
 select count(distinct nextval) from gp_dist_random('t_rep4');
 drop table rep_tbl, t_rep4;
 
+create table t_random(id int) distributed randomly;
+create table t_replicated as select random() from t_random distributed replicated;
+
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146


### PR DESCRIPTION
reproduce
```sql
set optimizer=off;
create table t_random(id int) distributed randomly;
create table t_rep as select random() from t_random distributed replicated;
gpadmin=# select version();

        version

--------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------
------------------------
 PostgreSQL 12.12 (Greenplum Database 7.1.0+dev.109.g2a14c41782d build dev) on x86_64-pc-linux-gnu, comp
iled by gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0, 64-bit compiled on Feb  1 2024 17:30:04 (with asser
t checking) Bhuvnesh C.
(1 row)
```
```gdb
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140077450003712)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140077450003712) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140077450003712, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007f6655660476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007f66556467f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x000055d4810191ff in ExceptionalCondition (
    conditionName=0x55d48173a5b0 "!(!((((const Node*)(lefttree))->type) == T_Motion))",
    errorType=0x55d4817394c6 "FailedAssertion", fileName=0x55d481739516 "createplan.c",
    lineNumber=7228) at assert.c:44
#6  0x000055d480cd2328 in make_motion (root=0x0, lefttree=0x55d4886bb650, numSortCols=0,
    sortColIdx=0x0, sortOperators=0x0, collations=0x0, nullsFirst=0x0) at createplan.c:7228
#7  0x000055d48111a55b in make_broadcast_motion (lefttree=0x55d4886bb650) at cdbmutate.c:140
#8  0x000055d480cd43a1 in cdbpathtoplan_create_motion_plan (root=0x55d4887b6790, path=0x55d4886ba948,
    subplan=0x55d4886bb650) at createplan.c:8160
#9  0x000055d480cca457 in create_motion_plan (root=0x55d4887b6790, path=0x55d4886ba948)
    at createplan.c:3165
#10 0x000055d480cc5a0c in create_plan_recurse (root=0x55d4887b6790, best_path=0x55d4886ba948, flags=1)
    at createplan.c:564
#11 0x000055d480cc545a in create_plan (root=0x55d4887b6790, best_path=0x55d4886ba948,
    curSlice=0x55d4887b6738) at createplan.c:363
#12 0x000055d480cda8ab in standard_planner (parse=0x55d4887b5ee8, cursorOptions=256, boundParams=0x0)
    at planner.c:579
```


If we create a replicated table when selecting project volatile functions from a randomly distributed table, we will try to add a Motion on a Motion node that will cause a crash. Create table t1(id int) distributed randomly;
Create table t2 as select random() from t1 distributed replicated;

planner may have add a top Motion earlier if we know the query's final locus. Some codes handle volatile functions lead us to create_motion_path_for_insert(), and we should consider the case to avoid Assertion failure when create_plan().

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
