### PR TITLE
Capture Non default planner gucs in minirepro

### DIFF
--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -295,13 +295,13 @@ def dump_extstats(cur, oid_str, f_out):
         f_out.writelines(setStmt.format(vals[0], vals[2], ',\n'.join(['\t%s = %s::%s' %
                                                                       t for t in zip(columns[3:], ['NULL' if x is None else "'" + x + "'" for x in vals[3:]], types)]),  vals[0]))
 
-def get_non_default_planner_gucs(cursor):
+def get_non_default_optimization_gucs(cursor):
     # Ignore 'optimizer' guc as it is turned off by minirepro while creating connection object
     query = "select name, setting from pg_settings where category like 'Query Tuning%' and setting!=boot_val and name!='optimizer';"
     try:
         cursor.execute(query)
     except psycopg2.DatabaseError as e:
-        sys.stderr.write('\nError while trying to retrieve non default planner gucs.\n\n' + str(e) + '\n\n')
+        sys.stderr.write('\nError while trying to retrieve non default optimization gucs.\n\n' + str(e) + '\n\n')
         sys.exit(1)
     vals = cursor.fetchall()
     return vals
@@ -363,8 +363,8 @@ def main():
 
     num_segments = get_num_segments(cursor)
 
-    # fetch non-default planner gucs
-    non_default_planner_gucs = get_non_default_planner_gucs(cursor)
+    # fetch non-default optimization gucs
+    non_default_optimization_gucs = get_non_default_optimization_gucs(cursor)
 
     """
     invoke gp_toolkit UDF, dump object oids as json text
@@ -441,15 +441,15 @@ def main():
     line = 'set optimizer_segments = ' + str(num_segments) + ';'
     f_out.writelines('\n-- ' + line + '\n')
 
-    # write non-default planner guc settings
-    print("Writing non-default planner guc settings ...")
+    # write non-default optimization gucs
+    print("Writing non-default optimization guc settings ...")
     f_out.writelines(['-- ',
-                      '\n-- Non-default planner guc settings',
+                      '\n-- Non-default optimization guc settings',
                       '\n--'])
-    if len(non_default_planner_gucs) == 0:
-        f_out.writelines('\n-- None Available')
+    if len(non_default_optimization_gucs) == 0:
+        f_out.writelines('\n-- Using all default guc settings')
     else:
-        for setting in non_default_planner_gucs:
+        for setting in non_default_optimization_gucs:
             f_out.writelines('\n-- set {0} = {1};'.format(setting[0], setting[1]))
     f_out.writelines('\n-- \n\n')
     with open(query_file, 'r') as query_f:

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -295,6 +295,17 @@ def dump_extstats(cur, oid_str, f_out):
         f_out.writelines(setStmt.format(vals[0], vals[2], ',\n'.join(['\t%s = %s::%s' %
                                                                       t for t in zip(columns[3:], ['NULL' if x is None else "'" + x + "'" for x in vals[3:]], types)]),  vals[0]))
 
+def get_non_default_planner_gucs(cursor):
+    # Ignore 'optimizer' guc as it is turned off by minirepro while creating connection object
+    query = "select name, setting from pg_settings where category like 'Query Tuning%' and setting!=boot_val and name!='optimizer';"
+    try:
+        cursor.execute(query)
+    except psycopg2.DatabaseError as e:
+        sys.stderr.write('\nError while trying to retrieve non default planner gucs.\n\n' + str(e) + '\n\n')
+        sys.exit(1)
+    vals = cursor.fetchall()
+    return vals
+
 def main():
     parser = parse_cmd_line()
     options, args = parser.parse_args()
@@ -351,6 +362,9 @@ def main():
     server_ver = get_server_version(cursor)
 
     num_segments = get_num_segments(cursor)
+
+    # fetch non-default planner gucs
+    non_default_planner_gucs = get_non_default_planner_gucs(cursor)
 
     """
     invoke gp_toolkit UDF, dump object oids as json text
@@ -426,6 +440,18 @@ def main():
                        '\n-- \n\n'])
     line = 'set optimizer_segments = ' + str(num_segments) + ';'
     f_out.writelines('\n-- ' + line + '\n')
+
+    # write non-default planner guc settings
+    print("Writing non-default planner guc settings ...")
+    f_out.writelines(['-- ',
+                      '\n-- Non-default planner guc settings',
+                      '\n--'])
+    if len(non_default_planner_gucs) == 0:
+        f_out.writelines('\n-- None Available')
+    else:
+        for setting in non_default_planner_gucs:
+            f_out.writelines('\n-- set {0} = {1};'.format(setting[0], setting[1]))
+    f_out.writelines('\n-- \n\n')
     with open(query_file, 'r') as query_f:
         for line in query_f:
             f_out.writelines('-- ' + line)

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -687,7 +687,7 @@ select stxname, stxdndistinct, stxddependencies, stxdmcv from pg_statistic_ext p
 drop table minirepro_foo;
 drop table minirepro_bar;
 --------------------------------------------------------------------------------
