### PR TITLE
View gp_toolkit.__check_orphaned_files checkes orphaned temp table files

### DIFF
--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -1,6 +1,7 @@
 EXTENSION = gp_toolkit
 DATA = gp_toolkit--1.1--1.2.sql gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql \
-		gp_toolkit--1.2--1.3.sql gp_toolkit--1.3.sql gp_toolkit--1.3--1.4.sql
+		gp_toolkit--1.2--1.3.sql gp_toolkit--1.3.sql gp_toolkit--1.3--1.4.sql \
+		gp_toolkit--1.4--1.5.sql
 MODULE_big = gp_toolkit
 ifeq ($(shell uname -s), Linux)
 OBJS = resgroup.o gp_partition_maint.o

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.4--1.5.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.4--1.5.sql
@@ -1,0 +1,14 @@
+/* gpcontrib/gp_toolkit/gp_toolkit--1.4--1.5.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_toolkit UPDATE TO '1.5" to load this file. \quit
+
+-- Check orphaned data files on default and user tablespaces.
+-- Compared to the previous version, add gp_segment_id to show which segment it is being executed.
+CREATE OR REPLACE VIEW gp_toolkit.__check_orphaned_files AS
+SELECT f1.tablespace, f1.filename, f1.filepath, pg_catalog.gp_execution_segment() AS gp_segment_id
+from gp_toolkit.__get_exist_files f1
+LEFT JOIN gp_toolkit.__get_expect_files f2
+ON f1.tablespace = f2.tablespace AND substring(f1.filename from '[0-9]+') = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '(t_)*[0-9]+(\.)?(\_)?%';

--- a/gpcontrib/gp_toolkit/gp_toolkit.control
+++ b/gpcontrib/gp_toolkit/gp_toolkit.control
@@ -1,5 +1,5 @@
 # gp_toolkit extension
 
 comment = 'various GPDB administrative views/functions'
-default_version = '1.4'
+default_version = '1.5'
 schema = gp_toolkit

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -67,6 +67,7 @@ select oid from pg_database where datname = current_database() \gset
 -- create some orphaned files
 \! touch 987654
 \! touch 987654.3
+\! touch t_98666
 
 -- check orphaned files, note that this forces a checkpoint internally.
 set client_min_messages = ERROR;

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -60,6 +60,7 @@ select oid from pg_database where datname = current_database() \gset
 -- create some orphaned files
 \! touch 987654
 \! touch 987654.3
+\! touch t_98666
 -- check orphaned files, note that this forces a checkpoint internally.
 set client_min_messages = ERROR;
 select gp_segment_id, filename from run_orphaned_files_view();
@@ -67,7 +68,8 @@ select gp_segment_id, filename from run_orphaned_files_view();
 ---------------+----------
              1 | 987654
              1 | 987654.3
-(2 rows)
+             1 | t_98666
+(3 rows)
 
 -- test moving the orphaned files
 -- firstly, should not move anything if the target directory doesn't exist
@@ -78,7 +80,8 @@ select gp_segment_id, filename from run_orphaned_files_view();
 ---------------+----------
              1 | 987654.3
              1 | 987654
-(2 rows)
+             1 | t_98666
+(3 rows)
 
 -- should also fail to move if no proper permission to the target directory
 \! mkdir @testtablespace@/moving_orphaned_file_test
@@ -91,7 +94,8 @@ select gp_segment_id, filename from run_orphaned_files_view();
 ---------------+----------
              1 | 987654.3
              1 | 987654
-(2 rows)
+             1 | t_98666
+(3 rows)
 
 -- should not allow non-superuser to run,
 -- though it would complain as soon as non-superuser tries to lock pg_class in gp_toolkit.gp_move_orphaned_files
@@ -112,7 +116,8 @@ from gp_toolkit.gp_move_orphaned_files('@testtablespace@/moving_orphaned_file_te
 gp_segment_id|move_success|oldpath|newpath
 1|t|987654|seg1_pg_tblspc_17816_GPDB_7_302307241_17470_987654
 1|t|987654.3|seg1_pg_tblspc_17816_GPDB_7_302307241_17470_987654.3
-(2 rows)
+1|t|t_98666|seg1_pg_tblspc_17816_GPDB_7_302307241_17470_t_98666
+(3 rows)
 \a
 -- The moved orphaned files are in the target directory tree with a name that indicates its original location in data directory
 \cd @testtablespace@/moving_orphaned_file_test/
@@ -120,6 +125,7 @@ gp_segment_id|move_success|oldpath|newpath
 \! ls
 seg1_pg_tblspc_37385_GPDB_7_302307241_37039_987654
 seg1_pg_tblspc_37385_GPDB_7_302307241_37039_987654.3
+seg1_pg_tblspc_37385_GPDB_7_302307241_37039_t_98666
 -- no orphaned files can be found now
 select gp_segment_id, filename from run_orphaned_files_view();
  gp_segment_id | filename 


### PR DESCRIPTION
If we create a temp table and insert a lot of data into it in an explicit transaction block, and then if one of segment got panic, the temp table's data file will be orphaned on that segment, and couldn't be cleaned up by `autovacuum`.

Though it can be cleaned up when `postmaster` restart, it might confuse users if it occupied a lot of disk space, and restart postmaster is not a frequent operation.

In this commit, orphaned temp tables' data file is also checked in `gp_toolkit.__check_orphaned_files`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
