### PR TITLE
[6X] Fixes to latch and spinlock infrastructure

### DIFF
--- a/src/backend/port/unix_latch.c
+++ b/src/backend/port/unix_latch.c
@@ -155,7 +155,7 @@ OwnLatch(volatile Latch *latch)
 
 	/* sanity check */
 	if (latch->owner_pid != 0)
-		elog(ERROR, "latch already owned by pid %d (is_set: %d)",
+		elog(PANIC, "latch already owned by pid %d (is_set: %d)",
 			 latch->owner_pid, (int) latch->is_set);
 
 	latch->owner_pid = MyProcPid;

--- a/src/backend/storage/lmgr/s_lock.c
+++ b/src/backend/storage/lmgr/s_lock.c
@@ -154,6 +154,18 @@ s_lock(volatile slock_t *lock, const char *file, int line)
 	return delays;
 }
 
+#ifdef USE_DEFAULT_S_UNLOCK
+void
+s_unlock(slock_t *lock)
+{
+#ifdef TAS_ACTIVE_WORD
+	/* HP's PA-RISC */
+	*TAS_ACTIVE_WORD(lock) = -1;
+#else
+	*lock = 0;
+#endif
+}
+#endif
 
 /*
  * Set local copy of spins_per_delay during backend startup.

--- a/src/backend/storage/lmgr/s_lock.c
+++ b/src/backend/storage/lmgr/s_lock.c
@@ -156,7 +156,7 @@ s_lock(volatile slock_t *lock, const char *file, int line)
 
 #ifdef USE_DEFAULT_S_UNLOCK
 void
-s_unlock(slock_t *lock)
+s_unlock(volatile slock_t *lock)
 {
 #ifdef TAS_ACTIVE_WORD
 	/* HP's PA-RISC */

--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -1091,7 +1091,7 @@ extern int	tas_sema(volatile slock_t *lock);
  * which the PostgreSQL project does not have access.
  */
 #define USE_DEFAULT_S_UNLOCK
-extern void s_unlock(volatile s_lock *lock);
+extern void s_unlock(volatile slock_t *lock);
 #define S_UNLOCK(lock)		s_unlock(lock)
 #endif	 /* S_UNLOCK */
 

--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -955,7 +955,7 @@ typedef unsigned int slock_t;
 /* On IA64, it's a win to use a non-locking test before the xchg proper */
 #define TAS_SPIN(lock)	(*(lock) ? 1 : TAS(lock))
 #define S_UNLOCK(lock)	\
-	do { _Asm_sched_fence(); (*(lock)) = 0); } while (0)
+	do { _Asm_sched_fence(); (*(lock)) = 0; } while (0)
 
 #endif	/* HPUX on IA64, non gcc */
 

--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -55,14 +55,16 @@
  *	on Alpha TAS() will "fail" if interrupted.  Therefore a retry loop must
  *	always be used, even if you are certain the lock is free.
  *
- *	Another caution for users of these macros is that it is the caller's
- *	responsibility to ensure that the compiler doesn't re-order accesses
- *	to shared memory to precede the actual lock acquisition, or follow the
- *	lock release.  Typically we handle this by using volatile-qualified
- *	pointers to refer to both the spinlock itself and the shared data
- *	structure being accessed within the spinlocked critical section.
- *	That fixes it because compilers are not allowed to re-order accesses
- *	to volatile objects relative to other such accesses.
+ *	It is the responsibility of these macros to make sure that the compiler
+ *	does not re-order accesses to shared memory to precede the actual lock
+ *	acquisition, or follow the lock release.  Prior to PostgreSQL 9.5, this
+ *	was the caller's responsibility, which meant that callers had to use
+ *	volatile-qualified pointers to refer to both the spinlock itself and the
+ *	shared data being accessed within the spinlocked critical section.  This
+ *	was notationally awkward, easy to forget (and thus error-prone), and
+ *	prevented some useful compiler optimizations.  For these reasons, we
+ *	now require that the macros themselves prevent compiler re-ordering,
+ *	so that the caller doesn't need to take special precautions.
  *
  *	On platforms with weak memory ordering, the TAS(), TAS_SPIN(), and
  *	S_UNLOCK() macros must further include hardware-level memory fence
@@ -441,7 +443,8 @@ tas(volatile slock_t *lock)
 #if defined(__sparcv7) || defined(__sparc_v7__)
 /*
  * No stbar or membar available, luckily no actually produced hardware
- * requires a barrier.
+ * requires a barrier.  We fall through to the default gcc definition of
+ * S_UNLOCK in this case.
  */
 #define S_UNLOCK(lock)		(*((volatile slock_t *) (lock)) = 0)
 #elif defined(__sparcv8) || defined(__sparc_v8__)
@@ -535,14 +538,14 @@ tas(volatile slock_t *lock)
 #define S_UNLOCK(lock)	\
 do \
 { \
-	__asm__ __volatile__ ("	lwsync \n"); \
+	__asm__ __volatile__ ("	lwsync \n" ::: "memory"); \
 	*((volatile slock_t *) (lock)) = 0; \
 } while (0)
 #else
 #define S_UNLOCK(lock)	\
 do \
 { \
-	__asm__ __volatile__ ("	sync \n"); \
+	__asm__ __volatile__ ("	sync \n" ::: "memory"); \
 	*((volatile slock_t *) (lock)) = 0; \
 } while (0)
 #endif /* USE_PPC_LWSYNC */