--- Scenario: Test if minirepro captures non-default planner settings
+-- Scenario: Test if minirepro captures non-default optimization settings
 --------------------------------------------------------------------------------
 create table minirepro_foo(a int, b int);
 alter database regression set enable_indexscan to off;
@@ -706,14 +706,14 @@ Writing table statistics ...
 Writing column statistics ...
 Writing correlated statistics ...
 Attaching raw query text ...
-Writing non-default guc settings ...
+Writing non-default optimization guc settings ...
 --- MiniRepro completed! ---
 WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.
 Please review output file to ensure it is within corporate policy to transport the output file.
 -- end_ignore
 -- Validate if above set gucs are captured in Non-default gucs section
-\! grep -E 'Non-default planner guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
--- Non-default planner guc settings
+\! grep -E 'Non-default optimization guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
+-- Non-default optimization guc settings
 -- set enable_indexscan = off;
 -- set optimizer_join_order = greedy;
 alter database regression reset enable_indexscan;
@@ -739,14 +739,14 @@ Writing table statistics ...
 Writing column statistics ...
 Writing correlated statistics ...
 Attaching raw query text ...
-Writing non-default guc settings ...
+Writing non-default optimization guc settings ...
 --- MiniRepro completed! ---
 WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.
 Please review output file to ensure it is within corporate policy to transport the output file.
 -- end_ignore
 -- Validate if appropriate message is reported in Non-default gucs section
-\! grep -E 'Non-default planner guc settings|None Available' data/minirepro.sql
--- Non-default planner guc settings
--- None Available
+\! grep -E 'Non-default optimization guc settings|Using all default guc settings' data/minirepro.sql
+-- Non-default optimization guc settings
+-- Using all default guc settings
 -- Cleanup
 drop table minirepro_foo;

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -686,3 +686,67 @@ select stxname, stxdndistinct, stxddependencies, stxdmcv from pg_statistic_ext p
 -- Cleanup
 drop table minirepro_foo;
 drop table minirepro_bar;
+--------------------------------------------------------------------------------
+-- Scenario: Test if minirepro captures non-default planner settings
+--------------------------------------------------------------------------------
+create table minirepro_foo(a int, b int);
+alter database regression set enable_indexscan to off;
+alter database regression set optimizer_join_order to greedy;
+-- start_ignore
+\! echo "select * from minirepro_foo" > ./data/minirepro_q.sql
+\! minirepro regression -q data/minirepro_q.sql -f data/minirepro.sql
+Connecting to database: host=testhost, port=7000, user=sanathv, db=regression ...
+Extracting metadata from query file data/minirepro_q.sql ...
+psql regression --pset footer --no-psqlrc -v ON_ERROR_STOP=1 -Atq -h testhost -p 7000 -U sanathv -f /tmp/20240209191217/toolkit.sql
+Invoking pg_dump to dump DDL ...
+pg_dump -h testhost -p 7000 -U sanathv -sxO regression --relation-oids 28826 --function-oids 0 -f /tmp/20240209191217/pg_dump_out.sql
+Writing schema DDLs ...
+Writing relation and function DDLs ...
+Writing table statistics ...
+Writing column statistics ...
+Writing correlated statistics ...
+Attaching raw query text ...
+Writing non-default guc settings ...
+--- MiniRepro completed! ---
+WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.
+Please review output file to ensure it is within corporate policy to transport the output file.
+-- end_ignore
+-- Validate if above set gucs are captured in Non-default gucs section
+\! grep -E 'Non-default planner guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
+-- Non-default planner guc settings
+-- set enable_indexscan = off;
+-- set optimizer_join_order = greedy;
+alter database regression reset enable_indexscan;
+alter database regression reset optimizer_join_order;
+-- Cleanup
+drop table minirepro_foo;
+--------------------------------------------------------------------------------
+-- Scenario: Test if minirepro reports appropriate message if no default
+--           planner settings are altered
+--------------------------------------------------------------------------------
+create table minirepro_foo(a int, b int);
+-- start_ignore
+\! echo "select * from minirepro_foo" > ./data/minirepro_q.sql
+\! minirepro regression -q data/minirepro_q.sql -f data/minirepro.sql
+Connecting to database: host=testhost, port=7000, user=sanathv, db=regression ...
+Extracting metadata from query file data/minirepro_q.sql ...
+psql regression --pset footer --no-psqlrc -v ON_ERROR_STOP=1 -Atq -h testhost -p 7000 -U sanathv -f /tmp/20240209191217/toolkit.sql
+Invoking pg_dump to dump DDL ...
+pg_dump -h testhost -p 7000 -U sanathv -sxO regression --relation-oids 28829 --function-oids 0 -f /tmp/20240209191217/pg_dump_out.sql
+Writing schema DDLs ...
+Writing relation and function DDLs ...
+Writing table statistics ...
+Writing column statistics ...
+Writing correlated statistics ...
+Attaching raw query text ...
+Writing non-default guc settings ...
+--- MiniRepro completed! ---
+WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.
+Please review output file to ensure it is within corporate policy to transport the output file.
+-- end_ignore
+-- Validate if appropriate message is reported in Non-default gucs section
+\! grep -E 'Non-default planner guc settings|None Available' data/minirepro.sql
+-- Non-default planner guc settings
+-- None Available
+-- Cleanup
+drop table minirepro_foo;

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -298,7 +298,7 @@ drop table minirepro_foo;
 drop table minirepro_bar;
 
 --------------------------------------------------------------------------------
