### PR TITLE
Allow folding of Stable functions when query has Sublinks

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/error/CException.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CException.h
@@ -135,6 +135,9 @@ public:
 		// unknown exception
 		ExmiUnhandled,
 
+		// ORCA in an invalid state
+		ExmiORCAInvalidState,
+
 		ExmiSentinel
 	};
 

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -173,18 +173,6 @@ gpos_exec(gpos_exec_params *params)
 			return 1;
 		}
 
-		if (pwpm->Self())
-		{
-			// Raise an exception, if a worker already exists in the Worker Pool
-			// Manager. Since, only one worker is supported, if a new worker is
-			// registered then the address of old worker will be lost and would
-			// lead to an undefined behaviour.
-			GPOS_ASSERT(
-				false &&
-				"New worker cannot be created, as a worker already exists. ORCA supports only one worker.");
-			GPOS_RAISE(CException::ExmaUnhandled, CException::ExmiUnhandled);
-		}
-
 		// if no stack start address is passed, use address in current stack frame
 		void *pvStackStart = params->stack_start;
 		if (NULL == pvStackStart)

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -173,6 +173,18 @@ gpos_exec(gpos_exec_params *params)
 			return 1;
 		}
 
+		if (pwpm->Self())
+		{
+			// Raise an exception, if a worker already exists in the Worker Pool
+			// Manager. Since, only one worker is supported, if a new worker is
+			// registered then the address of old worker will be lost and would
+			// lead to an undefined behaviour.
+			GPOS_ASSERT(
+				false &&
+				"New worker cannot be created, as a worker already exists. ORCA supports only one worker.");
+			GPOS_RAISE(CException::ExmaUnhandled, CException::ExmiUnhandled);
+		}
+
 		// if no stack start address is passed, use address in current stack frame
 		void *pvStackStart = params->stack_start;
 		if (NULL == pvStackStart)

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -173,6 +173,21 @@ gpos_exec(gpos_exec_params *params)
 			return 1;
 		}
 
+		if (pwpm->Self())
+		{
+			// Raise an exception, if a worker already exists in the Worker Pool
+			// Manager. Since, only one worker is supported, if a new worker is
+			// registered then the address of old worker will be lost and would
+			// lead to an undefined behaviour.
+			GPOS_ASSERT(
+				false &&
+				"New worker cannot be created, as a worker already exists. ORCA supports only one worker.");
+			GPOS_RAISE(
+				CException::ExmaInvalid, CException::ExmiInvalid,
+				GPOS_WSZ_LIT(
+					"This is an invalid state, please report this error."));
+		}
+
 		// if no stack start address is passed, use address in current stack frame
 		void *pvStackStart = params->stack_start;
 		if (NULL == pvStackStart)

--- a/src/backend/gporca/libgpos/src/error/CMessage.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessage.cpp
@@ -272,6 +272,16 @@ CMessage::GetMessage(ULONG index)
 			CException(CException::ExmaUnhandled, CException::ExmiUnhandled),
 			CException::ExsevError, GPOS_WSZ_WSZLEN("Unhandled exception"), 0,
 			GPOS_WSZ_WSZLEN("Unhandled exception")),
+
+		CMessage(CException(CException::ExmaInvalid,
+							CException::ExmiORCAInvalidState),
+				 CException::ExsevError,
+				 GPOS_WSZ_WSZLEN(
+					 "This is an invalid state, please report this error"),
+				 0,
+				 GPOS_WSZ_WSZLEN(
+					 "This is an invalid state, please report this error."))
+
 	};
 
 	return &msg[index];

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5876,13 +5876,17 @@ should_eval_stable_functions(PlannerInfo *root)
 	 * Without PlannerGlobal, we cannot mark the plan as a `oneoffPlan`
 	 */
 	if (root == NULL) return false;
-	if (root->glob == NULL) return false;
+	if (root->glob == NULL || root->parse == NULL) return false;
 
 	/*
 	 * If the query has no range table, then there is no reason to need to
 	 * pre-evaluate stable functions, as the output cannot be used as part
 	 * of static partition elimination, unless the query is part of a
 	 * subquery.
+	 *
+	 * Return true, if the query has Sublink, as RTE can be present in the
+	 * Sublink and pre-evaluation of stable function, can help in static
+	 * partition elimination.
 	 */
