### PR TITLE
fix create table as lateral join failed

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -184,6 +184,37 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	if (cdbpathlocus_equal(subpath->locus, locus))
 		return subpath;
 
+	/*
+	 * This can be only happened for create as or dml
+	 * The target locus is CdbLocusType_Replicated or CdbLocusType_Partitioned
+	 * However, the locus of subpath is CdbLocusType_OuterQuery
+	 * Adjust the locus of subpath according to target locus.
+	 */
+	if (CdbPathLocus_IsOuterQuery(subpath->locus)
+				&& !CdbPathLocus_IsOuterQuery(locus))
+	{
+		/*
+		 * If target locus is replicated
+		 * adjust locus of subpath to CdbLocusType_Replicated
+		 * and there is no need to add a motion between them.
+		 */
+		if (CdbPathLocus_IsReplicated(locus))
+		{
+			subpath->locus.locustype = CdbLocusType_Replicated;
+			subpath->locus.numsegments = locus.numsegments;
+		}
+		/*
+		 * If target locus is partitioned
+		 * Adjust locus of subpath to CdbLocusType_SingleQE
+		 * then add a redistribution motion above it.
+		 */
+		else if (CdbPathLocus_IsPartitioned(locus))
+		{
+			subpath->locus.locustype = CdbLocusType_SingleQE;
+			subpath->locus.numsegments = 1;
+		}
+	}
+
 	/* Moving subpath output to a single executor process (qDisp or qExec)? */
 	if (CdbPathLocus_IsOuterQuery(locus))
 	{
@@ -2402,6 +2433,28 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 				return subpath;
 			}
 
+			/* plan's data can be available on all segment, no motion needed */
+			if(CdbPathLocus_IsOuterQuery(subpath->locus))
+			{
+				/*
+				 * A query to reach here:
+				 * create table dest (tc1 int, tc2 int) distributed replicated;
+				 * insert into dest
+				 *   select
+				 *       a.tc1,ss.tc2
+				 *   from
+				 *       ttt1 a join lateral (
+				 *              select * from ttt2 b where b.tc2 =  a.tc2 limit 1)ss
+				 *   on true ;
+				 * The locus of subpath is outerquery, if locus of target table is replicated.
+				 * wo can modify locus of subpath to CdbLocusType_SegmentGeneral.
+				 * And there is no need to add a motion.
+				 */
+				subpath->locus.numsegments = Min(subpath->locus.numsegments, policy->numsegments) ;
+				subpath->locus.locustype = CdbLocusType_SegmentGeneral;
+				return subpath;
+			}
+
 		}
 		subpath = cdbpath_create_broadcast_motion_path(root, subpath, policy->numsegments);
 	}
