### PR TITLE
Remove AuxProcType from the abi ignore files for 7.1.0

### DIFF
--- a/.abi-check/7.1.0/postgres.types.ignore
+++ b/.abi-check/7.1.0/postgres.types.ignore
@@ -1,2 +1,1 @@
 enum PMSignalReason
-enum AuxProcType


### PR DESCRIPTION
Adding ignore symbols/types that were added as part of https://github.com/greenplum-db/gpdb/commit/128d497843152196a4414349c6a5f5bbd5e3c069 as it did not make it to the 7.1.0 release.