--- Scenario: Test if minirepro captures non-default planner settings
+-- Scenario: Test if minirepro captures non-default optimization settings
 --------------------------------------------------------------------------------
 create table minirepro_foo(a int, b int);
 alter database regression set enable_indexscan to off;
@@ -310,7 +310,7 @@ alter database regression set optimizer_join_order to greedy;
 -- end_ignore
 
 -- Validate if above set gucs are captured in Non-default gucs section
-\! grep -E 'Non-default planner guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
+\! grep -E 'Non-default optimization guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
 
 alter database regression reset enable_indexscan;
 alter database regression reset optimizer_join_order;
@@ -329,7 +329,7 @@ create table minirepro_foo(a int, b int);
 -- end_ignore
 
 -- Validate if appropriate message is reported in Non-default gucs section
-\! grep -E 'Non-default planner guc settings|None Available' data/minirepro.sql
+\! grep -E 'Non-default optimization guc settings|Using all default guc settings' data/minirepro.sql
 
 -- Cleanup
 drop table minirepro_foo;

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -296,3 +296,40 @@ select stxname, stxdndistinct, stxddependencies, stxdmcv from pg_statistic_ext p
 -- Cleanup
 drop table minirepro_foo;
 drop table minirepro_bar;
+
+--------------------------------------------------------------------------------
+-- Scenario: Test if minirepro captures non-default planner settings
+--------------------------------------------------------------------------------
+create table minirepro_foo(a int, b int);
+alter database regression set enable_indexscan to off;
+alter database regression set optimizer_join_order to greedy;
+
+-- start_ignore
+\! echo "select * from minirepro_foo" > ./data/minirepro_q.sql
+\! minirepro regression -q data/minirepro_q.sql -f data/minirepro.sql
+-- end_ignore
+
+-- Validate if above set gucs are captured in Non-default gucs section
+\! grep -E 'Non-default planner guc settings|enable_indexscan|optimizer_join_order' data/minirepro.sql
+
+alter database regression reset enable_indexscan;
+alter database regression reset optimizer_join_order;
+-- Cleanup
+drop table minirepro_foo;
+
+--------------------------------------------------------------------------------
+-- Scenario: Test if minirepro reports appropriate message if no default
+--           planner settings are altered
+--------------------------------------------------------------------------------
+create table minirepro_foo(a int, b int);
+
+-- start_ignore
+\! echo "select * from minirepro_foo" > ./data/minirepro_q.sql
+\! minirepro regression -q data/minirepro_q.sql -f data/minirepro.sql
+-- end_ignore
+
+-- Validate if appropriate message is reported in Non-default gucs section
+\! grep -E 'Non-default planner guc settings|None Available' data/minirepro.sql
+
+-- Cleanup
+drop table minirepro_foo;


### PR DESCRIPTION
This commit adds minor improvement to the minirepro tool. Minirepro now also captures and stores any Non-default planner related gucs set in the environment. This includes three categories of postgres settings: Query Tuning / Planner Cost Constants, Query Tuning / Planner Method Configuration and Query Tuning / Other Planner Options. If all the settings related to this category are set to the default values, minirepro reports appropriate message indicating the same. This improvement aids developers to reproduce the plan if customers aren't aware of guc settings done at cluster/database/user level.