-	return root->parse->rtable || root->query_level > 1;
+	return root->parse->rtable || root->query_level > 1 || root->parse->hasSubLinks;
 }

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14647,6 +14647,69 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (14 rows)
 
 DROP TABLE t_outer_srf, t_inner_srf;
+-- Test cases to check if a stable function is folded when the query has no RTEs
+-- but has Sub Links.
+CREATE OR REPLACE FUNCTION test_func_im(a int, b int)
+      RETURNS int
+      LANGUAGE sql
+      IMMUTABLE
+AS $$
+select a + b + 10;
+$$;
+CREATE OR REPLACE FUNCTION test_func_stable(a int)
+      RETURNS int
+      LANGUAGE sql
+      STABLE
+AS $$
+select (ceil (a + 10 + random())::int) ;
+$$;
+drop table if exists bar_pt;
+NOTICE:  table "bar_pt" does not exist, skipping
+create table bar_pt (a int, b int) distributed by (a) partition by range(a) (start (1) inclusive end (12) every (2), default partition other);
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_other" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_2" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_3" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_4" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_5" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_6" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_7" for table "bar_pt"
+insert into bar_pt select i,i from generate_series(1,11)i;
+analyze bar_pt;
+-- Without the fix, the following query crashes, but with the fix, the function
+-- call is folded to a constant.
+explain select test_func_im(10, (select min(a) from bar_pt where a < test_func_stable(6)));
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Result  (cost=8.24..8.25 rows=1 width=0)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Aggregate  (cost=8.23..8.24 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=8.17..8.22 rows=1 width=4)
+                 ->  Aggregate  (cost=8.17..8.18 rows=1 width=4)
+                       ->  Append  (cost=0.00..8.14 rows=4 width=4)
+                             ->  Seq Scan on bar_pt_1_prt_other  (cost=0.00..1.00 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_2  (cost=0.00..2.02 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_3  (cost=0.00..1.02 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_4  (cost=0.00..1.02 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_5  (cost=0.00..1.02 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_6  (cost=0.00..1.02 rows=1 width=4)
+                                   Filter: (a < 17)
+                             ->  Seq Scan on bar_pt_1_prt_7  (cost=0.00..1.01 rows=1 width=4)
+                                   Filter: (a < 17)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+select test_func_im(10, (select min(a) from bar_pt where a < test_func_stable(6)));
+ test_func_im 
+--------------
+           21
+(1 row)
+
+drop table if exists bar_pt;
 -- Testcases to validate the behavior of the GUC gp_max_system_slices
 -- start_ignore
 drop table if exists foo;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14685,40 +14685,20 @@ END;
 $$
 LANGUAGE plpgsql
 STABLE;
-explain select coalesce((select max(dtRepDate) from test_partitioned_2024
-                 where dtRepDate between date_trunc('month',current_date)::date  and any_func((ret_date()))),
-                (select max(dtRepDate) from test_partitioned_2024));
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=16902.45..16902.46 rows=1 width=0)
-   InitPlan 1 (returns $0)  (slice3)
-     ->  Aggregate  (cost=2787.37..2787.38 rows=1 width=4)
-           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2787.30..2787.36 rows=1 width=4)
-                 ->  Aggregate  (cost=2787.30..2787.32 rows=1 width=4)
-                       ->  Append  (cost=0.00..2783.00 rows=574 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_2  (cost=0.00..1391.50 rows=287 width=4)
-                                   Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
-                             ->  Seq Scan on test_partitioned_2024_1_prt_3  (cost=0.00..1391.50 rows=287 width=4)
-                                   Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
-   InitPlan 2 (returns $1)  (slice4)
-     ->  Aggregate  (cost=14115.06..14115.07 rows=1 width=4)
-           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=14115.00..14115.05 rows=1 width=4)
-                 ->  Aggregate  (cost=14115.00..14115.01 rows=1 width=4)
-                       ->  Append  (cost=0.00..11532.00 rows=344400 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_1  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_2 test_partitioned_2024_1_prt_2_1  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_3 test_partitioned_2024_1_prt_3_1  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_4  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_5  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_6  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_7  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_8  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_9  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_10  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_11  (cost=0.00..961.00 rows=28700 width=4)
-                             ->  Seq Scan on test_partitioned_2024_1_prt_12  (cost=0.00..961.00 rows=28700 width=4)
+explain select (select min(dtRepDate) from test_partitioned_2024 where dtRepDate = any_func(ret_date()));
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.01..0.02 rows=1 width=0)
+   InitPlan 2 (returns $1)  (slice3)
+     ->  Result  (cost=0.00..0.01 rows=1 width=0)
+           InitPlan 1 (returns $0)  (slice2)
+             ->  Limit  (cost=0.00..13.67 rows=1 width=4)
+                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1176.25 rows=87 width=4)
+                         ->  Append  (cost=0.00..1176.25 rows=29 width=4)
+                               ->  Seq Scan on test_partitioned_2024_1_prt_3  (cost=0.00..1176.25 rows=29 width=4)
+                                     Filter: ((dtrepdate IS NOT NULL) AND (dtrepdate = '03-01-2024'::date))
  Optimizer: Postgres query optimizer
-(28 rows)
+(10 rows)
 
 ------------------------------------------------
 -- TEST CASE-2

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14649,6 +14649,80 @@ EXPLAIN (VERBOSE, COSTS OFF)
 DROP TABLE t_outer_srf, t_inner_srf;
 -- Test cases to check if a stable function is folded when the query has no RTEs
 -- but has Sub Links.
+------------------------------------------------
+-- TEST CASE-1
+------------------------------------------------
+CREATE OR REPLACE FUNCTION any_func(p_dt date)
+    RETURNS date
+    LANGUAGE sql
+    IMMUTABLE
+AS $$
+    select (date_trunc('month', p_dt) + interval '1 month')::date;
+$$
+EXECUTE ON ANY;
+create TABLE test_partitioned_2024 ( nagreementid int4 NULL, dtrepdate date NULL) DISTRIBUTED BY (nagreementid)
+PARTITION BY RANGE(dtrepdate) ( START ('2024-01-01'::date) END ('2024-12-31'::date) EVERY ('1 mon'::interval));
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_1" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_2" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_3" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_4" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_5" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_6" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_7" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_8" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_9" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_10" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_11" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_12" for table "test_partitioned_2024"
+CREATE OR REPLACE FUNCTION ret_date()
+RETURNS DATE AS
+$$
+DECLARE
+    fix_date DATE := '2024-02-10';
+BEGIN
+    RETURN fix_date;
+END;
+$$
+LANGUAGE plpgsql
+STABLE;
+explain select coalesce((select max(dtRepDate) from test_partitioned_2024
+                 where dtRepDate between date_trunc('month',current_date)::date  and any_func((ret_date()))),
+                (select max(dtRepDate) from test_partitioned_2024));
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=16902.45..16902.46 rows=1 width=0)
+   InitPlan 1 (returns $0)  (slice3)
+     ->  Aggregate  (cost=2787.37..2787.38 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2787.30..2787.36 rows=1 width=4)
+                 ->  Aggregate  (cost=2787.30..2787.32 rows=1 width=4)
+                       ->  Append  (cost=0.00..2783.00 rows=574 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_2  (cost=0.00..1391.50 rows=287 width=4)
+                                   Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
+                             ->  Seq Scan on test_partitioned_2024_1_prt_3  (cost=0.00..1391.50 rows=287 width=4)
+                                   Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
+   InitPlan 2 (returns $1)  (slice4)
+     ->  Aggregate  (cost=14115.06..14115.07 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=14115.00..14115.05 rows=1 width=4)
+                 ->  Aggregate  (cost=14115.00..14115.01 rows=1 width=4)
+                       ->  Append  (cost=0.00..11532.00 rows=344400 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_1  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_2 test_partitioned_2024_1_prt_2_1  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_3 test_partitioned_2024_1_prt_3_1  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_4  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_5  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_6  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_7  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_8  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_9  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_10  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_11  (cost=0.00..961.00 rows=28700 width=4)
+                             ->  Seq Scan on test_partitioned_2024_1_prt_12  (cost=0.00..961.00 rows=28700 width=4)
+ Optimizer: Postgres query optimizer
+(28 rows)
+
+------------------------------------------------
+-- TEST CASE-2
+------------------------------------------------
 CREATE OR REPLACE FUNCTION test_func_im(a int, b int)
       RETURNS int
       LANGUAGE sql

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14922,9 +14922,7 @@ END;
 $$
 LANGUAGE plpgsql
 STABLE;
-explain select coalesce((select max(dtRepDate) from test_partitioned_2024
-                 where dtRepDate between date_trunc('month',current_date)::date  and any_func((ret_date()))),
-                (select max(dtRepDate) from test_partitioned_2024));
+explain select (select min(dtRepDate) from test_partitioned_2024 where dtRepDate = any_func(ret_date()));
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Query Parameter
 CONTEXT:  SQL statement "SELECT fix_date"
@@ -14932,31 +14930,22 @@ PL/pgSQL function ret_date() line 5 at RETURN
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Query Parameter
 CONTEXT:  SQL function "any_func" during startup
-                                                                              QUERY PLAN                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..904755290.84 rows=1 width=4)
-   ->  Nested Loop Left Join  (cost=0.00..904755290.84 rows=2 width=8)
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..882688.09 rows=1 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..882688.09 rows=1 width=4)
          Join Filter: true
-         ->  Nested Loop Left Join  (cost=0.00..882688.09 rows=1 width=4)
-               Join Filter: true
-               ->  Result  (cost=0.00..0.00 rows=1 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                             Partitions selected: 2 (out of 12)
-                                       ->  Dynamic Seq Scan on test_partitioned_2024 test_partitioned_2024_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
-                                             Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                       Partitions selected: 12 (out of 12)
-                                 ->  Dynamic Seq Scan on test_partitioned_2024 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                       Partitions selected: 1 (out of 12)
+                                 ->  Dynamic Seq Scan on test_partitioned_2024 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: (dtrepdate = '03-01-2024'::date)
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(13 rows)
 
 ------------------------------------------------
 -- TEST CASE-2

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14886,6 +14886,81 @@ EXPLAIN (VERBOSE, COSTS OFF)
 DROP TABLE t_outer_srf, t_inner_srf;
 -- Test cases to check if a stable function is folded when the query has no RTEs
 -- but has Sub Links.
+------------------------------------------------
+-- TEST CASE-1
+------------------------------------------------
+CREATE OR REPLACE FUNCTION any_func(p_dt date)
+    RETURNS date
+    LANGUAGE sql
+    IMMUTABLE
+AS $$
+    select (date_trunc('month', p_dt) + interval '1 month')::date;
+$$
+EXECUTE ON ANY;
+create TABLE test_partitioned_2024 ( nagreementid int4 NULL, dtrepdate date NULL) DISTRIBUTED BY (nagreementid)
+PARTITION BY RANGE(dtrepdate) ( START ('2024-01-01'::date) END ('2024-12-31'::date) EVERY ('1 mon'::interval));
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_1" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_2" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_3" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_4" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_5" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_6" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_7" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_8" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_9" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_10" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_11" for table "test_partitioned_2024"
+NOTICE:  CREATE TABLE will create partition "test_partitioned_2024_1_prt_12" for table "test_partitioned_2024"
+CREATE OR REPLACE FUNCTION ret_date()
+RETURNS DATE AS
+$$
+DECLARE
+    fix_date DATE := '2024-02-10';
+BEGIN
+    RETURN fix_date;
+END;
+$$
+LANGUAGE plpgsql
+STABLE;
+explain select coalesce((select max(dtRepDate) from test_partitioned_2024
+                 where dtRepDate between date_trunc('month',current_date)::date  and any_func((ret_date()))),
+                (select max(dtRepDate) from test_partitioned_2024));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Query Parameter
+CONTEXT:  SQL statement "SELECT fix_date"
+PL/pgSQL function ret_date() line 5 at RETURN
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Query Parameter
+CONTEXT:  SQL function "any_func" during startup
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..904755290.84 rows=1 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..904755290.84 rows=2 width=8)
+         Join Filter: true
+         ->  Nested Loop Left Join  (cost=0.00..882688.09 rows=1 width=4)
+               Join Filter: true
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             Partitions selected: 2 (out of 12)
+                                       ->  Dynamic Seq Scan on test_partitioned_2024 test_partitioned_2024_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+                                             Filter: ((dtrepdate >= '02-01-2024'::date) AND (dtrepdate <= '03-01-2024'::date))
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                       Partitions selected: 12 (out of 12)
+                                 ->  Dynamic Seq Scan on test_partitioned_2024 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
+
+------------------------------------------------
+-- TEST CASE-2
+------------------------------------------------
 CREATE OR REPLACE FUNCTION test_func_im(a int, b int)
       RETURNS int
       LANGUAGE sql

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14574,11 +14574,12 @@ EXPLAIN (COSTS OFF) SELECT (
                                  ->  Hash Join
                                        Hash Cond: (join_null_rej1.i = join_null_rej2.i)
                                        ->  Seq Scan on join_null_rej1
+                                             Filter: (i < 5)
                                        ->  Hash
                                              ->  Seq Scan on join_null_rej2
-                                                   Filter: (i < join_null_rej_func())
+                                                   Filter: (i < 5)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(16 rows)
 
 -- Optional, but let's check we get same result for both, folded and
 -- not folded join_null_rej_func() function.
@@ -14883,6 +14884,68 @@ EXPLAIN (VERBOSE, COSTS OFF)
 (13 rows)
 
 DROP TABLE t_outer_srf, t_inner_srf;
+-- Test cases to check if a stable function is folded when the query has no RTEs
+-- but has Sub Links.
+CREATE OR REPLACE FUNCTION test_func_im(a int, b int)
+      RETURNS int
+      LANGUAGE sql
+      IMMUTABLE
+AS $$
+select a + b + 10;
+$$;
+CREATE OR REPLACE FUNCTION test_func_stable(a int)
+      RETURNS int
+      LANGUAGE sql
+      STABLE
+AS $$
+select (ceil (a + 10 + random())::int) ;
+$$;
+drop table if exists bar_pt;
+NOTICE:  table "bar_pt" does not exist, skipping
+create table bar_pt (a int, b int) distributed by (a) partition by range(a) (start (1) inclusive end (12) every (2), default partition other);
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_other" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_2" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_3" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_4" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_5" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_6" for table "bar_pt"
+NOTICE:  CREATE TABLE will create partition "bar_pt_1_prt_7" for table "bar_pt"
+insert into bar_pt select i,i from generate_series(1,11)i;
+analyze bar_pt;
+-- Without the fix, the following query crashes, but with the fix, the function
+-- call is folded to a constant.
+explain select test_func_im(10, (select min(a) from bar_pt where a < test_func_stable(6)));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
+CONTEXT:  SQL function "test_func_stable" during startup
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..882688.30 rows=1 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..882688.30 rows=1 width=4)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Sequence  (cost=0.00..431.00 rows=4 width=4)
+                                       ->  Partition Selector for bar_pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             Partitions selected: 7 (out of 7)
+                                       ->  Dynamic Seq Scan on bar_pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=4)
+                                             Filter: (a < 17)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select test_func_im(10, (select min(a) from bar_pt where a < test_func_stable(6)));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
+CONTEXT:  SQL function "test_func_stable" during startup
+ test_func_im 
+--------------
+           21
+(1 row)
+
+drop table if exists bar_pt;
 -- Testcases to validate the behavior of the GUC gp_max_system_slices
 -- start_ignore
 drop table if exists foo;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3383,10 +3383,7 @@ $$
 LANGUAGE plpgsql
 STABLE;
 