@@ -2429,6 +2482,11 @@ create_motion_path_for_upddel(PlannerInfo *root, Index rti, GpPolicy *policy,
 		else
 		{
 			CdbPathLocus_MakeStrewn(&targetLocus, policy->numsegments);
+			if(CdbPathLocus_IsOuterQuery(subpath->locus))
+			{
+				subpath->locus.numsegments = 1;
+				subpath->locus.locustype = CdbLocusType_SingleQE;
+			}
 			subpath = cdbpath_create_explicit_motion_path(root,
 														  subpath,
 														  targetLocus);
@@ -2526,6 +2584,11 @@ create_split_update_path(PlannerInfo *root, Index rti, GpPolicy *policy, Path *s
 		targetLocus = cdbpathlocus_for_insert(root, policy, subpath->pathtarget);
 
 		subpath = (Path *) make_splitupdate_path(root, subpath, rti);
+		if(CdbPathLocus_IsOuterQuery(subpath->locus))
+		{
+			subpath->locus.numsegments = 1;
+			subpath->locus.locustype = CdbLocusType_SingleQE;
+		}
 		subpath = cdbpath_create_explicit_motion_path(root,
 													  subpath,
 													  targetLocus);

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -3063,18 +3063,20 @@ create table agg_group_1 as
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table agg_group_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+           array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
 create table agg_group_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3103,18 +3105,20 @@ create table agg_hash_1 as
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table agg_hash_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+          array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
 create table agg_hash_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3382,18 +3382,20 @@ select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+create table agg_group_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+           array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
 create table agg_group_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3426,18 +3428,20 @@ select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+create table agg_hash_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+          array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: LATERAL
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
 create table agg_hash_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -202,3 +202,387 @@ c1 int,c2 int,c3 int,c4 int,c5 int,c6 int,c7 int,c8 int,c9 int,c10 int,c11 int,c
 c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,c35,c36,c37,c38,c39,c40,c41,c42,c43,c44,c45,c46,c47,c48,c49,c50,c51,c52,c53,c54,c55,c56,c57,c58,c59,c60,c61,c62,c63,c64,c65,c66,c67,c68,c69,c70,c71,c72,c73,c74,c75,c76,c77,c78,c79,c80,c81,c82,c83,c84,c85,c86,c87,c88,c89,c90,c91,c92,c93,c94,c95,c96,c97,c98,c99,c100,c101,c102,c103,c104,c105,c106,c107,c108,c109,c110,c111,c112,c113,c114,c115,c116,c117,c118,c119,c120,c121,c122,c123,c124,c125,c126,c127,c128,c129,c130,c131,c132,c133,c134,c135,c136,c137,c138,c139,c140,c141,c142,c143,c144,c145,c146,c147,c148,c149,c150,c151,c152,c153,c154,c155,c156,c157,c158,c159,c160,c161,c162,c163,c164,c165,c166,c167,c168,c169,c170,c171,c172,c173,c174,c175,c176,c177,c178,c179,c180,c181,c182,c183,c184,c185,c186,c187,c188,c189,c190,c191,c192,c193,c194,c195,c196,c197,c198,c199,c200,c201,c202,c203,c204,c205,c206,c207,c208,c209,c210,c211,c212,c213,c214,c215,c216,c217,c218,c219,c220,c221,c222,c223,c224,c225,c226,c227,c228,c229,c230,c231,c232,c233,c234,c235,c236,c237,c238,c239,c240,c241,c242,c243,c244,c245,c246,c247,c248,c249,c250,c251,c252,c253,c254,c255,c256,c257,c258,c259,c260,c261,c262,c263,c264,c265,c266,c267,c268,c269,c270,c271,c272,c273,c274,c275,c276,c277,c278,c279,c280,c281,c282,c283,c284,c285,c286,c287,c288,c289,c290,c291,c292,c293,c294,c295,c296,c297,c298,c299,c300,c301,c302,c303,c304,c305,c306,c307,c308,c309,c310,c311,c312,c313,c314,c315,c316,c317,c318,c319,c320,c321,c322,c323,c324,c325,c326,c327,c328,c329,c330,c331,c332,c333,c334,c335,c336,c337,c338,c339,c340,c341,c342,c343,c344,c345,c346,c347,c348,c349,c350,c351,c352,c353,c354,c355,c356,c357,c358,c359,c360,c361,c362,c363,c364,c365,c366,c367,c368,c369,c370,c371,c372,c373,c374,c375,c376,c377,c378,c379,c380,c381,c382,c383,c384,c385,c386,c387,c388,c389,c390,c391,c392,c393,c394,c395,c396,c397,c398,c399,c400,c401,c402,c403,c404,c405,c406,c407,c408,c409,c410,c411,c412,c413,c414,c415,c416,c417,c418,c419,c420,c421,c422,c423,c424,c425,c426,c427,c428,c429,c430,c431,c432,c433,c434,c435,c436,c437,c438,c439,c440,c441,c442,c443,c444,c445,c446,c447,c448,c449,c450,c451,c452,c453,c454,c455,c456,c457,c458,c459,c460,c461,c462,c463,c464,c465,c466,c467,c468,c469,c470,c471,c472,c473,c474,c475,c476,c477,c478,c479,c480,c481,c482,c483,c484,c485,c486,c487,c488,c489,c490,c491,c492,c493,c494,c495,c496,c497,c498,c499,c500,c501,c502,c503,c504,c505,c506,c507,c508,c509,c510,c511,c512,c513,c514,c515,c516,c517,c518,c519,c520,c521,c522,c523,c524,c525,c526,c527,c528,c529,c530,c531,c532,c533,c534,c535,c536,c537,c538,c539,c540,c541,c542,c543,c544,c545,c546,c547,c548,c549,c550,c551,c552,c553,c554,c555,c556,c557,c558,c559,c560,c561,c562,c563,c564,c565,c566,c567,c568,c569,c570,c571,c572,c573,c574,c575,c576,c577,c578,c579,c580,c581,c582,c583,c584,c585,c586,c587,c588,c589,c590,c591,c592,c593,c594,c595,c596,c597,c598,c599,c600,c601,c602,c603,c604,c605,c606,c607,c608,c609,c610,c611,c612,c613,c614,c615,c616,c617,c618,c619,c620,c621,c622,c623,c624,c625,c626,c627,c628,c629,c630,c631,c632,c633,c634,c635,c636,c637,c638,c639,c640,c641,c642,c643,c644,c645,c646,c647,c648,c649,c650,c651,c652,c653,c654,c655,c656,c657,c658,c659,c660,c661,c662,c663,c664,c665,c666,c667,c668,c669,c670,c671,c672,c673,c674,c675,c676,c677,c678,c679,c680,c681,c682,c683,c684,c685,c686,c687,c688,c689,c690,c691,c692,c693,c694,c695,c696,c697,c698,c699,c700,c701,c702,c703,c704,c705,c706,c707,c708,c709,c710,c711,c712,c713,c714,c715,c716,c717,c718,c719,c720,c721,c722,c723,c724,c725,c726,c727,c728,c729,c730,c731,c732,c733,c734,c735,c736,c737,c738,c739,c740,c741,c742,c743,c744,c745,c746,c747,c748,c749,c750,c751,c752,c753,c754,c755,c756,c757,c758,c759,c760,c761,c762,c763,c764,c765,c766,c767,c768,c769,c770,c771,c772,c773,c774,c775,c776,c777,c778,c779,c780,c781,c782,c783,c784,c785,c786,c787,c788,c789,c790,c791,c792,c793,c794,c795,c796,c797,c798,c799,c800,c801,c802,c803,c804,c805,c806,c807,c808,c809,c810,c811,c812,c813,c814,c815,c816,c817,c818,c819,c820,c821,c822,c823,c824,c825,c826,c827,c828,c829,c830,c831,c832,c833,c834,c835,c836,c837,c838,c839,c840,c841,c842,c843,c844,c845,c846,c847,c848,c849,c850,c851,c852,c853,c854,c855,c856,c857,c858,c859,c860,c861,c862,c863,c864,c865,c866,c867,c868,c869,c870,c871,c872,c873,c874,c875,c876,c877,c878,c879,c880,c881,c882,c883,c884,c885,c886,c887,c888,c889,c890,c891,c892,c893,c894,c895,c896,c897,c898,c899,c900,c901,c902,c903,c904,c905,c906,c907,c908,c909,c910,c911,c912,c913,c914,c915,c916,c917,c918,c919,c920,c921,c922,c923,c924,c925,c926,c927,c928,c929,c930,c931,c932,c933,c934,c935,c936,c937,c938,c939,c940,c941,c942,c943,c944,c945,c946,c947,c948,c949,c950,c951,c952,c953,c954,c955,c956,c957,c958,c959,c960,c961,c962,c963,c964,c965,c966,c967,c968,c969,c970,c971,c972,c973,c974,c975,c976,c977,c978,c979,c980,c981,c982,c983,c984,c985,c986,c987,c988,c989,c990,c991,c992,c993,c994,c995,c996,c997,c998,c999,c1000,c1001,c1002,c1003,c1004,c1005,c1006,c1007,c1008,c1009,c1010,c1011,c1012,c1013,c1014,c1015,c1016,c1017,c1018,c1019,c1020,c1021,c1022,c1023,c1024,c1025,c1026,c1027,c1028,c1029,c1030,c1031,c1032,c1033,c1034,c1035,c1036,c1037,c1038,c1039,c1040,c1041,c1042,c1043,c1044,c1045,c1046,c1047,c1048,c1049,c1050,c1051,c1052,c1053,c1054,c1055,c1056,c1057,c1058,c1059,c1060,c1061,c1062,c1063,c1064,c1065,c1066,c1067,c1068,c1069,c1070,c1071,c1072,c1073,c1074,c1075,c1076,c1077,c1078,c1079,c1080,c1081,c1082,c1083,c1084,c1085,c1086,c1087,c1088,c1089,c1090,c1091,c1092,c1093,c1094,c1095,c1096,c1097,c1098,c1099,c1100,c1101,c1102,c1103,c1104,c1105,c1106,c1107,c1108,c1109,c1110,c1111,c1112,c1113,c1114,c1115,c1116,c1117,c1118,c1119,c1120,c1121,c1122,c1123,c1124,c1125,c1126,c1127,c1128,c1129,c1130,c1131,c1132,c1133,c1134,c1135,c1136,c1137,c1138,c1139,c1140,c1141,c1142,c1143,c1144,c1145,c1146,c1147,c1148,c1149,c1150,c1151,c1152,c1153,c1154,c1155,c1156,c1157,c1158,c1159,c1160,c1161,c1162,c1163,c1164,c1165,c1166,c1167,c1168,c1169,c1170,c1171,c1172,c1173,c1174,c1175,c1176,c1177,c1178,c1179,c1180,c1181,c1182,c1183,c1184,c1185,c1186,c1187,c1188,c1189,c1190,c1191,c1192,c1193,c1194,c1195,c1196,c1197,c1198,c1199,c1200,c1201,c1202,c1203,c1204,c1205,c1206,c1207,c1208,c1209,c1210,c1211,c1212,c1213,c1214,c1215,c1216,c1217,c1218,c1219,c1220,c1221,c1222,c1223,c1224,c1225,c1226,c1227,c1228,c1229,c1230,c1231,c1232,c1233,c1234,c1235,c1236,c1237,c1238,c1239,c1240,c1241,c1242,c1243,c1244,c1245,c1246,c1247,c1248,c1249,c1250,c1251,c1252,c1253,c1254,c1255,c1256,c1257,c1258,c1259,c1260,c1261,c1262,c1263,c1264,c1265,c1266,c1267,c1268,c1269,c1270,c1271,c1272,c1273,c1274,c1275,c1276,c1277,c1278,c1279,c1280,c1281,c1282,c1283,c1284,c1285,c1286,c1287,c1288,c1289,c1290,c1291,c1292,c1293,c1294,c1295,c1296,c1297,c1298,c1299,c1300,c1301,c1302,c1303,c1304,c1305,c1306,c1307,c1308,c1309,c1310,c1311,c1312,c1313,c1314,c1315,c1316,c1317,c1318,c1319,c1320,c1321,c1322,c1323,c1324,c1325,c1326,c1327,c1328,c1329,c1330,c1331,c1332,c1333,c1334,c1335,c1336,c1337,c1338,c1339,c1340,c1341,c1342,c1343,c1344,c1345,c1346,c1347,c1348,c1349,c1350,c1351,c1352,c1353,c1354,c1355,c1356,c1357,c1358,c1359,c1360,c1361,c1362,c1363,c1364,c1365,c1366,c1367,c1368,c1369,c1370,c1371,c1372,c1373,c1374,c1375,c1376,c1377,c1378,c1379,c1380,c1381,c1382,c1383,c1384,c1385,c1386,c1387,c1388,c1389,c1390,c1391,c1392,c1393,c1394,c1395,c1396,c1397,c1398,c1399,c1400,c1401,c1402,c1403,c1404,c1405,c1406,c1407,c1408,c1409,c1410,c1411,c1412,c1413,c1414,c1415,c1416,c1417,c1418,c1419,c1420,c1421,c1422,c1423,c1424,c1425,c1426,c1427,c1428,c1429,c1430,c1431,c1432,c1433,c1434,c1435,c1436,c1437,c1438,c1439,c1440,c1441,c1442,c1443,c1444,c1445,c1446,c1447,c1448,c1449,c1450,c1451,c1452,c1453,c1454,c1455,c1456,c1457,c1458,c1459,c1460,c1461,c1462,c1463,c1464,c1465,c1466,c1467,c1468,c1469,c1470,c1471,c1472,c1473,c1474,c1475,c1476,c1477,c1478,c1479,c1480,c1481,c1482,c1483,c1484,c1485,c1486,c1487,c1488,c1489,c1490,c1491,c1492,c1493,c1494,c1495,c1496,c1497,c1498,c1499,c1500,c1501,c1502,c1503,c1504,c1505,c1506,c1507,c1508,c1509,c1510,c1511,c1512,c1513,c1514,c1515,c1516,c1517,c1518,c1519,c1520,c1521,c1522,c1523,c1524,c1525,c1526,c1527,c1528,c1529,c1530,c1531,c1532,c1533,c1534,c1535,c1536,c1537,c1538,c1539,c1540,c1541,c1542,c1543,c1544,c1545,c1546,c1547,c1548,c1549,c1550,c1551,c1552,c1553,c1554,c1555,c1556,c1557,c1558,c1559,c1560,c1561,c1562,c1563,c1564,c1565,c1566,c1567,c1568,c1569,c1570,c1571,c1572,c1573,c1574,c1575,c1576,c1577,c1578,c1579,c1580,c1581,c1582,c1583,c1584,c1585,c1586,c1587,c1588,c1589,c1590,c1591,c1592,c1593,c1594,c1595,c1596,c1597,c1598,c1599,c1600,c1601
 );
 ERROR:  tables can have at most 1600 columns
+-- https://github.com/greenplum-db/gpdb/issues/16941
+-- test create table as select lateral join
+create table t1_16941(tc1 int,tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1_16941 select i,i from generate_series(1,5) i;
+create table t2_16941(tc1 int,tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t2_16941 select i,i from generate_series(1,5) i;
+-- do not specify distributed key explicitly.
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+   Hash Key: a.tc1
+   ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+               ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+               ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                     ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                           Filter: (b.tc2 = a.tc2)
+                           ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                       ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table xt;
+ -- specify distributed policy as randomly
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed randomly;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+               ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+               ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                     ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                           Filter: (b.tc2 = a.tc2)
+                           ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                       ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed randomly;
+drop table xt;
+-- specify distributed policy as hash
+explain create table xt(a,b) as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed by(a);
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+   Hash Key: a.tc1
+   ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+               ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+               ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                     ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                           Filter: (b.tc2 = a.tc2)
+                           ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                       ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+create table xt(a,b) as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed by(a);
+drop table xt;
+-- specify distributed policy as replicated
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed replicated;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+         ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+   ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+         ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+               ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                     Filter: (b.tc2 = a.tc2)
+                     ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                 ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(11 rows)
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed replicated;
+drop table xt;
+-- dest table is distributed by hash
+drop table dest;
+ERROR:  table "dest" does not exist
+create table dest (tc1 int,tc2 int) distributed by(tc2);
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Insert on dest  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+         Hash Key: b.tc2
+         ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+                     ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                           ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                 Filter: (b.tc2 = a.tc2)
+                                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                             ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(14 rows)
+
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+-- update with select lateral join
+explain update dest set tc2 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on dest  (cost=10000006400.33..10000009179.10 rows=14350 width=56)
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000006400.33..10000009179.10 rows=14350 width=56)
+         ->  Split  (cost=10000006400.33..10000008605.10 rows=43050 width=56)
+               ->  Hash Join  (cost=10000006400.33..10000008605.10 rows=21525 width=56)
+                     Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=18)
+                           ->  Seq Scan on dest  (cost=0.00..321.00 rows=28700 width=18)
+                     ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+                           ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                                 Group Key: a.tc1, ss.tc2
+                                 ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                             ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                                       ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                             ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                                   ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                                         ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                               Filter: (b.tc2 = a.tc2)
+                                                               ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                                           ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(22 rows)
+
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on dest  (cost=10000006400.33..10000008892.10 rows=7175 width=56)
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000006400.33..10000008892.10 rows=7175 width=56)
+         ->  Hash Join  (cost=10000006400.33..10000008605.10 rows=21525 width=56)
+               Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=18)
+                     ->  Seq Scan on dest  (cost=0.00..321.00 rows=28700 width=18)
+               ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+                     ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                           Group Key: a.tc1, ss.tc2
+                           ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                       ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                                 ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                       ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                             ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                         Filter: (b.tc2 = a.tc2)
+                                                         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                                     ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(21 rows)
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete on dest  (cost=10000006400.33..10000008892.10 rows=7175 width=48)
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000006400.33..10000008892.10 rows=7175 width=48)
+         ->  Hash Join  (cost=10000006400.33..10000008605.10 rows=21525 width=48)
+               Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=18)
+                     ->  Seq Scan on dest  (cost=0.00..321.00 rows=28700 width=18)
+               ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+                     ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                           Group Key: a.tc1, ss.tc2
+                           ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                       ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                                 ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                       ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                             ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                         Filter: (b.tc2 = a.tc2)
+                                                         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                                     ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(21 rows)
+
+drop table dest;
+-- dest table is distributed randomly
+create table dest (tc1 int,tc2 int) distributed randomly;
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Insert on dest  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000000000.00..10000007099.50 rows=28700 width=8)
+         ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+                     ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                           ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                 Filter: (b.tc2 = a.tc2)
+                                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                             ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(13 rows)
+
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+-- update with select lateral join
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on dest  (cost=10000006400.33..10000008892.10 rows=7175 width=56)
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000006400.33..10000008892.10 rows=7175 width=56)
+         ->  Hash Join  (cost=10000006400.33..10000008605.10 rows=21525 width=56)
+               Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=18)
+                     ->  Seq Scan on dest  (cost=0.00..321.00 rows=28700 width=18)
+               ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+                     ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                           Group Key: a.tc1, ss.tc2
+                           ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                       ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                                 ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                       ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                             ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                         Filter: (b.tc2 = a.tc2)
+                                                         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                                     ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(21 rows)
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete on dest  (cost=10000006400.33..10000008892.10 rows=7175 width=48)
+   ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=10000006400.33..10000008892.10 rows=7175 width=48)
+         ->  Hash Join  (cost=10000006400.33..10000008605.10 rows=21525 width=48)
+               Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=18)
+                     ->  Seq Scan on dest  (cost=0.00..321.00 rows=28700 width=18)
+               ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+                     ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                           Group Key: a.tc1, ss.tc2
+                           ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                       ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                                 ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                       ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                             ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                         Filter: (b.tc2 = a.tc2)
+                                                         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                                     ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(21 rows)
+
+drop table dest;
+-- dest table is distributed replicated
+create table dest (tc1 int,tc2 int) distributed replicated;
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Insert on dest  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=8)
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+               ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..0.05 rows=1 width=4)
+               ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                     ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                           Filter: (b.tc2 = a.tc2)
+                           ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                       ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=4)
+ Optimizer: Postgres-based planner
+(12 rows)
+
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+-- update with select lateral join
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on dest  (cost=10000006400.33..10000009819.10 rows=21525 width=56)
+   ->  Hash Join  (cost=10000006400.33..10000009819.10 rows=21525 width=56)
+         Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..2683.00 rows=86100 width=18)
+               ->  Seq Scan on dest  (cost=0.00..961.00 rows=86100 width=18)
+         ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+               ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                     Group Key: a.tc1, ss.tc2
+                     ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                 ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                           ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                 ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                       ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                             ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                   Filter: (b.tc2 = a.tc2)
+                                                   ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                               ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(20 rows)
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete on dest  (cost=10000006400.33..10000009819.10 rows=21525 width=48)
+   ->  Hash Join  (cost=10000006400.33..10000009819.10 rows=21525 width=48)
+         Hash Cond: ((dest.tc1 = a.tc1) AND (dest.tc2 = ss.tc2))
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..2683.00 rows=86100 width=18)
+               ->  Seq Scan on dest  (cost=0.00..961.00 rows=86100 width=18)
+         ->  Hash  (cost=10000006385.33..10000006385.33 rows=1000 width=46)
+               ->  HashAggregate  (cost=10000006382.00..10000006385.33 rows=1000 width=46)
+                     Group Key: a.tc1, ss.tc2
+                     ->  Nested Loop  (cost=10000000000.00..10000005951.50 rows=86100 width=46)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=14)
+                                 ->  Seq Scan on t1_16941 a  (cost=0.00..321.00 rows=28700 width=14)
+                           ->  Materialize  (cost=0.00..0.05 rows=1 width=36)
+                                 ->  Subquery Scan on ss  (cost=0.00..0.04 rows=1 width=36)
+                                       ->  Limit  (cost=0.00..0.03 rows=1 width=8)
+                                             ->  Result  (cost=0.00..2760.50 rows=86100 width=8)
+                                                   Filter: (b.tc2 = a.tc2)
+                                                   ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+                                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                                                               ->  Seq Scan on t2_16941 b  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(20 rows)
+
+drop table dest;
+drop table t1_16941;
+drop table t2_16941;

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1306,18 +1306,16 @@ select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
 
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+create table agg_group_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+           array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
 
 set jit_above_cost to default;
 
