### PR TITLE
Include distributed xid in transaction commit WAL in all dtx cases

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6793,8 +6793,8 @@ XactLogCommitRecord(TimestampTz commit_time,
 	xl_xact_distrib xl_distrib;
 	xl_xact_deldbs xl_deldbs;
 	XLogRecPtr recptr;
-	bool isOnePhaseQE = (Gp_role == GP_ROLE_EXECUTE && MyTmGxactLocal->isOnePhaseCommit);
 	bool isDtxPrepared = isPreparedDtxTransaction();
+	DistributedTransactionId distrib_xid = getDistributedTransactionId();
 
 	uint8		info;
 
@@ -6883,10 +6883,11 @@ XactLogCommitRecord(TimestampTz commit_time,
 		xl_origin.origin_timestamp = replorigin_session_origin_timestamp;
 	}
 
-	if (isDtxPrepared || isOnePhaseQE)
+	/* include distributed xid if there's one */
+	if (distrib_xid != InvalidDistributedTransactionId)
 	{
 		xl_xinfo.xinfo |= XACT_XINFO_HAS_DISTRIB;
-		xl_distrib.distrib_xid = getDistributedTransactionId();
+		xl_distrib.distrib_xid = distrib_xid;
 	}
 
 	if (xl_xinfo.xinfo != 0)


### PR DESCRIPTION
For distributed transactions, we write the transaction commit WAL record in these three cases:
1. For 1PC, QE writes it at the end of the commit;
2. For 2PC, QD writes it after PREPARE phase is done on all segments;
3. For 2PC, QE writes it at the end of COMMIT phase.

For 1 and 2, we include distributed xid in the records. But not 3. Therefore, a segment replaying such a record won't initialize distributed log for that xid. Essentially, the commit will be equivalent to a local commit from the view of that segment.

This has not been an issue because when a QE needs to replay a 2PC (that is, only during recovery), it does not need to conduct dtx visibility check for the 2PC, since no query is allowed during recovery.

However, this has become an issue when we want to support hot standby or change data capture (CDC) where the WAL-receiving entity needs to know the gxid of the transaction (either for isolation or for atomicity). Therefore, we now include the distributed xid for any transaction commit that has a valid distributed xid, which fills the missing piece as mentioned above.

There should be no customer impact from this change.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/write-gxid-2pc

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
