### PR TITLE
Backport upstream CVE-2023-5869 for integer overflows

### DIFF
--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -19,6 +19,7 @@
 
 #include "access/htup_details.h"
 #include "catalog/pg_type.h"
+#include "common/int.h"
 #include "funcapi.h"
 #include "access/tupmacs.h"
 #include "libpq/pqformat.h"
@@ -2312,22 +2313,38 @@ array_set_element(Datum arraydatum,
 	addedbefore = addedafter = 0;
 
 	/*
-	 * Check subscripts
+	 * Check subscripts.  We assume the existing subscripts passed
+	 * ArrayCheckBounds, so that dim[i] + lb[i] can be computed without
+	 * overflow.  But we must beware of other overflows in our calculations of
+	 * new dim[] values.
 	 */
 	if (ndim == 1)
 	{
 		if (indx[0] < lb[0])
 		{
-			addedbefore = lb[0] - indx[0];
-			dim[0] += addedbefore;
+			/* addedbefore = lb[0] - indx[0]; */
+			/* dim[0] += addedbefore; */
+			if (pg_sub_s32_overflow(lb[0], indx[0], &addedbefore) ||
+				pg_add_s32_overflow(dim[0], addedbefore, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
 			lb[0] = indx[0];
 			if (addedbefore > 1)
 				newhasnulls = true; /* will insert nulls */
 		}
 		if (indx[0] >= (dim[0] + lb[0]))
 		{
-			addedafter = indx[0] - (dim[0] + lb[0]) + 1;
-			dim[0] += addedafter;
+			/* addedafter = indx[0] - (dim[0] + lb[0]) + 1; */
+			/* dim[0] += addedafter; */
+			if (pg_sub_s32_overflow(indx[0], dim[0] + lb[0], &addedafter) ||
+				pg_add_s32_overflow(addedafter, 1, &addedafter) ||
+				pg_add_s32_overflow(dim[0], addedafter, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
 			if (addedafter > 1)
 				newhasnulls = true; /* will insert nulls */
 		}
@@ -2571,14 +2588,23 @@ array_set_element_expanded(Datum arraydatum,
 	addedbefore = addedafter = 0;
 
 	/*
-	 * Check subscripts (this logic matches original array_set_element)
+	 * Check subscripts (this logic must match array_set_element).  We assume
+	 * the existing subscripts passed ArrayCheckBounds, so that dim[i] + lb[i]
+	 * can be computed without overflow.  But we must beware of other
+	 * overflows in our calculations of new dim[] values.
 	 */
 	if (ndim == 1)
 	{
 		if (indx[0] < lb[0])
 		{
-			addedbefore = lb[0] - indx[0];
-			dim[0] += addedbefore;
+			/* addedbefore = lb[0] - indx[0]; */
+			/* dim[0] += addedbefore; */
+			if (pg_sub_s32_overflow(lb[0], indx[0], &addedbefore) ||
+				pg_add_s32_overflow(dim[0], addedbefore, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
 			lb[0] = indx[0];
 			dimschanged = true;
 			if (addedbefore > 1)
@@ -2586,8 +2612,15 @@ array_set_element_expanded(Datum arraydatum,
 		}
 		if (indx[0] >= (dim[0] + lb[0]))
 		{
-			addedafter = indx[0] - (dim[0] + lb[0]) + 1;
-			dim[0] += addedafter;
+			/* addedafter = indx[0] - (dim[0] + lb[0]) + 1; */
+			/* dim[0] += addedafter; */
+			if (pg_sub_s32_overflow(indx[0], dim[0] + lb[0], &addedafter) ||
+				pg_add_s32_overflow(addedafter, 1, &addedafter) ||
+				pg_add_s32_overflow(dim[0], addedafter, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
 			dimschanged = true;
 			if (addedafter > 1)
 				newhasnulls = true; /* will insert nulls */
@@ -2869,7 +2902,10 @@ array_set_slice(Datum arraydatum,
 	addedbefore = addedafter = 0;
 
 	/*
-	 * Check subscripts
+	 * Check subscripts.  We assume the existing subscripts passed
+	 * ArrayCheckBounds, so that dim[i] + lb[i] can be computed without
+	 * overflow.  But we must beware of other overflows in our calculations of
+	 * new dim[] values.
 	 */
 	if (ndim == 1)
 	{
@@ -2884,18 +2920,31 @@ array_set_slice(Datum arraydatum,
 					 errmsg("upper bound cannot be less than lower bound")));
 		if (lowerIndx[0] < lb[0])
 		{
-			if (upperIndx[0] < lb[0] - 1)
-				newhasnulls = true; /* will insert nulls */
-			addedbefore = lb[0] - lowerIndx[0];
-			dim[0] += addedbefore;
+			/* addedbefore = lb[0] - lowerIndx[0]; */
+			/* dim[0] += addedbefore; */
+			if (pg_sub_s32_overflow(lb[0], lowerIndx[0], &addedbefore) ||
+				pg_add_s32_overflow(dim[0], addedbefore, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
 			lb[0] = lowerIndx[0];
+			if (addedbefore > 1)
+				newhasnulls = true; /* will insert nulls */
 		}
 		if (upperIndx[0] >= (dim[0] + lb[0]))
 		{
-			if (lowerIndx[0] > (dim[0] + lb[0]))
+			/* addedafter = upperIndx[0] - (dim[0] + lb[0]) + 1; */
+			/* dim[0] += addedafter; */
+			if (pg_sub_s32_overflow(upperIndx[0], dim[0] + lb[0], &addedafter) ||
+				pg_add_s32_overflow(addedafter, 1, &addedafter) ||
+				pg_add_s32_overflow(dim[0], addedafter, &dim[0]))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("array size exceeds the maximum allowed (%d)",
+								(int) MaxArraySize)));
+			if (addedafter > 1)
 				newhasnulls = true; /* will insert nulls */
-			addedafter = upperIndx[0] - (dim[0] + lb[0]) + 1;
-			dim[0] += addedafter;
 		}
 	}
 	else

--- a/src/backend/utils/adt/arrayutils.c
+++ b/src/backend/utils/adt/arrayutils.c
@@ -64,10 +64,6 @@ ArrayGetOffset0(int n, const int *tup, const int *scale)
  * This must do overflow checking, since it is used to validate that a user
  * dimensionality request doesn't overflow what we can handle.
  *
- * We limit array sizes to at most about a quarter billion elements,
- * so that it's not necessary to check for overflow in quite so many
- * places --- for instance when palloc'ing Datum arrays.
- *
  * The multiplication overflow check only works on machines that have int64
  * arithmetic, but that is nearly all platforms these days, and doing check
  * divides for those that don't seems way too expensive.
@@ -77,8 +73,6 @@ ArrayGetNItems(int ndim, const int *dims)
 {
 	int32		ret;
 	int			i;
-
-#define MaxArraySize ((Size) (MaxAllocSize / sizeof(Datum)))
 
 	if (ndim <= 0)
 		return 0;

--- a/src/include/utils/array.h
+++ b/src/include/utils/array.h
@@ -70,6 +70,13 @@ struct ExprContext;
 
 
 /*
+ * Maximum number of elements in an array.  We limit this to at most about a
+ * quarter billion elements, so that it's not necessary to check for overflow
+ * in quite so many places --- for instance when palloc'ing Datum arrays.
+ */
+#define MaxArraySize ((Size) (MaxAllocSize / sizeof(Datum)))
+
+/*
  * Arrays are varlena objects, so must meet the varlena convention that
  * the first int32 of the object contains the total object size in bytes.
  * Be sure to use VARSIZE() and SET_VARSIZE() to access it, though!

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -1371,6 +1371,23 @@ insert into arr_pk_tbl(pk, f1[1:2]) values (1, '{6,7,8}') on conflict (pk)
 -- then you didn't get an indexscan plan, and something is busted.
 reset enable_seqscan;
 reset enable_bitmapscan;
+-- test subscript overflow detection
+-- The normal error message includes a platform-dependent limit,
+-- so suppress it to avoid needing multiple expected-files.
+\set VERBOSITY sqlstate
+insert into arr_pk_tbl values(10, '[-2147483648:-2147483647]={1,2}');
+update arr_pk_tbl set f1[2147483647] = 42 where pk = 10;
+ERROR:  54000
+update arr_pk_tbl set f1[2147483646:2147483647] = array[4,2] where pk = 10;
+ERROR:  54000
+-- also exercise the expanded-array case
+do $$ declare a int[];
+begin
+  a := '[-2147483648:-2147483647]={1,2}'::int[];
+  a[2147483647] := 42;
+end $$;
+ERROR:  54000
+\set VERBOSITY default
 -- test [not] (like|ilike) (any|all) (...)
 select 'foo' like any (array['%a', '%o']); -- t
  ?column? 

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -416,6 +416,25 @@ insert into arr_pk_tbl(pk, f1[1:2]) values (1, '{6,7,8}') on conflict (pk)
 reset enable_seqscan;
 reset enable_bitmapscan;
 
+-- test subscript overflow detection
+
+-- The normal error message includes a platform-dependent limit,
+-- so suppress it to avoid needing multiple expected-files.
+\set VERBOSITY sqlstate
+
+insert into arr_pk_tbl values(10, '[-2147483648:-2147483647]={1,2}');
+update arr_pk_tbl set f1[2147483647] = 42 where pk = 10;
+update arr_pk_tbl set f1[2147483646:2147483647] = array[4,2] where pk = 10;
+
+-- also exercise the expanded-array case
+do $$ declare a int[];
+begin
+  a := '[-2147483648:-2147483647]={1,2}'::int[];
+  a[2147483647] := 42;
+end $$;
+
+\set VERBOSITY default
+
 -- test [not] (like|ilike) (any|all) (...)
 select 'foo' like any (array['%a', '%o']); -- t
 select 'foo' like any (array['%a', '%b']); -- f


### PR DESCRIPTION
Detect integer overflow while computing new array dimensions.

array_set_element() and related functions allow an array to be enlarged by assigning to subscripts outside the current array bounds. While these places were careful to check that the new bounds are allowable, they neglected to consider the risk of integer overflow in computing the new bounds.  In edge cases, we could compute new bounds that are invalid but get past the subsequent checks, allowing bad things to happen.  Memory stomps that are potentially exploitable for arbitrary code execution are possible, and so is disclosure of server memory.

To fix, perform the hazardous computations using overflow-detecting arithmetic routines, which fortunately exist in all still-supported branches.

The test cases added for this generate (after patching) errors that mention the value of MaxArraySize, which is platform-dependent. Rather than introduce multiple expected-files, use psql's VERBOSITY parameter to suppress the printing of the message text.  v11 psql lacks that parameter, so omit the tests in that branch.

Our thanks to Pedro Gallegos for reporting this problem.

Security: CVE-2023-5869
(cherry picked from postgres commit 18b585155a891784ca8985f595ebc0dde94e0d43)