@@ -1348,18 +1346,16 @@ select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
 
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+create table agg_hash_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+          array_agg(g::numeric) as c2,
+           count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
 
 set jit_above_cost to default;
 

--- a/src/test/regress/sql/gp_create_table.sql
+++ b/src/test/regress/sql/gp_create_table.sql
@@ -129,3 +129,109 @@ c1 int,c2 int,c3 int,c4 int,c5 int,c6 int,c7 int,c8 int,c9 int,c10 int,c11 int,c
 (
 c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16,c17,c18,c19,c20,c21,c22,c23,c24,c25,c26,c27,c28,c29,c30,c31,c32,c33,c34,c35,c36,c37,c38,c39,c40,c41,c42,c43,c44,c45,c46,c47,c48,c49,c50,c51,c52,c53,c54,c55,c56,c57,c58,c59,c60,c61,c62,c63,c64,c65,c66,c67,c68,c69,c70,c71,c72,c73,c74,c75,c76,c77,c78,c79,c80,c81,c82,c83,c84,c85,c86,c87,c88,c89,c90,c91,c92,c93,c94,c95,c96,c97,c98,c99,c100,c101,c102,c103,c104,c105,c106,c107,c108,c109,c110,c111,c112,c113,c114,c115,c116,c117,c118,c119,c120,c121,c122,c123,c124,c125,c126,c127,c128,c129,c130,c131,c132,c133,c134,c135,c136,c137,c138,c139,c140,c141,c142,c143,c144,c145,c146,c147,c148,c149,c150,c151,c152,c153,c154,c155,c156,c157,c158,c159,c160,c161,c162,c163,c164,c165,c166,c167,c168,c169,c170,c171,c172,c173,c174,c175,c176,c177,c178,c179,c180,c181,c182,c183,c184,c185,c186,c187,c188,c189,c190,c191,c192,c193,c194,c195,c196,c197,c198,c199,c200,c201,c202,c203,c204,c205,c206,c207,c208,c209,c210,c211,c212,c213,c214,c215,c216,c217,c218,c219,c220,c221,c222,c223,c224,c225,c226,c227,c228,c229,c230,c231,c232,c233,c234,c235,c236,c237,c238,c239,c240,c241,c242,c243,c244,c245,c246,c247,c248,c249,c250,c251,c252,c253,c254,c255,c256,c257,c258,c259,c260,c261,c262,c263,c264,c265,c266,c267,c268,c269,c270,c271,c272,c273,c274,c275,c276,c277,c278,c279,c280,c281,c282,c283,c284,c285,c286,c287,c288,c289,c290,c291,c292,c293,c294,c295,c296,c297,c298,c299,c300,c301,c302,c303,c304,c305,c306,c307,c308,c309,c310,c311,c312,c313,c314,c315,c316,c317,c318,c319,c320,c321,c322,c323,c324,c325,c326,c327,c328,c329,c330,c331,c332,c333,c334,c335,c336,c337,c338,c339,c340,c341,c342,c343,c344,c345,c346,c347,c348,c349,c350,c351,c352,c353,c354,c355,c356,c357,c358,c359,c360,c361,c362,c363,c364,c365,c366,c367,c368,c369,c370,c371,c372,c373,c374,c375,c376,c377,c378,c379,c380,c381,c382,c383,c384,c385,c386,c387,c388,c389,c390,c391,c392,c393,c394,c395,c396,c397,c398,c399,c400,c401,c402,c403,c404,c405,c406,c407,c408,c409,c410,c411,c412,c413,c414,c415,c416,c417,c418,c419,c420,c421,c422,c423,c424,c425,c426,c427,c428,c429,c430,c431,c432,c433,c434,c435,c436,c437,c438,c439,c440,c441,c442,c443,c444,c445,c446,c447,c448,c449,c450,c451,c452,c453,c454,c455,c456,c457,c458,c459,c460,c461,c462,c463,c464,c465,c466,c467,c468,c469,c470,c471,c472,c473,c474,c475,c476,c477,c478,c479,c480,c481,c482,c483,c484,c485,c486,c487,c488,c489,c490,c491,c492,c493,c494,c495,c496,c497,c498,c499,c500,c501,c502,c503,c504,c505,c506,c507,c508,c509,c510,c511,c512,c513,c514,c515,c516,c517,c518,c519,c520,c521,c522,c523,c524,c525,c526,c527,c528,c529,c530,c531,c532,c533,c534,c535,c536,c537,c538,c539,c540,c541,c542,c543,c544,c545,c546,c547,c548,c549,c550,c551,c552,c553,c554,c555,c556,c557,c558,c559,c560,c561,c562,c563,c564,c565,c566,c567,c568,c569,c570,c571,c572,c573,c574,c575,c576,c577,c578,c579,c580,c581,c582,c583,c584,c585,c586,c587,c588,c589,c590,c591,c592,c593,c594,c595,c596,c597,c598,c599,c600,c601,c602,c603,c604,c605,c606,c607,c608,c609,c610,c611,c612,c613,c614,c615,c616,c617,c618,c619,c620,c621,c622,c623,c624,c625,c626,c627,c628,c629,c630,c631,c632,c633,c634,c635,c636,c637,c638,c639,c640,c641,c642,c643,c644,c645,c646,c647,c648,c649,c650,c651,c652,c653,c654,c655,c656,c657,c658,c659,c660,c661,c662,c663,c664,c665,c666,c667,c668,c669,c670,c671,c672,c673,c674,c675,c676,c677,c678,c679,c680,c681,c682,c683,c684,c685,c686,c687,c688,c689,c690,c691,c692,c693,c694,c695,c696,c697,c698,c699,c700,c701,c702,c703,c704,c705,c706,c707,c708,c709,c710,c711,c712,c713,c714,c715,c716,c717,c718,c719,c720,c721,c722,c723,c724,c725,c726,c727,c728,c729,c730,c731,c732,c733,c734,c735,c736,c737,c738,c739,c740,c741,c742,c743,c744,c745,c746,c747,c748,c749,c750,c751,c752,c753,c754,c755,c756,c757,c758,c759,c760,c761,c762,c763,c764,c765,c766,c767,c768,c769,c770,c771,c772,c773,c774,c775,c776,c777,c778,c779,c780,c781,c782,c783,c784,c785,c786,c787,c788,c789,c790,c791,c792,c793,c794,c795,c796,c797,c798,c799,c800,c801,c802,c803,c804,c805,c806,c807,c808,c809,c810,c811,c812,c813,c814,c815,c816,c817,c818,c819,c820,c821,c822,c823,c824,c825,c826,c827,c828,c829,c830,c831,c832,c833,c834,c835,c836,c837,c838,c839,c840,c841,c842,c843,c844,c845,c846,c847,c848,c849,c850,c851,c852,c853,c854,c855,c856,c857,c858,c859,c860,c861,c862,c863,c864,c865,c866,c867,c868,c869,c870,c871,c872,c873,c874,c875,c876,c877,c878,c879,c880,c881,c882,c883,c884,c885,c886,c887,c888,c889,c890,c891,c892,c893,c894,c895,c896,c897,c898,c899,c900,c901,c902,c903,c904,c905,c906,c907,c908,c909,c910,c911,c912,c913,c914,c915,c916,c917,c918,c919,c920,c921,c922,c923,c924,c925,c926,c927,c928,c929,c930,c931,c932,c933,c934,c935,c936,c937,c938,c939,c940,c941,c942,c943,c944,c945,c946,c947,c948,c949,c950,c951,c952,c953,c954,c955,c956,c957,c958,c959,c960,c961,c962,c963,c964,c965,c966,c967,c968,c969,c970,c971,c972,c973,c974,c975,c976,c977,c978,c979,c980,c981,c982,c983,c984,c985,c986,c987,c988,c989,c990,c991,c992,c993,c994,c995,c996,c997,c998,c999,c1000,c1001,c1002,c1003,c1004,c1005,c1006,c1007,c1008,c1009,c1010,c1011,c1012,c1013,c1014,c1015,c1016,c1017,c1018,c1019,c1020,c1021,c1022,c1023,c1024,c1025,c1026,c1027,c1028,c1029,c1030,c1031,c1032,c1033,c1034,c1035,c1036,c1037,c1038,c1039,c1040,c1041,c1042,c1043,c1044,c1045,c1046,c1047,c1048,c1049,c1050,c1051,c1052,c1053,c1054,c1055,c1056,c1057,c1058,c1059,c1060,c1061,c1062,c1063,c1064,c1065,c1066,c1067,c1068,c1069,c1070,c1071,c1072,c1073,c1074,c1075,c1076,c1077,c1078,c1079,c1080,c1081,c1082,c1083,c1084,c1085,c1086,c1087,c1088,c1089,c1090,c1091,c1092,c1093,c1094,c1095,c1096,c1097,c1098,c1099,c1100,c1101,c1102,c1103,c1104,c1105,c1106,c1107,c1108,c1109,c1110,c1111,c1112,c1113,c1114,c1115,c1116,c1117,c1118,c1119,c1120,c1121,c1122,c1123,c1124,c1125,c1126,c1127,c1128,c1129,c1130,c1131,c1132,c1133,c1134,c1135,c1136,c1137,c1138,c1139,c1140,c1141,c1142,c1143,c1144,c1145,c1146,c1147,c1148,c1149,c1150,c1151,c1152,c1153,c1154,c1155,c1156,c1157,c1158,c1159,c1160,c1161,c1162,c1163,c1164,c1165,c1166,c1167,c1168,c1169,c1170,c1171,c1172,c1173,c1174,c1175,c1176,c1177,c1178,c1179,c1180,c1181,c1182,c1183,c1184,c1185,c1186,c1187,c1188,c1189,c1190,c1191,c1192,c1193,c1194,c1195,c1196,c1197,c1198,c1199,c1200,c1201,c1202,c1203,c1204,c1205,c1206,c1207,c1208,c1209,c1210,c1211,c1212,c1213,c1214,c1215,c1216,c1217,c1218,c1219,c1220,c1221,c1222,c1223,c1224,c1225,c1226,c1227,c1228,c1229,c1230,c1231,c1232,c1233,c1234,c1235,c1236,c1237,c1238,c1239,c1240,c1241,c1242,c1243,c1244,c1245,c1246,c1247,c1248,c1249,c1250,c1251,c1252,c1253,c1254,c1255,c1256,c1257,c1258,c1259,c1260,c1261,c1262,c1263,c1264,c1265,c1266,c1267,c1268,c1269,c1270,c1271,c1272,c1273,c1274,c1275,c1276,c1277,c1278,c1279,c1280,c1281,c1282,c1283,c1284,c1285,c1286,c1287,c1288,c1289,c1290,c1291,c1292,c1293,c1294,c1295,c1296,c1297,c1298,c1299,c1300,c1301,c1302,c1303,c1304,c1305,c1306,c1307,c1308,c1309,c1310,c1311,c1312,c1313,c1314,c1315,c1316,c1317,c1318,c1319,c1320,c1321,c1322,c1323,c1324,c1325,c1326,c1327,c1328,c1329,c1330,c1331,c1332,c1333,c1334,c1335,c1336,c1337,c1338,c1339,c1340,c1341,c1342,c1343,c1344,c1345,c1346,c1347,c1348,c1349,c1350,c1351,c1352,c1353,c1354,c1355,c1356,c1357,c1358,c1359,c1360,c1361,c1362,c1363,c1364,c1365,c1366,c1367,c1368,c1369,c1370,c1371,c1372,c1373,c1374,c1375,c1376,c1377,c1378,c1379,c1380,c1381,c1382,c1383,c1384,c1385,c1386,c1387,c1388,c1389,c1390,c1391,c1392,c1393,c1394,c1395,c1396,c1397,c1398,c1399,c1400,c1401,c1402,c1403,c1404,c1405,c1406,c1407,c1408,c1409,c1410,c1411,c1412,c1413,c1414,c1415,c1416,c1417,c1418,c1419,c1420,c1421,c1422,c1423,c1424,c1425,c1426,c1427,c1428,c1429,c1430,c1431,c1432,c1433,c1434,c1435,c1436,c1437,c1438,c1439,c1440,c1441,c1442,c1443,c1444,c1445,c1446,c1447,c1448,c1449,c1450,c1451,c1452,c1453,c1454,c1455,c1456,c1457,c1458,c1459,c1460,c1461,c1462,c1463,c1464,c1465,c1466,c1467,c1468,c1469,c1470,c1471,c1472,c1473,c1474,c1475,c1476,c1477,c1478,c1479,c1480,c1481,c1482,c1483,c1484,c1485,c1486,c1487,c1488,c1489,c1490,c1491,c1492,c1493,c1494,c1495,c1496,c1497,c1498,c1499,c1500,c1501,c1502,c1503,c1504,c1505,c1506,c1507,c1508,c1509,c1510,c1511,c1512,c1513,c1514,c1515,c1516,c1517,c1518,c1519,c1520,c1521,c1522,c1523,c1524,c1525,c1526,c1527,c1528,c1529,c1530,c1531,c1532,c1533,c1534,c1535,c1536,c1537,c1538,c1539,c1540,c1541,c1542,c1543,c1544,c1545,c1546,c1547,c1548,c1549,c1550,c1551,c1552,c1553,c1554,c1555,c1556,c1557,c1558,c1559,c1560,c1561,c1562,c1563,c1564,c1565,c1566,c1567,c1568,c1569,c1570,c1571,c1572,c1573,c1574,c1575,c1576,c1577,c1578,c1579,c1580,c1581,c1582,c1583,c1584,c1585,c1586,c1587,c1588,c1589,c1590,c1591,c1592,c1593,c1594,c1595,c1596,c1597,c1598,c1599,c1600,c1601
 );