@@ -736,7 +739,9 @@ do \
 		"       .set noreorder      \n" \
 		"       .set nomacro        \n" \
 		"       sync                \n" \
-		"       .set pop              "); \
+		"       .set pop              "
+:
+:		"memory");
 	*((volatile slock_t *) (lock)) = 0; \
 } while (0)
 
@@ -794,6 +799,23 @@ tas(volatile slock_t *lock)
 typedef unsigned char slock_t;
 #endif
 
+/*
+ * Note that this implementation is unsafe for any platform that can speculate
+ * a memory access (either load or store) after a following store.  That
+ * happens not to be possible x86 and most legacy architectures (some are
+ * single-processor!), but many modern systems have weaker memory ordering.
+ * Those that do must define their own version S_UNLOCK() rather than relying
+ * on this one.
+ */
+#if !defined(S_UNLOCK)
+#if defined(__INTEL_COMPILER)
+#define S_UNLOCK(lock)	\
+	do { __memory_barrier(); *(lock) = 0; } while (0)
+#else
+#define S_UNLOCK(lock)	\
+	do { __asm__ __volatile__("" : : : "memory");  *(lock) = 0; } while (0)
+#endif
+#endif
 
 #endif	/* defined(__GNUC__) || defined(__INTEL_COMPILER) */
 
@@ -888,9 +910,13 @@ tas(volatile slock_t *lock)
 	return (lockval == 0);
 }
 
-#endif /* __GNUC__ */
+#define S_UNLOCK(lock)	\
+	do { \
+		__asm__ __volatile__("" : : : "memory"); \
+		*TAS_ACTIVE_WORD(lock) = -1; \
+	} while (0)
 
-#define S_UNLOCK(lock)	(*TAS_ACTIVE_WORD(lock) = -1)
+#endif /* __GNUC__ */
 
 #define S_INIT_LOCK(lock) \
 	do { \
@@ -928,6 +954,8 @@ typedef unsigned int slock_t;
 #define TAS(lock) _Asm_xchg(_SZ_W, lock, 1, _LDHINT_NONE)
 /* On IA64, it's a win to use a non-locking test before the xchg proper */
 #define TAS_SPIN(lock)	(*(lock) ? 1 : TAS(lock))
+#define S_UNLOCK(lock)	\
+	do { _Asm_sched_fence(); (*(lock)) = 0); } while (0)
 
 #endif	/* HPUX on IA64, non gcc */
 
@@ -990,6 +1018,12 @@ spin_delay(void)
 }
 #endif
 
+#include <intrin.h>
+#pragma intrinsic(_ReadWriteBarrier)
+
+#define S_UNLOCK(lock)	\
+	do { _ReadWriteBarrier(); (*(lock)) = 0); } while (0)
+
 #endif
 
 
@@ -1040,7 +1074,25 @@ extern int	tas_sema(volatile slock_t *lock);
 #endif	 /* S_LOCK_FREE */
 
 #if !defined(S_UNLOCK)
-#define S_UNLOCK(lock)		(*((volatile slock_t *) (lock)) = 0)
+/*
+ * Our default implementation of S_UNLOCK is essentially *(lock) = 0.  This
+ * is unsafe if the platform can speculate a memory access (either load or
+ * store) after a following store; platforms where this is possible must
+ * define their own S_UNLOCK.  But CPU reordering is not the only concern:
+ * if we simply defined S_UNLOCK() as an inline macro, the compiler might
+ * reorder instructions from inside the critical section to occur after the
+ * lock release.  Since the compiler probably can't know what the external
+ * function s_unlock is doing, putting the same logic there should be adequate.
+ * A sufficiently-smart globally optimizing compiler could break that
+ * assumption, though, and the cost of a function call for every spinlock
+ * release may hurt performance significantly, so we use this implementation
+ * only for platforms where we don't know of a suitable intrinsic.  For the
+ * most part, those are relatively obscure platform/compiler combinations to
+ * which the PostgreSQL project does not have access.
+ */
+#define USE_DEFAULT_S_UNLOCK
+extern void s_unlock(volatile s_lock *lock);
+#define S_UNLOCK(lock)		s_unlock(lock)
 #endif	 /* S_UNLOCK */
 
 #if !defined(S_INIT_LOCK)


### PR DESCRIPTION
## Problem we are trying to fix:

From a field report, we have seen a race condition between an exiting backend (Y) and another backend (X) undergoing init. If the act of returning the PGPROC to the freelist for Y gets reordered before the store for procLatch->pid = 0, then there is a chance that X can grab the same PGPROC object from the freelist and can still see that procLatch->pid = Y. This can lead to the sanity check blowing up inside OwnLatch(). This can only happen if X's OwnLatch() is scheduled before Y's store for pid = 0.

## Commit summary:

1. We now PANIC in OwnLatch(), instead of ERRORing out. The effect is the same. See commit message for details
2. Spinlock primitives now act as compiler barriers on top of being CPU barriers for reordering.
      * Follow-ups to that patch that contain minor upstream fixes
3. Adding an explicit memory barrier in OwnLatch()/DisownLatch() for added coverage and to make those functions self-sufficient (i.e. not depend on spinlock acquisitions/releases).

1 and 2 make us at par with higher versions of Postgres. 3 offers added protection, beyond the implicit compiler barrier protection offered by the spinlock calls after a DisownLatch().

Related upstream discussion: https://www.postgresql.org/message-id/CAE-ML%2B_CL3TfhLo6MjCSufinyugqSJWr8qEoWL8oAc-oT%2BP67g%40mail.gmail.com

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_latch