-explain select coalesce((select max(dtRepDate) from test_partitioned_2024
-                 where dtRepDate between date_trunc('month',current_date)::date  and any_func((ret_date()))),
-                (select max(dtRepDate) from test_partitioned_2024));
-
+explain select (select min(dtRepDate) from test_partitioned_2024 where dtRepDate = any_func(ret_date()));
 ------------------------------------------------
 -- TEST CASE-2
 ------------------------------------------------


### PR DESCRIPTION
OBJECTIVE
---------------------
Through this PR, aim is to allow folding of stable functions when the query has sublinks.
Earlier in [PR-5971](https://github.com/greenplum-db/gpdb/pull/5971), the folding of stable functions was restricted, it was only allowed if the query has RTEs. 

PROBLEM 
---------------------
It was reported that the following query is crashing in ORCA 

```
CREATE OR REPLACE FUNCTION any_func(p_dt date)
      RETURNS date
      LANGUAGE sql
      IMMUTABLE
AS $$
select (date_trunc('month', p_dt) + interval '1 month')::date;
$$
EXECUTE ON ANY;
```
```
create TABLE test_partitioned_2024 ( nagreementid int4 NULL, dtrepdate date NULL)
DISTRIBUTED BY (nagreementid)
PARTITION BY RANGE(dtrepdate)
(
    START ('2024-01-01'::date) END ('2024-12-31'::date) EVERY ('1 mon'::interval)
);

```
```
select coalesce(
                (select max(dtRepDate) from test_partitioned_2024 where dtRepDate between
                    date_trunc('month',current_date)::date  and any_func(current_date)),
                (select max(dtRepDate) from test_partitioned_2024)
               );

```


CAUSE OF FAILURE 
---------------------
1) For the above query, parsed query has no RTE but has Sublink. 
2) Prior to the fix, in such a scenario folding(to a const or inlining) of stable functions was restricted. 
3) Thus,  ** 'any_func(current_date)' in the query is not folded.**
    3.1) Not folded to constant - as restricted via check in PR-5971. any_func() has date_trunc() which is stable, and is not folded.
    3.2) Not inlined - as any_func() is an immutable function which contains a stable function date_trunc(). Thus violates condition for Inlining. 
    3.3) Thus in the algebrized query, a function call is present and it looks like - 

            |     |     +--CScalarCmp (<=)
            |     |        |--CScalarIdent "dtrepdate" (2)
            |     |        +--CScalarFunc (any_func)
            |     |           +--CScalarCoerceViaIO
            |     |              +--CScalarConst (6E6F7700)