+
+-- https://github.com/greenplum-db/gpdb/issues/16941
+-- test create table as select lateral join
+create table t1_16941(tc1 int,tc2 int);
+insert into t1_16941 select i,i from generate_series(1,5) i;
+create table t2_16941(tc1 int,tc2 int);
+insert into t2_16941 select i,i from generate_series(1,5) i;
+
+-- do not specify distributed key explicitly.
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+drop table xt;
+
+ -- specify distributed policy as randomly
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed randomly;
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed randomly;
+drop table xt;
+
+-- specify distributed policy as hash
+explain create table xt(a,b) as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed by(a);
+
+create table xt(a,b) as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed by(a);
+drop table xt;
+
+-- specify distributed policy as replicated
+explain create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed replicated;
+
+create table xt as
+select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true distributed replicated;
+drop table xt;
+
+-- dest table is distributed by hash
+drop table dest;
+create table dest (tc1 int,tc2 int) distributed by(tc2);
+
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+
+-- update with select lateral join
+explain update dest set tc2 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+drop table dest;
+
+-- dest table is distributed randomly
+create table dest (tc1 int,tc2 int) distributed randomly;
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+
+-- update with select lateral join
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+drop table dest;
+
+-- dest table is distributed replicated
+create table dest (tc1 int,tc2 int) distributed replicated;
+-- insert into select lateral join
+explain insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+insert into dest select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true;
+
+-- update with select lateral join
+explain update dest set tc1 = 2 where (tc1,tc2)in (select a.tc1,ss.tc2 from t1_16941 a  join  lateral (
+    select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+
+-- delete with select lateral join
+explain delete from dest where (tc1,tc2) in (select a.tc1,ss.tc2 from t1_16941 a
+    join lateral (select * from t2_16941 b where b.tc2 =  a.tc2 limit 1)ss on true) ;
+
+drop table dest;
+drop table t1_16941;
+drop table t2_16941;


### PR DESCRIPTION
The following sql failed in main branch after we bring in CdbLocusType_OuterQuery.
And it is ok in 6X_stable.
```
create table ttt1(tc1 int,tc2 int);
create table ttt2(tc1 int,tc2 int);
explain create table xt as
select a.tc1,ss.tc2 from ttt1 a join lateral (
select * from ttt2 b where b.tc2 = a.tc2 limit 1) ss on true;
-- In 6X_stable
explain(costs off) create table xt as
    select a.tc1,ss.tc2 from ttt1 a join lateral (
    select * from ttt2 b where b.tc2 = a.tc2 limit 1) ss on true;

                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Redistribute Motion 1:3  (slice3; segments: 1)
   Hash Key: a.tc1
   ->  Nested Loop
         ->  Gather Motion 3:1  (slice1; segments: 3)
               ->  Seq Scan on ttt1 a
         ->  Materialize
               ->  Subquery Scan on ss
                     ->  Limit
                           ->  Result
                                 Filter: (b.tc2 = a.tc2)
                                 ->  Materialize
                                       ->  Gather Motion 3:1  (slice2; segments: 3)
                                             ->  Seq Scan on ttt2 b
 Optimizer: Postgres query optimizer
(14 rows)
```
However, In main branch it hits the error: unexpected Motion requested from CdbLocusType_OuterQuery locus.
When we create motion for a subpath,  If target locus is not CdbLocusType_OuterQuery, however locus of subpath
is CdbLocusType_OuterQuery, we should adjust locus of subpath to CdbLocusType_SingleQE or CdbLocusType_Replicated.

fix issue:https://github.com/greenplum-db/gpdb/issues/16941