4) When the query is optimized, **a worker is registerd in the worker pool manager (say W1 for this task)**. During dxl to planned statment translation, the translation of partition selectors is done. During this time to find the bounds for static parition elimination, the Quals in the query are evaluted. Since function call is present in the Quals, the function call is evaluated first. 

5) During this evaluation, optimization of any_func(current_date) is inititated, which fails, during query to dxl stage because of presence of T_PARAMs. This optimization is performed by the planner.

6) Note, **before initiating the above optimization (point-5), a new worker is registerd (say W2). ORCA only supports one worker, 
as a new worker is registered, the track of the old worker (W1), carrying out the initial task is lost** 
    
7) As ORCA return to the normal flow of dxl to planned statment translation after optimizing the quals, now no worker is present.
**Now whenever a worker is accessed, it is like access a nullptr, which cause the crash.** 

8) In the case of  query this crash happens to be while checking trace flags.

**POST FIX**

Now that, folding is allowed if Sublink is present, thus the function call is folded to a constant. Thus, another round of query optimization during 
static partition elimination is not performed. 


Now, ORCA is producing a plan. 

```
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Result  (cost=0.00..904755290.84 rows=1 width=4)
   ->  Nested Loop Left Join  (cost=0.00..904755290.84 rows=2 width=8)
         Join Filter: true
         ->  Nested Loop Left Join  (cost=0.00..882688.09 rows=1 width=4)
               Join Filter: true
               ->  Result  (cost=0.00..0.00 rows=1 width=1)
               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
                                       ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                             Partitions selected: 2 (out of 12)
                                       ->  Dynamic Seq Scan on test_partitioned_2024 test_partitioned_2024_1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
                                             Filter: ((dtrepdate >= '2024-02-01'::date) AND (dtrepdate <= '2024-03-01'::date))
         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                           ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
                                 ->  Partition Selector for test_partitioned_2024 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                       Partitions selected: 12 (out of 12)
                                 ->  Dynamic Seq Scan on test_partitioned_2024 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=4)
 Optimizer: Pivotal Optimizer (GPORCA)
(22 rows)
```
